### PR TITLE
Get rid of a lot of `mut`s

### DIFF
--- a/Generator/Types/InterfaceDef.cs
+++ b/Generator/Types/InterfaceDef.cs
@@ -94,7 +94,7 @@ namespace Generator.Types
 				else
 				{
 					rawMethodDeclarationsWithFeatures.Insert(0, featureAttr + decl);
-					rawMethodDeclarationsWithFeatures.Insert(0, feature.GetInvertedAttribute() + "fn __Dummy" + i + "(&mut self) -> ()");
+					rawMethodDeclarationsWithFeatures.Insert(0, feature.GetInvertedAttribute() + "fn __Dummy" + i + "(&self) -> ()");
 				}
 			}
 

--- a/Generator/Types/MethodDef.cs
+++ b/Generator/Types/MethodDef.cs
@@ -122,7 +122,7 @@ namespace Generator.Types
 			var inputParameters = Details.MakeInputParameters(DeclaringType.Generator, this);
 			var outType = Details.MakeOutType(DeclaringType.Generator, this);
 
-			return "#[inline] pub unsafe fn " + Details.WrappedName + "(" + String.Join(", ", new string[] { "&mut self" }.Concat(inputParameters)) + ") -> Result<" + outType + @"> {" + Details.WrapperBody + @"
+			return "#[inline] pub unsafe fn " + Details.WrappedName + "(" + String.Join(", ", new string[] { "&self" }.Concat(inputParameters)) + ") -> Result<" + outType + @"> {" + Details.WrapperBody + @"
 			}";
 		}
 
