### PR TITLE
Rework instance activation

### DIFF
--- a/Generator/AssemblyCollection.cs
+++ b/Generator/AssemblyCollection.cs
@@ -44,5 +44,9 @@ namespace Generator
 		{
 			throw new NotImplementedException();
 		}
+
+		void IDisposable.Dispose()
+		{
+		}
 	}
 }

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -35,12 +35,20 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -54,6 +54,7 @@
     <Compile Include="AssemblyCollection.cs" />
     <Compile Include="ParametricInterfaceInstance.cs" />
     <Compile Include="Types\ClassDef.cs" />
+    <Compile Include="Types\ClassMethodDef.cs" />
     <Compile Include="Types\EnumDef.cs" />
     <Compile Include="Types\InterfaceDef.cs" />
     <Compile Include="Types\ITypeRequestSource.cs" />

--- a/Generator/ParametricInterfaceInstance.cs
+++ b/Generator/ParametricInterfaceInstance.cs
@@ -140,10 +140,8 @@ namespace Generator
 			}
 			else if (def.Kind == TypeKind.Class)
 			{
-				var mainInterface = def.Type.Interfaces[0];
-				if (def.Type.CustomAttributes.Any(a => a.AttributeType.Name == "DefaultInterfaceAttribute"))
-					throw new NotImplementedException();
-				return "rc(" + def.Type.FullName + ";" + GetTypeIIDDescriptor(gen, mainInterface) + ")";
+				var defaultInterface = TypeHelpers.GetDefaultInterface(def.Type);
+				return "rc(" + def.Type.FullName + ";" + GetTypeIIDDescriptor(gen, defaultInterface) + ")";
 			}
 			else
 			{

--- a/Generator/ParametricInterfaceManager.cs
+++ b/Generator/ParametricInterfaceManager.cs
@@ -50,7 +50,7 @@ namespace Generator
 			var tyIReferenceArray = gen.GetTypeDefinition("Windows.Foundation.IReferenceArray`1");
 			var assembly = tyIReference.Module.Assembly; // we need just any assembly
 
-			var allBaseTypes = baseTypes.Select(t => assembly.MainModule.Import(t)).Concat(baseTypes2.Select(t => gen.GetTypeDefinition("Windows.Foundation." + t).Type));
+			var allBaseTypes = baseTypes.Select(t => assembly.MainModule.ImportReference(t)).Concat(baseTypes2.Select(t => gen.GetTypeDefinition("Windows.Foundation." + t).Type));
 
 			foreach (var baseType in allBaseTypes)
 			{
@@ -82,7 +82,7 @@ namespace Generator
 			}
 
 			// recursively add implemented interfaces	
-			foreach (var intf in def.Interfaces.Where(i => i.ContainsGenericParameter && i is GenericInstanceType).Cast<GenericInstanceType>())
+			foreach (var intf in def.Interfaces.Select(i => i.InterfaceType).Where(i => i.ContainsGenericParameter && i is GenericInstanceType).Cast<GenericInstanceType>())
 			{
 				var type = TypeHelpers.InstantiateType(intf, genericParameterMap);
 				if (type is GenericInstanceType)

--- a/Generator/Types/ClassDef.cs
+++ b/Generator/Types/ClassDef.cs
@@ -47,8 +47,8 @@ namespace Generator.Types
 			
 			if (Type.Interfaces.Count > 0)
 			{
-				var mainInterface = Type.Interfaces[0];
-				aliasedType = TypeHelpers.GetTypeName(Generator, this, mainInterface, TypeUsage.Alias);
+				var defaultInterface = TypeHelpers.GetDefaultInterface(Type);
+				aliasedType = TypeHelpers.GetTypeName(Generator, this, defaultInterface, TypeUsage.Alias);
 			}
 
 			var factoryMethods = GetFactoryTypes().SelectMany(f => Generator.GetTypeDefinition(f).Methods).ToArray();

--- a/Generator/Types/ClassMethodDef.cs
+++ b/Generator/Types/ClassMethodDef.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using static System.Diagnostics.Debug;
+
+using Mono.Cecil;
+
+namespace Generator.Types
+{
+    /// <summary>
+    /// Definition of a wrapped method in a class.
+    /// Those are static methods that call get_activation_factory in their implementation.
+    /// </summary>
+    public class ClassMethodDef : ITypeRequestSource
+    {
+        public MethodDef WrappedMethod { get; private set; }
+        public ClassDef ContainingClass { get; private set; }
+
+        public string Name { get; private set; }
+
+        public Module Module
+        {
+            get
+            {
+                return ContainingClass.Module;
+            }
+        }
+
+        public Generator Generator
+        {
+            get
+            {
+                return WrappedMethod.DeclaringType.Generator;
+            }
+        }
+
+        private HashSet<TypeDef> dependencies = new HashSet<TypeDef>();
+        public IEnumerable<TypeDef> Dependencies
+        {
+            get
+            {
+                return dependencies;
+            }
+        }
+
+        private string[] inputParameters;
+        private string outType;
+
+        public IEnumerable<TypeDef> ForeignAssemblyDependencies
+        {
+            get
+            {
+                return dependencies.Where(t => t.Module.Assembly != Module.Assembly && t.Module.Assembly.Name.Name != "Windows.Foundation");
+            }
+        }
+
+        public ClassMethodDef(MethodDef method, ClassDef containingClass)
+        {
+            WrappedMethod = method;
+            ContainingClass = containingClass;
+            Name = WrappedMethod.Details.WrappedName;
+
+            AddDependency(method.DeclaringType);
+            inputParameters = WrappedMethod.Details.MakeInputParameters(Generator, this);
+            outType = WrappedMethod.Details.MakeOutType(Generator, this);
+        }
+
+        public void FixupName(string suffix)
+        {
+            Name += suffix;
+        }
+
+        public string Emit()
+        {
+            var m = WrappedMethod;
+            var dependsOnAssemblies = new List<string>(ForeignAssemblyDependencies.GroupBy(t => t.Module.Assembly.Name.Name).Select(g => g.Key));
+            var features = new FeatureConditions(dependsOnAssemblies);
+
+            return features.GetAttribute() + "#[inline] pub fn " + Name + "(" + String.Join(", ", inputParameters) + ") -> Result<" + outType + @"> { unsafe {
+                <Self as RtActivatable<" + m.DeclaringType.Name + ">>::get_activation_factory()." + m.Details.WrappedName + "(" + String.Join(", ", m.Details.InputParameterNames) + @")
+            }}";
+        }
+
+        public void AddDependency(TypeDef other)
+        {
+            Assert(Generator.AllowAddDependencies);
+            dependencies.Add(other);
+        }
+    }
+}

--- a/Generator/Types/ClassMethodDef.cs
+++ b/Generator/Types/ClassMethodDef.cs
@@ -7,84 +7,84 @@ using Mono.Cecil;
 
 namespace Generator.Types
 {
-    /// <summary>
-    /// Definition of a wrapped method in a class.
-    /// Those are static methods that call get_activation_factory in their implementation.
-    /// </summary>
-    public class ClassMethodDef : ITypeRequestSource
-    {
-        public MethodDef WrappedMethod { get; private set; }
-        public ClassDef ContainingClass { get; private set; }
+	/// <summary>
+	/// Definition of a wrapped method in a class.
+	/// Those are static methods that call get_activation_factory in their implementation.
+	/// </summary>
+	public class ClassMethodDef : ITypeRequestSource
+	{
+		public MethodDef WrappedMethod { get; private set; }
+		public ClassDef ContainingClass { get; private set; }
 
-        public string Name { get; private set; }
+		public string Name { get; private set; }
 
-        public Module Module
-        {
-            get
-            {
-                return ContainingClass.Module;
-            }
-        }
+		public Module Module
+		{
+			get
+			{
+				return ContainingClass.Module;
+			}
+		}
 
-        public Generator Generator
-        {
-            get
-            {
-                return WrappedMethod.DeclaringType.Generator;
-            }
-        }
+		public Generator Generator
+		{
+			get
+			{
+				return WrappedMethod.DeclaringType.Generator;
+			}
+		}
 
-        private HashSet<TypeDef> dependencies = new HashSet<TypeDef>();
-        public IEnumerable<TypeDef> Dependencies
-        {
-            get
-            {
-                return dependencies;
-            }
-        }
+		private HashSet<TypeDef> dependencies = new HashSet<TypeDef>();
+		public IEnumerable<TypeDef> Dependencies
+		{
+			get
+			{
+				return dependencies;
+			}
+		}
 
-        private string[] inputParameters;
-        private string outType;
+		private string[] inputParameters;
+		private string outType;
 
-        public IEnumerable<TypeDef> ForeignAssemblyDependencies
-        {
-            get
-            {
-                return dependencies.Where(t => t.Module.Assembly != Module.Assembly && t.Module.Assembly.Name.Name != "Windows.Foundation");
-            }
-        }
+		public IEnumerable<TypeDef> ForeignAssemblyDependencies
+		{
+			get
+			{
+				return dependencies.Where(t => t.Module.Assembly != Module.Assembly && t.Module.Assembly.Name.Name != "Windows.Foundation");
+			}
+		}
 
-        public ClassMethodDef(MethodDef method, ClassDef containingClass)
-        {
-            WrappedMethod = method;
-            ContainingClass = containingClass;
-            Name = WrappedMethod.Details.WrappedName;
+		public ClassMethodDef(MethodDef method, ClassDef containingClass)
+		{
+			WrappedMethod = method;
+			ContainingClass = containingClass;
+			Name = WrappedMethod.Details.WrappedName;
 
-            AddDependency(method.DeclaringType);
-            inputParameters = WrappedMethod.Details.MakeInputParameters(Generator, this);
-            outType = WrappedMethod.Details.MakeOutType(Generator, this);
-        }
+			AddDependency(method.DeclaringType);
+			inputParameters = WrappedMethod.Details.MakeInputParameters(Generator, this);
+			outType = WrappedMethod.Details.MakeOutType(Generator, this);
+		}
 
-        public void FixupName(string suffix)
-        {
-            Name += suffix;
-        }
+		public void FixupName(string suffix)
+		{
+			Name += suffix;
+		}
 
-        public string Emit()
-        {
-            var m = WrappedMethod;
-            var dependsOnAssemblies = new List<string>(ForeignAssemblyDependencies.GroupBy(t => t.Module.Assembly.Name.Name).Select(g => g.Key));
-            var features = new FeatureConditions(dependsOnAssemblies);
+		public string Emit()
+		{
+			var m = WrappedMethod;
+			var dependsOnAssemblies = new List<string>(ForeignAssemblyDependencies.GroupBy(t => t.Module.Assembly.Name.Name).Select(g => g.Key));
+			var features = new FeatureConditions(dependsOnAssemblies);
 
-            return features.GetAttribute() + "#[inline] pub fn " + Name + "(" + String.Join(", ", inputParameters) + ") -> Result<" + outType + @"> { unsafe {
-                <Self as RtActivatable<" + m.DeclaringType.Name + ">>::get_activation_factory()." + m.Details.WrappedName + "(" + String.Join(", ", m.Details.InputParameterNames) + @")
-            }}";
-        }
+			return features.GetAttribute() + "#[inline] pub fn " + Name + "(" + String.Join(", ", inputParameters) + ") -> Result<" + outType + @"> { unsafe {
+				<Self as RtActivatable<" + m.DeclaringType.Name + ">>::get_activation_factory()." + m.Details.WrappedName + "(" + String.Join(", ", m.Details.InputParameterNames) + @")
+			}}";
+		}
 