@@ -209,7 +209,7 @@ namespace Generator.Types
 
 		private string GetWrapperBody(string rawName, bool isGetMany, string getManyPname, List<Tuple<string, TypeReference>> output)
 		{
-			var rawParams = new List<string> { "self" };
+			var rawParams = new List<string> { "self as *const _ as *mut _" };
 			foreach (var p in Method.Parameters)
 			{
 				var pname = NameHelpers.PreventKeywords(NameHelpers.FirstToLower(p.Name));
@@ -293,7 +293,7 @@ namespace Generator.Types
 
 		public IEnumerable<string> GetParameterDeclarations()
 		{
-			yield return "&mut self";
+			yield return "&self";
 			foreach (var p in Method.Parameters)
 			{
 				Assert(!p.IsReturnValue);

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ use winrt::windows::system::diagnostics::*; // import namespace Windows.System.D
 
 fn main() {
     let rt = RuntimeContext::init(); // initialize the Windows Runtime
-    let mut infos = ProcessDiagnosticInfo::get_for_processes().unwrap();
+    let infos = ProcessDiagnosticInfo::get_for_processes().unwrap();
     println!("Currently executed processes ({}):", unsafe { infos.get_size().unwrap() });
-    for mut p in infos.into_iter() {
+    for p in infos.into_iter() {
         let pid = unsafe { p.get_process_id().unwrap() };
         let exe = unsafe { p.get_executable_file_name().unwrap() };
         println!("[{}] {}", pid, exe);

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -63,11 +63,11 @@ fn run() {
         // NOTE: `res` is still null pointer at this point
     };
 
-    let mut async_op = DeviceInformation::find_all_async().unwrap();
+    let async_op = DeviceInformation::find_all_async().unwrap();
     
     println!("CLS: {}",  async_op.get_runtime_class_name());
     
-    let mut asi = async_op.query_interface::<IAsyncInfo>().unwrap();
+    let asi = async_op.query_interface::<IAsyncInfo>().unwrap();
     println!("IAsyncInfo: {:p}, Iasync_operation: {:p}", asi, async_op);
     
     let unknown = async_op.query_interface::<IUnknown>().unwrap();
@@ -81,14 +81,14 @@ fn run() {
     let status = unsafe { asi.get_status().unwrap() };
     println!("status: {:?}", status);
 
-    let mut device_information_collection = async_op.blocking_get();
+    let device_information_collection = async_op.blocking_get();
     println!("CLS: {}", device_information_collection.get_runtime_class_name());
     let count = unsafe { device_information_collection.get_size().unwrap() };
     println!("Device Count: {}", count);
     
     let mut remember = None;
     let mut i = 0;
-    for mut current in device_information_collection.into_iter() {
+    for current in device_information_collection.into_iter() {
         let device_name = unsafe { current.get_name().unwrap() };
         println!("Device Name ({}): {}", i, device_name);
         if i == 100 {
@@ -121,9 +121,9 @@ fn run() {
 
     let array = &mut [true, false, false, true];
     let boxed_array = PropertyValue::create_boolean_array(array);
-    let mut boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
+    let boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType_BooleanArray);
-    let mut boxed_array = boxed_array.query_interface::<IReferenceArray<bool>>().unwrap();
+    let boxed_array = boxed_array.query_interface::<IReferenceArray<bool>>().unwrap();
     let returned_array = unsafe { boxed_array.get_value().unwrap() };
     println!("{:?} = {:?}", array, &returned_array[..]);
     assert_eq!(array, &returned_array[..]);
@@ -132,9 +132,9 @@ fn run() {
     let str2 = FastHString::new("bar");
     let array = &mut [&*str1, &*str2, &*str1, &*str2];
     let boxed_array = PropertyValue::create_string_array(array);
-    let mut boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
+    let boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType_StringArray);
-    let mut boxed_array = boxed_array.query_interface::<IReferenceArray<HString>>().unwrap();
+    let boxed_array = boxed_array.query_interface::<IReferenceArray<HString>>().unwrap();
     let returned_array = unsafe { boxed_array.get_value().unwrap() };
     assert_eq!(array.len(), returned_array.len());
     for i in 0..array.len() {

--- a/examples/toast_notify.rs
+++ b/examples/toast_notify.rs
@@ -17,10 +17,10 @@ fn main() {
 
 fn run() { unsafe {
     // Get a toast XML template
-    let mut toast_xml = ToastNotificationManager::get_template_content(ToastTemplateType_ToastText02).unwrap();
+    let toast_xml = ToastNotificationManager::get_template_content(ToastTemplateType_ToastText02).unwrap();
 
     // Fill in the text elements
-    let mut toast_text_elements = toast_xml.get_elements_by_tag_name(&FastHString::new("text")).unwrap();
+    let toast_text_elements = toast_xml.get_elements_by_tag_name(&FastHString::new("text")).unwrap();
     
     toast_text_elements.item(0).unwrap().append_child(&*toast_xml.create_text_node(&FastHString::new("Hello from Rust!")).unwrap().query_interface::<IXmlNode>().unwrap()).unwrap();
     toast_text_elements.item(1).unwrap().append_child(&*toast_xml.create_text_node(&FastHString::new("This is some more text.")).unwrap().query_interface::<IXmlNode>().unwrap()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 //!
 //! fn main() {
 //!     let rt = RuntimeContext::init(); // initialize the Windows Runtime
-//!     let mut infos = ProcessDiagnosticInfo::get_for_processes().unwrap();
+//!     let infos = ProcessDiagnosticInfo::get_for_processes().unwrap();
 //!     println!("Currently executed processes ({}):", unsafe { infos.get_size().unwrap() });
-//!     for mut p in infos.into_iter() {
+//!     for p in infos.into_iter() {
 //!         let pid = unsafe { p.get_process_id().unwrap() };
 //!         let exe = unsafe { p.get_executable_file_name().unwrap() };
 //!         println!("[{}] {}", pid, exe);


### PR DESCRIPTION
We were already using immutable references for all object parameters except `self`. Now the `self` parameter is passed as `&self` instead of `&mut self` for WinRT objects. Any mutation happening inside WinRT should be invisible to Rust (cf. interior mutability).

Fixes #39