-        public void AddDependency(TypeDef other)
-        {
-            Assert(Generator.AllowAddDependencies);
-            dependencies.Add(other);
-        }
-    }
+		public void AddDependency(TypeDef other)
+		{
+			Assert(Generator.AllowAddDependencies);
+			dependencies.Add(other);
+		}
+	}
 }

--- a/Generator/Types/InterfaceDef.cs
+++ b/Generator/Types/InterfaceDef.cs
@@ -149,7 +149,7 @@ namespace Generator.Types
 				}
 			}
 
-			return candidates.Any(c => c.GetFactoryType() == t.Type || c.GetStaticTypes().Contains(t.Type));
+			return candidates.Any(c => c.GetFactoryTypes().Contains(t.Type) || c.GetStaticTypes().Contains(t.Type));
 		}
 	}
 }

--- a/Generator/Types/InterfaceDef.cs
+++ b/Generator/Types/InterfaceDef.cs
@@ -102,14 +102,14 @@ namespace Generator.Types
 			{
 				Module.Append(@"
 		RT_INTERFACE!{" + prependStatic + "interface " + name + generic + "(" + name + "Vtbl): IInspectable(IInspectableVtbl) [IID_" + name + @"] {
-			" + String.Join(",\r\n			", rawMethodDeclarationsWithFeatures) + @"
+			" + String.Join(",\r\n\t\t\t", rawMethodDeclarationsWithFeatures) + @"
 		}}");
 			}
 			else
 			{
 				Module.Append(@"
 		RT_DELEGATE!{delegate " + name + generic + "(" + name + "Vtbl, " + name + "Impl) [IID_" + name + @"] {
-			" + String.Join(",\r\n			", rawMethodDeclarationsWithFeatures) + @"
+			" + String.Join(",\r\n\t\t\t", rawMethodDeclarationsWithFeatures) + @"
 		}}");
 			}
 

--- a/Generator/Types/MethodDef.cs
+++ b/Generator/Types/MethodDef.cs
@@ -165,7 +165,7 @@ namespace Generator.Types
 							else
 							{
 								//TODO: this should probably be a mutable, write-only, empty slice -> what type?
-								input.Add(new Tuple<string, TypeReference, InputKind>(pname + "Size", Method.Module.Import(typeof(uint)), InputKind.Default));
+								input.Add(new Tuple<string, TypeReference, InputKind>(pname + "Size", Method.Module.ImportReference(typeof(uint)), InputKind.Default));
 								input.Add(new Tuple<string, TypeReference, InputKind>(pname, p.ParameterType, InputKind.Raw));
 							}
 						}

--- a/Generator/Types/TypeHelpers.cs
+++ b/Generator/Types/TypeHelpers.cs
@@ -367,6 +367,11 @@ namespace Generator.Types
 				return "ComPtr::wrap(" + name + ")";
 			}
 		}
+
+		public static TypeReference GetDefaultInterface(TypeDefinition type)
+		{
+			return type.Interfaces.Single(i => i.CustomAttributes.Any(a => a.AttributeType.Name == "DefaultAttribute")).InterfaceType;
+		}
 	}
 
 	public enum TypeUsage

--- a/Generator/packages.config
+++ b/Generator/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
+  <package id="Mono.Cecil" version="0.10.0-beta2" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ use winrt::windows::system::diagnostics::*; // import namespace Windows.System.D
 fn main() {
     let rt = RuntimeContext::init(); // initialize the Windows Runtime
     // get factory, which is also used to call static methods
-    let mut pdi_statics = IProcessDiagnosticInfoStatics::factory();
+    let mut pdi_statics = ProcessDiagnosticInfo::get_activation_factory();
     let mut infos = unsafe { pdi_statics.get_for_processes().unwrap() };
     println!("Currently executed processes ({}):", unsafe { infos.get_size().unwrap() });
     for mut p in infos.into_iter() {

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ use winrt::windows::system::diagnostics::*; // import namespace Windows.System.D
 
 fn main() {
     let rt = RuntimeContext::init(); // initialize the Windows Runtime
-    // get factory, which is also used to call static methods
-    let mut pdi_statics = ProcessDiagnosticInfo::get_activation_factory();
-    let mut infos = unsafe { pdi_statics.get_for_processes().unwrap() };
+    let mut infos = ProcessDiagnosticInfo::get_for_processes().unwrap();
     println!("Currently executed processes ({}):", unsafe { infos.get_size().unwrap() });
     for mut p in infos.into_iter() {
         let pid = unsafe { p.get_process_id().unwrap() };

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,14 +1,14 @@
 extern crate winapi as w;
-extern crate winrt as wrt;
+extern crate winrt;
 // TODO: don't use functions from runtimeobject directly 
 extern crate runtimeobject;
 
 use std::ptr;
 
-use wrt::*;
-use wrt::windows::foundation::*;
-use wrt::windows::devices::enumeration::*;
-use wrt::windows::devices::midi::*;
+use winrt::*;
+use winrt::windows::foundation::*;
+use winrt::windows::devices::enumeration::*;
+use winrt::windows::devices::midi::*;
 
 fn main() {
     let rt = RuntimeContext::init();

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -19,10 +19,9 @@ fn main() {
 fn run() {
     use std::sync::{Arc, Mutex, Condvar};
 
-    let mut uri_factory: ComPtr<IUriRuntimeClassFactory> = Uri::get_activation_factory();
     let base = FastHString::new("https://github.com");
     let relative = FastHString::new("contextfree/winrt-rust");
-    let uri = unsafe { uri_factory.create_with_relative_uri(&base, &relative).unwrap() };
+    let uri = Uri::create_with_relative_uri(&base, &relative).unwrap();
     let to_string = unsafe { uri.query_interface::<IStringable>().unwrap().to_string().unwrap() };
     println!("{} -> {}", uri.get_runtime_class_name(), to_string);
     println!("TrustLevel: {:?}", uri.get_trust_level());
@@ -32,13 +31,11 @@ fn run() {
         println!("  [{}] = {:?}", i, iids[i]);
     }
 
-    let mut out_port_statics = MidiOutPort::get_activation_factory();
+    //let mut out_port_statics = MidiOutPort::get_activation_factory();
     //println!("out_port_statics: {}", out_port_statics.get_runtime_class_name()); // this is not allowed (prevented statically)
     
-    let device_selector = unsafe { out_port_statics.get_device_selector().unwrap() };
+    let device_selector = MidiOutPort::get_device_selector().unwrap();
     println!("{}", device_selector);
-    
-    let mut device_information_statics: ComPtr<IDeviceInformationStatics> = DeviceInformation::get_activation_factory();
     
     unsafe {
         use runtimeobject::*;
@@ -46,7 +43,7 @@ fn run() {
 
         // Test some error reporting by using an invalid device selector
         let wrong_deviceselector: FastHString = "Foobar".into();
-        let res = device_information_statics.find_all_async_aqs_filter(&wrong_deviceselector);
+        let res = DeviceInformation::find_all_async_aqs_filter(&wrong_deviceselector);
         if let Err(e) = res {
             println!("HRESULT (FindAllAsyncAqsFilter) = {:?}", e.as_hresult());
             let mut error_info = {
@@ -68,8 +65,7 @@ fn run() {
         // NOTE: `res` is still null pointer at this point
     };
 
-    //let mut async_op = unsafe { device_information_statics.find_all_async_aqs_filter(device_selector.get_ref()).unwrap() };
-    let mut async_op = unsafe { device_information_statics.find_all_async().unwrap() };
+    let mut async_op = DeviceInformation::find_all_async().unwrap();
     
     println!("CLS: {}",  async_op.get_runtime_class_name());
     
@@ -151,7 +147,7 @@ fn run() {
     };
 
     let array = &mut [true, false, false, true];
-    let boxed_array = unsafe { PropertyValue::get_activation_factory().create_boolean_array(array) };
+    let boxed_array = PropertyValue::create_boolean_array(array);
     let mut boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType_BooleanArray);
     let mut boxed_array = boxed_array.query_interface::<IReferenceArray<bool>>().unwrap();
@@ -162,7 +158,7 @@ fn run() {
     let str1 = FastHString::new("foo");
     let str2 = FastHString::new("bar");
     let array = &mut [&*str1, &*str2, &*str1, &*str2];
-    let boxed_array = unsafe { PropertyValue::get_activation_factory().create_string_array(array) };
+    let boxed_array = PropertyValue::create_string_array(array);
     let mut boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType_StringArray);
     let mut boxed_array = boxed_array.query_interface::<IReferenceArray<HString>>().unwrap();

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -19,7 +19,7 @@ fn main() {
 fn run() {
     use std::sync::{Arc, Mutex, Condvar};
 
-    let mut uri_factory = Uri::factory();
+    let mut uri_factory: ComPtr<IUriRuntimeClassFactory> = Uri::get_activation_factory();
     let base = FastHString::new("https://github.com");
     let relative = FastHString::new("contextfree/winrt-rust");
     let uri = unsafe { uri_factory.create_with_relative_uri(&base, &relative).unwrap() };
@@ -32,13 +32,13 @@ fn run() {
         println!("  [{}] = {:?}", i, iids[i]);
     }
 
-    let mut out_port_statics = IMidiOutPortStatics::factory();
+    let mut out_port_statics = MidiOutPort::get_activation_factory();
     //println!("out_port_statics: {}", out_port_statics.get_runtime_class_name()); // this is not allowed (prevented statically)
     
     let device_selector = unsafe { out_port_statics.get_device_selector().unwrap() };
     println!("{}", device_selector);
     
-    let mut device_information_statics = IDeviceInformationStatics::factory();
+    let mut device_information_statics: ComPtr<IDeviceInformationStatics> = DeviceInformation::get_activation_factory();
     
     unsafe {
         use runtimeobject::*;
@@ -151,7 +151,7 @@ fn run() {
     };
 
     let array = &mut [true, false, false, true];
-    let boxed_array = unsafe { IPropertyValueStatics::factory().create_boolean_array(array) };
+    let boxed_array = unsafe { PropertyValue::get_activation_factory().create_boolean_array(array) };
     let mut boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType_BooleanArray);
     let mut boxed_array = boxed_array.query_interface::<IReferenceArray<bool>>().unwrap();
@@ -162,7 +162,7 @@ fn run() {
     let str1 = FastHString::new("foo");
     let str2 = FastHString::new("bar");
     let array = &mut [&*str1, &*str2, &*str1, &*str2];
-    let boxed_array = unsafe { IPropertyValueStatics::factory().create_string_array(array) };
+    let boxed_array = unsafe { PropertyValue::get_activation_factory().create_string_array(array) };
     let mut boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType_StringArray);
     let mut boxed_array = boxed_array.query_interface::<IReferenceArray<HString>>().unwrap();

--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -77,9 +77,8 @@ impl<T> ComPtr<T> {
     /// use winrt::windows::foundation::Uri;
     ///
     /// # let rt = winrt::RuntimeContext::init();
-    /// let mut uri_factory: ComPtr<IUriRuntimeClassFactory> = Uri::get_activation_factory();
     /// let uri = FastHString::new("https://www.rust-lang.org");
-    /// let uri = unsafe { uri_factory.create_uri(&uri).unwrap() };
+    /// let uri = Uri::create_uri(&uri).unwrap();
     /// assert_eq!("Windows.Foundation.Uri", uri.get_runtime_class_name().to_string());
     /// ```
     #[inline]

--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -56,6 +56,13 @@ impl<T> ComPtr<T> {
     fn as_unknown(&self) -> &mut ::w::IUnknown {
         unsafe { &mut *(self.0 as *mut ::w::IUnknown) }
     }
+
+    /// Changes the type of the underlying COM object to a different interface without doing `QueryInterface`.
+    /// This is a runtime no-op, but you need to be sure that the interface is compatible.
+    #[inline]
+    pub unsafe fn into_unchecked<Interface>(self) -> ComPtr<Interface> where Interface: ComInterface {
+        ::std::mem::transmute(self)
+    }
     
     /// Gets the fully qualified name of the current Windows Runtime object.
     /// This is only available for interfaces that inherit from `IInspectable` and
@@ -70,7 +77,7 @@ impl<T> ComPtr<T> {
     /// use winrt::windows::foundation::Uri;
     ///
     /// # let rt = winrt::RuntimeContext::init();
-    /// let mut uri_factory = Uri::factory();
+    /// let mut uri_factory: ComPtr<IUriRuntimeClassFactory> = Uri::get_activation_factory();
     /// let uri = FastHString::new("https://www.rust-lang.org");
     /// let uri = unsafe { uri_factory.create_uri(&uri).unwrap() };
     /// assert_eq!("Windows.Foundation.Uri", uri.get_runtime_class_name().to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! fn main() {
 //!     let rt = RuntimeContext::init(); // initialize the Windows Runtime
 //!     // get factory, which is also used to call static methods
-//!     let mut pdi_statics = IProcessDiagnosticInfoStatics::factory();
+//!     let mut pdi_statics = ProcessDiagnosticInfo::get_activation_factory();
 //!     let mut infos = unsafe { pdi_statics.get_for_processes().unwrap() };
 //!     println!("Currently executed processes ({}):", unsafe { infos.get_size().unwrap() });
 //!     for mut p in infos.into_iter() {
@@ -69,7 +69,7 @@ mod cominterfaces;
 pub use cominterfaces::{ComInterface, ComIid, IUnknown, IRestrictedErrorInfo, IAgileObject};
 
 mod rt;
-pub use rt::{RtInterface, RtClassInterface, RtValueType, RtType, RtActivatable, IInspectable, IInspectableVtbl, Char, RuntimeContext};
+pub use rt::{RtInterface, RtClassInterface, RtNamedClass, RtValueType, RtType, RtActivatable, IInspectable, IInspectableVtbl, IActivationFactory, Char, RuntimeContext};
 
 mod result;
 pub use result::{Result, Error, HRESULT};
@@ -80,7 +80,7 @@ pub mod windows {
 
 /// This is only for internal use within the generated code
 mod prelude {
-    pub use ::rt::{RtType, IInspectable, IInspectableVtbl, Char};
+    pub use ::rt::{RtType, IInspectable, IInspectableVtbl, IActivationFactory, Char};
     pub use ::rt::handler::IntoInterface;
     pub use ::cominterfaces::{ComInterface, ComIid, IUnknown};
     pub use ::comptr::{ComPtr, ComArray};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,7 @@
 //!
 //! fn main() {
 //!     let rt = RuntimeContext::init(); // initialize the Windows Runtime
-//!     // get factory, which is also used to call static methods
-//!     let mut pdi_statics = ProcessDiagnosticInfo::get_activation_factory();
-//!     let mut infos = unsafe { pdi_statics.get_for_processes().unwrap() };
+//!     let mut infos = ProcessDiagnosticInfo::get_for_processes().unwrap();
 //!     println!("Currently executed processes ({}):", unsafe { infos.get_size().unwrap() });
 //!     for mut p in infos.into_iter() {
 //!         let pid = unsafe { p.get_process_id().unwrap() };
@@ -80,7 +78,7 @@ pub mod windows {
 
 /// This is only for internal use within the generated code
 mod prelude {
-    pub use ::rt::{RtType, IInspectable, IInspectableVtbl, IActivationFactory, Char};
+    pub use ::rt::{RtType, RtActivatable, IInspectable, IInspectableVtbl, IActivationFactory, Char};
     pub use ::rt::handler::IntoInterface;
     pub use ::cominterfaces::{ComInterface, ComIid, IUnknown};
     pub use ::comptr::{ComPtr, ComArray};

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -99,6 +99,7 @@ pub trait RtNamedClass {
 
 pub trait RtActivatable<Interface> : RtNamedClass {
     /// Returns a factory object to create instances of this class or to call static methods.
+    #[inline]
     fn get_activation_factory() -> ComPtr<Interface> where Interface: RtInterface + ComIid {
         let mut res = ptr::null_mut();
         let class_id = unsafe { HStringReference::from_utf16_unchecked(Self::name()) };
@@ -113,7 +114,8 @@ pub trait RtActivatable<Interface> : RtNamedClass {
     }
 
     /// Uses the default constructor to create an instance of this class.
-    fn activate_instance() -> ComPtr<Self> where Self: Sized + RtActivatable<IActivationFactory> + ComInterface {
+    #[inline]
+    fn new() -> ComPtr<Self> where Self: Sized + RtActivatable<IActivationFactory> + ComInterface {
         let factory: ComPtr<IActivationFactory> = Self::get_activation_factory();
         unsafe { factory.activate_instance().into_unchecked() }
     }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -394,11 +394,11 @@ macro_rules! RT_DELEGATE {
         }}
 
         impl $interface {
-			#[inline] pub fn new<_F_>(f: _F_) -> ComPtr<$interface>
-				where _F_: 'static + Send + FnMut($($t),*) -> Result<()>, $interface: ComIid {
-				$imp::new(f).into_interface()
-    		}
-		}
+            #[inline] pub fn new<_F_>(f: _F_) -> ComPtr<$interface>
+                where _F_: 'static + Send + FnMut($($t),*) -> Result<()>, $interface: ComIid {
+                $imp::new(f).into_interface()
+            }
+        }
 
         struct $imp<_F_> where _F_: 'static + Send + FnMut($($t),*) -> Result<()> {
             invoke: _F_
@@ -460,11 +460,11 @@ macro_rules! RT_DELEGATE {
         }}
 
         impl<$($ht: RtType + 'static),+> $interface<$($ht),+> {
-			#[inline] pub fn new<_F_>(f: _F_) -> ComPtr<$interface<$($ht),+>>
-				where _F_: 'static + Send + FnMut($($t),*) -> Result<()>, $interface<$($ht),+>: ComIid {
-				$imp::new(f).into_interface()
-    		}
-		}
+            #[inline] pub fn new<_F_>(f: _F_) -> ComPtr<$interface<$($ht),+>>
+                where _F_: 'static + Send + FnMut($($t),*) -> Result<()>, $interface<$($ht),+>: ComIid {
+                $imp::new(f).into_interface()
+            }
+        }
 
         struct $imp<$($ht: RtType),+ , _F_> where _F_: 'static + Send + FnMut($($t),*) -> Result<()> {
             invoke: _F_,
@@ -613,9 +613,9 @@ macro_rules! RT_PINTERFACE {
         $b6:expr, $b7:expr, $b8:expr] as $iid:ident
     ) => {
         DEFINE_IID!($iid, $l,$w1,$w2,$b1,$b2,$b3,$b4,$b5,$b6,$b7,$b8);
-		impl ComIid for $t {
-			#[inline] fn iid() -> &'static ::Guid { &$iid }
-		}
+        impl ComIid for $t {
+            #[inline] fn iid() -> &'static ::Guid { &$iid }
+        }
     };
 }
 


### PR DESCRIPTION
This adds previously missing activation factories, e.g. the (parameterless) ones for default constructors implementing `IActivationFactory`.
Furthermore, all factory and static methods are now wrapped directly in `impl` blocks of the corresponding classes, to allow calls such as `Uri::create_uri`.