### PR TITLE
Provide hstr! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["Generator/**"]
 
 [dependencies]
 winapi = { version = "0.3", features = ["winnt", "combaseapi", "oleauto", "roapi", "roerrorapi", "hstring", "winstring", "winerror", "restrictederrorinfo"] }
+wstr = "0.2"
 
 [features]
 nightly = []

--- a/Generator/NameHelpers.cs
+++ b/Generator/NameHelpers.cs
@@ -46,12 +46,6 @@ namespace Generator
             return newName.ToString();
         }
 
-        // Returns the string as an UTF16 encoded, null-terminated sequence of u16 values
-        public static string StringToUTF16WithZero(string str)
-        {
-            return String.Join(",", str.Select(c => ((ushort)c).ToString()).Concat(new string[] { "0" }));
-        }
-
         public static Tuple<string, int> GetSortKeyIgnoringInterfacePrefix(string str)
         {
             if (str[0] == 'I' && char.IsUpper(str[1]))

--- a/Generator/Types/ClassDef.cs
+++ b/Generator/Types/ClassDef.cs
@@ -137,7 +137,7 @@ impl { DefinitionName } {{
             if (needClassID)
             {
                 Module.Append($@"
-DEFINE_CLSID!({ classType }(&[{ NameHelpers.StringToUTF16WithZero(Type.FullName) }]) [CLSID_{ classType }]);");
+DEFINE_CLSID!({ classType }: ""{ Type.FullName }"");");
             }
         }
     }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -15,8 +15,8 @@ fn main() {
 }
 
 fn run() {
-    let base = FastHString::new("https://github.com");
-    let relative = FastHString::new("contextfree/winrt-rust");
+    let base = hstr!("https://github.com");
+    let relative = hstr!("contextfree/winrt-rust");
     let uri = Uri::create_with_relative_uri(&base, &relative).unwrap();
     let to_string = unsafe { uri.query_interface::<IStringable>().unwrap().to_string().unwrap() };
     println!("{} -> {}", uri.get_runtime_class_name(), to_string);
@@ -126,9 +126,9 @@ fn run() {
     println!("{:?} = {:?}", array, &returned_array[..]);
     assert_eq!(array, &returned_array[..]);
 
-    let str1 = FastHString::new("foo");
-    let str2 = FastHString::new("bar");
-    let array = &mut [&*str1, &*str2, &*str1, &*str2];
+    let str1 = hstr!("foo");
+    let str2 = hstr!("bar");
+    let array = &mut [&*str1, &*str2, &*str1, &*str2]; // convert to array of `&HStringArg`
     let boxed_array = PropertyValue::create_string_array(array);
     let boxed_array = boxed_array.unwrap().query_interface::<IPropertyValue>().unwrap();
     assert_eq!(unsafe { boxed_array.get_type().unwrap() }, PropertyType::StringArray);
@@ -136,7 +136,7 @@ fn run() {
     let returned_array = unsafe { boxed_array.get_value().unwrap() };
     assert_eq!(array.len(), returned_array.len());
     for i in 0..array.len() {
-        assert!(returned_array[i] == (if i % 2 == 0 { &str1 } else { &str2 }));
+        assert!(returned_array[i] == (if i % 2 == 0 { str1 } else { str2 }));
     }
     // TODO: test array interface objects (also see if ComArray drops contents correctly)
     

--- a/examples/toast_notify.rs
+++ b/examples/toast_notify.rs
@@ -3,6 +3,7 @@
 // Use the following command to run this example:
 // > cargo run --example toast_notify --features "windows-data windows-ui"
 
+#[macro_use]
 extern crate winrt;
 
 use winrt::*;
@@ -20,10 +21,10 @@ fn run() { unsafe {
     let toast_xml = ToastNotificationManager::get_template_content(ToastTemplateType::ToastText02).unwrap();
 
     // Fill in the text elements
-    let toast_text_elements = toast_xml.get_elements_by_tag_name(&FastHString::new("text")).unwrap();
+    let toast_text_elements = toast_xml.get_elements_by_tag_name(&*hstr!("text")).unwrap();
     
-    toast_text_elements.item(0).unwrap().append_child(&*toast_xml.create_text_node(&FastHString::new("Hello from Rust!")).unwrap().query_interface::<IXmlNode>().unwrap()).unwrap();
-    toast_text_elements.item(1).unwrap().append_child(&*toast_xml.create_text_node(&FastHString::new("This is some more text.")).unwrap().query_interface::<IXmlNode>().unwrap()).unwrap();
+    toast_text_elements.item(0).unwrap().append_child(&*toast_xml.create_text_node(&*hstr!("Hello from Rust!")).unwrap().query_interface::<IXmlNode>().unwrap()).unwrap();
+    toast_text_elements.item(1).unwrap().append_child(&*toast_xml.create_text_node(&*hstr!("This is some more text.")).unwrap().query_interface::<IXmlNode>().unwrap()).unwrap();
 
     // could use the following to get the XML code for the notification
     //println!("{}", toast_xml.query_interface::<IXmlNodeSerializer>().unwrap().get_xml().unwrap());
@@ -32,5 +33,5 @@ fn run() { unsafe {
     let toast = ToastNotification::create_toast_notification(&*toast_xml).unwrap();
 
     // Show the toast. Use PowerShell's App ID to circumvent the need to register one (this is only an example!).
-    ToastNotificationManager::create_toast_notifier_with_id(&FastHString::new("{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe")).unwrap().show(&*toast).unwrap();
+    ToastNotificationManager::create_toast_notifier_with_id(&*hstr!("{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe")).unwrap().show(&*toast).unwrap();
 }}

--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -83,7 +83,7 @@ impl<T> ComPtr<T> {
     /// use winrt::windows::foundation::Uri;
     ///
     /// # let rt = winrt::RuntimeContext::init();
-    /// let uri = FastHString::new("https://www.rust-lang.org");
+    /// let uri = hstr!("https://www.rust-lang.org");
     /// let uri = Uri::create_uri(&uri).unwrap();
     /// assert_eq!("Windows.Foundation.Uri", uri.get_runtime_class_name().to_string());
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,26 @@
 
 #![allow(dead_code,non_upper_case_globals,non_snake_case)]
 
+#[macro_use]
+extern crate wstr;
+pub use wstr::*;
+
 extern crate winapi as w;
 
 mod guid;
 pub use guid::Guid;
+
+/// Creates an `HStringReference` from a string literal.
+/// This is the fastest and easiest way to pass `HString` literals
+/// to WinRT functions.
+#[macro_export]
+macro_rules! hstr {
+    ($str: tt) => {{
+        let s = wstrz!($str);
+        #[allow(unused_unsafe)]
+        unsafe { HStringReference::from_utf16_unchecked(s) }
+    }}
+}
 
 ///Represents the trust level of an activatable class (re-export from WinAPI crate)
 pub type TrustLevel = ::w::winrt::inspectable::TrustLevel;

--- a/src/rt/gen/windows/applicationmodel.rs
+++ b/src/rt/gen/windows/applicationmodel.rs
@@ -64,7 +64,7 @@ impl DesignMode {
         <Self as RtActivatable<IDesignModeStatics2>>::get_activation_factory().get_design_mode2_enabled()
     }}
 }
-DEFINE_CLSID!(DesignMode(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,101,115,105,103,110,77,111,100,101,0]) [CLSID_DesignMode]);
+DEFINE_CLSID!(DesignMode: "Windows.ApplicationModel.DesignMode");
 DEFINE_IID!(IID_IDesignModeStatics, 741905356, 63514, 20090, 184, 87, 118, 168, 8, 135, 225, 133);
 RT_INTERFACE!{static interface IDesignModeStatics(IDesignModeStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDesignModeStatics] {
     fn get_DesignModeEnabled(&self, out: *mut bool) -> HRESULT
@@ -115,7 +115,7 @@ impl FullTrustProcessLauncher {
         <Self as RtActivatable<IFullTrustProcessLauncherStatics>>::get_activation_factory().launch_full_trust_process_for_app_with_parameters_async(fullTrustPackageRelativeAppId, parameterGroupId)
     }}
 }
-DEFINE_CLSID!(FullTrustProcessLauncher(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,70,117,108,108,84,114,117,115,116,80,114,111,99,101,115,115,76,97,117,110,99,104,101,114,0]) [CLSID_FullTrustProcessLauncher]);
+DEFINE_CLSID!(FullTrustProcessLauncher: "Windows.ApplicationModel.FullTrustProcessLauncher");
 DEFINE_IID!(IID_IFullTrustProcessLauncherStatics, 3615785855, 4352, 15467, 164, 85, 246, 38, 44, 195, 49, 182);
 RT_INTERFACE!{static interface IFullTrustProcessLauncherStatics(IFullTrustProcessLauncherStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFullTrustProcessLauncherStatics] {
     fn LaunchFullTrustProcessForCurrentAppAsync(&self, out: *mut *mut super::foundation::IAsyncAction) -> HRESULT,
@@ -194,7 +194,7 @@ impl Package {
         <Self as RtActivatable<IPackageStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(Package(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,99,107,97,103,101,0]) [CLSID_Package]);
+DEFINE_CLSID!(Package: "Windows.ApplicationModel.Package");
 DEFINE_IID!(IID_IPackage2, 2791387062, 30344, 19150, 149, 251, 53, 149, 56, 231, 170, 1);
 RT_INTERFACE!{interface IPackage2(IPackage2Vtbl): IInspectable(IInspectableVtbl) [IID_IPackage2] {
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -393,7 +393,7 @@ impl PackageCatalog {
         <Self as RtActivatable<IPackageCatalogStatics>>::get_activation_factory().open_for_current_user()
     }}
 }
-DEFINE_CLSID!(PackageCatalog(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,99,107,97,103,101,67,97,116,97,108,111,103,0]) [CLSID_PackageCatalog]);
+DEFINE_CLSID!(PackageCatalog: "Windows.ApplicationModel.PackageCatalog");
 DEFINE_IID!(IID_IPackageCatalog2, 2527464502, 36855, 17220, 182, 191, 238, 100, 194, 32, 126, 210);
 RT_INTERFACE!{interface IPackageCatalog2(IPackageCatalog2Vtbl): IInspectable(IInspectableVtbl) [IID_IPackageCatalog2] {
     fn add_PackageContentGroupStaging(&self, handler: *mut super::foundation::TypedEventHandler<PackageCatalog, PackageContentGroupStagingEventArgs>, out: *mut super::foundation::EventRegistrationToken) -> HRESULT,
@@ -516,7 +516,7 @@ impl PackageContentGroup {
         <Self as RtActivatable<IPackageContentGroupStatics>>::get_activation_factory().get_required_group_name()
     }}
 }
-DEFINE_CLSID!(PackageContentGroup(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,99,107,97,103,101,67,111,110,116,101,110,116,71,114,111,117,112,0]) [CLSID_PackageContentGroup]);
+DEFINE_CLSID!(PackageContentGroup: "Windows.ApplicationModel.PackageContentGroup");
 DEFINE_IID!(IID_IPackageContentGroupStagingEventArgs, 1031520894, 28455, 17516, 152, 110, 212, 115, 61, 77, 145, 19);
 RT_INTERFACE!{interface IPackageContentGroupStagingEventArgs(IPackageContentGroupStagingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPackageContentGroupStagingEventArgs] {
     fn get_ActivityId(&self, out: *mut Guid) -> HRESULT,
@@ -979,7 +979,7 @@ impl StartupTask {
         <Self as RtActivatable<IStartupTaskStatics>>::get_activation_factory().get_async(taskId)
     }}
 }
-DEFINE_CLSID!(StartupTask(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,97,114,116,117,112,84,97,115,107,0]) [CLSID_StartupTask]);
+DEFINE_CLSID!(StartupTask: "Windows.ApplicationModel.StartupTask");
 RT_ENUM! { enum StartupTaskState: i32 {
     Disabled (StartupTaskState_Disabled) = 0, DisabledByUser (StartupTaskState_DisabledByUser) = 1, Enabled (StartupTaskState_Enabled) = 2, DisabledByPolicy (StartupTaskState_DisabledByPolicy) = 3,
 }}
@@ -1359,7 +1359,7 @@ impl IPhoneCallHistoryEntry {
 }
 RT_CLASS!{class PhoneCallHistoryEntry: IPhoneCallHistoryEntry}
 impl RtActivatable<IActivationFactory> for PhoneCallHistoryEntry {}
-DEFINE_CLSID!(PhoneCallHistoryEntry(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,67,97,108,108,72,105,115,116,111,114,121,69,110,116,114,121,0]) [CLSID_PhoneCallHistoryEntry]);
+DEFINE_CLSID!(PhoneCallHistoryEntry: "Windows.ApplicationModel.Calls.PhoneCallHistoryEntry");
 DEFINE_IID!(IID_IPhoneCallHistoryEntryAddress, 821123546, 14677, 16450, 132, 230, 102, 238, 191, 130, 230, 127);
 RT_INTERFACE!{interface IPhoneCallHistoryEntryAddress(IPhoneCallHistoryEntryAddressVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallHistoryEntryAddress] {
     fn get_ContactId(&self, out: *mut HSTRING) -> HRESULT,
@@ -1417,7 +1417,7 @@ impl PhoneCallHistoryEntryAddress {
         <Self as RtActivatable<IPhoneCallHistoryEntryAddressFactory>>::get_activation_factory().create(rawAddress, rawAddressKind)
     }}
 }
-DEFINE_CLSID!(PhoneCallHistoryEntryAddress(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,67,97,108,108,72,105,115,116,111,114,121,69,110,116,114,121,65,100,100,114,101,115,115,0]) [CLSID_PhoneCallHistoryEntryAddress]);
+DEFINE_CLSID!(PhoneCallHistoryEntryAddress: "Windows.ApplicationModel.Calls.PhoneCallHistoryEntryAddress");
 DEFINE_IID!(IID_IPhoneCallHistoryEntryAddressFactory, 4212108730, 51184, 19382, 159, 107, 186, 93, 115, 32, 154, 202);
 RT_INTERFACE!{static interface IPhoneCallHistoryEntryAddressFactory(IPhoneCallHistoryEntryAddressFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallHistoryEntryAddressFactory] {
     fn Create(&self, rawAddress: HSTRING, rawAddressKind: PhoneCallHistoryEntryRawAddressKind, out: *mut *mut PhoneCallHistoryEntryAddress) -> HRESULT
@@ -1462,7 +1462,7 @@ impl IPhoneCallHistoryEntryQueryOptions {
 }
 RT_CLASS!{class PhoneCallHistoryEntryQueryOptions: IPhoneCallHistoryEntryQueryOptions}
 impl RtActivatable<IActivationFactory> for PhoneCallHistoryEntryQueryOptions {}
-DEFINE_CLSID!(PhoneCallHistoryEntryQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,67,97,108,108,72,105,115,116,111,114,121,69,110,116,114,121,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_PhoneCallHistoryEntryQueryOptions]);
+DEFINE_CLSID!(PhoneCallHistoryEntryQueryOptions: "Windows.ApplicationModel.Calls.PhoneCallHistoryEntryQueryOptions");
 RT_ENUM! { enum PhoneCallHistoryEntryRawAddressKind: i32 {
     PhoneNumber (PhoneCallHistoryEntryRawAddressKind_PhoneNumber) = 0, Custom (PhoneCallHistoryEntryRawAddressKind_Custom) = 1,
 }}
@@ -1489,7 +1489,7 @@ impl PhoneCallHistoryManager {
         <Self as RtActivatable<IPhoneCallHistoryManagerStatics2>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(PhoneCallHistoryManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,67,97,108,108,72,105,115,116,111,114,121,77,97,110,97,103,101,114,0]) [CLSID_PhoneCallHistoryManager]);
+DEFINE_CLSID!(PhoneCallHistoryManager: "Windows.ApplicationModel.Calls.PhoneCallHistoryManager");
 DEFINE_IID!(IID_IPhoneCallHistoryManagerForUser, 3643131171, 62815, 17235, 157, 180, 2, 5, 165, 38, 90, 85);
 RT_INTERFACE!{interface IPhoneCallHistoryManagerForUser(IPhoneCallHistoryManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallHistoryManagerForUser] {
     fn RequestStoreAsync(&self, accessType: PhoneCallHistoryStoreAccessType, out: *mut *mut super::super::foundation::IAsyncOperation<PhoneCallHistoryStore>) -> HRESULT,
@@ -1687,7 +1687,7 @@ impl VoipCallCoordinator {
         <Self as RtActivatable<IVoipCallCoordinatorStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(VoipCallCoordinator(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,86,111,105,112,67,97,108,108,67,111,111,114,100,105,110,97,116,111,114,0]) [CLSID_VoipCallCoordinator]);
+DEFINE_CLSID!(VoipCallCoordinator: "Windows.ApplicationModel.Calls.VoipCallCoordinator");
 DEFINE_IID!(IID_IVoipCallCoordinator2, 3199511027, 50948, 16948, 137, 206, 232, 140, 192, 210, 143, 190);
 RT_INTERFACE!{interface IVoipCallCoordinator2(IVoipCallCoordinator2Vtbl): IInspectable(IInspectableVtbl) [IID_IVoipCallCoordinator2] {
     fn SetupNewAcceptedCall(&self, context: HSTRING, contactName: HSTRING, contactNumber: HSTRING, serviceName: HSTRING, media: VoipPhoneCallMedia, out: *mut *mut VoipPhoneCall) -> HRESULT
@@ -2018,7 +2018,7 @@ impl ISocialFeedChildItem {
 }
 RT_CLASS!{class SocialFeedChildItem: ISocialFeedChildItem}
 impl RtActivatable<IActivationFactory> for SocialFeedChildItem {}
-DEFINE_CLSID!(SocialFeedChildItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,70,101,101,100,67,104,105,108,100,73,116,101,109,0]) [CLSID_SocialFeedChildItem]);
+DEFINE_CLSID!(SocialFeedChildItem: "Windows.ApplicationModel.SocialInfo.SocialFeedChildItem");
 DEFINE_IID!(IID_ISocialFeedContent, 2721375273, 15929, 18765, 163, 124, 244, 98, 162, 73, 69, 20);
 RT_INTERFACE!{interface ISocialFeedContent(ISocialFeedContentVtbl): IInspectable(IInspectableVtbl) [IID_ISocialFeedContent] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -2177,7 +2177,7 @@ impl ISocialFeedItem {
 }
 RT_CLASS!{class SocialFeedItem: ISocialFeedItem}
 impl RtActivatable<IActivationFactory> for SocialFeedItem {}
-DEFINE_CLSID!(SocialFeedItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,70,101,101,100,73,116,101,109,0]) [CLSID_SocialFeedItem]);
+DEFINE_CLSID!(SocialFeedItem: "Windows.ApplicationModel.SocialInfo.SocialFeedItem");
 RT_ENUM! { enum SocialFeedItemStyle: i32 {
     Default (SocialFeedItemStyle_Default) = 0, Photo (SocialFeedItemStyle_Photo) = 1,
 }}
@@ -2241,7 +2241,7 @@ impl ISocialFeedSharedItem {
 }
 RT_CLASS!{class SocialFeedSharedItem: ISocialFeedSharedItem}
 impl RtActivatable<IActivationFactory> for SocialFeedSharedItem {}
-DEFINE_CLSID!(SocialFeedSharedItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,70,101,101,100,83,104,97,114,101,100,73,116,101,109,0]) [CLSID_SocialFeedSharedItem]);
+DEFINE_CLSID!(SocialFeedSharedItem: "Windows.ApplicationModel.SocialInfo.SocialFeedSharedItem");
 RT_ENUM! { enum SocialFeedUpdateMode: i32 {
     Append (SocialFeedUpdateMode_Append) = 0, Replace (SocialFeedUpdateMode_Replace) = 1,
 }}
@@ -2296,7 +2296,7 @@ impl ISocialItemThumbnail {
 }
 RT_CLASS!{class SocialItemThumbnail: ISocialItemThumbnail}
 impl RtActivatable<IActivationFactory> for SocialItemThumbnail {}
-DEFINE_CLSID!(SocialItemThumbnail(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,73,116,101,109,84,104,117,109,98,110,97,105,108,0]) [CLSID_SocialItemThumbnail]);
+DEFINE_CLSID!(SocialItemThumbnail: "Windows.ApplicationModel.SocialInfo.SocialItemThumbnail");
 DEFINE_IID!(IID_ISocialUserInfo, 2656967633, 37072, 19997, 149, 84, 132, 77, 70, 96, 127, 97);
 RT_INTERFACE!{interface ISocialUserInfo(ISocialUserInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISocialUserInfo] {
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2458,7 +2458,7 @@ impl SocialInfoProviderManager {
         <Self as RtActivatable<ISocialInfoProviderManagerStatics>>::get_activation_factory().deprovision_async()
     }}
 }
-DEFINE_CLSID!(SocialInfoProviderManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,80,114,111,118,105,100,101,114,46,83,111,99,105,97,108,73,110,102,111,80,114,111,118,105,100,101,114,77,97,110,97,103,101,114,0]) [CLSID_SocialInfoProviderManager]);
+DEFINE_CLSID!(SocialInfoProviderManager: "Windows.ApplicationModel.SocialInfo.Provider.SocialInfoProviderManager");
 DEFINE_IID!(IID_ISocialInfoProviderManagerStatics, 461956395, 30599, 18646, 170, 18, 216, 232, 244, 122, 184, 90);
 RT_INTERFACE!{static interface ISocialInfoProviderManagerStatics(ISocialInfoProviderManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISocialInfoProviderManagerStatics] {
     fn CreateSocialFeedUpdaterAsync(&self, kind: super::SocialFeedKind, mode: super::SocialFeedUpdateMode, ownerRemoteId: HSTRING, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<SocialFeedUpdater>) -> HRESULT,
@@ -2544,7 +2544,7 @@ impl ILocalContentSuggestionSettings {
 }
 RT_CLASS!{class LocalContentSuggestionSettings: ILocalContentSuggestionSettings}
 impl RtActivatable<IActivationFactory> for LocalContentSuggestionSettings {}
-DEFINE_CLSID!(LocalContentSuggestionSettings(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,101,97,114,99,104,46,76,111,99,97,108,67,111,110,116,101,110,116,83,117,103,103,101,115,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_LocalContentSuggestionSettings]);
+DEFINE_CLSID!(LocalContentSuggestionSettings: "Windows.ApplicationModel.Search.LocalContentSuggestionSettings");
 DEFINE_IID!(IID_ISearchPane, 4255968312, 14080, 19827, 145, 161, 47, 153, 134, 116, 35, 138);
 RT_INTERFACE!{interface ISearchPane(ISearchPaneVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPane] {
     fn put_SearchHistoryEnabled(&self, value: bool) -> HRESULT,
@@ -2699,7 +2699,7 @@ impl SearchPane {
         <Self as RtActivatable<ISearchPaneStaticsWithHideThisApplication>>::get_activation_factory().hide_this_application()
     }}
 }
-DEFINE_CLSID!(SearchPane(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,101,97,114,99,104,46,83,101,97,114,99,104,80,97,110,101,0]) [CLSID_SearchPane]);
+DEFINE_CLSID!(SearchPane: "Windows.ApplicationModel.Search.SearchPane");
 DEFINE_IID!(IID_ISearchPaneQueryChangedEventArgs, 1007046633, 9041, 16968, 165, 41, 113, 16, 244, 100, 167, 133);
 RT_INTERFACE!{interface ISearchPaneQueryChangedEventArgs(ISearchPaneQueryChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneQueryChangedEventArgs] {
     fn get_QueryText(&self, out: *mut HSTRING) -> HRESULT,
@@ -2899,7 +2899,7 @@ impl SearchQueryLinguisticDetails {
         <Self as RtActivatable<ISearchQueryLinguisticDetailsFactory>>::get_activation_factory().create_instance(queryTextAlternatives, queryTextCompositionStart, queryTextCompositionLength)
     }}
 }
-DEFINE_CLSID!(SearchQueryLinguisticDetails(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,101,97,114,99,104,46,83,101,97,114,99,104,81,117,101,114,121,76,105,110,103,117,105,115,116,105,99,68,101,116,97,105,108,115,0]) [CLSID_SearchQueryLinguisticDetails]);
+DEFINE_CLSID!(SearchQueryLinguisticDetails: "Windows.ApplicationModel.Search.SearchQueryLinguisticDetails");
 DEFINE_IID!(IID_ISearchQueryLinguisticDetailsFactory, 3402023864, 15460, 19965, 173, 159, 71, 158, 77, 64, 101, 164);
 RT_INTERFACE!{static interface ISearchQueryLinguisticDetailsFactory(ISearchQueryLinguisticDetailsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISearchQueryLinguisticDetailsFactory] {
     fn CreateInstance(&self, queryTextAlternatives: *mut super::super::foundation::collections::IIterable<HString>, queryTextCompositionStart: u32, queryTextCompositionLength: u32, out: *mut *mut SearchQueryLinguisticDetails) -> HRESULT
@@ -3124,7 +3124,7 @@ impl ISearchSuggestionManager {
 }
 RT_CLASS!{class SearchSuggestionManager: ISearchSuggestionManager}
 impl RtActivatable<IActivationFactory> for SearchSuggestionManager {}
-DEFINE_CLSID!(SearchSuggestionManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,101,97,114,99,104,46,67,111,114,101,46,83,101,97,114,99,104,83,117,103,103,101,115,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_SearchSuggestionManager]);
+DEFINE_CLSID!(SearchSuggestionManager: "Windows.ApplicationModel.Search.Core.SearchSuggestionManager");
 DEFINE_IID!(IID_ISearchSuggestionsRequestedEventArgs, 1876236773, 40574, 19124, 139, 227, 199, 107, 27, 212, 52, 74);
 RT_INTERFACE!{interface ISearchSuggestionsRequestedEventArgs(ISearchSuggestionsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchSuggestionsRequestedEventArgs] {
     fn get_QueryText(&self, out: *mut HSTRING) -> HRESULT,
@@ -3197,7 +3197,7 @@ impl ActivitySensorTrigger {
         <Self as RtActivatable<IActivitySensorTriggerFactory>>::get_activation_factory().create(reportIntervalInMilliseconds)
     }}
 }
-DEFINE_CLSID!(ActivitySensorTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,99,116,105,118,105,116,121,83,101,110,115,111,114,84,114,105,103,103,101,114,0]) [CLSID_ActivitySensorTrigger]);
+DEFINE_CLSID!(ActivitySensorTrigger: "Windows.ApplicationModel.Background.ActivitySensorTrigger");
 DEFINE_IID!(IID_IActivitySensorTriggerFactory, 2804322755, 14391, 17655, 131, 27, 1, 50, 204, 135, 43, 195);
 RT_INTERFACE!{static interface IActivitySensorTriggerFactory(IActivitySensorTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IActivitySensorTriggerFactory] {
     fn Create(&self, reportIntervalInMilliseconds: u32, out: *mut *mut ActivitySensorTrigger) -> HRESULT
@@ -3222,7 +3222,7 @@ impl AlarmApplicationManager {
         <Self as RtActivatable<IAlarmApplicationManagerStatics>>::get_activation_factory().get_access_status()
     }}
 }
-DEFINE_CLSID!(AlarmApplicationManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,108,97,114,109,65,112,112,108,105,99,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_AlarmApplicationManager]);
+DEFINE_CLSID!(AlarmApplicationManager: "Windows.ApplicationModel.Background.AlarmApplicationManager");
 DEFINE_IID!(IID_IAlarmApplicationManagerStatics, 3389258299, 52454, 19938, 176, 155, 150, 40, 189, 51, 187, 190);
 RT_INTERFACE!{static interface IAlarmApplicationManagerStatics(IAlarmApplicationManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAlarmApplicationManagerStatics] {
     fn RequestAccessAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<AlarmAccessStatus>) -> HRESULT,
@@ -3263,7 +3263,7 @@ impl AppBroadcastTrigger {
         <Self as RtActivatable<IAppBroadcastTriggerFactory>>::get_activation_factory().create_app_broadcast_trigger(providerKey)
     }}
 }
-DEFINE_CLSID!(AppBroadcastTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,112,112,66,114,111,97,100,99,97,115,116,84,114,105,103,103,101,114,0]) [CLSID_AppBroadcastTrigger]);
+DEFINE_CLSID!(AppBroadcastTrigger: "Windows.ApplicationModel.Background.AppBroadcastTrigger");
 DEFINE_IID!(IID_IAppBroadcastTriggerFactory, 671850308, 8948, 17944, 160, 46, 231, 228, 17, 235, 114, 56);
 RT_INTERFACE!{static interface IAppBroadcastTriggerFactory(IAppBroadcastTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastTriggerFactory] {
     fn CreateAppBroadcastTrigger(&self, providerKey: HSTRING, out: *mut *mut AppBroadcastTrigger) -> HRESULT
@@ -3366,7 +3366,7 @@ impl IApplicationTrigger {
 }
 RT_CLASS!{class ApplicationTrigger: IApplicationTrigger}
 impl RtActivatable<IActivationFactory> for ApplicationTrigger {}
-DEFINE_CLSID!(ApplicationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,112,112,108,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ApplicationTrigger]);
+DEFINE_CLSID!(ApplicationTrigger: "Windows.ApplicationModel.Background.ApplicationTrigger");
 DEFINE_IID!(IID_IApplicationTriggerDetails, 2547804850, 8729, 19102, 156, 94, 65, 208, 71, 247, 110, 130);
 RT_INTERFACE!{interface IApplicationTriggerDetails(IApplicationTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationTriggerDetails] {
     fn get_Arguments(&self, out: *mut *mut super::super::foundation::collections::ValueSet) -> HRESULT
@@ -3388,7 +3388,7 @@ RT_INTERFACE!{interface IAppointmentStoreNotificationTrigger(IAppointmentStoreNo
 }}
 RT_CLASS!{class AppointmentStoreNotificationTrigger: IAppointmentStoreNotificationTrigger}
 impl RtActivatable<IActivationFactory> for AppointmentStoreNotificationTrigger {}
-DEFINE_CLSID!(AppointmentStoreNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,112,112,111,105,110,116,109,101,110,116,83,116,111,114,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_AppointmentStoreNotificationTrigger]);
+DEFINE_CLSID!(AppointmentStoreNotificationTrigger: "Windows.ApplicationModel.Background.AppointmentStoreNotificationTrigger");
 RT_ENUM! { enum BackgroundAccessStatus: i32 {
     Unspecified (BackgroundAccessStatus_Unspecified) = 0, AllowedWithAlwaysOnRealTimeConnectivity (BackgroundAccessStatus_AllowedWithAlwaysOnRealTimeConnectivity) = 1, AllowedMayUseActiveRealTimeConnectivity (BackgroundAccessStatus_AllowedMayUseActiveRealTimeConnectivity) = 2, Denied (BackgroundAccessStatus_Denied) = 3, AlwaysAllowed (BackgroundAccessStatus_AlwaysAllowed) = 4, AllowedSubjectToSystemPolicy (BackgroundAccessStatus_AllowedSubjectToSystemPolicy) = 5, DeniedBySystemPolicy (BackgroundAccessStatus_DeniedBySystemPolicy) = 6, DeniedByUser (BackgroundAccessStatus_DeniedByUser) = 7,
 }}
@@ -3418,7 +3418,7 @@ impl BackgroundExecutionManager {
         <Self as RtActivatable<IBackgroundExecutionManagerStatics>>::get_activation_factory().get_access_status_for_application(applicationId)
     }}
 }
-DEFINE_CLSID!(BackgroundExecutionManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,97,99,107,103,114,111,117,110,100,69,120,101,99,117,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_BackgroundExecutionManager]);
+DEFINE_CLSID!(BackgroundExecutionManager: "Windows.ApplicationModel.Background.BackgroundExecutionManager");
 DEFINE_IID!(IID_IBackgroundExecutionManagerStatics, 3894864472, 26281, 19777, 131, 212, 180, 193, 140, 135, 184, 70);
 RT_INTERFACE!{static interface IBackgroundExecutionManagerStatics(IBackgroundExecutionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundExecutionManagerStatics] {
     fn RequestAccessAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<BackgroundAccessStatus>) -> HRESULT,
@@ -3513,7 +3513,7 @@ impl IBackgroundTaskBuilder {
 }
 RT_CLASS!{class BackgroundTaskBuilder: IBackgroundTaskBuilder}
 impl RtActivatable<IActivationFactory> for BackgroundTaskBuilder {}
-DEFINE_CLSID!(BackgroundTaskBuilder(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,97,99,107,103,114,111,117,110,100,84,97,115,107,66,117,105,108,100,101,114,0]) [CLSID_BackgroundTaskBuilder]);
+DEFINE_CLSID!(BackgroundTaskBuilder: "Windows.ApplicationModel.Background.BackgroundTaskBuilder");
 DEFINE_IID!(IID_IBackgroundTaskBuilder2, 1793576881, 4175, 16493, 141, 182, 132, 74, 87, 15, 66, 187);
 RT_INTERFACE!{interface IBackgroundTaskBuilder2(IBackgroundTaskBuilder2Vtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTaskBuilder2] {
     fn put_CancelOnConditionLoss(&self, value: bool) -> HRESULT,
@@ -3778,7 +3778,7 @@ impl BackgroundTaskRegistration {
         <Self as RtActivatable<IBackgroundTaskRegistrationStatics2>>::get_activation_factory().get_task_group(groupId)
     }}
 }
-DEFINE_CLSID!(BackgroundTaskRegistration(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,97,99,107,103,114,111,117,110,100,84,97,115,107,82,101,103,105,115,116,114,97,116,105,111,110,0]) [CLSID_BackgroundTaskRegistration]);
+DEFINE_CLSID!(BackgroundTaskRegistration: "Windows.ApplicationModel.Background.BackgroundTaskRegistration");
 DEFINE_IID!(IID_IBackgroundTaskRegistration2, 1631110915, 48006, 16658, 175, 195, 127, 147, 155, 22, 110, 59);
 RT_INTERFACE!{interface IBackgroundTaskRegistration2(IBackgroundTaskRegistration2Vtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTaskRegistration2] {
     fn get_Trigger(&self, out: *mut *mut IBackgroundTrigger) -> HRESULT
@@ -3845,7 +3845,7 @@ impl BackgroundTaskRegistrationGroup {
         <Self as RtActivatable<IBackgroundTaskRegistrationGroupFactory>>::get_activation_factory().create_with_name(id, name)
     }}
 }
-DEFINE_CLSID!(BackgroundTaskRegistrationGroup(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,97,99,107,103,114,111,117,110,100,84,97,115,107,82,101,103,105,115,116,114,97,116,105,111,110,71,114,111,117,112,0]) [CLSID_BackgroundTaskRegistrationGroup]);
+DEFINE_CLSID!(BackgroundTaskRegistrationGroup: "Windows.ApplicationModel.Background.BackgroundTaskRegistrationGroup");
 DEFINE_IID!(IID_IBackgroundTaskRegistrationGroupFactory, 2212047721, 17615, 17969, 151, 64, 3, 199, 216, 116, 27, 197);
 RT_INTERFACE!{static interface IBackgroundTaskRegistrationGroupFactory(IBackgroundTaskRegistrationGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTaskRegistrationGroupFactory] {
     fn Create(&self, id: HSTRING, out: *mut *mut BackgroundTaskRegistrationGroup) -> HRESULT,
@@ -3905,7 +3905,7 @@ impl BackgroundWorkCost {
         <Self as RtActivatable<IBackgroundWorkCostStatics>>::get_activation_factory().get_current_background_work_cost()
     }}
 }
-DEFINE_CLSID!(BackgroundWorkCost(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,97,99,107,103,114,111,117,110,100,87,111,114,107,67,111,115,116,0]) [CLSID_BackgroundWorkCost]);
+DEFINE_CLSID!(BackgroundWorkCost: "Windows.ApplicationModel.Background.BackgroundWorkCost");
 DEFINE_IID!(IID_IBackgroundWorkCostStatics, 3342902882, 49936, 19330, 179, 227, 59, 207, 185, 228, 199, 125);
 RT_INTERFACE!{static interface IBackgroundWorkCostStatics(IBackgroundWorkCostStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundWorkCostStatics] {
     fn get_CurrentBackgroundWorkCost(&self, out: *mut BackgroundWorkCostValue) -> HRESULT
@@ -3933,7 +3933,7 @@ impl IBluetoothLEAdvertisementPublisherTrigger {
 }
 RT_CLASS!{class BluetoothLEAdvertisementPublisherTrigger: IBluetoothLEAdvertisementPublisherTrigger}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementPublisherTrigger {}
-DEFINE_CLSID!(BluetoothLEAdvertisementPublisherTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,80,117,98,108,105,115,104,101,114,84,114,105,103,103,101,114,0]) [CLSID_BluetoothLEAdvertisementPublisherTrigger]);
+DEFINE_CLSID!(BluetoothLEAdvertisementPublisherTrigger: "Windows.ApplicationModel.Background.BluetoothLEAdvertisementPublisherTrigger");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementWatcherTrigger, 447420441, 48353, 18667, 168, 39, 89, 251, 124, 238, 82, 166);
 RT_INTERFACE!{interface IBluetoothLEAdvertisementWatcherTrigger(IBluetoothLEAdvertisementWatcherTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementWatcherTrigger] {
     fn get_MinSamplingInterval(&self, out: *mut super::super::foundation::TimeSpan) -> HRESULT,
@@ -3987,14 +3987,14 @@ impl IBluetoothLEAdvertisementWatcherTrigger {
 }
 RT_CLASS!{class BluetoothLEAdvertisementWatcherTrigger: IBluetoothLEAdvertisementWatcherTrigger}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementWatcherTrigger {}
-DEFINE_CLSID!(BluetoothLEAdvertisementWatcherTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,87,97,116,99,104,101,114,84,114,105,103,103,101,114,0]) [CLSID_BluetoothLEAdvertisementWatcherTrigger]);
+DEFINE_CLSID!(BluetoothLEAdvertisementWatcherTrigger: "Windows.ApplicationModel.Background.BluetoothLEAdvertisementWatcherTrigger");
 DEFINE_IID!(IID_ICachedFileUpdaterTrigger, 3793530603, 13042, 19761, 181, 83, 185, 224, 27, 222, 55, 224);
 RT_INTERFACE!{interface ICachedFileUpdaterTrigger(ICachedFileUpdaterTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileUpdaterTrigger] {
     
 }}
 RT_CLASS!{class CachedFileUpdaterTrigger: ICachedFileUpdaterTrigger}
 impl RtActivatable<IActivationFactory> for CachedFileUpdaterTrigger {}
-DEFINE_CLSID!(CachedFileUpdaterTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,97,99,104,101,100,70,105,108,101,85,112,100,97,116,101,114,84,114,105,103,103,101,114,0]) [CLSID_CachedFileUpdaterTrigger]);
+DEFINE_CLSID!(CachedFileUpdaterTrigger: "Windows.ApplicationModel.Background.CachedFileUpdaterTrigger");
 DEFINE_IID!(IID_ICachedFileUpdaterTriggerDetails, 1904446483, 4884, 18356, 149, 151, 220, 126, 36, 140, 23, 204);
 RT_INTERFACE!{interface ICachedFileUpdaterTriggerDetails(ICachedFileUpdaterTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileUpdaterTriggerDetails] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -4027,21 +4027,21 @@ RT_INTERFACE!{interface IChatMessageNotificationTrigger(IChatMessageNotification
 }}
 RT_CLASS!{class ChatMessageNotificationTrigger: IChatMessageNotificationTrigger}
 impl RtActivatable<IActivationFactory> for ChatMessageNotificationTrigger {}
-DEFINE_CLSID!(ChatMessageNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,104,97,116,77,101,115,115,97,103,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ChatMessageNotificationTrigger]);
+DEFINE_CLSID!(ChatMessageNotificationTrigger: "Windows.ApplicationModel.Background.ChatMessageNotificationTrigger");
 DEFINE_IID!(IID_IChatMessageReceivedNotificationTrigger, 1050899982, 47861, 16503, 136, 233, 6, 12, 246, 240, 198, 213);
 RT_INTERFACE!{interface IChatMessageReceivedNotificationTrigger(IChatMessageReceivedNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageReceivedNotificationTrigger] {
     
 }}
 RT_CLASS!{class ChatMessageReceivedNotificationTrigger: IChatMessageReceivedNotificationTrigger}
 impl RtActivatable<IActivationFactory> for ChatMessageReceivedNotificationTrigger {}
-DEFINE_CLSID!(ChatMessageReceivedNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,104,97,116,77,101,115,115,97,103,101,82,101,99,101,105,118,101,100,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ChatMessageReceivedNotificationTrigger]);
+DEFINE_CLSID!(ChatMessageReceivedNotificationTrigger: "Windows.ApplicationModel.Background.ChatMessageReceivedNotificationTrigger");
 DEFINE_IID!(IID_IContactStoreNotificationTrigger, 3358802331, 18181, 17777, 154, 22, 6, 185, 151, 191, 156, 150);
 RT_INTERFACE!{interface IContactStoreNotificationTrigger(IContactStoreNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IContactStoreNotificationTrigger] {
     
 }}
 RT_CLASS!{class ContactStoreNotificationTrigger: IContactStoreNotificationTrigger}
 impl RtActivatable<IActivationFactory> for ContactStoreNotificationTrigger {}
-DEFINE_CLSID!(ContactStoreNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,111,110,116,97,99,116,83,116,111,114,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ContactStoreNotificationTrigger]);
+DEFINE_CLSID!(ContactStoreNotificationTrigger: "Windows.ApplicationModel.Background.ContactStoreNotificationTrigger");
 DEFINE_IID!(IID_IContentPrefetchTrigger, 1896228846, 1274, 17419, 128, 192, 23, 50, 2, 25, 158, 93);
 RT_INTERFACE!{interface IContentPrefetchTrigger(IContentPrefetchTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IContentPrefetchTrigger] {
     fn get_WaitInterval(&self, out: *mut super::super::foundation::TimeSpan) -> HRESULT
@@ -4061,7 +4061,7 @@ impl ContentPrefetchTrigger {
         <Self as RtActivatable<IContentPrefetchTriggerFactory>>::get_activation_factory().create(waitInterval)
     }}
 }
-DEFINE_CLSID!(ContentPrefetchTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,111,110,116,101,110,116,80,114,101,102,101,116,99,104,84,114,105,103,103,101,114,0]) [CLSID_ContentPrefetchTrigger]);
+DEFINE_CLSID!(ContentPrefetchTrigger: "Windows.ApplicationModel.Background.ContentPrefetchTrigger");
 DEFINE_IID!(IID_IContentPrefetchTriggerFactory, 3261349594, 35331, 16542, 184, 196, 136, 129, 76, 40, 204, 182);
 RT_INTERFACE!{static interface IContentPrefetchTriggerFactory(IContentPrefetchTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IContentPrefetchTriggerFactory] {
     fn Create(&self, waitInterval: super::super::foundation::TimeSpan, out: *mut *mut ContentPrefetchTrigger) -> HRESULT
@@ -4108,7 +4108,7 @@ impl DeviceConnectionChangeTrigger {
         <Self as RtActivatable<IDeviceConnectionChangeTriggerStatics>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(DeviceConnectionChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,68,101,118,105,99,101,67,111,110,110,101,99,116,105,111,110,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_DeviceConnectionChangeTrigger]);
+DEFINE_CLSID!(DeviceConnectionChangeTrigger: "Windows.ApplicationModel.Background.DeviceConnectionChangeTrigger");
 DEFINE_IID!(IID_IDeviceConnectionChangeTriggerStatics, 3286901866, 20221, 17560, 170, 96, 164, 228, 227, 177, 122, 185);
 RT_INTERFACE!{static interface IDeviceConnectionChangeTriggerStatics(IDeviceConnectionChangeTriggerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceConnectionChangeTriggerStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<DeviceConnectionChangeTrigger>) -> HRESULT
@@ -4144,7 +4144,7 @@ impl DeviceManufacturerNotificationTrigger {
         <Self as RtActivatable<IDeviceManufacturerNotificationTriggerFactory>>::get_activation_factory().create(triggerQualifier, oneShot)
     }}
 }
-DEFINE_CLSID!(DeviceManufacturerNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,68,101,118,105,99,101,77,97,110,117,102,97,99,116,117,114,101,114,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_DeviceManufacturerNotificationTrigger]);
+DEFINE_CLSID!(DeviceManufacturerNotificationTrigger: "Windows.ApplicationModel.Background.DeviceManufacturerNotificationTrigger");
 DEFINE_IID!(IID_IDeviceManufacturerNotificationTriggerFactory, 2035670645, 9659, 16723, 161, 162, 48, 41, 252, 171, 182, 82);
 RT_INTERFACE!{static interface IDeviceManufacturerNotificationTriggerFactory(IDeviceManufacturerNotificationTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceManufacturerNotificationTriggerFactory] {
     fn Create(&self, triggerQualifier: HSTRING, oneShot: bool, out: *mut *mut DeviceManufacturerNotificationTrigger) -> HRESULT
@@ -4175,7 +4175,7 @@ impl IDeviceServicingTrigger {
 }
 RT_CLASS!{class DeviceServicingTrigger: IDeviceServicingTrigger}
 impl RtActivatable<IActivationFactory> for DeviceServicingTrigger {}
-DEFINE_CLSID!(DeviceServicingTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,68,101,118,105,99,101,83,101,114,118,105,99,105,110,103,84,114,105,103,103,101,114,0]) [CLSID_DeviceServicingTrigger]);
+DEFINE_CLSID!(DeviceServicingTrigger: "Windows.ApplicationModel.Background.DeviceServicingTrigger");
 RT_ENUM! { enum DeviceTriggerResult: i32 {
     Allowed (DeviceTriggerResult_Allowed) = 0, DeniedByUser (DeviceTriggerResult_DeniedByUser) = 1, DeniedBySystem (DeviceTriggerResult_DeniedBySystem) = 2, LowBattery (DeviceTriggerResult_LowBattery) = 3,
 }}
@@ -4198,7 +4198,7 @@ impl IDeviceUseTrigger {
 }
 RT_CLASS!{class DeviceUseTrigger: IDeviceUseTrigger}
 impl RtActivatable<IActivationFactory> for DeviceUseTrigger {}
-DEFINE_CLSID!(DeviceUseTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,68,101,118,105,99,101,85,115,101,84,114,105,103,103,101,114,0]) [CLSID_DeviceUseTrigger]);
+DEFINE_CLSID!(DeviceUseTrigger: "Windows.ApplicationModel.Background.DeviceUseTrigger");
 DEFINE_IID!(IID_IDeviceWatcherTrigger, 2757853149, 34163, 16992, 190, 252, 91, 236, 137, 203, 105, 61);
 RT_INTERFACE!{interface IDeviceWatcherTrigger(IDeviceWatcherTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceWatcherTrigger] {
     
@@ -4210,7 +4210,7 @@ RT_INTERFACE!{interface IEmailStoreNotificationTrigger(IEmailStoreNotificationTr
 }}
 RT_CLASS!{class EmailStoreNotificationTrigger: IEmailStoreNotificationTrigger}
 impl RtActivatable<IActivationFactory> for EmailStoreNotificationTrigger {}
-DEFINE_CLSID!(EmailStoreNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,69,109,97,105,108,83,116,111,114,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_EmailStoreNotificationTrigger]);
+DEFINE_CLSID!(EmailStoreNotificationTrigger: "Windows.ApplicationModel.Background.EmailStoreNotificationTrigger");
 DEFINE_IID!(IID_IGattCharacteristicNotificationTrigger, 3797913544, 1686, 18255, 167, 50, 242, 146, 176, 206, 188, 93);
 RT_INTERFACE!{interface IGattCharacteristicNotificationTrigger(IGattCharacteristicNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicNotificationTrigger] {
     #[cfg(feature="windows-devices")] fn get_Characteristic(&self, out: *mut *mut super::super::devices::bluetooth::genericattributeprofile::GattCharacteristic) -> HRESULT
@@ -4233,7 +4233,7 @@ impl GattCharacteristicNotificationTrigger {
         <Self as RtActivatable<IGattCharacteristicNotificationTriggerFactory2>>::get_activation_factory().create_with_event_triggering_mode(characteristic, eventTriggeringMode)
     }}
 }
-DEFINE_CLSID!(GattCharacteristicNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,71,97,116,116,67,104,97,114,97,99,116,101,114,105,115,116,105,99,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_GattCharacteristicNotificationTrigger]);
+DEFINE_CLSID!(GattCharacteristicNotificationTrigger: "Windows.ApplicationModel.Background.GattCharacteristicNotificationTrigger");
 DEFINE_IID!(IID_IGattCharacteristicNotificationTrigger2, 2468520644, 44558, 17138, 178, 140, 245, 19, 114, 230, 146, 69);
 RT_INTERFACE!{interface IGattCharacteristicNotificationTrigger2(IGattCharacteristicNotificationTrigger2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicNotificationTrigger2] {
     #[cfg(feature="windows-devices")] fn get_EventTriggeringMode(&self, out: *mut super::super::devices::bluetooth::background::BluetoothEventTriggeringMode) -> HRESULT
@@ -4302,7 +4302,7 @@ impl GattServiceProviderTrigger {
         <Self as RtActivatable<IGattServiceProviderTriggerStatics>>::get_activation_factory().create_async(triggerId, serviceUuid)
     }}
 }
-DEFINE_CLSID!(GattServiceProviderTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,71,97,116,116,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,84,114,105,103,103,101,114,0]) [CLSID_GattServiceProviderTrigger]);
+DEFINE_CLSID!(GattServiceProviderTrigger: "Windows.ApplicationModel.Background.GattServiceProviderTrigger");
 DEFINE_IID!(IID_IGattServiceProviderTriggerResult, 1011257777, 45464, 20100, 186, 212, 207, 74, 210, 153, 237, 58);
 RT_INTERFACE!{interface IGattServiceProviderTriggerResult(IGattServiceProviderTriggerResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProviderTriggerResult] {
     fn get_Trigger(&self, out: *mut *mut GattServiceProviderTrigger) -> HRESULT,
@@ -4350,7 +4350,7 @@ impl IGeovisitTrigger {
 }
 RT_CLASS!{class GeovisitTrigger: IGeovisitTrigger}
 impl RtActivatable<IActivationFactory> for GeovisitTrigger {}
-DEFINE_CLSID!(GeovisitTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,71,101,111,118,105,115,105,116,84,114,105,103,103,101,114,0]) [CLSID_GeovisitTrigger]);
+DEFINE_CLSID!(GeovisitTrigger: "Windows.ApplicationModel.Background.GeovisitTrigger");
 DEFINE_IID!(IID_ILocationTrigger, 1197894172, 26743, 18462, 128, 38, 255, 126, 20, 168, 17, 160);
 RT_INTERFACE!{interface ILocationTrigger(ILocationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ILocationTrigger] {
     fn get_TriggerType(&self, out: *mut LocationTriggerType) -> HRESULT
@@ -4369,7 +4369,7 @@ impl LocationTrigger {
         <Self as RtActivatable<ILocationTriggerFactory>>::get_activation_factory().create(triggerType)
     }}
 }
-DEFINE_CLSID!(LocationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,76,111,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_LocationTrigger]);
+DEFINE_CLSID!(LocationTrigger: "Windows.ApplicationModel.Background.LocationTrigger");
 DEFINE_IID!(IID_ILocationTriggerFactory, 285653767, 65385, 19977, 170, 139, 19, 132, 234, 71, 94, 152);
 RT_INTERFACE!{static interface ILocationTriggerFactory(ILocationTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILocationTriggerFactory] {
     fn Create(&self, triggerType: LocationTriggerType, out: *mut *mut LocationTrigger) -> HRESULT
@@ -4408,7 +4408,7 @@ impl MaintenanceTrigger {
         <Self as RtActivatable<IMaintenanceTriggerFactory>>::get_activation_factory().create(freshnessTime, oneShot)
     }}
 }
-DEFINE_CLSID!(MaintenanceTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,97,105,110,116,101,110,97,110,99,101,84,114,105,103,103,101,114,0]) [CLSID_MaintenanceTrigger]);
+DEFINE_CLSID!(MaintenanceTrigger: "Windows.ApplicationModel.Background.MaintenanceTrigger");
 DEFINE_IID!(IID_IMaintenanceTriggerFactory, 1262345006, 38877, 17961, 136, 176, 176, 108, 249, 72, 42, 229);
 RT_INTERFACE!{static interface IMaintenanceTriggerFactory(IMaintenanceTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMaintenanceTriggerFactory] {
     fn Create(&self, freshnessTime: u32, oneShot: bool, out: *mut *mut MaintenanceTrigger) -> HRESULT
@@ -4439,29 +4439,29 @@ impl IMediaProcessingTrigger {
 }
 RT_CLASS!{class MediaProcessingTrigger: IMediaProcessingTrigger}
 impl RtActivatable<IActivationFactory> for MediaProcessingTrigger {}
-DEFINE_CLSID!(MediaProcessingTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,101,100,105,97,80,114,111,99,101,115,115,105,110,103,84,114,105,103,103,101,114,0]) [CLSID_MediaProcessingTrigger]);
+DEFINE_CLSID!(MediaProcessingTrigger: "Windows.ApplicationModel.Background.MediaProcessingTrigger");
 RT_ENUM! { enum MediaProcessingTriggerResult: i32 {
     Allowed (MediaProcessingTriggerResult_Allowed) = 0, CurrentlyRunning (MediaProcessingTriggerResult_CurrentlyRunning) = 1, DisabledByPolicy (MediaProcessingTriggerResult_DisabledByPolicy) = 2, UnknownError (MediaProcessingTriggerResult_UnknownError) = 3,
 }}
 RT_CLASS!{class MobileBroadbandDeviceServiceNotificationTrigger: IBackgroundTrigger}
 impl RtActivatable<IActivationFactory> for MobileBroadbandDeviceServiceNotificationTrigger {}
-DEFINE_CLSID!(MobileBroadbandDeviceServiceNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,68,101,118,105,99,101,83,101,114,118,105,99,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandDeviceServiceNotificationTrigger]);
+DEFINE_CLSID!(MobileBroadbandDeviceServiceNotificationTrigger: "Windows.ApplicationModel.Background.MobileBroadbandDeviceServiceNotificationTrigger");
 RT_CLASS!{class MobileBroadbandPinLockStateChangeTrigger: IBackgroundTrigger}
 impl RtActivatable<IActivationFactory> for MobileBroadbandPinLockStateChangeTrigger {}
-DEFINE_CLSID!(MobileBroadbandPinLockStateChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,80,105,110,76,111,99,107,83,116,97,116,101,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandPinLockStateChangeTrigger]);
+DEFINE_CLSID!(MobileBroadbandPinLockStateChangeTrigger: "Windows.ApplicationModel.Background.MobileBroadbandPinLockStateChangeTrigger");
 RT_CLASS!{class MobileBroadbandRadioStateChangeTrigger: IBackgroundTrigger}
 impl RtActivatable<IActivationFactory> for MobileBroadbandRadioStateChangeTrigger {}
-DEFINE_CLSID!(MobileBroadbandRadioStateChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,82,97,100,105,111,83,116,97,116,101,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandRadioStateChangeTrigger]);
+DEFINE_CLSID!(MobileBroadbandRadioStateChangeTrigger: "Windows.ApplicationModel.Background.MobileBroadbandRadioStateChangeTrigger");
 RT_CLASS!{class MobileBroadbandRegistrationStateChangeTrigger: IBackgroundTrigger}
 impl RtActivatable<IActivationFactory> for MobileBroadbandRegistrationStateChangeTrigger {}
-DEFINE_CLSID!(MobileBroadbandRegistrationStateChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,82,101,103,105,115,116,114,97,116,105,111,110,83,116,97,116,101,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandRegistrationStateChangeTrigger]);
+DEFINE_CLSID!(MobileBroadbandRegistrationStateChangeTrigger: "Windows.ApplicationModel.Background.MobileBroadbandRegistrationStateChangeTrigger");
 DEFINE_IID!(IID_INetworkOperatorHotspotAuthenticationTrigger, 3881224081, 12289, 19941, 131, 199, 222, 97, 216, 136, 49, 208);
 RT_INTERFACE!{interface INetworkOperatorHotspotAuthenticationTrigger(INetworkOperatorHotspotAuthenticationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorHotspotAuthenticationTrigger] {
     
 }}
 RT_CLASS!{class NetworkOperatorHotspotAuthenticationTrigger: INetworkOperatorHotspotAuthenticationTrigger}
 impl RtActivatable<IActivationFactory> for NetworkOperatorHotspotAuthenticationTrigger {}
-DEFINE_CLSID!(NetworkOperatorHotspotAuthenticationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,72,111,116,115,112,111,116,65,117,116,104,101,110,116,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_NetworkOperatorHotspotAuthenticationTrigger]);
+DEFINE_CLSID!(NetworkOperatorHotspotAuthenticationTrigger: "Windows.ApplicationModel.Background.NetworkOperatorHotspotAuthenticationTrigger");
 DEFINE_IID!(IID_INetworkOperatorNotificationTrigger, 2416483526, 25549, 18444, 149, 209, 110, 106, 239, 128, 30, 74);
 RT_INTERFACE!{interface INetworkOperatorNotificationTrigger(INetworkOperatorNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorNotificationTrigger] {
     fn get_NetworkAccountId(&self, out: *mut HSTRING) -> HRESULT
@@ -4480,7 +4480,7 @@ impl NetworkOperatorNotificationTrigger {
         <Self as RtActivatable<INetworkOperatorNotificationTriggerFactory>>::get_activation_factory().create(networkAccountId)
     }}
 }
-DEFINE_CLSID!(NetworkOperatorNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_NetworkOperatorNotificationTrigger]);
+DEFINE_CLSID!(NetworkOperatorNotificationTrigger: "Windows.ApplicationModel.Background.NetworkOperatorNotificationTrigger");
 DEFINE_IID!(IID_INetworkOperatorNotificationTriggerFactory, 170016256, 10199, 17235, 173, 185, 146, 101, 170, 234, 87, 157);
 RT_INTERFACE!{static interface INetworkOperatorNotificationTriggerFactory(INetworkOperatorNotificationTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorNotificationTriggerFactory] {
     fn Create(&self, networkAccountId: HSTRING, out: *mut *mut NetworkOperatorNotificationTrigger) -> HRESULT
@@ -4494,7 +4494,7 @@ impl INetworkOperatorNotificationTriggerFactory {
 }
 RT_CLASS!{class PaymentAppCanMakePaymentTrigger: IBackgroundTrigger}
 impl RtActivatable<IActivationFactory> for PaymentAppCanMakePaymentTrigger {}
-DEFINE_CLSID!(PaymentAppCanMakePaymentTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,80,97,121,109,101,110,116,65,112,112,67,97,110,77,97,107,101,80,97,121,109,101,110,116,84,114,105,103,103,101,114,0]) [CLSID_PaymentAppCanMakePaymentTrigger]);
+DEFINE_CLSID!(PaymentAppCanMakePaymentTrigger: "Windows.ApplicationModel.Background.PaymentAppCanMakePaymentTrigger");
 DEFINE_IID!(IID_IPhoneTrigger, 2379213211, 54469, 18929, 183, 211, 130, 232, 122, 14, 157, 222);
 RT_INTERFACE!{interface IPhoneTrigger(IPhoneTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneTrigger] {
     fn get_OneShot(&self, out: *mut bool) -> HRESULT,
@@ -4519,7 +4519,7 @@ impl PhoneTrigger {
         <Self as RtActivatable<IPhoneTriggerFactory>>::get_activation_factory().create(type_, oneShot)
     }}
 }
-DEFINE_CLSID!(PhoneTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,80,104,111,110,101,84,114,105,103,103,101,114,0]) [CLSID_PhoneTrigger]);
+DEFINE_CLSID!(PhoneTrigger: "Windows.ApplicationModel.Background.PhoneTrigger");
 DEFINE_IID!(IID_IPhoneTriggerFactory, 2698591450, 24513, 18683, 165, 70, 50, 38, 32, 64, 21, 123);
 RT_INTERFACE!{static interface IPhoneTriggerFactory(IPhoneTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneTriggerFactory] {
     fn Create(&self, type_: super::calls::background::PhoneTriggerType, oneShot: bool, out: *mut *mut PhoneTrigger) -> HRESULT
@@ -4539,7 +4539,7 @@ impl PushNotificationTrigger {
         <Self as RtActivatable<IPushNotificationTriggerFactory>>::get_activation_factory().create(applicationId)
     }}
 }
-DEFINE_CLSID!(PushNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,80,117,115,104,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_PushNotificationTrigger]);
+DEFINE_CLSID!(PushNotificationTrigger: "Windows.ApplicationModel.Background.PushNotificationTrigger");
 DEFINE_IID!(IID_IPushNotificationTriggerFactory, 1842933019, 17806, 20418, 188, 46, 213, 102, 79, 119, 237, 25);
 RT_INTERFACE!{static interface IPushNotificationTriggerFactory(IPushNotificationTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPushNotificationTriggerFactory] {
     fn Create(&self, applicationId: HSTRING, out: *mut *mut PushNotificationTrigger) -> HRESULT
@@ -4557,7 +4557,7 @@ RT_INTERFACE!{interface IRcsEndUserMessageAvailableTrigger(IRcsEndUserMessageAva
 }}
 RT_CLASS!{class RcsEndUserMessageAvailableTrigger: IRcsEndUserMessageAvailableTrigger}
 impl RtActivatable<IActivationFactory> for RcsEndUserMessageAvailableTrigger {}
-DEFINE_CLSID!(RcsEndUserMessageAvailableTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,82,99,115,69,110,100,85,115,101,114,77,101,115,115,97,103,101,65,118,97,105,108,97,98,108,101,84,114,105,103,103,101,114,0]) [CLSID_RcsEndUserMessageAvailableTrigger]);
+DEFINE_CLSID!(RcsEndUserMessageAvailableTrigger: "Windows.ApplicationModel.Background.RcsEndUserMessageAvailableTrigger");
 DEFINE_IID!(IID_IRfcommConnectionTrigger, 3905211106, 2899, 17508, 147, 148, 253, 135, 86, 84, 222, 100);
 RT_INTERFACE!{interface IRfcommConnectionTrigger(IRfcommConnectionTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommConnectionTrigger] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -4612,14 +4612,14 @@ impl IRfcommConnectionTrigger {
 }
 RT_CLASS!{class RfcommConnectionTrigger: IRfcommConnectionTrigger}
 impl RtActivatable<IActivationFactory> for RfcommConnectionTrigger {}
-DEFINE_CLSID!(RfcommConnectionTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,82,102,99,111,109,109,67,111,110,110,101,99,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_RfcommConnectionTrigger]);
+DEFINE_CLSID!(RfcommConnectionTrigger: "Windows.ApplicationModel.Background.RfcommConnectionTrigger");
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationTrigger, 4063752999, 20865, 20260, 150, 167, 112, 10, 78, 95, 172, 98);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorAuthenticationTrigger(ISecondaryAuthenticationFactorAuthenticationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorAuthenticationTrigger] {
     
 }}
 RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationTrigger: ISecondaryAuthenticationFactorAuthenticationTrigger}
 impl RtActivatable<IActivationFactory> for SecondaryAuthenticationFactorAuthenticationTrigger {}
-DEFINE_CLSID!(SecondaryAuthenticationFactorAuthenticationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,101,99,111,110,100,97,114,121,65,117,116,104,101,110,116,105,99,97,116,105,111,110,70,97,99,116,111,114,65,117,116,104,101,110,116,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_SecondaryAuthenticationFactorAuthenticationTrigger]);
+DEFINE_CLSID!(SecondaryAuthenticationFactorAuthenticationTrigger: "Windows.ApplicationModel.Background.SecondaryAuthenticationFactorAuthenticationTrigger");
 DEFINE_IID!(IID_ISensorDataThresholdTrigger, 1539371890, 54411, 19327, 171, 236, 21, 249, 186, 204, 18, 226);
 RT_INTERFACE!{interface ISensorDataThresholdTrigger(ISensorDataThresholdTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ISensorDataThresholdTrigger] {
     
@@ -4631,7 +4631,7 @@ impl SensorDataThresholdTrigger {
         <Self as RtActivatable<ISensorDataThresholdTriggerFactory>>::get_activation_factory().create(threshold)
     }}
 }
-DEFINE_CLSID!(SensorDataThresholdTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,101,110,115,111,114,68,97,116,97,84,104,114,101,115,104,111,108,100,84,114,105,103,103,101,114,0]) [CLSID_SensorDataThresholdTrigger]);
+DEFINE_CLSID!(SensorDataThresholdTrigger: "Windows.ApplicationModel.Background.SensorDataThresholdTrigger");
 DEFINE_IID!(IID_ISensorDataThresholdTriggerFactory, 2451564149, 32240, 19875, 151, 179, 229, 68, 238, 133, 127, 230);
 RT_INTERFACE!{static interface ISensorDataThresholdTriggerFactory(ISensorDataThresholdTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISensorDataThresholdTriggerFactory] {
     #[cfg(feature="windows-devices")] fn Create(&self, threshold: *mut super::super::devices::sensors::ISensorDataThreshold, out: *mut *mut SensorDataThresholdTrigger) -> HRESULT
@@ -4661,7 +4661,7 @@ impl SmartCardTrigger {
         <Self as RtActivatable<ISmartCardTriggerFactory>>::get_activation_factory().create(triggerType)
     }}
 }
-DEFINE_CLSID!(SmartCardTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,109,97,114,116,67,97,114,100,84,114,105,103,103,101,114,0]) [CLSID_SmartCardTrigger]);
+DEFINE_CLSID!(SmartCardTrigger: "Windows.ApplicationModel.Background.SmartCardTrigger");
 DEFINE_IID!(IID_ISmartCardTriggerFactory, 1673483459, 35265, 19968, 169, 211, 151, 198, 41, 38, 157, 173);
 RT_INTERFACE!{static interface ISmartCardTriggerFactory(ISmartCardTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardTriggerFactory] {
     #[cfg(feature="windows-devices")] fn Create(&self, triggerType: super::super::devices::smartcards::SmartCardTriggerType, out: *mut *mut SmartCardTrigger) -> HRESULT
@@ -4680,7 +4680,7 @@ impl SmsMessageReceivedTrigger {
         <Self as RtActivatable<ISmsMessageReceivedTriggerFactory>>::get_activation_factory().create(filterRules)
     }}
 }
-DEFINE_CLSID!(SmsMessageReceivedTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,109,115,77,101,115,115,97,103,101,82,101,99,101,105,118,101,100,84,114,105,103,103,101,114,0]) [CLSID_SmsMessageReceivedTrigger]);
+DEFINE_CLSID!(SmsMessageReceivedTrigger: "Windows.ApplicationModel.Background.SmsMessageReceivedTrigger");
 DEFINE_IID!(IID_ISmsMessageReceivedTriggerFactory, 3929725128, 27556, 19122, 141, 33, 188, 107, 9, 199, 117, 100);
 RT_INTERFACE!{static interface ISmsMessageReceivedTriggerFactory(ISmsMessageReceivedTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISmsMessageReceivedTriggerFactory] {
     #[cfg(feature="windows-devices")] fn Create(&self, filterRules: *mut super::super::devices::sms::SmsFilterRules, out: *mut *mut SmsMessageReceivedTrigger) -> HRESULT
@@ -4705,7 +4705,7 @@ impl ISocketActivityTrigger {
 }
 RT_CLASS!{class SocketActivityTrigger: IBackgroundTrigger}
 impl RtActivatable<IActivationFactory> for SocketActivityTrigger {}
-DEFINE_CLSID!(SocketActivityTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,111,99,107,101,116,65,99,116,105,118,105,116,121,84,114,105,103,103,101,114,0]) [CLSID_SocketActivityTrigger]);
+DEFINE_CLSID!(SocketActivityTrigger: "Windows.ApplicationModel.Background.SocketActivityTrigger");
 DEFINE_IID!(IID_IStorageLibraryContentChangedTrigger, 372760743, 33436, 17852, 146, 155, 161, 231, 234, 120, 216, 155);
 RT_INTERFACE!{interface IStorageLibraryContentChangedTrigger(IStorageLibraryContentChangedTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryContentChangedTrigger] {
     
@@ -4720,7 +4720,7 @@ impl StorageLibraryContentChangedTrigger {
         <Self as RtActivatable<IStorageLibraryContentChangedTriggerStatics>>::get_activation_factory().create_from_libraries(storageLibraries)
     }}
 }
-DEFINE_CLSID!(StorageLibraryContentChangedTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,116,111,114,97,103,101,76,105,98,114,97,114,121,67,111,110,116,101,110,116,67,104,97,110,103,101,100,84,114,105,103,103,101,114,0]) [CLSID_StorageLibraryContentChangedTrigger]);
+DEFINE_CLSID!(StorageLibraryContentChangedTrigger: "Windows.ApplicationModel.Background.StorageLibraryContentChangedTrigger");
 DEFINE_IID!(IID_IStorageLibraryContentChangedTriggerStatics, 2141133625, 24464, 19986, 145, 78, 167, 216, 224, 187, 251, 24);
 RT_INTERFACE!{static interface IStorageLibraryContentChangedTriggerStatics(IStorageLibraryContentChangedTriggerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryContentChangedTriggerStatics] {
     #[cfg(feature="windows-storage")] fn Create(&self, storageLibrary: *mut super::super::storage::StorageLibrary, out: *mut *mut StorageLibraryContentChangedTrigger) -> HRESULT,
@@ -4756,7 +4756,7 @@ impl SystemCondition {
         <Self as RtActivatable<ISystemConditionFactory>>::get_activation_factory().create(conditionType)
     }}
 }
-DEFINE_CLSID!(SystemCondition(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,121,115,116,101,109,67,111,110,100,105,116,105,111,110,0]) [CLSID_SystemCondition]);
+DEFINE_CLSID!(SystemCondition: "Windows.ApplicationModel.Background.SystemCondition");
 DEFINE_IID!(IID_ISystemConditionFactory, 3530150385, 1447, 18862, 135, 215, 22, 178, 184, 185, 165, 83);
 RT_INTERFACE!{static interface ISystemConditionFactory(ISystemConditionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISystemConditionFactory] {
     fn Create(&self, conditionType: SystemConditionType, out: *mut *mut SystemCondition) -> HRESULT
@@ -4795,7 +4795,7 @@ impl SystemTrigger {
         <Self as RtActivatable<ISystemTriggerFactory>>::get_activation_factory().create(triggerType, oneShot)
     }}
 }
-DEFINE_CLSID!(SystemTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,121,115,116,101,109,84,114,105,103,103,101,114,0]) [CLSID_SystemTrigger]);
+DEFINE_CLSID!(SystemTrigger: "Windows.ApplicationModel.Background.SystemTrigger");
 DEFINE_IID!(IID_ISystemTriggerFactory, 3892585428, 34705, 17785, 129, 38, 135, 236, 138, 170, 64, 122);
 RT_INTERFACE!{static interface ISystemTriggerFactory(ISystemTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISystemTriggerFactory] {
     fn Create(&self, triggerType: SystemTriggerType, oneShot: bool, out: *mut *mut SystemTrigger) -> HRESULT
@@ -4834,7 +4834,7 @@ impl TimeTrigger {
         <Self as RtActivatable<ITimeTriggerFactory>>::get_activation_factory().create(freshnessTime, oneShot)
     }}
 }
-DEFINE_CLSID!(TimeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,84,105,109,101,84,114,105,103,103,101,114,0]) [CLSID_TimeTrigger]);
+DEFINE_CLSID!(TimeTrigger: "Windows.ApplicationModel.Background.TimeTrigger");
 DEFINE_IID!(IID_ITimeTriggerFactory, 952533758, 39764, 17894, 178, 243, 38, 155, 135, 166, 247, 52);
 RT_INTERFACE!{static interface ITimeTriggerFactory(ITimeTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ITimeTriggerFactory] {
     fn Create(&self, freshnessTime: u32, oneShot: bool, out: *mut *mut TimeTrigger) -> HRESULT
@@ -4854,7 +4854,7 @@ impl ToastNotificationActionTrigger {
         <Self as RtActivatable<IToastNotificationActionTriggerFactory>>::get_activation_factory().create(applicationId)
     }}
 }
-DEFINE_CLSID!(ToastNotificationActionTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,84,111,97,115,116,78,111,116,105,102,105,99,97,116,105,111,110,65,99,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ToastNotificationActionTrigger]);
+DEFINE_CLSID!(ToastNotificationActionTrigger: "Windows.ApplicationModel.Background.ToastNotificationActionTrigger");
 DEFINE_IID!(IID_IToastNotificationActionTriggerFactory, 2963143719, 25728, 17225, 129, 37, 151, 179, 239, 170, 10, 58);
 RT_INTERFACE!{static interface IToastNotificationActionTriggerFactory(IToastNotificationActionTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationActionTriggerFactory] {
     fn Create(&self, applicationId: HSTRING, out: *mut *mut ToastNotificationActionTrigger) -> HRESULT
@@ -4874,7 +4874,7 @@ impl ToastNotificationHistoryChangedTrigger {
         <Self as RtActivatable<IToastNotificationHistoryChangedTriggerFactory>>::get_activation_factory().create(applicationId)
     }}
 }
-DEFINE_CLSID!(ToastNotificationHistoryChangedTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,84,111,97,115,116,78,111,116,105,102,105,99,97,116,105,111,110,72,105,115,116,111,114,121,67,104,97,110,103,101,100,84,114,105,103,103,101,114,0]) [CLSID_ToastNotificationHistoryChangedTrigger]);
+DEFINE_CLSID!(ToastNotificationHistoryChangedTrigger: "Windows.ApplicationModel.Background.ToastNotificationHistoryChangedTrigger");
 DEFINE_IID!(IID_IToastNotificationHistoryChangedTriggerFactory, 2177301165, 34711, 18309, 129, 180, 176, 204, 203, 115, 209, 217);
 RT_INTERFACE!{static interface IToastNotificationHistoryChangedTriggerFactory(IToastNotificationHistoryChangedTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationHistoryChangedTriggerFactory] {
     fn Create(&self, applicationId: HSTRING, out: *mut *mut ToastNotificationHistoryChangedTrigger) -> HRESULT
@@ -4893,7 +4893,7 @@ impl UserNotificationChangedTrigger {
         <Self as RtActivatable<IUserNotificationChangedTriggerFactory>>::get_activation_factory().create(notificationKinds)
     }}
 }
-DEFINE_CLSID!(UserNotificationChangedTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,85,115,101,114,78,111,116,105,102,105,99,97,116,105,111,110,67,104,97,110,103,101,100,84,114,105,103,103,101,114,0]) [CLSID_UserNotificationChangedTrigger]);
+DEFINE_CLSID!(UserNotificationChangedTrigger: "Windows.ApplicationModel.Background.UserNotificationChangedTrigger");
 DEFINE_IID!(IID_IUserNotificationChangedTriggerFactory, 3402908524, 27051, 19992, 164, 138, 94, 210, 172, 67, 89, 87);
 RT_INTERFACE!{static interface IUserNotificationChangedTriggerFactory(IUserNotificationChangedTriggerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IUserNotificationChangedTriggerFactory] {
     #[cfg(feature="windows-ui")] fn Create(&self, notificationKinds: super::super::ui::notifications::NotificationKinds, out: *mut *mut UserNotificationChangedTrigger) -> HRESULT
@@ -5097,7 +5097,7 @@ impl CoreApplication {
         <Self as RtActivatable<ICoreImmersiveApplication3>>::get_activation_factory().create_new_view_with_view_source(viewSource)
     }}
 }
-DEFINE_CLSID!(CoreApplication(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,114,101,46,67,111,114,101,65,112,112,108,105,99,97,116,105,111,110,0]) [CLSID_CoreApplication]);
+DEFINE_CLSID!(CoreApplication: "Windows.ApplicationModel.Core.CoreApplication");
 DEFINE_IID!(IID_ICoreApplication2, 2575729147, 6838, 19327, 190, 74, 154, 6, 69, 34, 76, 4);
 RT_INTERFACE!{static interface ICoreApplication2(ICoreApplication2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreApplication2] {
     fn add_BackgroundActivated(&self, handler: *mut super::super::foundation::EventHandler<super::activation::BackgroundActivatedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -5508,7 +5508,7 @@ impl AppServiceCatalog {
         <Self as RtActivatable<IAppServiceCatalogStatics>>::get_activation_factory().find_app_service_providers_async(appServiceName)
     }}
 }
-DEFINE_CLSID!(AppServiceCatalog(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,83,101,114,118,105,99,101,46,65,112,112,83,101,114,118,105,99,101,67,97,116,97,108,111,103,0]) [CLSID_AppServiceCatalog]);
+DEFINE_CLSID!(AppServiceCatalog: "Windows.ApplicationModel.AppService.AppServiceCatalog");
 DEFINE_IID!(IID_IAppServiceCatalogStatics, 4010616071, 53554, 19589, 131, 149, 60, 49, 213, 161, 233, 65);
 RT_INTERFACE!{static interface IAppServiceCatalogStatics(IAppServiceCatalogStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppServiceCatalogStatics] {
     fn FindAppServiceProvidersAsync(&self, appServiceName: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<super::super::foundation::collections::IVectorView<super::AppInfo>>) -> HRESULT
@@ -5598,7 +5598,7 @@ impl IAppServiceConnection {
 }
 RT_CLASS!{class AppServiceConnection: IAppServiceConnection}
 impl RtActivatable<IActivationFactory> for AppServiceConnection {}
-DEFINE_CLSID!(AppServiceConnection(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,83,101,114,118,105,99,101,46,65,112,112,83,101,114,118,105,99,101,67,111,110,110,101,99,116,105,111,110,0]) [CLSID_AppServiceConnection]);
+DEFINE_CLSID!(AppServiceConnection: "Windows.ApplicationModel.AppService.AppServiceConnection");
 DEFINE_IID!(IID_IAppServiceConnection2, 2346700127, 8962, 20413, 128, 97, 82, 81, 28, 47, 139, 249);
 RT_INTERFACE!{interface IAppServiceConnection2(IAppServiceConnection2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppServiceConnection2] {
     #[cfg(feature="windows-system")] fn OpenRemoteAsync(&self, remoteSystemConnectionRequest: *mut super::super::system::remotesystems::RemoteSystemConnectionRequest, out: *mut *mut super::super::foundation::IAsyncOperation<AppServiceConnectionStatus>) -> HRESULT,
@@ -5886,7 +5886,7 @@ impl IAppointment {
 }
 RT_CLASS!{class Appointment: IAppointment}
 impl RtActivatable<IActivationFactory> for Appointment {}
-DEFINE_CLSID!(Appointment(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,0]) [CLSID_Appointment]);
+DEFINE_CLSID!(Appointment: "Windows.ApplicationModel.Appointments.Appointment");
 DEFINE_IID!(IID_IAppointment2, 1585813564, 21519, 13394, 155, 92, 13, 215, 173, 76, 101, 162);
 RT_INTERFACE!{interface IAppointment2(IAppointment2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointment2] {
     fn get_LocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -6506,7 +6506,7 @@ impl IAppointmentInvitee {
 }
 RT_CLASS!{class AppointmentInvitee: IAppointmentInvitee}
 impl RtActivatable<IActivationFactory> for AppointmentInvitee {}
-DEFINE_CLSID!(AppointmentInvitee(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,73,110,118,105,116,101,101,0]) [CLSID_AppointmentInvitee]);
+DEFINE_CLSID!(AppointmentInvitee: "Windows.ApplicationModel.Appointments.AppointmentInvitee");
 RT_CLASS!{static class AppointmentManager}
 impl RtActivatable<IAppointmentManagerStatics> for AppointmentManager {}
 impl RtActivatable<IAppointmentManagerStatics2> for AppointmentManager {}
@@ -6555,7 +6555,7 @@ impl AppointmentManager {
         <Self as RtActivatable<IAppointmentManagerStatics3>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(AppointmentManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,77,97,110,97,103,101,114,0]) [CLSID_AppointmentManager]);
+DEFINE_CLSID!(AppointmentManager: "Windows.ApplicationModel.Appointments.AppointmentManager");
 DEFINE_IID!(IID_IAppointmentManagerForUser, 1881543715, 29644, 18016, 179, 24, 176, 19, 101, 48, 42, 3);
 RT_INTERFACE!{interface IAppointmentManagerForUser(IAppointmentManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentManagerForUser] {
     fn ShowAddAppointmentAsync(&self, appointment: *mut Appointment, selection: super::super::foundation::Rect, out: *mut *mut super::super::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -6757,7 +6757,7 @@ impl IAppointmentManagerStatics3 {
 }
 RT_CLASS!{class AppointmentOrganizer: IAppointmentParticipant}
 impl RtActivatable<IActivationFactory> for AppointmentOrganizer {}
-DEFINE_CLSID!(AppointmentOrganizer(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,79,114,103,97,110,105,122,101,114,0]) [CLSID_AppointmentOrganizer]);
+DEFINE_CLSID!(AppointmentOrganizer: "Windows.ApplicationModel.Appointments.AppointmentOrganizer");
 DEFINE_IID!(IID_IAppointmentParticipant, 1633560834, 38680, 18043, 131, 251, 178, 147, 161, 145, 33, 222);
 RT_INTERFACE!{interface IAppointmentParticipant(IAppointmentParticipantVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentParticipant] {
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -6874,7 +6874,7 @@ impl AppointmentProperties {
         <Self as RtActivatable<IAppointmentPropertiesStatics2>>::get_activation_factory().get_details_kind()
     }}
 }
-DEFINE_CLSID!(AppointmentProperties(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_AppointmentProperties]);
+DEFINE_CLSID!(AppointmentProperties: "Windows.ApplicationModel.Appointments.AppointmentProperties");
 DEFINE_IID!(IID_IAppointmentPropertiesStatics, 622075881, 26798, 15022, 133, 95, 188, 68, 65, 202, 162, 52);
 RT_INTERFACE!{static interface IAppointmentPropertiesStatics(IAppointmentPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentPropertiesStatics] {
     fn get_Subject(&self, out: *mut HSTRING) -> HRESULT,
@@ -7136,7 +7136,7 @@ impl IAppointmentRecurrence {
 }
 RT_CLASS!{class AppointmentRecurrence: IAppointmentRecurrence}
 impl RtActivatable<IActivationFactory> for AppointmentRecurrence {}
-DEFINE_CLSID!(AppointmentRecurrence(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,82,101,99,117,114,114,101,110,99,101,0]) [CLSID_AppointmentRecurrence]);
+DEFINE_CLSID!(AppointmentRecurrence: "Windows.ApplicationModel.Appointments.AppointmentRecurrence");
 DEFINE_IID!(IID_IAppointmentRecurrence2, 1039377120, 1447, 20304, 159, 134, 176, 63, 148, 54, 37, 77);
 RT_INTERFACE!{interface IAppointmentRecurrence2(IAppointmentRecurrence2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentRecurrence2] {
     fn get_RecurrenceType(&self, out: *mut RecurrenceType) -> HRESULT,
@@ -7511,7 +7511,7 @@ impl IFindAppointmentsOptions {
 }
 RT_CLASS!{class FindAppointmentsOptions: IFindAppointmentsOptions}
 impl RtActivatable<IActivationFactory> for FindAppointmentsOptions {}
-DEFINE_CLSID!(FindAppointmentsOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,70,105,110,100,65,112,112,111,105,110,116,109,101,110,116,115,79,112,116,105,111,110,115,0]) [CLSID_FindAppointmentsOptions]);
+DEFINE_CLSID!(FindAppointmentsOptions: "Windows.ApplicationModel.Appointments.FindAppointmentsOptions");
 RT_ENUM! { enum RecurrenceType: i32 {
     Master (RecurrenceType_Master) = 0, Instance (RecurrenceType_Instance) = 1, ExceptionInstance (RecurrenceType_ExceptionInstance) = 2,
 }}
@@ -7575,7 +7575,7 @@ impl AppointmentsProviderLaunchActionVerbs {
         <Self as RtActivatable<IAppointmentsProviderLaunchActionVerbsStatics2>>::get_activation_factory().get_show_appointment_details()
     }}
 }
-DEFINE_CLSID!(AppointmentsProviderLaunchActionVerbs(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,115,80,114,111,118,105,100,101,114,46,65,112,112,111,105,110,116,109,101,110,116,115,80,114,111,118,105,100,101,114,76,97,117,110,99,104,65,99,116,105,111,110,86,101,114,98,115,0]) [CLSID_AppointmentsProviderLaunchActionVerbs]);
+DEFINE_CLSID!(AppointmentsProviderLaunchActionVerbs: "Windows.ApplicationModel.Appointments.AppointmentsProvider.AppointmentsProviderLaunchActionVerbs");
 DEFINE_IID!(IID_IAppointmentsProviderLaunchActionVerbsStatics, 920369704, 40494, 18886, 142, 247, 58, 183, 165, 220, 200, 184);
 RT_INTERFACE!{static interface IAppointmentsProviderLaunchActionVerbsStatics(IAppointmentsProviderLaunchActionVerbsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentsProviderLaunchActionVerbsStatics] {
     fn get_AddAppointment(&self, out: *mut HSTRING) -> HRESULT,
@@ -9183,7 +9183,7 @@ impl ChatCapabilitiesManager {
         <Self as RtActivatable<IChatCapabilitiesManagerStatics>>::get_activation_factory().get_capabilities_from_network_async(address)
     }}
 }
-DEFINE_CLSID!(ChatCapabilitiesManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,67,97,112,97,98,105,108,105,116,105,101,115,77,97,110,97,103,101,114,0]) [CLSID_ChatCapabilitiesManager]);
+DEFINE_CLSID!(ChatCapabilitiesManager: "Windows.ApplicationModel.Chat.ChatCapabilitiesManager");
 DEFINE_IID!(IID_IChatCapabilitiesManagerStatics, 3044683568, 28737, 17806, 176, 207, 124, 13, 159, 234, 51, 58);
 RT_INTERFACE!{static interface IChatCapabilitiesManagerStatics(IChatCapabilitiesManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IChatCapabilitiesManagerStatics] {
     fn GetCachedCapabilitiesAsync(&self, address: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<ChatCapabilities>) -> HRESULT,
@@ -9401,7 +9401,7 @@ impl IChatConversationThreadingInfo {
 }
 RT_CLASS!{class ChatConversationThreadingInfo: IChatConversationThreadingInfo}
 impl RtActivatable<IActivationFactory> for ChatConversationThreadingInfo {}
-DEFINE_CLSID!(ChatConversationThreadingInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,67,111,110,118,101,114,115,97,116,105,111,110,84,104,114,101,97,100,105,110,103,73,110,102,111,0]) [CLSID_ChatConversationThreadingInfo]);
+DEFINE_CLSID!(ChatConversationThreadingInfo: "Windows.ApplicationModel.Chat.ChatConversationThreadingInfo");
 RT_ENUM! { enum ChatConversationThreadingKind: i32 {
     Participants (ChatConversationThreadingKind_Participants) = 0, ContactId (ChatConversationThreadingKind_ContactId) = 1, ConversationId (ChatConversationThreadingKind_ConversationId) = 2, Custom (ChatConversationThreadingKind_Custom) = 3,
 }}
@@ -9526,7 +9526,7 @@ impl IChatMessage {
 }
 RT_CLASS!{class ChatMessage: IChatMessage}
 impl RtActivatable<IActivationFactory> for ChatMessage {}
-DEFINE_CLSID!(ChatMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,77,101,115,115,97,103,101,0]) [CLSID_ChatMessage]);
+DEFINE_CLSID!(ChatMessage: "Windows.ApplicationModel.Chat.ChatMessage");
 DEFINE_IID!(IID_IChatMessage2, 2254865202, 21567, 18933, 172, 113, 108, 42, 252, 101, 101, 253);
 RT_INTERFACE!{interface IChatMessage2(IChatMessage2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatMessage2] {
     fn get_EstimatedDownloadSize(&self, out: *mut u64) -> HRESULT,
@@ -9768,7 +9768,7 @@ impl ChatMessageAttachment {
         <Self as RtActivatable<IChatMessageAttachmentFactory>>::get_activation_factory().create_chat_message_attachment(mimeType, dataStreamReference)
     }}
 }
-DEFINE_CLSID!(ChatMessageAttachment(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,77,101,115,115,97,103,101,65,116,116,97,99,104,109,101,110,116,0]) [CLSID_ChatMessageAttachment]);
+DEFINE_CLSID!(ChatMessageAttachment: "Windows.ApplicationModel.Chat.ChatMessageAttachment");
 DEFINE_IID!(IID_IChatMessageAttachment2, 1591317104, 32209, 19079, 168, 206, 172, 221, 135, 216, 13, 200);
 RT_INTERFACE!{interface IChatMessageAttachment2(IChatMessageAttachment2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageAttachment2] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -9827,7 +9827,7 @@ impl ChatMessageBlocking {
         <Self as RtActivatable<IChatMessageBlockingStatic>>::get_activation_factory().mark_message_as_blocked_async(localChatMessageId, blocked)
     }}
 }
-DEFINE_CLSID!(ChatMessageBlocking(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,77,101,115,115,97,103,101,66,108,111,99,107,105,110,103,0]) [CLSID_ChatMessageBlocking]);
+DEFINE_CLSID!(ChatMessageBlocking: "Windows.ApplicationModel.Chat.ChatMessageBlocking");
 DEFINE_IID!(IID_IChatMessageBlockingStatic, 4139361152, 52714, 4580, 136, 48, 8, 0, 32, 12, 154, 102);
 RT_INTERFACE!{static interface IChatMessageBlockingStatic(IChatMessageBlockingStaticVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageBlockingStatic] {
     fn MarkMessageAsBlockedAsync(&self, localChatMessageId: HSTRING, blocked: bool, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT
@@ -9957,7 +9957,7 @@ impl ChatMessageManager {
         <Self as RtActivatable<IChatMessageManagerStatics3>>::get_activation_factory().request_sync_manager_async()
     }}
 }
-DEFINE_CLSID!(ChatMessageManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,77,101,115,115,97,103,101,77,97,110,97,103,101,114,0]) [CLSID_ChatMessageManager]);
+DEFINE_CLSID!(ChatMessageManager: "Windows.ApplicationModel.Chat.ChatMessageManager");
 DEFINE_IID!(IID_IChatMessageManager2Statics, 491075855, 40783, 20021, 150, 78, 27, 156, 166, 26, 192, 68);
 RT_INTERFACE!{static interface IChatMessageManager2Statics(IChatMessageManager2StaticsVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageManager2Statics] {
     fn RegisterTransportAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -10440,7 +10440,7 @@ impl IChatQueryOptions {
 }
 RT_CLASS!{class ChatQueryOptions: IChatQueryOptions}
 impl RtActivatable<IActivationFactory> for ChatQueryOptions {}
-DEFINE_CLSID!(ChatQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_ChatQueryOptions]);
+DEFINE_CLSID!(ChatQueryOptions: "Windows.ApplicationModel.Chat.ChatQueryOptions");
 DEFINE_IID!(IID_IChatRecipientDeliveryInfo, 4291277474, 10300, 19466, 138, 14, 140, 51, 189, 191, 5, 69);
 RT_INTERFACE!{interface IChatRecipientDeliveryInfo(IChatRecipientDeliveryInfoVtbl): IInspectable(IInspectableVtbl) [IID_IChatRecipientDeliveryInfo] {
     fn get_TransportAddress(&self, out: *mut HSTRING) -> HRESULT,
@@ -10511,7 +10511,7 @@ impl IChatRecipientDeliveryInfo {
 }
 RT_CLASS!{class ChatRecipientDeliveryInfo: IChatRecipientDeliveryInfo}
 impl RtActivatable<IActivationFactory> for ChatRecipientDeliveryInfo {}
-DEFINE_CLSID!(ChatRecipientDeliveryInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,82,101,99,105,112,105,101,110,116,68,101,108,105,118,101,114,121,73,110,102,111,0]) [CLSID_ChatRecipientDeliveryInfo]);
+DEFINE_CLSID!(ChatRecipientDeliveryInfo: "Windows.ApplicationModel.Chat.ChatRecipientDeliveryInfo");
 RT_ENUM! { enum ChatRestoreHistorySpan: i32 {
     LastMonth (ChatRestoreHistorySpan_LastMonth) = 0, LastYear (ChatRestoreHistorySpan_LastYear) = 1, AnyTime (ChatRestoreHistorySpan_AnyTime) = 2,
 }}
@@ -10742,7 +10742,7 @@ impl RcsManager {
         <Self as RtActivatable<IRcsManagerStatics>>::get_activation_factory().leave_conversation_async(conversation)
     }}
 }
-DEFINE_CLSID!(RcsManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,82,99,115,77,97,110,97,103,101,114,0]) [CLSID_RcsManager]);
+DEFINE_CLSID!(RcsManager: "Windows.ApplicationModel.Chat.RcsManager");
 DEFINE_IID!(IID_IRcsManagerStatics, 2099710661, 2749, 20273, 155, 153, 165, 158, 113, 167, 183, 49);
 RT_INTERFACE!{static interface IRcsManagerStatics(IRcsManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRcsManagerStatics] {
     fn GetEndUserMessageManager(&self, out: *mut *mut RcsEndUserMessageManager) -> HRESULT,
@@ -10993,7 +10993,7 @@ impl IContact {
 }
 RT_CLASS!{class Contact: IContact}
 impl RtActivatable<IActivationFactory> for Contact {}
-DEFINE_CLSID!(Contact(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,0]) [CLSID_Contact]);
+DEFINE_CLSID!(Contact: "Windows.ApplicationModel.Contacts.Contact");
 DEFINE_IID!(IID_IContact2, 4078105445, 47991, 19604, 128, 45, 131, 40, 206, 228, 12, 8);
 RT_INTERFACE!{interface IContact2(IContact2Vtbl): IInspectable(IInspectableVtbl) [IID_IContact2] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -11305,7 +11305,7 @@ impl IContactAddress {
 }
 RT_CLASS!{class ContactAddress: IContactAddress}
 impl RtActivatable<IActivationFactory> for ContactAddress {}
-DEFINE_CLSID!(ContactAddress(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,65,100,100,114,101,115,115,0]) [CLSID_ContactAddress]);
+DEFINE_CLSID!(ContactAddress: "Windows.ApplicationModel.Contacts.ContactAddress");
 RT_ENUM! { enum ContactAddressKind: i32 {
     Home (ContactAddressKind_Home) = 0, Work (ContactAddressKind_Work) = 1, Other (ContactAddressKind_Other) = 2,
 }}
@@ -11373,7 +11373,7 @@ impl IContactAnnotation {
 }
 RT_CLASS!{class ContactAnnotation: IContactAnnotation}
 impl RtActivatable<IActivationFactory> for ContactAnnotation {}
-DEFINE_CLSID!(ContactAnnotation(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,65,110,110,111,116,97,116,105,111,110,0]) [CLSID_ContactAnnotation]);
+DEFINE_CLSID!(ContactAnnotation: "Windows.ApplicationModel.Contacts.ContactAnnotation");
 DEFINE_IID!(IID_IContactAnnotation2, 3063016691, 19127, 18975, 153, 65, 12, 156, 243, 23, 27, 117);
 RT_INTERFACE!{interface IContactAnnotation2(IContactAnnotation2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactAnnotation2] {
     fn get_ContactListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -11585,7 +11585,7 @@ impl IContactCardOptions {
 }
 RT_CLASS!{class ContactCardOptions: IContactCardOptions}
 impl RtActivatable<IActivationFactory> for ContactCardOptions {}
-DEFINE_CLSID!(ContactCardOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,67,97,114,100,79,112,116,105,111,110,115,0]) [CLSID_ContactCardOptions]);
+DEFINE_CLSID!(ContactCardOptions: "Windows.ApplicationModel.Contacts.ContactCardOptions");
 DEFINE_IID!(IID_IContactCardOptions2, 2401704864, 55115, 19654, 159, 83, 27, 14, 181, 209, 39, 60);
 RT_INTERFACE!{interface IContactCardOptions2(IContactCardOptions2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactCardOptions2] {
     fn get_ServerSearchContactListIds(&self, out: *mut *mut super::super::foundation::collections::IVector<HString>) -> HRESULT
@@ -11728,7 +11728,7 @@ impl IContactConnectedServiceAccount {
 }
 RT_CLASS!{class ContactConnectedServiceAccount: IContactConnectedServiceAccount}
 impl RtActivatable<IActivationFactory> for ContactConnectedServiceAccount {}
-DEFINE_CLSID!(ContactConnectedServiceAccount(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,67,111,110,110,101,99,116,101,100,83,101,114,118,105,99,101,65,99,99,111,117,110,116,0]) [CLSID_ContactConnectedServiceAccount]);
+DEFINE_CLSID!(ContactConnectedServiceAccount: "Windows.ApplicationModel.Contacts.ContactConnectedServiceAccount");
 DEFINE_IID!(IID_IContactDate, 4271418982, 45573, 18740, 145, 116, 15, 242, 176, 86, 87, 7);
 RT_INTERFACE!{interface IContactDate(IContactDateVtbl): IInspectable(IInspectableVtbl) [IID_IContactDate] {
     fn get_Day(&self, out: *mut *mut super::super::foundation::IReference<u32>) -> HRESULT,
@@ -11791,7 +11791,7 @@ impl IContactDate {
 }
 RT_CLASS!{class ContactDate: IContactDate}
 impl RtActivatable<IActivationFactory> for ContactDate {}
-DEFINE_CLSID!(ContactDate(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,68,97,116,101,0]) [CLSID_ContactDate]);
+DEFINE_CLSID!(ContactDate: "Windows.ApplicationModel.Contacts.ContactDate");
 RT_ENUM! { enum ContactDateKind: i32 {
     Birthday (ContactDateKind_Birthday) = 0, Anniversary (ContactDateKind_Anniversary) = 1, Other (ContactDateKind_Other) = 2,
 }}
@@ -11835,7 +11835,7 @@ impl IContactEmail {
 }
 RT_CLASS!{class ContactEmail: IContactEmail}
 impl RtActivatable<IActivationFactory> for ContactEmail {}
-DEFINE_CLSID!(ContactEmail(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,69,109,97,105,108,0]) [CLSID_ContactEmail]);
+DEFINE_CLSID!(ContactEmail: "Windows.ApplicationModel.Contacts.ContactEmail");
 RT_ENUM! { enum ContactEmailKind: i32 {
     Personal (ContactEmailKind_Personal) = 0, Work (ContactEmailKind_Work) = 1, Other (ContactEmailKind_Other) = 2,
 }}
@@ -11881,7 +11881,7 @@ impl ContactField {
         <Self as RtActivatable<IContactFieldFactory>>::get_activation_factory().create_field_custom(name, value, type_, category)
     }}
 }
-DEFINE_CLSID!(ContactField(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,70,105,101,108,100,0]) [CLSID_ContactField]);
+DEFINE_CLSID!(ContactField: "Windows.ApplicationModel.Contacts.ContactField");
 RT_ENUM! { enum ContactFieldCategory: i32 {
     None (ContactFieldCategory_None) = 0, Home (ContactFieldCategory_Home) = 1, Work (ContactFieldCategory_Work) = 2, Mobile (ContactFieldCategory_Mobile) = 3, Other (ContactFieldCategory_Other) = 4,
 }}
@@ -11910,7 +11910,7 @@ impl IContactFieldFactory {
 }
 RT_CLASS!{class ContactFieldFactory: IContactFieldFactory}
 impl RtActivatable<IActivationFactory> for ContactFieldFactory {}
-DEFINE_CLSID!(ContactFieldFactory(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,70,105,101,108,100,70,97,99,116,111,114,121,0]) [CLSID_ContactFieldFactory]);
+DEFINE_CLSID!(ContactFieldFactory: "Windows.ApplicationModel.Contacts.ContactFieldFactory");
 RT_ENUM! { enum ContactFieldType: i32 {
     Email (ContactFieldType_Email) = 0, PhoneNumber (ContactFieldType_PhoneNumber) = 1, Location (ContactFieldType_Location) = 2, InstantMessage (ContactFieldType_InstantMessage) = 3, Custom (ContactFieldType_Custom) = 4, ConnectedServiceAccount (ContactFieldType_ConnectedServiceAccount) = 5, ImportantDate (ContactFieldType_ImportantDate) = 6, Address (ContactFieldType_Address) = 7, SignificantOther (ContactFieldType_SignificantOther) = 8, Notes (ContactFieldType_Notes) = 9, Website (ContactFieldType_Website) = 10, JobInfo (ContactFieldType_JobInfo) = 11,
 }}
@@ -12016,7 +12016,7 @@ impl ContactInstantMessageField {
         <Self as RtActivatable<IContactInstantMessageFieldFactory>>::get_activation_factory().create_instant_message_all(userName, category, service, displayText, verb)
     }}
 }
-DEFINE_CLSID!(ContactInstantMessageField(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,73,110,115,116,97,110,116,77,101,115,115,97,103,101,70,105,101,108,100,0]) [CLSID_ContactInstantMessageField]);
+DEFINE_CLSID!(ContactInstantMessageField: "Windows.ApplicationModel.Contacts.ContactInstantMessageField");
 DEFINE_IID!(IID_IContactInstantMessageFieldFactory, 3121309588, 37283, 19378, 177, 185, 105, 165, 223, 240, 186, 9);
 RT_INTERFACE!{static interface IContactInstantMessageFieldFactory(IContactInstantMessageFieldFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IContactInstantMessageFieldFactory] {
     fn CreateInstantMessage_Default(&self, userName: HSTRING, out: *mut *mut ContactInstantMessageField) -> HRESULT,
@@ -12135,7 +12135,7 @@ impl IContactJobInfo {
 }
 RT_CLASS!{class ContactJobInfo: IContactJobInfo}
 impl RtActivatable<IActivationFactory> for ContactJobInfo {}
-DEFINE_CLSID!(ContactJobInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,74,111,98,73,110,102,111,0]) [CLSID_ContactJobInfo]);
+DEFINE_CLSID!(ContactJobInfo: "Windows.ApplicationModel.Contacts.ContactJobInfo");
 RT_CLASS!{static class ContactLaunchActionVerbs}
 impl RtActivatable<IContactLaunchActionVerbsStatics> for ContactLaunchActionVerbs {}
 impl ContactLaunchActionVerbs {
@@ -12155,7 +12155,7 @@ impl ContactLaunchActionVerbs {
         <Self as RtActivatable<IContactLaunchActionVerbsStatics>>::get_activation_factory().get_video_call()
     }}
 }
-DEFINE_CLSID!(ContactLaunchActionVerbs(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,76,97,117,110,99,104,65,99,116,105,111,110,86,101,114,98,115,0]) [CLSID_ContactLaunchActionVerbs]);
+DEFINE_CLSID!(ContactLaunchActionVerbs: "Windows.ApplicationModel.Contacts.ContactLaunchActionVerbs");
 DEFINE_IID!(IID_IContactLaunchActionVerbsStatics, 4212273878, 61043, 18151, 135, 97, 17, 205, 1, 87, 114, 143);
 RT_INTERFACE!{static interface IContactLaunchActionVerbsStatics(IContactLaunchActionVerbsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IContactLaunchActionVerbsStatics] {
     fn get_Call(&self, out: *mut HSTRING) -> HRESULT,
@@ -12837,7 +12837,7 @@ impl ContactLocationField {
         <Self as RtActivatable<IContactLocationFieldFactory>>::get_activation_factory().create_location_all(unstructuredAddress, category, street, city, region, country, postalCode)
     }}
 }
-DEFINE_CLSID!(ContactLocationField(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,76,111,99,97,116,105,111,110,70,105,101,108,100,0]) [CLSID_ContactLocationField]);
+DEFINE_CLSID!(ContactLocationField: "Windows.ApplicationModel.Contacts.ContactLocationField");
 DEFINE_IID!(IID_IContactLocationFieldFactory, 4154012375, 12255, 17406, 143, 24, 65, 137, 115, 144, 188, 254);
 RT_INTERFACE!{static interface IContactLocationFieldFactory(IContactLocationFieldFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IContactLocationFieldFactory] {
     fn CreateLocation_Default(&self, unstructuredAddress: HSTRING, out: *mut *mut ContactLocationField) -> HRESULT,
@@ -12935,7 +12935,7 @@ impl ContactManager {
         <Self as RtActivatable<IContactManagerStatics5>>::get_activation_factory().set_include_middle_name_in_system_display_and_sort(value)
     }}
 }
-DEFINE_CLSID!(ContactManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,77,97,110,97,103,101,114,0]) [CLSID_ContactManager]);
+DEFINE_CLSID!(ContactManager: "Windows.ApplicationModel.Contacts.ContactManager");
 DEFINE_IID!(IID_IContactManagerForUser, 3075193431, 4214, 19439, 174, 243, 84, 104, 109, 24, 56, 125);
 RT_INTERFACE!{interface IContactManagerForUser(IContactManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IContactManagerForUser] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -13408,7 +13408,7 @@ impl IContactPhone {
 }
 RT_CLASS!{class ContactPhone: IContactPhone}
 impl RtActivatable<IActivationFactory> for ContactPhone {}
-DEFINE_CLSID!(ContactPhone(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,80,104,111,110,101,0]) [CLSID_ContactPhone]);
+DEFINE_CLSID!(ContactPhone: "Windows.ApplicationModel.Contacts.ContactPhone");
 RT_ENUM! { enum ContactPhoneKind: i32 {
     Home (ContactPhoneKind_Home) = 0, Mobile (ContactPhoneKind_Mobile) = 1, Work (ContactPhoneKind_Work) = 2, Other (ContactPhoneKind_Other) = 3, Pager (ContactPhoneKind_Pager) = 4, BusinessFax (ContactPhoneKind_BusinessFax) = 5, HomeFax (ContactPhoneKind_HomeFax) = 6, Company (ContactPhoneKind_Company) = 7, Assistant (ContactPhoneKind_Assistant) = 8, Radio (ContactPhoneKind_Radio) = 9,
 }}
@@ -13468,7 +13468,7 @@ impl ContactPicker {
         <Self as RtActivatable<IContactPickerStatics>>::get_activation_factory().is_supported_async()
     }}
 }
-DEFINE_CLSID!(ContactPicker(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,80,105,99,107,101,114,0]) [CLSID_ContactPicker]);
+DEFINE_CLSID!(ContactPicker: "Windows.ApplicationModel.Contacts.ContactPicker");
 DEFINE_IID!(IID_IContactPicker2, 3008369103, 23791, 19748, 170, 12, 52, 12, 82, 8, 114, 93);
 RT_INTERFACE!{interface IContactPicker2(IContactPicker2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactPicker2] {
     fn get_DesiredFieldsWithContactFieldType(&self, out: *mut *mut super::super::foundation::collections::IVector<ContactFieldType>) -> HRESULT,
@@ -13591,7 +13591,7 @@ impl ContactQueryOptions {
         <Self as RtActivatable<IContactQueryOptionsFactory>>::get_activation_factory().create_with_text_and_fields(text, fields)
     }}
 }
-DEFINE_CLSID!(ContactQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_ContactQueryOptions]);
+DEFINE_CLSID!(ContactQueryOptions: "Windows.ApplicationModel.Contacts.ContactQueryOptions");
 DEFINE_IID!(IID_IContactQueryOptionsFactory, 1413462599, 36071, 18123, 157, 172, 154, 164, 42, 27, 200, 226);
 RT_INTERFACE!{static interface IContactQueryOptionsFactory(IContactQueryOptionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IContactQueryOptionsFactory] {
     fn CreateWithText(&self, text: HSTRING, out: *mut *mut ContactQueryOptions) -> HRESULT,
@@ -13707,7 +13707,7 @@ impl IContactSignificantOther {
 }
 RT_CLASS!{class ContactSignificantOther: IContactSignificantOther}
 impl RtActivatable<IActivationFactory> for ContactSignificantOther {}
-DEFINE_CLSID!(ContactSignificantOther(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,83,105,103,110,105,102,105,99,97,110,116,79,116,104,101,114,0]) [CLSID_ContactSignificantOther]);
+DEFINE_CLSID!(ContactSignificantOther: "Windows.ApplicationModel.Contacts.ContactSignificantOther");
 DEFINE_IID!(IID_IContactSignificantOther2, 2373702772, 16131, 17912, 186, 15, 196, 237, 55, 214, 66, 25);
 RT_INTERFACE!{interface IContactSignificantOther2(IContactSignificantOther2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactSignificantOther2] {
     fn get_Relationship(&self, out: *mut ContactRelationship) -> HRESULT,
@@ -13866,7 +13866,7 @@ impl IContactWebsite {
 }
 RT_CLASS!{class ContactWebsite: IContactWebsite}
 impl RtActivatable<IActivationFactory> for ContactWebsite {}
-DEFINE_CLSID!(ContactWebsite(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,87,101,98,115,105,116,101,0]) [CLSID_ContactWebsite]);
+DEFINE_CLSID!(ContactWebsite: "Windows.ApplicationModel.Contacts.ContactWebsite");
 DEFINE_IID!(IID_IContactWebsite2, 4169066782, 22087, 16488, 187, 94, 75, 111, 67, 124, 227, 8);
 RT_INTERFACE!{interface IContactWebsite2(IContactWebsite2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactWebsite2] {
     fn get_RawValue(&self, out: *mut HSTRING) -> HRESULT,
@@ -13901,7 +13901,7 @@ impl IFullContactCardOptions {
 }
 RT_CLASS!{class FullContactCardOptions: IFullContactCardOptions}
 impl RtActivatable<IActivationFactory> for FullContactCardOptions {}
-DEFINE_CLSID!(FullContactCardOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,70,117,108,108,67,111,110,116,97,99,116,67,97,114,100,79,112,116,105,111,110,115,0]) [CLSID_FullContactCardOptions]);
+DEFINE_CLSID!(FullContactCardOptions: "Windows.ApplicationModel.Contacts.FullContactCardOptions");
 RT_CLASS!{static class KnownContactField}
 impl RtActivatable<IKnownContactFieldStatics> for KnownContactField {}
 impl KnownContactField {
@@ -13924,7 +13924,7 @@ impl KnownContactField {
         <Self as RtActivatable<IKnownContactFieldStatics>>::get_activation_factory().convert_type_to_name(type_)
     }}
 }
-DEFINE_CLSID!(KnownContactField(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,75,110,111,119,110,67,111,110,116,97,99,116,70,105,101,108,100,0]) [CLSID_KnownContactField]);
+DEFINE_CLSID!(KnownContactField: "Windows.ApplicationModel.Contacts.KnownContactField");
 DEFINE_IID!(IID_IKnownContactFieldStatics, 772676370, 54823, 20426, 186, 212, 31, 175, 22, 140, 125, 20);
 RT_INTERFACE!{static interface IKnownContactFieldStatics(IKnownContactFieldStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownContactFieldStatics] {
     fn get_Email(&self, out: *mut HSTRING) -> HRESULT,
@@ -14044,7 +14044,7 @@ impl PinnedContactManager {
         <Self as RtActivatable<IPinnedContactManagerStatics>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(PinnedContactManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,80,105,110,110,101,100,67,111,110,116,97,99,116,77,97,110,97,103,101,114,0]) [CLSID_PinnedContactManager]);
+DEFINE_CLSID!(PinnedContactManager: "Windows.ApplicationModel.Contacts.PinnedContactManager");
 DEFINE_IID!(IID_IPinnedContactManagerStatics, 4133276798, 65017, 18538, 172, 233, 188, 49, 29, 10, 231, 240);
 RT_INTERFACE!{static interface IPinnedContactManagerStatics(IPinnedContactManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPinnedContactManagerStatics] {
     fn GetDefault(&self, out: *mut *mut PinnedContactManager) -> HRESULT,
@@ -14457,7 +14457,7 @@ impl Clipboard {
         <Self as RtActivatable<IClipboardStatics>>::get_activation_factory().remove_content_changed(token)
     }}
 }
-DEFINE_CLSID!(Clipboard(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,67,108,105,112,98,111,97,114,100,0]) [CLSID_Clipboard]);
+DEFINE_CLSID!(Clipboard: "Windows.ApplicationModel.DataTransfer.Clipboard");
 DEFINE_IID!(IID_IClipboardStatics, 3324502673, 13538, 18787, 142, 237, 147, 203, 176, 234, 61, 112);
 RT_INTERFACE!{static interface IClipboardStatics(IClipboardStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IClipboardStatics] {
     fn GetContent(&self, out: *mut *mut DataPackageView) -> HRESULT,
@@ -14598,7 +14598,7 @@ impl IDataPackage {
 }
 RT_CLASS!{class DataPackage: IDataPackage}
 impl RtActivatable<IActivationFactory> for DataPackage {}
-DEFINE_CLSID!(DataPackage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,68,97,116,97,80,97,99,107,97,103,101,0]) [CLSID_DataPackage]);
+DEFINE_CLSID!(DataPackage: "Windows.ApplicationModel.DataTransfer.DataPackage");
 DEFINE_IID!(IID_IDataPackage2, 68952041, 9225, 17889, 165, 56, 76, 83, 238, 238, 4, 167);
 RT_INTERFACE!{interface IDataPackage2(IDataPackage2Vtbl): IInspectable(IInspectableVtbl) [IID_IDataPackage2] {
     fn SetApplicationLink(&self, value: *mut super::super::foundation::Uri) -> HRESULT,
@@ -15161,7 +15161,7 @@ impl DataTransferManager {
         <Self as RtActivatable<IDataTransferManagerStatics3>>::get_activation_factory().show_share_uiwith_options(options)
     }}
 }
-DEFINE_CLSID!(DataTransferManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,68,97,116,97,84,114,97,110,115,102,101,114,77,97,110,97,103,101,114,0]) [CLSID_DataTransferManager]);
+DEFINE_CLSID!(DataTransferManager: "Windows.ApplicationModel.DataTransfer.DataTransferManager");
 DEFINE_IID!(IID_IDataTransferManager2, 816741745, 35752, 19458, 142, 63, 221, 178, 59, 56, 135, 21);
 RT_INTERFACE!{interface IDataTransferManager2(IDataTransferManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IDataTransferManager2] {
     fn add_ShareProvidersRequested(&self, handler: *mut super::super::foundation::TypedEventHandler<DataTransferManager, ShareProvidersRequestedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -15225,7 +15225,7 @@ impl HtmlFormatHelper {
         <Self as RtActivatable<IHtmlFormatHelperStatics>>::get_activation_factory().create_html_format(htmlFragment)
     }}
 }
-DEFINE_CLSID!(HtmlFormatHelper(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,72,116,109,108,70,111,114,109,97,116,72,101,108,112,101,114,0]) [CLSID_HtmlFormatHelper]);
+DEFINE_CLSID!(HtmlFormatHelper: "Windows.ApplicationModel.DataTransfer.HtmlFormatHelper");
 DEFINE_IID!(IID_IHtmlFormatHelperStatics, 3794696009, 56688, 17519, 174, 252, 97, 206, 229, 159, 101, 94);
 RT_INTERFACE!{static interface IHtmlFormatHelperStatics(IHtmlFormatHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHtmlFormatHelperStatics] {
     fn GetStaticFragment(&self, htmlFormat: HSTRING, out: *mut HSTRING) -> HRESULT,
@@ -15291,7 +15291,7 @@ impl SharedStorageAccessManager {
         <Self as RtActivatable<ISharedStorageAccessManagerStatics>>::get_activation_factory().remove_file(token)
     }}
 }
-DEFINE_CLSID!(SharedStorageAccessManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,104,97,114,101,100,83,116,111,114,97,103,101,65,99,99,101,115,115,77,97,110,97,103,101,114,0]) [CLSID_SharedStorageAccessManager]);
+DEFINE_CLSID!(SharedStorageAccessManager: "Windows.ApplicationModel.DataTransfer.SharedStorageAccessManager");
 DEFINE_IID!(IID_ISharedStorageAccessManagerStatics, 3323144922, 13489, 18505, 189, 95, 208, 159, 238, 49, 88, 197);
 RT_INTERFACE!{static interface ISharedStorageAccessManagerStatics(ISharedStorageAccessManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISharedStorageAccessManagerStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -15359,7 +15359,7 @@ impl ShareProvider {
         <Self as RtActivatable<IShareProviderFactory>>::get_activation_factory().create(title, displayIcon, backgroundColor, handler)
     }}
 }
-DEFINE_CLSID!(ShareProvider(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,104,97,114,101,80,114,111,118,105,100,101,114,0]) [CLSID_ShareProvider]);
+DEFINE_CLSID!(ShareProvider: "Windows.ApplicationModel.DataTransfer.ShareProvider");
 DEFINE_IID!(IID_IShareProviderFactory, 388634444, 59294, 20333, 176, 125, 18, 143, 70, 158, 2, 150);
 RT_INTERFACE!{static interface IShareProviderFactory(IShareProviderFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IShareProviderFactory] {
     #[cfg(all(feature="windows-storage",feature="windows-ui"))] fn Create(&self, title: HSTRING, displayIcon: *mut super::super::storage::streams::RandomAccessStreamReference, backgroundColor: super::super::ui::Color, handler: *mut ShareProviderHandler, out: *mut *mut ShareProvider) -> HRESULT
@@ -15475,7 +15475,7 @@ impl IShareUIOptions {
 }
 RT_CLASS!{class ShareUIOptions: IShareUIOptions}
 impl RtActivatable<IActivationFactory> for ShareUIOptions {}
-DEFINE_CLSID!(ShareUIOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,104,97,114,101,85,73,79,112,116,105,111,110,115,0]) [CLSID_ShareUIOptions]);
+DEFINE_CLSID!(ShareUIOptions: "Windows.ApplicationModel.DataTransfer.ShareUIOptions");
 RT_ENUM! { enum ShareUITheme: i32 {
     Default (ShareUITheme_Default) = 0, Light (ShareUITheme_Light) = 1, Dark (ShareUITheme_Dark) = 2,
 }}
@@ -15508,7 +15508,7 @@ impl StandardDataFormats {
         <Self as RtActivatable<IStandardDataFormatsStatics2>>::get_activation_factory().get_application_link()
     }}
 }
-DEFINE_CLSID!(StandardDataFormats(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,116,97,110,100,97,114,100,68,97,116,97,70,111,114,109,97,116,115,0]) [CLSID_StandardDataFormats]);
+DEFINE_CLSID!(StandardDataFormats: "Windows.ApplicationModel.DataTransfer.StandardDataFormats");
 DEFINE_IID!(IID_IStandardDataFormatsStatics, 2127987105, 43136, 16585, 180, 237, 11, 238, 30, 21, 245, 73);
 RT_INTERFACE!{static interface IStandardDataFormatsStatics(IStandardDataFormatsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStandardDataFormatsStatics] {
     fn get_Text(&self, out: *mut HSTRING) -> HRESULT,
@@ -15620,7 +15620,7 @@ impl CoreDragDropManager {
         <Self as RtActivatable<ICoreDragDropManagerStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(CoreDragDropManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,68,114,97,103,68,114,111,112,46,67,111,114,101,46,67,111,114,101,68,114,97,103,68,114,111,112,77,97,110,97,103,101,114,0]) [CLSID_CoreDragDropManager]);
+DEFINE_CLSID!(CoreDragDropManager: "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragDropManager");
 DEFINE_IID!(IID_ICoreDragDropManagerStatics, 2504195530, 55826, 19484, 141, 6, 4, 29, 178, 151, 51, 195);
 RT_INTERFACE!{static interface ICoreDragDropManagerStatics(ICoreDragDropManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreDragDropManagerStatics] {
     fn GetForCurrentView(&self, out: *mut *mut CoreDragDropManager) -> HRESULT
@@ -15714,7 +15714,7 @@ impl ICoreDragOperation {
 }
 RT_CLASS!{class CoreDragOperation: ICoreDragOperation}
 impl RtActivatable<IActivationFactory> for CoreDragOperation {}
-DEFINE_CLSID!(CoreDragOperation(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,68,114,97,103,68,114,111,112,46,67,111,114,101,46,67,111,114,101,68,114,97,103,79,112,101,114,97,116,105,111,110,0]) [CLSID_CoreDragOperation]);
+DEFINE_CLSID!(CoreDragOperation: "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragOperation");
 DEFINE_IID!(IID_ICoreDragOperation2, 2185961004, 55706, 20419, 133, 7, 108, 24, 47, 51, 180, 106);
 RT_INTERFACE!{interface ICoreDragOperation2(ICoreDragOperation2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreDragOperation2] {
     fn get_AllowedOperations(&self, out: *mut super::super::DataPackageOperation) -> HRESULT,
@@ -15899,7 +15899,7 @@ impl IQuickLink {
 }
 RT_CLASS!{class QuickLink: IQuickLink}
 impl RtActivatable<IActivationFactory> for QuickLink {}
-DEFINE_CLSID!(QuickLink(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,104,97,114,101,84,97,114,103,101,116,46,81,117,105,99,107,76,105,110,107,0]) [CLSID_QuickLink]);
+DEFINE_CLSID!(QuickLink: "Windows.ApplicationModel.DataTransfer.ShareTarget.QuickLink");
 DEFINE_IID!(IID_IShareOperation, 575060664, 53496, 16833, 168, 42, 65, 55, 219, 101, 4, 251);
 RT_INTERFACE!{interface IShareOperation(IShareOperationVtbl): IInspectable(IInspectableVtbl) [IID_IShareOperation] {
     fn get_Data(&self, out: *mut *mut super::DataPackageView) -> HRESULT,
@@ -16017,7 +16017,7 @@ impl EmailAttachment {
         <Self as RtActivatable<IEmailAttachmentFactory2>>::get_activation_factory().create(fileName, data, mimeType)
     }}
 }
-DEFINE_CLSID!(EmailAttachment(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,65,116,116,97,99,104,109,101,110,116,0]) [CLSID_EmailAttachment]);
+DEFINE_CLSID!(EmailAttachment: "Windows.ApplicationModel.Email.EmailAttachment");
 DEFINE_IID!(IID_IEmailAttachment2, 576655472, 45311, 17777, 157, 84, 167, 6, 196, 141, 85, 198);
 RT_INTERFACE!{interface IEmailAttachment2(IEmailAttachment2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailAttachment2] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -16561,7 +16561,7 @@ impl EmailIrmInfo {
         <Self as RtActivatable<IEmailIrmInfoFactory>>::get_activation_factory().create(expiration, irmTemplate)
     }}
 }
-DEFINE_CLSID!(EmailIrmInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,73,114,109,73,110,102,111,0]) [CLSID_EmailIrmInfo]);
+DEFINE_CLSID!(EmailIrmInfo: "Windows.ApplicationModel.Email.EmailIrmInfo");
 DEFINE_IID!(IID_IEmailIrmInfoFactory, 827044236, 58342, 19835, 190, 141, 145, 169, 99, 17, 176, 27);
 RT_INTERFACE!{static interface IEmailIrmInfoFactory(IEmailIrmInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEmailIrmInfoFactory] {
     fn Create(&self, expiration: super::super::foundation::DateTime, irmTemplate: *mut EmailIrmTemplate, out: *mut *mut EmailIrmInfo) -> HRESULT
@@ -16619,7 +16619,7 @@ impl EmailIrmTemplate {
         <Self as RtActivatable<IEmailIrmTemplateFactory>>::get_activation_factory().create(id, name, description)
     }}
 }
-DEFINE_CLSID!(EmailIrmTemplate(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,73,114,109,84,101,109,112,108,97,116,101,0]) [CLSID_EmailIrmTemplate]);
+DEFINE_CLSID!(EmailIrmTemplate: "Windows.ApplicationModel.Email.EmailIrmTemplate");
 DEFINE_IID!(IID_IEmailIrmTemplateFactory, 1034098806, 34616, 17432, 185, 203, 71, 27, 147, 111, 231, 30);
 RT_INTERFACE!{static interface IEmailIrmTemplateFactory(IEmailIrmTemplateFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEmailIrmTemplateFactory] {
     fn Create(&self, id: HSTRING, name: HSTRING, description: HSTRING, out: *mut *mut EmailIrmTemplate) -> HRESULT
@@ -17167,7 +17167,7 @@ impl IEmailMailboxAutoReplySettings {
 }
 RT_CLASS!{class EmailMailboxAutoReplySettings: IEmailMailboxAutoReplySettings}
 impl RtActivatable<IActivationFactory> for EmailMailboxAutoReplySettings {}
-DEFINE_CLSID!(EmailMailboxAutoReplySettings(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,97,105,108,98,111,120,65,117,116,111,82,101,112,108,121,83,101,116,116,105,110,103,115,0]) [CLSID_EmailMailboxAutoReplySettings]);
+DEFINE_CLSID!(EmailMailboxAutoReplySettings: "Windows.ApplicationModel.Email.EmailMailboxAutoReplySettings");
 DEFINE_IID!(IID_IEmailMailboxCapabilities, 4007576486, 35291, 17157, 130, 196, 67, 158, 10, 51, 218, 17);
 RT_INTERFACE!{interface IEmailMailboxCapabilities(IEmailMailboxCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxCapabilities] {
     fn get_CanForwardMeetings(&self, out: *mut bool) -> HRESULT,
@@ -17644,7 +17644,7 @@ impl EmailManager {
         <Self as RtActivatable<IEmailManagerStatics3>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(EmailManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,97,110,97,103,101,114,0]) [CLSID_EmailManager]);
+DEFINE_CLSID!(EmailManager: "Windows.ApplicationModel.Email.EmailManager");
 DEFINE_IID!(IID_IEmailManagerForUser, 4151565983, 15525, 19215, 144, 193, 21, 110, 64, 23, 76, 229);
 RT_INTERFACE!{interface IEmailManagerForUser(IEmailManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IEmailManagerForUser] {
     fn ShowComposeNewEmailAsync(&self, message: *mut EmailMessage, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT,
@@ -17852,7 +17852,7 @@ impl IEmailMeetingInfo {
 }
 RT_CLASS!{class EmailMeetingInfo: IEmailMeetingInfo}
 impl RtActivatable<IActivationFactory> for EmailMeetingInfo {}
-DEFINE_CLSID!(EmailMeetingInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,101,101,116,105,110,103,73,110,102,111,0]) [CLSID_EmailMeetingInfo]);
+DEFINE_CLSID!(EmailMeetingInfo: "Windows.ApplicationModel.Email.EmailMeetingInfo");
 DEFINE_IID!(IID_IEmailMeetingInfo2, 2119776365, 45273, 20453, 134, 124, 227, 30, 210, 181, 136, 184);
 RT_INTERFACE!{interface IEmailMeetingInfo2(IEmailMeetingInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailMeetingInfo2] {
     fn get_IsReportedOutOfDateByServer(&self, out: *mut bool) -> HRESULT
@@ -17920,7 +17920,7 @@ impl IEmailMessage {
 }
 RT_CLASS!{class EmailMessage: IEmailMessage}
 impl RtActivatable<IActivationFactory> for EmailMessage {}
-DEFINE_CLSID!(EmailMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,101,115,115,97,103,101,0]) [CLSID_EmailMessage]);
+DEFINE_CLSID!(EmailMessage: "Windows.ApplicationModel.Email.EmailMessage");
 DEFINE_IID!(IID_IEmailMessage2, 4257752203, 40730, 17627, 189, 60, 101, 195, 132, 119, 15, 134);
 RT_INTERFACE!{interface IEmailMessage2(IEmailMessage2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailMessage2] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -18336,7 +18336,7 @@ impl EmailQueryOptions {
         <Self as RtActivatable<IEmailQueryOptionsFactory>>::get_activation_factory().create_with_text_and_fields(text, fields)
     }}
 }
-DEFINE_CLSID!(EmailQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_EmailQueryOptions]);
+DEFINE_CLSID!(EmailQueryOptions: "Windows.ApplicationModel.Email.EmailQueryOptions");
 DEFINE_IID!(IID_IEmailQueryOptionsFactory, 2297536952, 30891, 20200, 180, 227, 4, 109, 110, 47, 229, 226);
 RT_INTERFACE!{static interface IEmailQueryOptionsFactory(IEmailQueryOptionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEmailQueryOptionsFactory] {
     fn CreateWithText(&self, text: HSTRING, out: *mut *mut EmailQueryOptions) -> HRESULT,
@@ -18443,7 +18443,7 @@ impl EmailRecipient {
         <Self as RtActivatable<IEmailRecipientFactory>>::get_activation_factory().create_with_name(address, name)
     }}
 }
-DEFINE_CLSID!(EmailRecipient(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,82,101,99,105,112,105,101,110,116,0]) [CLSID_EmailRecipient]);
+DEFINE_CLSID!(EmailRecipient: "Windows.ApplicationModel.Email.EmailRecipient");
 DEFINE_IID!(IID_IEmailRecipientFactory, 1426110541, 51098, 20216, 185, 9, 114, 46, 24, 227, 147, 93);
 RT_INTERFACE!{static interface IEmailRecipientFactory(IEmailRecipientFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEmailRecipientFactory] {
     fn Create(&self, address: HSTRING, out: *mut *mut EmailRecipient) -> HRESULT,
@@ -18480,7 +18480,7 @@ impl IEmailRecipientResolutionResult {
 }
 RT_CLASS!{class EmailRecipientResolutionResult: IEmailRecipientResolutionResult}
 impl RtActivatable<IActivationFactory> for EmailRecipientResolutionResult {}
-DEFINE_CLSID!(EmailRecipientResolutionResult(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,82,101,99,105,112,105,101,110,116,82,101,115,111,108,117,116,105,111,110,82,101,115,117,108,116,0]) [CLSID_EmailRecipientResolutionResult]);
+DEFINE_CLSID!(EmailRecipientResolutionResult: "Windows.ApplicationModel.Email.EmailRecipientResolutionResult");
 DEFINE_IID!(IID_IEmailRecipientResolutionResult2, 1581386678, 52827, 19422, 185, 212, 225, 109, 160, 176, 159, 202);
 RT_INTERFACE!{interface IEmailRecipientResolutionResult2(IEmailRecipientResolutionResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailRecipientResolutionResult2] {
     fn put_Status(&self, value: EmailRecipientResolutionStatus) -> HRESULT,
@@ -19695,7 +19695,7 @@ impl IExtendedExecutionSession {
 }
 RT_CLASS!{class ExtendedExecutionSession: IExtendedExecutionSession}
 impl RtActivatable<IActivationFactory> for ExtendedExecutionSession {}
-DEFINE_CLSID!(ExtendedExecutionSession(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,83,101,115,115,105,111,110,0]) [CLSID_ExtendedExecutionSession]);
+DEFINE_CLSID!(ExtendedExecutionSession: "Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionSession");
 pub mod foreground { // Windows.ApplicationModel.ExtendedExecution.Foreground
 use ::prelude::*;
 RT_ENUM! { enum ExtendedExecutionForegroundReason: i32 {
@@ -19765,7 +19765,7 @@ impl IExtendedExecutionForegroundSession {
 }
 RT_CLASS!{class ExtendedExecutionForegroundSession: IExtendedExecutionForegroundSession}
 impl RtActivatable<IActivationFactory> for ExtendedExecutionForegroundSession {}
-DEFINE_CLSID!(ExtendedExecutionForegroundSession(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,46,70,111,114,101,103,114,111,117,110,100,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,70,111,114,101,103,114,111,117,110,100,83,101,115,115,105,111,110,0]) [CLSID_ExtendedExecutionForegroundSession]);
+DEFINE_CLSID!(ExtendedExecutionForegroundSession: "Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundSession");
 } // Windows.ApplicationModel.ExtendedExecution.Foreground
 } // Windows.ApplicationModel.ExtendedExecution
 pub mod userdatatasks { // Windows.ApplicationModel.UserDataTasks
@@ -19927,7 +19927,7 @@ impl IUserDataTask {
 }
 RT_CLASS!{class UserDataTask: IUserDataTask}
 impl RtActivatable<IActivationFactory> for UserDataTask {}
-DEFINE_CLSID!(UserDataTask(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,0]) [CLSID_UserDataTask]);
+DEFINE_CLSID!(UserDataTask: "Windows.ApplicationModel.UserDataTasks.UserDataTask");
 DEFINE_IID!(IID_IUserDataTaskBatch, 942515710, 8373, 17180, 143, 66, 165, 210, 146, 236, 147, 12);
 RT_INTERFACE!{interface IUserDataTaskBatch(IUserDataTaskBatchVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskBatch] {
     fn get_Tasks(&self, out: *mut *mut super::super::foundation::collections::IVectorView<UserDataTask>) -> HRESULT
@@ -20188,7 +20188,7 @@ impl UserDataTaskManager {
         <Self as RtActivatable<IUserDataTaskManagerStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(UserDataTaskManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,77,97,110,97,103,101,114,0]) [CLSID_UserDataTaskManager]);
+DEFINE_CLSID!(UserDataTaskManager: "Windows.ApplicationModel.UserDataTasks.UserDataTaskManager");
 DEFINE_IID!(IID_IUserDataTaskManagerStatics, 3008707064, 50434, 18428, 168, 30, 16, 8, 131, 113, 157, 85);
 RT_INTERFACE!{static interface IUserDataTaskManagerStatics(IUserDataTaskManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskManagerStatics] {
     fn GetDefault(&self, out: *mut *mut UserDataTaskManager) -> HRESULT,
@@ -20241,7 +20241,7 @@ impl IUserDataTaskQueryOptions {
 }
 RT_CLASS!{class UserDataTaskQueryOptions: IUserDataTaskQueryOptions}
 impl RtActivatable<IActivationFactory> for UserDataTaskQueryOptions {}
-DEFINE_CLSID!(UserDataTaskQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_UserDataTaskQueryOptions]);
+DEFINE_CLSID!(UserDataTaskQueryOptions: "Windows.ApplicationModel.UserDataTasks.UserDataTaskQueryOptions");
 RT_ENUM! { enum UserDataTaskQuerySortProperty: i32 {
     DueDate (UserDataTaskQuerySortProperty_DueDate) = 0,
 }}
@@ -20352,7 +20352,7 @@ impl IUserDataTaskRecurrenceProperties {
 }
 RT_CLASS!{class UserDataTaskRecurrenceProperties: IUserDataTaskRecurrenceProperties}
 impl RtActivatable<IActivationFactory> for UserDataTaskRecurrenceProperties {}
-DEFINE_CLSID!(UserDataTaskRecurrenceProperties(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,82,101,99,117,114,114,101,110,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_UserDataTaskRecurrenceProperties]);
+DEFINE_CLSID!(UserDataTaskRecurrenceProperties: "Windows.ApplicationModel.UserDataTasks.UserDataTaskRecurrenceProperties");
 RT_ENUM! { enum UserDataTaskRecurrenceUnit: i32 {
     Daily (UserDataTaskRecurrenceUnit_Daily) = 0, Weekly (UserDataTaskRecurrenceUnit_Weekly) = 1, Monthly (UserDataTaskRecurrenceUnit_Monthly) = 2, MonthlyOnDay (UserDataTaskRecurrenceUnit_MonthlyOnDay) = 3, Yearly (UserDataTaskRecurrenceUnit_Yearly) = 4, YearlyOnDay (UserDataTaskRecurrenceUnit_YearlyOnDay) = 5,
 }}
@@ -20407,7 +20407,7 @@ impl IUserDataTaskRegenerationProperties {
 }
 RT_CLASS!{class UserDataTaskRegenerationProperties: IUserDataTaskRegenerationProperties}
 impl RtActivatable<IActivationFactory> for UserDataTaskRegenerationProperties {}
-DEFINE_CLSID!(UserDataTaskRegenerationProperties(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,82,101,103,101,110,101,114,97,116,105,111,110,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_UserDataTaskRegenerationProperties]);
+DEFINE_CLSID!(UserDataTaskRegenerationProperties: "Windows.ApplicationModel.UserDataTasks.UserDataTaskRegenerationProperties");
 RT_ENUM! { enum UserDataTaskRegenerationUnit: i32 {
     Daily (UserDataTaskRegenerationUnit_Daily) = 0, Weekly (UserDataTaskRegenerationUnit_Weekly) = 1, Monthly (UserDataTaskRegenerationUnit_Monthly) = 2, Yearly (UserDataTaskRegenerationUnit_Yearly) = 4,
 }}
@@ -20905,7 +20905,7 @@ impl UserActivityAttribution {
         <Self as RtActivatable<IUserActivityAttributionFactory>>::get_activation_factory().create_with_uri(iconUri)
     }}
 }
-DEFINE_CLSID!(UserActivityAttribution(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,65,99,116,105,118,105,116,105,101,115,46,85,115,101,114,65,99,116,105,118,105,116,121,65,116,116,114,105,98,117,116,105,111,110,0]) [CLSID_UserActivityAttribution]);
+DEFINE_CLSID!(UserActivityAttribution: "Windows.ApplicationModel.UserActivities.UserActivityAttribution");
 DEFINE_IID!(IID_IUserActivityAttributionFactory, 3861631570, 50534, 20290, 153, 116, 145, 108, 77, 118, 55, 126);
 RT_INTERFACE!{static interface IUserActivityAttributionFactory(IUserActivityAttributionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivityAttributionFactory] {
     fn CreateWithUri(&self, iconUri: *mut super::super::foundation::Uri, out: *mut *mut UserActivityAttribution) -> HRESULT
@@ -20947,7 +20947,7 @@ impl UserActivityChannel {
         <Self as RtActivatable<IUserActivityChannelStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(UserActivityChannel(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,65,99,116,105,118,105,116,105,101,115,46,85,115,101,114,65,99,116,105,118,105,116,121,67,104,97,110,110,101,108,0]) [CLSID_UserActivityChannel]);
+DEFINE_CLSID!(UserActivityChannel: "Windows.ApplicationModel.UserActivities.UserActivityChannel");
 DEFINE_IID!(IID_IUserActivityChannelStatics, 3368027563, 6541, 19840, 171, 178, 201, 119, 94, 196, 167, 41);
 RT_INTERFACE!{static interface IUserActivityChannelStatics(IUserActivityChannelStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivityChannelStatics] {
     fn GetDefault(&self, out: *mut *mut UserActivityChannel) -> HRESULT
@@ -20977,7 +20977,7 @@ impl UserActivityContentInfo {
         <Self as RtActivatable<IUserActivityContentInfoStatics>>::get_activation_factory().from_json(value)
     }}
 }
-DEFINE_CLSID!(UserActivityContentInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,65,99,116,105,118,105,116,105,101,115,46,85,115,101,114,65,99,116,105,118,105,116,121,67,111,110,116,101,110,116,73,110,102,111,0]) [CLSID_UserActivityContentInfo]);
+DEFINE_CLSID!(UserActivityContentInfo: "Windows.ApplicationModel.UserActivities.UserActivityContentInfo");
 DEFINE_IID!(IID_IUserActivityContentInfoStatics, 2575876939, 902, 19401, 150, 138, 130, 0, 176, 4, 20, 79);
 RT_INTERFACE!{static interface IUserActivityContentInfoStatics(IUserActivityContentInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivityContentInfoStatics] {
     fn FromJson(&self, value: HSTRING, out: *mut *mut UserActivityContentInfo) -> HRESULT
@@ -21077,7 +21077,7 @@ impl CoreUserActivityManager {
         <Self as RtActivatable<ICoreUserActivityManagerStatics>>::get_activation_factory().delete_user_activity_sessions_in_time_range_async(channel, startTime, endTime)
     }}
 }
-DEFINE_CLSID!(CoreUserActivityManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,65,99,116,105,118,105,116,105,101,115,46,67,111,114,101,46,67,111,114,101,85,115,101,114,65,99,116,105,118,105,116,121,77,97,110,97,103,101,114,0]) [CLSID_CoreUserActivityManager]);
+DEFINE_CLSID!(CoreUserActivityManager: "Windows.ApplicationModel.UserActivities.Core.CoreUserActivityManager");
 DEFINE_IID!(IID_ICoreUserActivityManagerStatics, 3392854786, 42174, 19789, 191, 168, 103, 149, 244, 38, 78, 251);
 RT_INTERFACE!{static interface ICoreUserActivityManagerStatics(ICoreUserActivityManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreUserActivityManagerStatics] {
     fn CreateUserActivitySessionInBackground(&self, activity: *mut super::UserActivity, out: *mut *mut super::UserActivitySession) -> HRESULT,
@@ -21300,7 +21300,7 @@ impl UserDataAccountManager {
         <Self as RtActivatable<IUserDataAccountManagerStatics2>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(UserDataAccountManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,65,99,99,111,117,110,116,115,46,85,115,101,114,68,97,116,97,65,99,99,111,117,110,116,77,97,110,97,103,101,114,0]) [CLSID_UserDataAccountManager]);
+DEFINE_CLSID!(UserDataAccountManager: "Windows.ApplicationModel.UserDataAccounts.UserDataAccountManager");
 DEFINE_IID!(IID_IUserDataAccountManagerForUser, 1453779163, 56207, 16811, 166, 95, 140, 89, 113, 170, 201, 130);
 RT_INTERFACE!{interface IUserDataAccountManagerForUser(IUserDataAccountManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountManagerForUser] {
     fn RequestStoreAsync(&self, storeAccessType: UserDataAccountStoreAccessType, out: *mut *mut super::super::foundation::IAsyncOperation<UserDataAccountStore>) -> HRESULT,
@@ -21723,7 +21723,7 @@ impl IDeviceAccountConfiguration {
 }
 RT_CLASS!{class DeviceAccountConfiguration: IDeviceAccountConfiguration}
 impl RtActivatable<IActivationFactory> for DeviceAccountConfiguration {}
-DEFINE_CLSID!(DeviceAccountConfiguration(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,65,99,99,111,117,110,116,115,46,83,121,115,116,101,109,65,99,99,101,115,115,46,68,101,118,105,99,101,65,99,99,111,117,110,116,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_DeviceAccountConfiguration]);
+DEFINE_CLSID!(DeviceAccountConfiguration: "Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountConfiguration");
 DEFINE_IID!(IID_IDeviceAccountConfiguration2, 4071810470, 29325, 19018, 137, 69, 43, 248, 88, 1, 54, 222);
 RT_INTERFACE!{interface IDeviceAccountConfiguration2(IDeviceAccountConfiguration2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceAccountConfiguration2] {
     #[cfg(not(feature="windows-security"))] fn __Dummy0(&self) -> (),
@@ -22074,7 +22074,7 @@ impl UserDataAccountSystemAccessManager {
         <Self as RtActivatable<IUserDataAccountSystemAccessManagerStatics2>>::get_activation_factory().get_device_account_configuration_async(accountId)
     }}
 }
-DEFINE_CLSID!(UserDataAccountSystemAccessManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,65,99,99,111,117,110,116,115,46,83,121,115,116,101,109,65,99,99,101,115,115,46,85,115,101,114,68,97,116,97,65,99,99,111,117,110,116,83,121,115,116,101,109,65,99,99,101,115,115,77,97,110,97,103,101,114,0]) [CLSID_UserDataAccountSystemAccessManager]);
+DEFINE_CLSID!(UserDataAccountSystemAccessManager: "Windows.ApplicationModel.UserDataAccounts.SystemAccess.UserDataAccountSystemAccessManager");
 DEFINE_IID!(IID_IUserDataAccountSystemAccessManagerStatics, 2641039801, 52197, 17909, 130, 43, 194, 103, 184, 29, 189, 182);
 RT_INTERFACE!{static interface IUserDataAccountSystemAccessManagerStatics(IUserDataAccountSystemAccessManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountSystemAccessManagerStatics] {
     fn AddAndShowDeviceAccountsAsync(&self, accounts: *mut ::rt::gen::windows::foundation::collections::IIterable<DeviceAccountConfiguration>, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<::rt::gen::windows::foundation::collections::IVectorView<HString>>) -> HRESULT
@@ -22246,7 +22246,7 @@ impl AppExtensionCatalog {
         <Self as RtActivatable<IAppExtensionCatalogStatics>>::get_activation_factory().open(appExtensionName)
     }}
 }
-DEFINE_CLSID!(AppExtensionCatalog(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,69,120,116,101,110,115,105,111,110,115,46,65,112,112,69,120,116,101,110,115,105,111,110,67,97,116,97,108,111,103,0]) [CLSID_AppExtensionCatalog]);
+DEFINE_CLSID!(AppExtensionCatalog: "Windows.ApplicationModel.AppExtensions.AppExtensionCatalog");
 DEFINE_IID!(IID_IAppExtensionCatalogStatics, 1010198154, 24344, 20235, 156, 229, 202, 182, 29, 25, 111, 17);
 RT_INTERFACE!{static interface IAppExtensionCatalogStatics(IAppExtensionCatalogStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtensionCatalogStatics] {
     fn Open(&self, appExtensionName: HSTRING, out: *mut *mut AppExtensionCatalog) -> HRESULT
@@ -22391,7 +22391,7 @@ impl LockApplicationHost {
         <Self as RtActivatable<ILockApplicationHostStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(LockApplicationHost(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,76,111,99,107,83,99,114,101,101,110,46,76,111,99,107,65,112,112,108,105,99,97,116,105,111,110,72,111,115,116,0]) [CLSID_LockApplicationHost]);
+DEFINE_CLSID!(LockApplicationHost: "Windows.ApplicationModel.LockScreen.LockApplicationHost");
 DEFINE_IID!(IID_ILockApplicationHostStatics, 4103056270, 9175, 20067, 150, 161, 102, 111, 245, 45, 59, 44);
 RT_INTERFACE!{static interface ILockApplicationHostStatics(ILockApplicationHostStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILockApplicationHostStatics] {
     fn GetForCurrentView(&self, out: *mut *mut LockApplicationHost) -> HRESULT
@@ -22680,7 +22680,7 @@ impl IPaymentAddress {
 }
 RT_CLASS!{class PaymentAddress: IPaymentAddress}
 impl RtActivatable<IActivationFactory> for PaymentAddress {}
-DEFINE_CLSID!(PaymentAddress(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,65,100,100,114,101,115,115,0]) [CLSID_PaymentAddress]);
+DEFINE_CLSID!(PaymentAddress: "Windows.ApplicationModel.Payments.PaymentAddress");
 DEFINE_IID!(IID_IPaymentCanMakePaymentResult, 1989606997, 54739, 19773, 179, 69, 69, 89, 23, 89, 197, 16);
 RT_INTERFACE!{interface IPaymentCanMakePaymentResult(IPaymentCanMakePaymentResultVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentCanMakePaymentResult] {
     fn get_Status(&self, out: *mut PaymentCanMakePaymentResultStatus) -> HRESULT
@@ -22699,7 +22699,7 @@ impl PaymentCanMakePaymentResult {
         <Self as RtActivatable<IPaymentCanMakePaymentResultFactory>>::get_activation_factory().create(value)
     }}
 }
-DEFINE_CLSID!(PaymentCanMakePaymentResult(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,67,97,110,77,97,107,101,80,97,121,109,101,110,116,82,101,115,117,108,116,0]) [CLSID_PaymentCanMakePaymentResult]);
+DEFINE_CLSID!(PaymentCanMakePaymentResult: "Windows.ApplicationModel.Payments.PaymentCanMakePaymentResult");
 DEFINE_IID!(IID_IPaymentCanMakePaymentResultFactory, 3151800894, 32073, 20329, 170, 83, 42, 15, 129, 100, 183, 201);
 RT_INTERFACE!{static interface IPaymentCanMakePaymentResultFactory(IPaymentCanMakePaymentResultFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentCanMakePaymentResultFactory] {
     fn Create(&self, value: PaymentCanMakePaymentResultStatus, out: *mut *mut PaymentCanMakePaymentResult) -> HRESULT
@@ -22762,7 +22762,7 @@ impl PaymentCurrencyAmount {
         <Self as RtActivatable<IPaymentCurrencyAmountFactory>>::get_activation_factory().create_with_currency_system(value, currency, currencySystem)
     }}
 }
-DEFINE_CLSID!(PaymentCurrencyAmount(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,67,117,114,114,101,110,99,121,65,109,111,117,110,116,0]) [CLSID_PaymentCurrencyAmount]);
+DEFINE_CLSID!(PaymentCurrencyAmount: "Windows.ApplicationModel.Payments.PaymentCurrencyAmount");
 DEFINE_IID!(IID_IPaymentCurrencyAmountFactory, 844616504, 5132, 17781, 133, 53, 247, 115, 23, 140, 9, 167);
 RT_INTERFACE!{static interface IPaymentCurrencyAmountFactory(IPaymentCurrencyAmountFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentCurrencyAmountFactory] {
     fn Create(&self, value: HSTRING, currency: HSTRING, out: *mut *mut PaymentCurrencyAmount) -> HRESULT,
@@ -22840,7 +22840,7 @@ impl PaymentDetails {
         <Self as RtActivatable<IPaymentDetailsFactory>>::get_activation_factory().create_with_display_items(total, displayItems)
     }}
 }
-DEFINE_CLSID!(PaymentDetails(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,68,101,116,97,105,108,115,0]) [CLSID_PaymentDetails]);
+DEFINE_CLSID!(PaymentDetails: "Windows.ApplicationModel.Payments.PaymentDetails");
 DEFINE_IID!(IID_IPaymentDetailsFactory, 3488133102, 49386, 19617, 139, 199, 109, 230, 123, 31, 55, 99);
 RT_INTERFACE!{static interface IPaymentDetailsFactory(IPaymentDetailsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentDetailsFactory] {
     fn Create(&self, total: *mut PaymentItem, out: *mut *mut PaymentDetails) -> HRESULT,
@@ -22900,7 +22900,7 @@ impl PaymentDetailsModifier {
         <Self as RtActivatable<IPaymentDetailsModifierFactory>>::get_activation_factory().create_with_additional_display_items_and_json_data(supportedMethodIds, total, additionalDisplayItems, jsonData)
     }}
 }
-DEFINE_CLSID!(PaymentDetailsModifier(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,68,101,116,97,105,108,115,77,111,100,105,102,105,101,114,0]) [CLSID_PaymentDetailsModifier]);
+DEFINE_CLSID!(PaymentDetailsModifier: "Windows.ApplicationModel.Payments.PaymentDetailsModifier");
 DEFINE_IID!(IID_IPaymentDetailsModifierFactory, 2030064262, 21726, 17052, 158, 79, 93, 206, 110, 16, 235, 206);
 RT_INTERFACE!{static interface IPaymentDetailsModifierFactory(IPaymentDetailsModifierFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentDetailsModifierFactory] {
     fn Create(&self, supportedMethodIds: *mut super::super::foundation::collections::IIterable<HString>, total: *mut PaymentItem, out: *mut *mut PaymentDetailsModifier) -> HRESULT,
@@ -22969,7 +22969,7 @@ impl PaymentItem {
         <Self as RtActivatable<IPaymentItemFactory>>::get_activation_factory().create(label, amount)
     }}
 }
-DEFINE_CLSID!(PaymentItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,73,116,101,109,0]) [CLSID_PaymentItem]);
+DEFINE_CLSID!(PaymentItem: "Windows.ApplicationModel.Payments.PaymentItem");
 DEFINE_IID!(IID_IPaymentItemFactory, 3333126872, 9475, 19741, 167, 120, 2, 178, 229, 146, 123, 44);
 RT_INTERFACE!{static interface IPaymentItemFactory(IPaymentItemFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentItemFactory] {
     fn Create(&self, label: HSTRING, amount: *mut PaymentCurrencyAmount, out: *mut *mut PaymentItem) -> HRESULT
@@ -23006,7 +23006,7 @@ impl IPaymentMediator {
 }
 RT_CLASS!{class PaymentMediator: IPaymentMediator}
 impl RtActivatable<IActivationFactory> for PaymentMediator {}
-DEFINE_CLSID!(PaymentMediator(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,77,101,100,105,97,116,111,114,0]) [CLSID_PaymentMediator]);
+DEFINE_CLSID!(PaymentMediator: "Windows.ApplicationModel.Payments.PaymentMediator");
 DEFINE_IID!(IID_IPaymentMediator2, 3471808753, 58375, 16680, 142, 115, 217, 61, 95, 130, 39, 134);
 RT_INTERFACE!{interface IPaymentMediator2(IPaymentMediator2Vtbl): IInspectable(IInspectableVtbl) [IID_IPaymentMediator2] {
     fn CanMakePaymentAsync(&self, paymentRequest: *mut PaymentRequest, out: *mut *mut super::super::foundation::IAsyncOperation<PaymentCanMakePaymentResult>) -> HRESULT
@@ -23043,7 +23043,7 @@ impl PaymentMerchantInfo {
         <Self as RtActivatable<IPaymentMerchantInfoFactory>>::get_activation_factory().create(uri)
     }}
 }
-DEFINE_CLSID!(PaymentMerchantInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,77,101,114,99,104,97,110,116,73,110,102,111,0]) [CLSID_PaymentMerchantInfo]);
+DEFINE_CLSID!(PaymentMerchantInfo: "Windows.ApplicationModel.Payments.PaymentMerchantInfo");
 DEFINE_IID!(IID_IPaymentMerchantInfoFactory, 2659831507, 52407, 16743, 168, 236, 225, 10, 233, 109, 188, 209);
 RT_INTERFACE!{static interface IPaymentMerchantInfoFactory(IPaymentMerchantInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentMerchantInfoFactory] {
     fn Create(&self, uri: *mut super::super::foundation::Uri, out: *mut *mut PaymentMerchantInfo) -> HRESULT
@@ -23082,7 +23082,7 @@ impl PaymentMethodData {
         <Self as RtActivatable<IPaymentMethodDataFactory>>::get_activation_factory().create_with_json_data(supportedMethodIds, jsonData)
     }}
 }
-DEFINE_CLSID!(PaymentMethodData(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,77,101,116,104,111,100,68,97,116,97,0]) [CLSID_PaymentMethodData]);
+DEFINE_CLSID!(PaymentMethodData: "Windows.ApplicationModel.Payments.PaymentMethodData");
 DEFINE_IID!(IID_IPaymentMethodDataFactory, 2329793151, 39850, 19074, 131, 66, 168, 33, 9, 146, 163, 107);
 RT_INTERFACE!{static interface IPaymentMethodDataFactory(IPaymentMethodDataFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentMethodDataFactory] {
     fn Create(&self, supportedMethodIds: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut PaymentMethodData) -> HRESULT,
@@ -23165,7 +23165,7 @@ impl IPaymentOptions {
 }
 RT_CLASS!{class PaymentOptions: IPaymentOptions}
 impl RtActivatable<IActivationFactory> for PaymentOptions {}
-DEFINE_CLSID!(PaymentOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,79,112,116,105,111,110,115,0]) [CLSID_PaymentOptions]);
+DEFINE_CLSID!(PaymentOptions: "Windows.ApplicationModel.Payments.PaymentOptions");
 DEFINE_IID!(IID_IPaymentRequest, 3075031777, 60795, 18411, 188, 8, 120, 204, 93, 104, 150, 182);
 RT_INTERFACE!{interface IPaymentRequest(IPaymentRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentRequest] {
     fn get_MerchantInfo(&self, out: *mut *mut PaymentMerchantInfo) -> HRESULT,
@@ -23212,7 +23212,7 @@ impl PaymentRequest {
         <Self as RtActivatable<IPaymentRequestFactory2>>::get_activation_factory().create_with_merchant_info_options_and_id(details, methodData, merchantInfo, options, id)
     }}
 }
-DEFINE_CLSID!(PaymentRequest(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,82,101,113,117,101,115,116,0]) [CLSID_PaymentRequest]);
+DEFINE_CLSID!(PaymentRequest: "Windows.ApplicationModel.Payments.PaymentRequest");
 DEFINE_IID!(IID_IPaymentRequest2, 3057438645, 22936, 18750, 160, 76, 103, 4, 138, 80, 241, 65);
 RT_INTERFACE!{interface IPaymentRequest2(IPaymentRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IPaymentRequest2] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT
@@ -23311,7 +23311,7 @@ impl PaymentRequestChangedResult {
         <Self as RtActivatable<IPaymentRequestChangedResultFactory>>::get_activation_factory().create_with_payment_details(changeAcceptedByMerchant, updatedPaymentDetails)
     }}
 }
-DEFINE_CLSID!(PaymentRequestChangedResult(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,82,101,113,117,101,115,116,67,104,97,110,103,101,100,82,101,115,117,108,116,0]) [CLSID_PaymentRequestChangedResult]);
+DEFINE_CLSID!(PaymentRequestChangedResult: "Windows.ApplicationModel.Payments.PaymentRequestChangedResult");
 DEFINE_IID!(IID_IPaymentRequestChangedResultFactory, 141823830, 7475, 17457, 129, 75, 103, 234, 36, 191, 33, 219);
 RT_INTERFACE!{static interface IPaymentRequestChangedResultFactory(IPaymentRequestChangedResultFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentRequestChangedResultFactory] {
     fn Create(&self, changeAcceptedByMerchant: bool, out: *mut *mut PaymentRequestChangedResult) -> HRESULT,
@@ -23500,7 +23500,7 @@ impl PaymentShippingOption {
         <Self as RtActivatable<IPaymentShippingOptionFactory>>::get_activation_factory().create_with_selected_and_tag(label, amount, selected, tag)
     }}
 }
-DEFINE_CLSID!(PaymentShippingOption(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,83,104,105,112,112,105,110,103,79,112,116,105,111,110,0]) [CLSID_PaymentShippingOption]);
+DEFINE_CLSID!(PaymentShippingOption: "Windows.ApplicationModel.Payments.PaymentShippingOption");
 DEFINE_IID!(IID_IPaymentShippingOptionFactory, 1575352599, 45783, 17515, 157, 115, 97, 35, 251, 202, 59, 198);
 RT_INTERFACE!{static interface IPaymentShippingOptionFactory(IPaymentShippingOptionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentShippingOptionFactory] {
     fn Create(&self, label: HSTRING, amount: *mut PaymentCurrencyAmount, out: *mut *mut PaymentShippingOption) -> HRESULT,
@@ -23554,7 +23554,7 @@ impl PaymentToken {
         <Self as RtActivatable<IPaymentTokenFactory>>::get_activation_factory().create_with_json_details(paymentMethodId, jsonDetails)
     }}
 }
-DEFINE_CLSID!(PaymentToken(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,84,111,107,101,110,0]) [CLSID_PaymentToken]);
+DEFINE_CLSID!(PaymentToken: "Windows.ApplicationModel.Payments.PaymentToken");
 DEFINE_IID!(IID_IPaymentTokenFactory, 2559367082, 18259, 18692, 131, 115, 221, 123, 8, 185, 149, 193);
 RT_INTERFACE!{static interface IPaymentTokenFactory(IPaymentTokenFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentTokenFactory] {
     fn Create(&self, paymentMethodId: HSTRING, out: *mut *mut PaymentToken) -> HRESULT,
@@ -23615,7 +23615,7 @@ impl PaymentAppManager {
         <Self as RtActivatable<IPaymentAppManagerStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(PaymentAppManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,114,111,118,105,100,101,114,46,80,97,121,109,101,110,116,65,112,112,77,97,110,97,103,101,114,0]) [CLSID_PaymentAppManager]);
+DEFINE_CLSID!(PaymentAppManager: "Windows.ApplicationModel.Payments.Provider.PaymentAppManager");
 DEFINE_IID!(IID_IPaymentAppManagerStatics, 2738990120, 64649, 17414, 180, 217, 52, 231, 254, 121, 223, 182);
 RT_INTERFACE!{static interface IPaymentAppManagerStatics(IPaymentAppManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentAppManagerStatics] {
     fn get_Current(&self, out: *mut *mut PaymentAppManager) -> HRESULT
@@ -23701,7 +23701,7 @@ impl PaymentTransaction {
         <Self as RtActivatable<IPaymentTransactionStatics>>::get_activation_factory().from_id_async(id)
     }}
 }
-DEFINE_CLSID!(PaymentTransaction(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,114,111,118,105,100,101,114,46,80,97,121,109,101,110,116,84,114,97,110,115,97,99,116,105,111,110,0]) [CLSID_PaymentTransaction]);
+DEFINE_CLSID!(PaymentTransaction: "Windows.ApplicationModel.Payments.Provider.PaymentTransaction");
 DEFINE_IID!(IID_IPaymentTransactionAcceptResult, 101593718, 54028, 18455, 149, 162, 223, 122, 233, 39, 59, 86);
 RT_INTERFACE!{interface IPaymentTransactionAcceptResult(IPaymentTransactionAcceptResultVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentTransactionAcceptResult] {
     fn get_Status(&self, out: *mut super::PaymentRequestCompletionStatus) -> HRESULT
@@ -23765,7 +23765,7 @@ impl ResourceLoader {
         <Self as RtActivatable<IResourceLoaderStatics2>>::get_activation_factory().get_for_view_independent_use_with_name(name)
     }}
 }
-DEFINE_CLSID!(ResourceLoader(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,82,101,115,111,117,114,99,101,115,46,82,101,115,111,117,114,99,101,76,111,97,100,101,114,0]) [CLSID_ResourceLoader]);
+DEFINE_CLSID!(ResourceLoader: "Windows.ApplicationModel.Resources.ResourceLoader");
 DEFINE_IID!(IID_IResourceLoader2, 283864774, 33080, 18625, 188, 101, 225, 241, 66, 7, 54, 124);
 RT_INTERFACE!{interface IResourceLoader2(IResourceLoader2Vtbl): IInspectable(IInspectableVtbl) [IID_IResourceLoader2] {
     fn GetStringForUri(&self, uri: *mut super::super::foundation::Uri, out: *mut HSTRING) -> HRESULT
@@ -24004,7 +24004,7 @@ impl ResourceContext {
         <Self as RtActivatable<IResourceContextStatics3>>::get_activation_factory().set_global_qualifier_value_with_persistence(key, value, persistence)
     }}
 }
-DEFINE_CLSID!(ResourceContext(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,82,101,115,111,117,114,99,101,115,46,67,111,114,101,46,82,101,115,111,117,114,99,101,67,111,110,116,101,120,116,0]) [CLSID_ResourceContext]);
+DEFINE_CLSID!(ResourceContext: "Windows.ApplicationModel.Resources.Core.ResourceContext");
 RT_CLASS!{class ResourceContextLanguagesVectorView: ::rt::gen::windows::foundation::collections::IVectorView<HString>}
 DEFINE_IID!(IID_IResourceContextStatics, 2562628972, 25400, 19249, 153, 223, 178, 180, 66, 241, 113, 73);
 RT_INTERFACE!{static interface IResourceContextStatics(IResourceContextStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IResourceContextStatics] {
@@ -24105,7 +24105,7 @@ impl ResourceManager {
         <Self as RtActivatable<IResourceManagerStatics>>::get_activation_factory().is_resource_reference(resourceReference)
     }}
 }
-DEFINE_CLSID!(ResourceManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,82,101,115,111,117,114,99,101,115,46,67,111,114,101,46,82,101,115,111,117,114,99,101,77,97,110,97,103,101,114,0]) [CLSID_ResourceManager]);
+DEFINE_CLSID!(ResourceManager: "Windows.ApplicationModel.Resources.Core.ResourceManager");
 DEFINE_IID!(IID_IResourceManager2, 2640772716, 42199, 19491, 158, 133, 103, 95, 48, 76, 37, 45);
 RT_INTERFACE!{interface IResourceManager2(IResourceManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IResourceManager2] {
     fn GetAllNamedResourcesForPackage(&self, packageName: HSTRING, resourceLayoutInfo: ResourceLayoutInfo, out: *mut *mut ::rt::gen::windows::foundation::collections::IVectorView<NamedResource>) -> HRESULT,
@@ -24309,7 +24309,7 @@ impl ResourceIndexer {
         <Self as RtActivatable<IResourceIndexerFactory2>>::get_activation_factory().create_resource_indexer_with_extension(projectRoot, extensionDllPath)
     }}
 }
-DEFINE_CLSID!(ResourceIndexer(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,82,101,115,111,117,114,99,101,115,46,77,97,110,97,103,101,109,101,110,116,46,82,101,115,111,117,114,99,101,73,110,100,101,120,101,114,0]) [CLSID_ResourceIndexer]);
+DEFINE_CLSID!(ResourceIndexer: "Windows.ApplicationModel.Resources.Management.ResourceIndexer");
 DEFINE_IID!(IID_IResourceIndexerFactory, 3101572873, 12749, 19863, 189, 48, 141, 57, 247, 66, 188, 97);
 RT_INTERFACE!{static interface IResourceIndexerFactory(IResourceIndexerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IResourceIndexerFactory] {
     fn CreateResourceIndexer(&self, projectRoot: *mut ::rt::gen::windows::foundation::Uri, out: *mut *mut ResourceIndexer) -> HRESULT
@@ -24451,7 +24451,7 @@ impl CurrentApp {
         <Self as RtActivatable<ICurrentAppWithConsumables>>::get_activation_factory().get_unfulfilled_consumables_async()
     }}
 }
-DEFINE_CLSID!(CurrentApp(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,67,117,114,114,101,110,116,65,112,112,0]) [CLSID_CurrentApp]);
+DEFINE_CLSID!(CurrentApp: "Windows.ApplicationModel.Store.CurrentApp");
 DEFINE_IID!(IID_ICurrentApp2Statics, 3746459181, 12657, 19155, 134, 20, 44, 97, 36, 67, 115, 203);
 RT_INTERFACE!{static interface ICurrentApp2Statics(ICurrentApp2StaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICurrentApp2Statics] {
     fn GetCustomerPurchaseIdAsync(&self, serviceTicket: HSTRING, publisherUserId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -24583,7 +24583,7 @@ impl CurrentAppSimulator {
         <Self as RtActivatable<ICurrentAppSimulatorWithConsumables>>::get_activation_factory().get_unfulfilled_consumables_async()
     }}
 }
-DEFINE_CLSID!(CurrentAppSimulator(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,67,117,114,114,101,110,116,65,112,112,83,105,109,117,108,97,116,111,114,0]) [CLSID_CurrentAppSimulator]);
+DEFINE_CLSID!(CurrentAppSimulator: "Windows.ApplicationModel.Store.CurrentAppSimulator");
 DEFINE_IID!(IID_ICurrentAppSimulatorStaticsWithFiltering, 1635676386, 63599, 19284, 150, 102, 221, 226, 133, 9, 44, 104);
 RT_INTERFACE!{static interface ICurrentAppSimulatorStaticsWithFiltering(ICurrentAppSimulatorStaticsWithFilteringVtbl): IInspectable(IInspectableVtbl) [IID_ICurrentAppSimulatorStaticsWithFiltering] {
     fn LoadListingInformationByProductIdsAsync(&self, productIds: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut super::super::foundation::IAsyncOperation<ListingInformation>) -> HRESULT,
@@ -25008,7 +25008,7 @@ impl ProductPurchaseDisplayProperties {
         <Self as RtActivatable<IProductPurchaseDisplayPropertiesFactory>>::get_activation_factory().create_product_purchase_display_properties(name)
     }}
 }
-DEFINE_CLSID!(ProductPurchaseDisplayProperties(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,111,100,117,99,116,80,117,114,99,104,97,115,101,68,105,115,112,108,97,121,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_ProductPurchaseDisplayProperties]);
+DEFINE_CLSID!(ProductPurchaseDisplayProperties: "Windows.ApplicationModel.Store.ProductPurchaseDisplayProperties");
 DEFINE_IID!(IID_IProductPurchaseDisplayPropertiesFactory, 1867062772, 13014, 19264, 180, 116, 184, 48, 56, 164, 217, 207);
 RT_INTERFACE!{static interface IProductPurchaseDisplayPropertiesFactory(IProductPurchaseDisplayPropertiesFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IProductPurchaseDisplayPropertiesFactory] {
     fn CreateProductPurchaseDisplayProperties(&self, name: HSTRING, out: *mut *mut ProductPurchaseDisplayProperties) -> HRESULT
@@ -25158,7 +25158,7 @@ impl StoreConfiguration {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().should_restrict_to_enterprise_store_only_for_user(user)
     }}
 }
-DEFINE_CLSID!(StoreConfiguration(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,83,116,111,114,101,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_StoreConfiguration]);
+DEFINE_CLSID!(StoreConfiguration: "Windows.ApplicationModel.Store.Preview.StoreConfiguration");
 DEFINE_IID!(IID_IStoreConfigurationStatics, 1922006976, 34344, 17132, 132, 162, 7, 120, 14, 180, 77, 139);
 RT_INTERFACE!{static interface IStoreConfigurationStatics(IStoreConfigurationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStoreConfigurationStatics] {
     fn SetSystemConfiguration(&self, catalogHardwareManufacturerId: HSTRING, catalogStoreContentModifierId: HSTRING, systemConfigurationExpiration: ::rt::gen::windows::foundation::DateTime, catalogHardwareDescriptor: HSTRING) -> HRESULT,
@@ -25370,7 +25370,7 @@ impl StorePreview {
         <Self as RtActivatable<IStorePreview>>::get_activation_factory().load_add_on_product_infos_async()
     }}
 }
-DEFINE_CLSID!(StorePreview(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,83,116,111,114,101,80,114,101,118,105,101,119,0]) [CLSID_StorePreview]);
+DEFINE_CLSID!(StorePreview: "Windows.ApplicationModel.Store.Preview.StorePreview");
 DEFINE_IID!(IID_IStorePreviewProductInfo, 423091123, 27649, 19613, 133, 205, 91, 171, 170, 194, 179, 81);
 RT_INTERFACE!{interface IStorePreviewProductInfo(IStorePreviewProductInfoVtbl): IInspectable(IInspectableVtbl) [IID_IStorePreviewProductInfo] {
     fn get_ProductId(&self, out: *mut HSTRING) -> HRESULT,
@@ -25512,7 +25512,7 @@ impl WebAuthenticationCoreManagerHelper {
         <Self as RtActivatable<IWebAuthenticationCoreManagerHelper>>::get_activation_factory().request_token_with_uielement_hosting_and_web_account_async(request, webAccount, uiElement)
     }}
 }
-DEFINE_CLSID!(WebAuthenticationCoreManagerHelper(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,87,101,98,65,117,116,104,101,110,116,105,99,97,116,105,111,110,67,111,114,101,77,97,110,97,103,101,114,72,101,108,112,101,114,0]) [CLSID_WebAuthenticationCoreManagerHelper]);
+DEFINE_CLSID!(WebAuthenticationCoreManagerHelper: "Windows.ApplicationModel.Store.Preview.WebAuthenticationCoreManagerHelper");
 pub mod installcontrol { // Windows.ApplicationModel.Store.Preview.InstallControl
 use ::prelude::*;
 DEFINE_IID!(IID_IAppInstallItem, 1238622123, 5770, 19647, 169, 58, 158, 68, 140, 130, 115, 125);
@@ -25739,7 +25739,7 @@ impl IAppInstallManager {
 }
 RT_CLASS!{class AppInstallManager: IAppInstallManager}
 impl RtActivatable<IActivationFactory> for AppInstallManager {}
-DEFINE_CLSID!(AppInstallManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,73,110,115,116,97,108,108,67,111,110,116,114,111,108,46,65,112,112,73,110,115,116,97,108,108,77,97,110,97,103,101,114,0]) [CLSID_AppInstallManager]);
+DEFINE_CLSID!(AppInstallManager: "Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallManager");
 DEFINE_IID!(IID_IAppInstallManager2, 378763345, 60727, 18445, 131, 20, 82, 226, 124, 3, 240, 74);
 RT_INTERFACE!{interface IAppInstallManager2(IAppInstallManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallManager2] {
     fn StartAppInstallWithTelemetryAsync(&self, productId: HSTRING, skuId: HSTRING, repair: bool, forceUseOfNonRemovableStorage: bool, catalogId: HSTRING, bundleId: HSTRING, correlationVector: HSTRING, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
@@ -25992,7 +25992,7 @@ impl LicenseManager {
         <Self as RtActivatable<ILicenseManagerStatics2>>::get_activation_factory().refresh_licenses_async(refreshOption)
     }}
 }
-DEFINE_CLSID!(LicenseManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,76,105,99,101,110,115,101,77,97,110,97,103,101,109,101,110,116,46,76,105,99,101,110,115,101,77,97,110,97,103,101,114,0]) [CLSID_LicenseManager]);
+DEFINE_CLSID!(LicenseManager: "Windows.ApplicationModel.Store.LicenseManagement.LicenseManager");
 DEFINE_IID!(IID_ILicenseManagerStatics, 3047963360, 55879, 20256, 154, 35, 9, 24, 44, 148, 118, 255);
 RT_INTERFACE!{static interface ILicenseManagerStatics(ILicenseManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILicenseManagerStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -26243,7 +26243,7 @@ impl IVoiceCommandContentTile {
 }
 RT_CLASS!{class VoiceCommandContentTile: IVoiceCommandContentTile}
 impl RtActivatable<IActivationFactory> for VoiceCommandContentTile {}
-DEFINE_CLSID!(VoiceCommandContentTile(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,67,111,110,116,101,110,116,84,105,108,101,0]) [CLSID_VoiceCommandContentTile]);
+DEFINE_CLSID!(VoiceCommandContentTile: "Windows.ApplicationModel.VoiceCommands.VoiceCommandContentTile");
 RT_ENUM! { enum VoiceCommandContentTileType: i32 {
     TitleOnly (VoiceCommandContentTileType_TitleOnly) = 0, TitleWithText (VoiceCommandContentTileType_TitleWithText) = 1, TitleWith68x68Icon (VoiceCommandContentTileType_TitleWith68x68Icon) = 2, TitleWith68x68IconAndText (VoiceCommandContentTileType_TitleWith68x68IconAndText) = 3, TitleWith68x92Icon (VoiceCommandContentTileType_TitleWith68x92Icon) = 4, TitleWith68x92IconAndText (VoiceCommandContentTileType_TitleWith68x92IconAndText) = 5, TitleWith280x140Icon (VoiceCommandContentTileType_TitleWith280x140Icon) = 6, TitleWith280x140IconAndText (VoiceCommandContentTileType_TitleWith280x140IconAndText) = 7,
 }}
@@ -26281,7 +26281,7 @@ impl VoiceCommandDefinitionManager {
         <Self as RtActivatable<IVoiceCommandDefinitionManagerStatics>>::get_activation_factory().get_installed_command_definitions()
     }}
 }
-DEFINE_CLSID!(VoiceCommandDefinitionManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,68,101,102,105,110,105,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_VoiceCommandDefinitionManager]);
+DEFINE_CLSID!(VoiceCommandDefinitionManager: "Windows.ApplicationModel.VoiceCommands.VoiceCommandDefinitionManager");
 DEFINE_IID!(IID_IVoiceCommandDefinitionManagerStatics, 2414323358, 1662, 20246, 161, 140, 91, 23, 233, 73, 153, 64);
 RT_INTERFACE!{static interface IVoiceCommandDefinitionManagerStatics(IVoiceCommandDefinitionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommandDefinitionManagerStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -26375,7 +26375,7 @@ impl VoiceCommandResponse {
         <Self as RtActivatable<IVoiceCommandResponseStatics>>::get_activation_factory().create_response_for_prompt_with_tiles(message, repeatMessage, contentTiles)
     }}
 }
-DEFINE_CLSID!(VoiceCommandResponse(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,82,101,115,112,111,110,115,101,0]) [CLSID_VoiceCommandResponse]);
+DEFINE_CLSID!(VoiceCommandResponse: "Windows.ApplicationModel.VoiceCommands.VoiceCommandResponse");
 DEFINE_IID!(IID_IVoiceCommandResponseStatics, 691206163, 3387, 18930, 150, 221, 98, 80, 25, 189, 59, 93);
 RT_INTERFACE!{static interface IVoiceCommandResponseStatics(IVoiceCommandResponseStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommandResponseStatics] {
     fn get_MaxSupportedVoiceCommandContentTiles(&self, out: *mut u32) -> HRESULT,
@@ -26483,7 +26483,7 @@ impl VoiceCommandServiceConnection {
         <Self as RtActivatable<IVoiceCommandServiceConnectionStatics>>::get_activation_factory().from_app_service_trigger_details(triggerDetails)
     }}
 }
-DEFINE_CLSID!(VoiceCommandServiceConnection(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,83,101,114,118,105,99,101,67,111,110,110,101,99,116,105,111,110,0]) [CLSID_VoiceCommandServiceConnection]);
+DEFINE_CLSID!(VoiceCommandServiceConnection: "Windows.ApplicationModel.VoiceCommands.VoiceCommandServiceConnection");
 DEFINE_IID!(IID_IVoiceCommandServiceConnectionStatics, 923713531, 11572, 17119, 135, 112, 7, 77, 15, 51, 70, 151);
 RT_INTERFACE!{static interface IVoiceCommandServiceConnectionStatics(IVoiceCommandServiceConnectionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommandServiceConnectionStatics] {
     fn FromAppServiceTriggerDetails(&self, triggerDetails: *mut super::appservice::AppServiceTriggerDetails, out: *mut *mut VoiceCommandServiceConnection) -> HRESULT
@@ -26524,7 +26524,7 @@ impl IVoiceCommandUserMessage {
 }
 RT_CLASS!{class VoiceCommandUserMessage: IVoiceCommandUserMessage}
 impl RtActivatable<IActivationFactory> for VoiceCommandUserMessage {}
-DEFINE_CLSID!(VoiceCommandUserMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,85,115,101,114,77,101,115,115,97,103,101,0]) [CLSID_VoiceCommandUserMessage]);
+DEFINE_CLSID!(VoiceCommandUserMessage: "Windows.ApplicationModel.VoiceCommands.VoiceCommandUserMessage");
 } // Windows.ApplicationModel.VoiceCommands
 pub mod preview { // Windows.ApplicationModel.Preview
 pub mod holographic { // Windows.ApplicationModel.Preview.Holographic
@@ -26539,7 +26539,7 @@ impl HolographicApplicationPreview {
         <Self as RtActivatable<IHolographicApplicationPreviewStatics>>::get_activation_factory().is_holographic_activation(activatedEventArgs)
     }}
 }
-DEFINE_CLSID!(HolographicApplicationPreview(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,114,101,118,105,101,119,46,72,111,108,111,103,114,97,112,104,105,99,46,72,111,108,111,103,114,97,112,104,105,99,65,112,112,108,105,99,97,116,105,111,110,80,114,101,118,105,101,119,0]) [CLSID_HolographicApplicationPreview]);
+DEFINE_CLSID!(HolographicApplicationPreview: "Windows.ApplicationModel.Preview.Holographic.HolographicApplicationPreview");
 DEFINE_IID!(IID_IHolographicApplicationPreviewStatics, 4261643921, 10810, 17833, 162, 8, 123, 237, 105, 25, 25, 243);
 RT_INTERFACE!{static interface IHolographicApplicationPreviewStatics(IHolographicApplicationPreviewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicApplicationPreviewStatics] {
     fn IsCurrentViewPresentedOnHolographicDisplay(&self, out: *mut bool) -> HRESULT,
@@ -26669,7 +26669,7 @@ impl NotesWindowManagerPreview {
         <Self as RtActivatable<INotesWindowManagerPreviewStatics>>::get_activation_factory().get_for_current_app()
     }}
 }
-DEFINE_CLSID!(NotesWindowManagerPreview(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,114,101,118,105,101,119,46,78,111,116,101,115,46,78,111,116,101,115,87,105,110,100,111,119,77,97,110,97,103,101,114,80,114,101,118,105,101,119,0]) [CLSID_NotesWindowManagerPreview]);
+DEFINE_CLSID!(NotesWindowManagerPreview: "Windows.ApplicationModel.Preview.Notes.NotesWindowManagerPreview");
 DEFINE_IID!(IID_INotesWindowManagerPreview2, 3992880714, 8020, 19209, 152, 35, 255, 71, 127, 111, 163, 188);
 RT_INTERFACE!{interface INotesWindowManagerPreview2(INotesWindowManagerPreview2Vtbl): IInspectable(IInspectableVtbl) [IID_INotesWindowManagerPreview2] {
     fn ShowNoteRelativeToWithOptions(&self, noteViewId: i32, anchorNoteViewId: i32, options: *mut NotesWindowManagerPreviewShowNoteOptions) -> HRESULT,
@@ -26715,7 +26715,7 @@ impl INotesWindowManagerPreviewShowNoteOptions {
 }
 RT_CLASS!{class NotesWindowManagerPreviewShowNoteOptions: INotesWindowManagerPreviewShowNoteOptions}
 impl RtActivatable<IActivationFactory> for NotesWindowManagerPreviewShowNoteOptions {}
-DEFINE_CLSID!(NotesWindowManagerPreviewShowNoteOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,114,101,118,105,101,119,46,78,111,116,101,115,46,78,111,116,101,115,87,105,110,100,111,119,77,97,110,97,103,101,114,80,114,101,118,105,101,119,83,104,111,119,78,111,116,101,79,112,116,105,111,110,115,0]) [CLSID_NotesWindowManagerPreviewShowNoteOptions]);
+DEFINE_CLSID!(NotesWindowManagerPreviewShowNoteOptions: "Windows.ApplicationModel.Preview.Notes.NotesWindowManagerPreviewShowNoteOptions");
 DEFINE_IID!(IID_INotesWindowManagerPreviewStatics, 1718144136, 2702, 16679, 163, 142, 153, 84, 69, 134, 138, 120);
 RT_INTERFACE!{static interface INotesWindowManagerPreviewStatics(INotesWindowManagerPreviewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_INotesWindowManagerPreviewStatics] {
     fn GetForCurrentApp(&self, out: *mut *mut NotesWindowManagerPreview) -> HRESULT
@@ -26766,7 +26766,7 @@ impl InkWorkspaceHostedAppManager {
         <Self as RtActivatable<IInkWorkspaceHostedAppManagerStatics>>::get_activation_factory().get_for_current_app()
     }}
 }
-DEFINE_CLSID!(InkWorkspaceHostedAppManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,114,101,118,105,101,119,46,73,110,107,87,111,114,107,115,112,97,99,101,46,73,110,107,87,111,114,107,115,112,97,99,101,72,111,115,116,101,100,65,112,112,77,97,110,97,103,101,114,0]) [CLSID_InkWorkspaceHostedAppManager]);
+DEFINE_CLSID!(InkWorkspaceHostedAppManager: "Windows.ApplicationModel.Preview.InkWorkspace.InkWorkspaceHostedAppManager");
 DEFINE_IID!(IID_IInkWorkspaceHostedAppManagerStatics, 3422391493, 41314, 19396, 132, 238, 232, 113, 109, 82, 51, 197);
 RT_INTERFACE!{static interface IInkWorkspaceHostedAppManagerStatics(IInkWorkspaceHostedAppManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInkWorkspaceHostedAppManagerStatics] {
     fn GetForCurrentApp(&self, out: *mut *mut InkWorkspaceHostedAppManager) -> HRESULT
@@ -26818,7 +26818,7 @@ impl WalletBarcode {
         <Self as RtActivatable<IWalletBarcodeFactory>>::get_activation_factory().create_custom_wallet_barcode(streamToBarcodeImage)
     }}
 }
-DEFINE_CLSID!(WalletBarcode(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,66,97,114,99,111,100,101,0]) [CLSID_WalletBarcode]);
+DEFINE_CLSID!(WalletBarcode: "Windows.ApplicationModel.Wallet.WalletBarcode");
 DEFINE_IID!(IID_IWalletBarcodeFactory, 806449505, 60828, 18078, 187, 253, 48, 108, 149, 234, 113, 8);
 RT_INTERFACE!{static interface IWalletBarcodeFactory(IWalletBarcodeFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWalletBarcodeFactory] {
     fn CreateWalletBarcode(&self, symbology: WalletBarcodeSymbology, value: HSTRING, out: *mut *mut WalletBarcode) -> HRESULT,
@@ -27165,7 +27165,7 @@ impl WalletItem {
         <Self as RtActivatable<IWalletItemFactory>>::get_activation_factory().create_wallet_item(kind, displayName)
     }}
 }
-DEFINE_CLSID!(WalletItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,73,116,101,109,0]) [CLSID_WalletItem]);
+DEFINE_CLSID!(WalletItem: "Windows.ApplicationModel.Wallet.WalletItem");
 DEFINE_IID!(IID_IWalletItemCustomProperty, 3108716787, 64000, 16637, 152, 220, 157, 228, 102, 151, 241, 231);
 RT_INTERFACE!{interface IWalletItemCustomProperty(IWalletItemCustomPropertyVtbl): IInspectable(IInspectableVtbl) [IID_IWalletItemCustomProperty] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -27233,7 +27233,7 @@ impl WalletItemCustomProperty {
         <Self as RtActivatable<IWalletItemCustomPropertyFactory>>::get_activation_factory().create_wallet_item_custom_property(name, value)
     }}
 }
-DEFINE_CLSID!(WalletItemCustomProperty(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,73,116,101,109,67,117,115,116,111,109,80,114,111,112,101,114,116,121,0]) [CLSID_WalletItemCustomProperty]);
+DEFINE_CLSID!(WalletItemCustomProperty: "Windows.ApplicationModel.Wallet.WalletItemCustomProperty");
 DEFINE_IID!(IID_IWalletItemCustomPropertyFactory, 3489950276, 24993, 16810, 178, 89, 165, 97, 10, 181, 213, 117);
 RT_INTERFACE!{static interface IWalletItemCustomPropertyFactory(IWalletItemCustomPropertyFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWalletItemCustomPropertyFactory] {
     fn CreateWalletItemCustomProperty(&self, name: HSTRING, value: HSTRING, out: *mut *mut WalletItemCustomProperty) -> HRESULT
@@ -27349,7 +27349,7 @@ impl WalletManager {
         <Self as RtActivatable<IWalletManagerStatics>>::get_activation_factory().request_store_async()
     }}
 }
-DEFINE_CLSID!(WalletManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,77,97,110,97,103,101,114,0]) [CLSID_WalletManager]);
+DEFINE_CLSID!(WalletManager: "Windows.ApplicationModel.Wallet.WalletManager");
 DEFINE_IID!(IID_IWalletManagerStatics, 1360123576, 51620, 19556, 180, 221, 225, 229, 72, 0, 28, 13);
 RT_INTERFACE!{static interface IWalletManagerStatics(IWalletManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWalletManagerStatics] {
     fn RequestStoreAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<WalletItemStore>) -> HRESULT
@@ -27392,7 +27392,7 @@ impl IWalletRelevantLocation {
 }
 RT_CLASS!{class WalletRelevantLocation: IWalletRelevantLocation}
 impl RtActivatable<IActivationFactory> for WalletRelevantLocation {}
-DEFINE_CLSID!(WalletRelevantLocation(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,82,101,108,101,118,97,110,116,76,111,99,97,116,105,111,110,0]) [CLSID_WalletRelevantLocation]);
+DEFINE_CLSID!(WalletRelevantLocation: "Windows.ApplicationModel.Wallet.WalletRelevantLocation");
 RT_ENUM! { enum WalletSummaryViewPosition: i32 {
     Hidden (WalletSummaryViewPosition_Hidden) = 0, Field1 (WalletSummaryViewPosition_Field1) = 1, Field2 (WalletSummaryViewPosition_Field2) = 2,
 }}
@@ -27469,7 +27469,7 @@ impl IWalletTransaction {
 }
 RT_CLASS!{class WalletTransaction: IWalletTransaction}
 impl RtActivatable<IActivationFactory> for WalletTransaction {}
-DEFINE_CLSID!(WalletTransaction(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,84,114,97,110,115,97,99,116,105,111,110,0]) [CLSID_WalletTransaction]);
+DEFINE_CLSID!(WalletTransaction: "Windows.ApplicationModel.Wallet.WalletTransaction");
 DEFINE_IID!(IID_IWalletVerb, 397944534, 58305, 19572, 138, 148, 33, 122, 173, 188, 72, 132);
 RT_INTERFACE!{interface IWalletVerb(IWalletVerbVtbl): IInspectable(IInspectableVtbl) [IID_IWalletVerb] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -27493,7 +27493,7 @@ impl WalletVerb {
         <Self as RtActivatable<IWalletVerbFactory>>::get_activation_factory().create_wallet_verb(name)
     }}
 }
-DEFINE_CLSID!(WalletVerb(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,86,101,114,98,0]) [CLSID_WalletVerb]);
+DEFINE_CLSID!(WalletVerb: "Windows.ApplicationModel.Wallet.WalletVerb");
 DEFINE_IID!(IID_IWalletVerbFactory, 1979787121, 48728, 19806, 131, 237, 88, 177, 102, 156, 122, 217);
 RT_INTERFACE!{static interface IWalletVerbFactory(IWalletVerbFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWalletVerbFactory] {
     fn CreateWalletVerb(&self, name: HSTRING, out: *mut *mut WalletVerb) -> HRESULT
@@ -27570,7 +27570,7 @@ impl WalletManagerSystem {
         <Self as RtActivatable<IWalletManagerSystemStatics>>::get_activation_factory().request_store_async()
     }}
 }
-DEFINE_CLSID!(WalletManagerSystem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,83,121,115,116,101,109,46,87,97,108,108,101,116,77,97,110,97,103,101,114,83,121,115,116,101,109,0]) [CLSID_WalletManagerSystem]);
+DEFINE_CLSID!(WalletManagerSystem: "Windows.ApplicationModel.Wallet.System.WalletManagerSystem");
 DEFINE_IID!(IID_IWalletManagerSystemStatics, 3202935689, 9780, 19354, 139, 35, 238, 137, 3, 201, 31, 224);
 RT_INTERFACE!{static interface IWalletManagerSystemStatics(IWalletManagerSystemStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWalletManagerSystemStatics] {
     fn RequestStoreAsync(&self, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<WalletItemSystemStore>) -> HRESULT

--- a/src/rt/gen/windows/data.rs
+++ b/src/rt/gen/windows/data.rs
@@ -46,7 +46,7 @@ impl JsonArray {
         <Self as RtActivatable<IJsonArrayStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(JsonArray(&[87,105,110,100,111,119,115,46,68,97,116,97,46,74,115,111,110,46,74,115,111,110,65,114,114,97,121,0]) [CLSID_JsonArray]);
+DEFINE_CLSID!(JsonArray: "Windows.Data.Json.JsonArray");
 DEFINE_IID!(IID_IJsonArrayStatics, 3675534505, 57700, 18847, 147, 226, 138, 143, 73, 187, 144, 186);
 RT_INTERFACE!{static interface IJsonArrayStatics(IJsonArrayStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IJsonArrayStatics] {
     fn Parse(&self, input: HSTRING, out: *mut *mut JsonArray) -> HRESULT,
@@ -71,7 +71,7 @@ impl JsonError {
         <Self as RtActivatable<IJsonErrorStatics2>>::get_activation_factory().get_json_status(hresult)
     }}
 }
-DEFINE_CLSID!(JsonError(&[87,105,110,100,111,119,115,46,68,97,116,97,46,74,115,111,110,46,74,115,111,110,69,114,114,111,114,0]) [CLSID_JsonError]);
+DEFINE_CLSID!(JsonError: "Windows.Data.Json.JsonError");
 DEFINE_IID!(IID_IJsonErrorStatics2, 1077948634, 34768, 17260, 131, 171, 252, 123, 18, 192, 204, 38);
 RT_INTERFACE!{static interface IJsonErrorStatics2(IJsonErrorStatics2Vtbl): IInspectable(IInspectableVtbl) [IID_IJsonErrorStatics2] {
     fn GetJsonStatus(&self, hresult: i32, out: *mut JsonErrorStatus) -> HRESULT
@@ -143,7 +143,7 @@ impl JsonObject {
         <Self as RtActivatable<IJsonObjectStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(JsonObject(&[87,105,110,100,111,119,115,46,68,97,116,97,46,74,115,111,110,46,74,115,111,110,79,98,106,101,99,116,0]) [CLSID_JsonObject]);
+DEFINE_CLSID!(JsonObject: "Windows.Data.Json.JsonObject");
 DEFINE_IID!(IID_IJsonObjectStatics, 579465561, 21726, 17880, 171, 204, 34, 96, 63, 160, 102, 160);
 RT_INTERFACE!{static interface IJsonObjectStatics(IJsonObjectStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IJsonObjectStatics] {
     fn Parse(&self, input: HSTRING, out: *mut *mut JsonObject) -> HRESULT,
@@ -272,7 +272,7 @@ impl JsonValue {
         <Self as RtActivatable<IJsonValueStatics2>>::get_activation_factory().create_null_value()
     }}
 }
-DEFINE_CLSID!(JsonValue(&[87,105,110,100,111,119,115,46,68,97,116,97,46,74,115,111,110,46,74,115,111,110,86,97,108,117,101,0]) [CLSID_JsonValue]);
+DEFINE_CLSID!(JsonValue: "Windows.Data.Json.JsonValue");
 DEFINE_IID!(IID_IJsonValueStatics, 1600869450, 12115, 18657, 145, 163, 247, 139, 80, 166, 52, 92);
 RT_INTERFACE!{static interface IJsonValueStatics(IJsonValueStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IJsonValueStatics] {
     fn Parse(&self, input: HSTRING, out: *mut *mut JsonValue) -> HRESULT,
@@ -582,7 +582,7 @@ impl XmlDocument {
         <Self as RtActivatable<IXmlDocumentStatics>>::get_activation_factory().load_from_file_with_settings_async(file, loadSettings)
     }}
 }
-DEFINE_CLSID!(XmlDocument(&[87,105,110,100,111,119,115,46,68,97,116,97,46,88,109,108,46,68,111,109,46,88,109,108,68,111,99,117,109,101,110,116,0]) [CLSID_XmlDocument]);
+DEFINE_CLSID!(XmlDocument: "Windows.Data.Xml.Dom.XmlDocument");
 DEFINE_IID!(IID_IXmlDocumentFragment, 3807013526, 3105, 17573, 139, 201, 158, 74, 38, 39, 8, 236);
 RT_INTERFACE!{interface IXmlDocumentFragment(IXmlDocumentFragmentVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocumentFragment] {
     
@@ -836,7 +836,7 @@ impl IXmlLoadSettings {
 }
 RT_CLASS!{class XmlLoadSettings: IXmlLoadSettings}
 impl RtActivatable<IActivationFactory> for XmlLoadSettings {}
-DEFINE_CLSID!(XmlLoadSettings(&[87,105,110,100,111,119,115,46,68,97,116,97,46,88,109,108,46,68,111,109,46,88,109,108,76,111,97,100,83,101,116,116,105,110,103,115,0]) [CLSID_XmlLoadSettings]);
+DEFINE_CLSID!(XmlLoadSettings: "Windows.Data.Xml.Dom.XmlLoadSettings");
 DEFINE_IID!(IID_IXmlNamedNodeMap, 3014041264, 43696, 19330, 166, 250, 177, 69, 63, 124, 2, 27);
 RT_INTERFACE!{interface IXmlNamedNodeMap(IXmlNamedNodeMapVtbl): IInspectable(IInspectableVtbl) [IID_IXmlNamedNodeMap] {
     fn get_Length(&self, out: *mut u32) -> HRESULT,
@@ -1156,7 +1156,7 @@ impl XsltProcessor {
         <Self as RtActivatable<IXsltProcessorFactory>>::get_activation_factory().create_instance(document)
     }}
 }
-DEFINE_CLSID!(XsltProcessor(&[87,105,110,100,111,119,115,46,68,97,116,97,46,88,109,108,46,88,115,108,46,88,115,108,116,80,114,111,99,101,115,115,111,114,0]) [CLSID_XsltProcessor]);
+DEFINE_CLSID!(XsltProcessor: "Windows.Data.Xml.Xsl.XsltProcessor");
 DEFINE_IID!(IID_IXsltProcessor2, 2376358998, 38821, 17611, 168, 190, 39, 216, 98, 128, 199, 10);
 RT_INTERFACE!{interface IXsltProcessor2(IXsltProcessor2Vtbl): IInspectable(IInspectableVtbl) [IID_IXsltProcessor2] {
     fn TransformToDocument(&self, inputNode: *mut super::dom::IXmlNode, out: *mut *mut super::dom::XmlDocument) -> HRESULT
@@ -1201,7 +1201,7 @@ impl HtmlUtilities {
         <Self as RtActivatable<IHtmlUtilities>>::get_activation_factory().convert_to_text(html)
     }}
 }
-DEFINE_CLSID!(HtmlUtilities(&[87,105,110,100,111,119,115,46,68,97,116,97,46,72,116,109,108,46,72,116,109,108,85,116,105,108,105,116,105,101,115,0]) [CLSID_HtmlUtilities]);
+DEFINE_CLSID!(HtmlUtilities: "Windows.Data.Html.HtmlUtilities");
 } // Windows.Data.Html
 pub mod pdf { // Windows.Data.Pdf
 use ::prelude::*;
@@ -1244,7 +1244,7 @@ impl PdfDocument {
         <Self as RtActivatable<IPdfDocumentStatics>>::get_activation_factory().load_from_stream_with_password_async(inputStream, password)
     }}
 }
-DEFINE_CLSID!(PdfDocument(&[87,105,110,100,111,119,115,46,68,97,116,97,46,80,100,102,46,80,100,102,68,111,99,117,109,101,110,116,0]) [CLSID_PdfDocument]);
+DEFINE_CLSID!(PdfDocument: "Windows.Data.Pdf.PdfDocument");
 DEFINE_IID!(IID_IPdfDocumentStatics, 1127877471, 49159, 18312, 144, 242, 8, 20, 61, 146, 37, 153);
 RT_INTERFACE!{static interface IPdfDocumentStatics(IPdfDocumentStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPdfDocumentStatics] {
     #[cfg(feature="windows-storage")] fn LoadFromFileAsync(&self, file: *mut super::super::storage::IStorageFile, out: *mut *mut super::super::foundation::IAsyncOperation<PdfDocument>) -> HRESULT,
@@ -1441,7 +1441,7 @@ impl IPdfPageRenderOptions {
 }
 RT_CLASS!{class PdfPageRenderOptions: IPdfPageRenderOptions}
 impl RtActivatable<IActivationFactory> for PdfPageRenderOptions {}
-DEFINE_CLSID!(PdfPageRenderOptions(&[87,105,110,100,111,119,115,46,68,97,116,97,46,80,100,102,46,80,100,102,80,97,103,101,82,101,110,100,101,114,79,112,116,105,111,110,115,0]) [CLSID_PdfPageRenderOptions]);
+DEFINE_CLSID!(PdfPageRenderOptions: "Windows.Data.Pdf.PdfPageRenderOptions");
 RT_ENUM! { enum PdfPageRotation: i32 {
     Normal (PdfPageRotation_Normal) = 0, Rotate90 (PdfPageRotation_Rotate90) = 1, Rotate180 (PdfPageRotation_Rotate180) = 2, Rotate270 (PdfPageRotation_Rotate270) = 3,
 }}
@@ -1538,7 +1538,7 @@ impl SelectableWordsSegmenter {
         <Self as RtActivatable<ISelectableWordsSegmenterFactory>>::get_activation_factory().create_with_language(language)
     }}
 }
-DEFINE_CLSID!(SelectableWordsSegmenter(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,83,101,108,101,99,116,97,98,108,101,87,111,114,100,115,83,101,103,109,101,110,116,101,114,0]) [CLSID_SelectableWordsSegmenter]);
+DEFINE_CLSID!(SelectableWordsSegmenter: "Windows.Data.Text.SelectableWordsSegmenter");
 DEFINE_IID!(IID_ISelectableWordsSegmenterFactory, 2356835912, 24663, 17209, 188, 112, 242, 16, 1, 10, 65, 80);
 RT_INTERFACE!{static interface ISelectableWordsSegmenterFactory(ISelectableWordsSegmenterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISelectableWordsSegmenterFactory] {
     fn CreateWithLanguage(&self, language: HSTRING, out: *mut *mut SelectableWordsSegmenter) -> HRESULT
@@ -1577,7 +1577,7 @@ impl SemanticTextQuery {
         <Self as RtActivatable<ISemanticTextQueryFactory>>::get_activation_factory().create_with_language(aqsFilter, filterLanguage)
     }}
 }
-DEFINE_CLSID!(SemanticTextQuery(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,83,101,109,97,110,116,105,99,84,101,120,116,81,117,101,114,121,0]) [CLSID_SemanticTextQuery]);
+DEFINE_CLSID!(SemanticTextQuery: "Windows.Data.Text.SemanticTextQuery");
 DEFINE_IID!(IID_ISemanticTextQueryFactory, 596378883, 63893, 17799, 135, 119, 162, 183, 216, 10, 207, 239);
 RT_INTERFACE!{static interface ISemanticTextQueryFactory(ISemanticTextQueryFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISemanticTextQueryFactory] {
     fn Create(&self, aqsFilter: HSTRING, out: *mut *mut SemanticTextQuery) -> HRESULT,
@@ -1631,7 +1631,7 @@ impl TextConversionGenerator {
         <Self as RtActivatable<ITextConversionGeneratorFactory>>::get_activation_factory().create(languageTag)
     }}
 }
-DEFINE_CLSID!(TextConversionGenerator(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,84,101,120,116,67,111,110,118,101,114,115,105,111,110,71,101,110,101,114,97,116,111,114,0]) [CLSID_TextConversionGenerator]);
+DEFINE_CLSID!(TextConversionGenerator: "Windows.Data.Text.TextConversionGenerator");
 DEFINE_IID!(IID_ITextConversionGeneratorFactory, 4239013761, 12419, 18859, 190, 21, 86, 223, 187, 183, 77, 111);
 RT_INTERFACE!{static interface ITextConversionGeneratorFactory(ITextConversionGeneratorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ITextConversionGeneratorFactory] {
     fn Create(&self, languageTag: HSTRING, out: *mut *mut TextConversionGenerator) -> HRESULT
@@ -1697,7 +1697,7 @@ impl TextPredictionGenerator {
         <Self as RtActivatable<ITextPredictionGeneratorFactory>>::get_activation_factory().create(languageTag)
     }}
 }
-DEFINE_CLSID!(TextPredictionGenerator(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,84,101,120,116,80,114,101,100,105,99,116,105,111,110,71,101,110,101,114,97,116,111,114,0]) [CLSID_TextPredictionGenerator]);
+DEFINE_CLSID!(TextPredictionGenerator: "Windows.Data.Text.TextPredictionGenerator");
 DEFINE_IID!(IID_ITextPredictionGeneratorFactory, 1918350358, 35746, 18257, 157, 48, 157, 133, 67, 86, 83, 162);
 RT_INTERFACE!{static interface ITextPredictionGeneratorFactory(ITextPredictionGeneratorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ITextPredictionGeneratorFactory] {
     fn Create(&self, languageTag: HSTRING, out: *mut *mut TextPredictionGenerator) -> HRESULT
@@ -1739,7 +1739,7 @@ impl TextReverseConversionGenerator {
         <Self as RtActivatable<ITextReverseConversionGeneratorFactory>>::get_activation_factory().create(languageTag)
     }}
 }
-DEFINE_CLSID!(TextReverseConversionGenerator(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,84,101,120,116,82,101,118,101,114,115,101,67,111,110,118,101,114,115,105,111,110,71,101,110,101,114,97,116,111,114,0]) [CLSID_TextReverseConversionGenerator]);
+DEFINE_CLSID!(TextReverseConversionGenerator: "Windows.Data.Text.TextReverseConversionGenerator");
 DEFINE_IID!(IID_ITextReverseConversionGenerator2, 447730412, 34262, 18173, 130, 138, 58, 72, 48, 250, 110, 24);
 RT_INTERFACE!{interface ITextReverseConversionGenerator2(ITextReverseConversionGenerator2Vtbl): IInspectable(IInspectableVtbl) [IID_ITextReverseConversionGenerator2] {
     fn GetPhonemesAsync(&self, input: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<super::super::foundation::collections::IVectorView<TextPhoneme>>) -> HRESULT
@@ -1820,7 +1820,7 @@ impl UnicodeCharacters {
         <Self as RtActivatable<IUnicodeCharactersStatics>>::get_activation_factory().get_general_category(codepoint)
     }}
 }
-DEFINE_CLSID!(UnicodeCharacters(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,85,110,105,99,111,100,101,67,104,97,114,97,99,116,101,114,115,0]) [CLSID_UnicodeCharacters]);
+DEFINE_CLSID!(UnicodeCharacters: "Windows.Data.Text.UnicodeCharacters");
 DEFINE_IID!(IID_IUnicodeCharactersStatics, 2542837383, 37521, 20369, 182, 200, 182, 227, 89, 215, 167, 251);
 RT_INTERFACE!{static interface IUnicodeCharactersStatics(IUnicodeCharactersStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUnicodeCharactersStatics] {
     fn GetCodepointFromSurrogatePair(&self, highSurrogate: u32, lowSurrogate: u32, out: *mut u32) -> HRESULT,
@@ -2003,7 +2003,7 @@ impl WordsSegmenter {
         <Self as RtActivatable<IWordsSegmenterFactory>>::get_activation_factory().create_with_language(language)
     }}
 }
-DEFINE_CLSID!(WordsSegmenter(&[87,105,110,100,111,119,115,46,68,97,116,97,46,84,101,120,116,46,87,111,114,100,115,83,101,103,109,101,110,116,101,114,0]) [CLSID_WordsSegmenter]);
+DEFINE_CLSID!(WordsSegmenter: "Windows.Data.Text.WordsSegmenter");
 DEFINE_IID!(IID_IWordsSegmenterFactory, 3868684916, 64565, 17756, 139, 251, 109, 127, 70, 83, 202, 151);
 RT_INTERFACE!{static interface IWordsSegmenterFactory(IWordsSegmenterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWordsSegmenterFactory] {
     fn CreateWithLanguage(&self, language: HSTRING, out: *mut *mut WordsSegmenter) -> HRESULT

--- a/src/rt/gen/windows/devices.rs
+++ b/src/rt/gen/windows/devices.rs
@@ -41,7 +41,7 @@ impl LowLevelDevicesAggregateProvider {
         <Self as RtActivatable<ILowLevelDevicesAggregateProviderFactory>>::get_activation_factory().create(adc, pwm, gpio, i2c, spi)
     }}
 }
-DEFINE_CLSID!(LowLevelDevicesAggregateProvider(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,76,111,119,76,101,118,101,108,68,101,118,105,99,101,115,65,103,103,114,101,103,97,116,101,80,114,111,118,105,100,101,114,0]) [CLSID_LowLevelDevicesAggregateProvider]);
+DEFINE_CLSID!(LowLevelDevicesAggregateProvider: "Windows.Devices.LowLevelDevicesAggregateProvider");
 DEFINE_IID!(IID_ILowLevelDevicesAggregateProviderFactory, 2596580086, 13427, 18014, 150, 213, 54, 40, 26, 44, 87, 175);
 RT_INTERFACE!{static interface ILowLevelDevicesAggregateProviderFactory(ILowLevelDevicesAggregateProviderFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILowLevelDevicesAggregateProviderFactory] {
     fn Create(&self, adc: *mut adc::provider::IAdcControllerProvider, pwm: *mut pwm::provider::IPwmControllerProvider, gpio: *mut gpio::provider::IGpioControllerProvider, i2c: *mut i2c::provider::II2cControllerProvider, spi: *mut spi::provider::ISpiControllerProvider, out: *mut *mut LowLevelDevicesAggregateProvider) -> HRESULT
@@ -67,7 +67,7 @@ impl LowLevelDevicesController {
         <Self as RtActivatable<ILowLevelDevicesControllerStatics>>::get_activation_factory().set_default_provider(value)
     }}
 }
-DEFINE_CLSID!(LowLevelDevicesController(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,76,111,119,76,101,118,101,108,68,101,118,105,99,101,115,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_LowLevelDevicesController]);
+DEFINE_CLSID!(LowLevelDevicesController: "Windows.Devices.LowLevelDevicesController");
 DEFINE_IID!(IID_ILowLevelDevicesControllerStatics, 155095658, 64715, 17300, 166, 151, 25, 222, 99, 124, 45, 179);
 RT_INTERFACE!{static interface ILowLevelDevicesControllerStatics(ILowLevelDevicesControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILowLevelDevicesControllerStatics] {
     fn get_DefaultProvider(&self, out: *mut *mut ILowLevelDevicesAggregateProvider) -> HRESULT,
@@ -125,7 +125,7 @@ impl CustomDevice {
         <Self as RtActivatable<ICustomDeviceStatics>>::get_activation_factory().from_id_async(deviceId, desiredAccess, sharingMode)
     }}
 }
-DEFINE_CLSID!(CustomDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,67,117,115,116,111,109,46,67,117,115,116,111,109,68,101,118,105,99,101,0]) [CLSID_CustomDevice]);
+DEFINE_CLSID!(CustomDevice: "Windows.Devices.Custom.CustomDevice");
 DEFINE_IID!(IID_ICustomDeviceStatics, 3357672210, 61260, 18097, 165, 142, 238, 179, 8, 220, 137, 23);
 RT_INTERFACE!{static interface ICustomDeviceStatics(ICustomDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICustomDeviceStatics] {
     fn GetDeviceSelector(&self, classGuid: Guid, out: *mut HSTRING) -> HRESULT,
@@ -202,7 +202,7 @@ impl KnownDeviceTypes {
         <Self as RtActivatable<IKnownDeviceTypesStatics>>::get_activation_factory().get_unknown()
     }}
 }
-DEFINE_CLSID!(KnownDeviceTypes(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,67,117,115,116,111,109,46,75,110,111,119,110,68,101,118,105,99,101,84,121,112,101,115,0]) [CLSID_KnownDeviceTypes]);
+DEFINE_CLSID!(KnownDeviceTypes: "Windows.Devices.Custom.KnownDeviceTypes");
 DEFINE_IID!(IID_IKnownDeviceTypesStatics, 3998513602, 21576, 17882, 173, 27, 36, 148, 140, 35, 144, 148);
 RT_INTERFACE!{static interface IKnownDeviceTypesStatics(IKnownDeviceTypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownDeviceTypesStatics] {
     fn get_Unknown(&self, out: *mut u16) -> HRESULT
@@ -227,7 +227,7 @@ impl IOControlCode {
         <Self as RtActivatable<IIOControlCodeFactory>>::get_activation_factory().create_iocontrol_code(deviceType, function, accessMode, bufferingMethod)
     }}
 }
-DEFINE_CLSID!(IOControlCode(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,67,117,115,116,111,109,46,73,79,67,111,110,116,114,111,108,67,111,100,101,0]) [CLSID_IOControlCode]);
+DEFINE_CLSID!(IOControlCode: "Windows.Devices.Custom.IOControlCode");
 } // Windows.Devices.Custom
 pub mod printers { // Windows.Devices.Printers
 use ::prelude::*;
@@ -252,7 +252,7 @@ impl Print3DDevice {
         <Self as RtActivatable<IPrint3DDeviceStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(Print3DDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,114,105,110,116,101,114,115,46,80,114,105,110,116,51,68,68,101,118,105,99,101,0]) [CLSID_Print3DDevice]);
+DEFINE_CLSID!(Print3DDevice: "Windows.Devices.Printers.Print3DDevice");
 DEFINE_IID!(IID_IPrint3DDeviceStatics, 4259537418, 26573, 16823, 163, 68, 81, 80, 161, 253, 117, 181);
 RT_INTERFACE!{static interface IPrint3DDeviceStatics(IPrint3DDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DDeviceStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<Print3DDevice>) -> HRESULT,
@@ -404,7 +404,7 @@ impl PrintExtensionContext {
         <Self as RtActivatable<IPrintExtensionContextStatic>>::get_activation_factory().from_device_id(deviceId)
     }}
 }
-DEFINE_CLSID!(PrintExtensionContext(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,114,105,110,116,101,114,115,46,69,120,116,101,110,115,105,111,110,115,46,80,114,105,110,116,69,120,116,101,110,115,105,111,110,67,111,110,116,101,120,116,0]) [CLSID_PrintExtensionContext]);
+DEFINE_CLSID!(PrintExtensionContext: "Windows.Devices.Printers.Extensions.PrintExtensionContext");
 DEFINE_IID!(IID_IPrintExtensionContextStatic, 3876429761, 65401, 19108, 140, 155, 12, 147, 174, 223, 222, 138);
 RT_INTERFACE!{static interface IPrintExtensionContextStatic(IPrintExtensionContextStaticVtbl): IInspectable(IInspectableVtbl) [IID_IPrintExtensionContextStatic] {
     fn FromDeviceId(&self, deviceId: HSTRING, out: *mut *mut IInspectable) -> HRESULT
@@ -607,7 +607,7 @@ impl AdcController {
         <Self as RtActivatable<IAdcControllerStatics2>>::get_activation_factory().get_default_async()
     }}
 }
-DEFINE_CLSID!(AdcController(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,100,99,46,65,100,99,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_AdcController]);
+DEFINE_CLSID!(AdcController: "Windows.Devices.Adc.AdcController");
 DEFINE_IID!(IID_IAdcControllerStatics, 3437858316, 504, 18577, 188, 59, 190, 83, 239, 39, 156, 164);
 RT_INTERFACE!{static interface IAdcControllerStatics(IAdcControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAdcControllerStatics] {
     fn GetControllersAsync(&self, provider: *mut provider::IAdcProvider, out: *mut *mut super::super::foundation::IAsyncOperation<super::super::foundation::collections::IVectorView<AdcController>>) -> HRESULT
@@ -766,7 +766,7 @@ impl GpioChangeCounter {
         <Self as RtActivatable<IGpioChangeCounterFactory>>::get_activation_factory().create(pin)
     }}
 }
-DEFINE_CLSID!(GpioChangeCounter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,112,105,111,46,71,112,105,111,67,104,97,110,103,101,67,111,117,110,116,101,114,0]) [CLSID_GpioChangeCounter]);
+DEFINE_CLSID!(GpioChangeCounter: "Windows.Devices.Gpio.GpioChangeCounter");
 DEFINE_IID!(IID_IGpioChangeCounterFactory, 343774390, 2718, 16652, 180, 250, 248, 159, 64, 82, 8, 77);
 RT_INTERFACE!{static interface IGpioChangeCounterFactory(IGpioChangeCounterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGpioChangeCounterFactory] {
     fn Create(&self, pin: *mut GpioPin, out: *mut *mut GpioChangeCounter) -> HRESULT
@@ -876,7 +876,7 @@ impl GpioChangeReader {
         <Self as RtActivatable<IGpioChangeReaderFactory>>::get_activation_factory().create_with_capacity(pin, minCapacity)
     }}
 }
-DEFINE_CLSID!(GpioChangeReader(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,112,105,111,46,71,112,105,111,67,104,97,110,103,101,82,101,97,100,101,114,0]) [CLSID_GpioChangeReader]);
+DEFINE_CLSID!(GpioChangeReader: "Windows.Devices.Gpio.GpioChangeReader");
 DEFINE_IID!(IID_IGpioChangeReaderFactory, 2841218803, 14606, 17434, 157, 28, 232, 222, 11, 45, 240, 223);
 RT_INTERFACE!{static interface IGpioChangeReaderFactory(IGpioChangeReaderFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGpioChangeReaderFactory] {
     fn Create(&self, pin: *mut GpioPin, out: *mut *mut GpioChangeReader) -> HRESULT,
@@ -940,7 +940,7 @@ impl GpioController {
         <Self as RtActivatable<IGpioControllerStatics2>>::get_activation_factory().get_default_async()
     }}
 }
-DEFINE_CLSID!(GpioController(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,112,105,111,46,71,112,105,111,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_GpioController]);
+DEFINE_CLSID!(GpioController: "Windows.Devices.Gpio.GpioController");
 DEFINE_IID!(IID_IGpioControllerStatics, 785839150, 31479, 16662, 149, 51, 196, 61, 153, 161, 251, 100);
 RT_INTERFACE!{static interface IGpioControllerStatics(IGpioControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGpioControllerStatics] {
     fn GetDefault(&self, out: *mut *mut GpioController) -> HRESULT
@@ -1168,7 +1168,7 @@ impl GpioPinProviderValueChangedEventArgs {
         <Self as RtActivatable<IGpioPinProviderValueChangedEventArgsFactory>>::get_activation_factory().create(edge)
     }}
 }
-DEFINE_CLSID!(GpioPinProviderValueChangedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,112,105,111,46,80,114,111,118,105,100,101,114,46,71,112,105,111,80,105,110,80,114,111,118,105,100,101,114,86,97,108,117,101,67,104,97,110,103,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_GpioPinProviderValueChangedEventArgs]);
+DEFINE_CLSID!(GpioPinProviderValueChangedEventArgs: "Windows.Devices.Gpio.Provider.GpioPinProviderValueChangedEventArgs");
 DEFINE_IID!(IID_IGpioPinProviderValueChangedEventArgsFactory, 1053494105, 22156, 17298, 178, 74, 138, 89, 169, 2, 177, 241);
 RT_INTERFACE!{static interface IGpioPinProviderValueChangedEventArgsFactory(IGpioPinProviderValueChangedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGpioPinProviderValueChangedEventArgsFactory] {
     fn Create(&self, edge: ProviderGpioPinEdge, out: *mut *mut GpioPinProviderValueChangedEventArgs) -> HRESULT
@@ -1255,7 +1255,7 @@ impl I2cConnectionSettings {
         <Self as RtActivatable<II2cConnectionSettingsFactory>>::get_activation_factory().create(slaveAddress)
     }}
 }
-DEFINE_CLSID!(I2cConnectionSettings(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,50,99,46,73,50,99,67,111,110,110,101,99,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_I2cConnectionSettings]);
+DEFINE_CLSID!(I2cConnectionSettings: "Windows.Devices.I2c.I2cConnectionSettings");
 DEFINE_IID!(IID_II2cConnectionSettingsFactory, 2176157363, 38547, 16817, 162, 67, 222, 212, 246, 230, 105, 38);
 RT_INTERFACE!{static interface II2cConnectionSettingsFactory(II2cConnectionSettingsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_II2cConnectionSettingsFactory] {
     fn Create(&self, slaveAddress: i32, out: *mut *mut I2cConnectionSettings) -> HRESULT
@@ -1288,7 +1288,7 @@ impl I2cController {
         <Self as RtActivatable<II2cControllerStatics>>::get_activation_factory().get_default_async()
     }}
 }
-DEFINE_CLSID!(I2cController(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,50,99,46,73,50,99,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_I2cController]);
+DEFINE_CLSID!(I2cController: "Windows.Devices.I2c.I2cController");
 DEFINE_IID!(IID_II2cControllerStatics, 1090257765, 24325, 20094, 132, 189, 16, 13, 184, 224, 174, 197);
 RT_INTERFACE!{static interface II2cControllerStatics(II2cControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_II2cControllerStatics] {
     fn GetControllersAsync(&self, provider: *mut provider::II2cProvider, out: *mut *mut super::super::foundation::IAsyncOperation<super::super::foundation::collections::IVectorView<I2cController>>) -> HRESULT,
@@ -1369,7 +1369,7 @@ impl I2cDevice {
         <Self as RtActivatable<II2cDeviceStatics>>::get_activation_factory().from_id_async(deviceId, settings)
     }}
 }
-DEFINE_CLSID!(I2cDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,50,99,46,73,50,99,68,101,118,105,99,101,0]) [CLSID_I2cDevice]);
+DEFINE_CLSID!(I2cDevice: "Windows.Devices.I2c.I2cDevice");
 DEFINE_IID!(IID_II2cDeviceStatics, 2443394019, 29492, 17682, 150, 188, 251, 174, 148, 89, 245, 246);
 RT_INTERFACE!{static interface II2cDeviceStatics(II2cDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_II2cDeviceStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -1587,7 +1587,7 @@ impl PwmController {
         <Self as RtActivatable<IPwmControllerStatics3>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(PwmController(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,119,109,46,80,119,109,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_PwmController]);
+DEFINE_CLSID!(PwmController: "Windows.Devices.Pwm.PwmController");
 DEFINE_IID!(IID_IPwmControllerStatics, 1113832865, 35142, 17412, 189, 72, 129, 221, 18, 74, 244, 217);
 RT_INTERFACE!{static interface IPwmControllerStatics(IPwmControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPwmControllerStatics] {
     fn GetControllersAsync(&self, provider: *mut provider::IPwmProvider, out: *mut *mut super::super::foundation::IAsyncOperation<super::super::foundation::collections::IVectorView<PwmController>>) -> HRESULT
@@ -1860,7 +1860,7 @@ impl SpiConnectionSettings {
         <Self as RtActivatable<ISpiConnectionSettingsFactory>>::get_activation_factory().create(chipSelectLine)
     }}
 }
-DEFINE_CLSID!(SpiConnectionSettings(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,112,105,46,83,112,105,67,111,110,110,101,99,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_SpiConnectionSettings]);
+DEFINE_CLSID!(SpiConnectionSettings: "Windows.Devices.Spi.SpiConnectionSettings");
 DEFINE_IID!(IID_ISpiConnectionSettingsFactory, 4288219166, 4292, 17591, 159, 234, 167, 72, 181, 164, 111, 49);
 RT_INTERFACE!{static interface ISpiConnectionSettingsFactory(ISpiConnectionSettingsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISpiConnectionSettingsFactory] {
     fn Create(&self, chipSelectLine: i32, out: *mut *mut SpiConnectionSettings) -> HRESULT
@@ -1893,7 +1893,7 @@ impl SpiController {
         <Self as RtActivatable<ISpiControllerStatics>>::get_activation_factory().get_controllers_async(provider)
     }}
 }
-DEFINE_CLSID!(SpiController(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,112,105,46,83,112,105,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_SpiController]);
+DEFINE_CLSID!(SpiController: "Windows.Devices.Spi.SpiController");
 DEFINE_IID!(IID_ISpiControllerStatics, 223488482, 5003, 20040, 185, 100, 79, 47, 121, 185, 197, 162);
 RT_INTERFACE!{static interface ISpiControllerStatics(ISpiControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpiControllerStatics] {
     fn GetDefaultAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<SpiController>) -> HRESULT,
@@ -1964,7 +1964,7 @@ impl SpiDevice {
         <Self as RtActivatable<ISpiDeviceStatics>>::get_activation_factory().from_id_async(busId, settings)
     }}
 }
-DEFINE_CLSID!(SpiDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,112,105,46,83,112,105,68,101,118,105,99,101,0]) [CLSID_SpiDevice]);
+DEFINE_CLSID!(SpiDevice: "Windows.Devices.Spi.SpiDevice");
 DEFINE_IID!(IID_ISpiDeviceStatics, 2725832025, 22304, 19775, 189, 147, 86, 245, 255, 90, 88, 121);
 RT_INTERFACE!{static interface ISpiDeviceStatics(ISpiDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpiDeviceStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -2069,7 +2069,7 @@ impl ProviderSpiConnectionSettings {
         <Self as RtActivatable<IProviderSpiConnectionSettingsFactory>>::get_activation_factory().create(chipSelectLine)
     }}
 }
-DEFINE_CLSID!(ProviderSpiConnectionSettings(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,112,105,46,80,114,111,118,105,100,101,114,46,80,114,111,118,105,100,101,114,83,112,105,67,111,110,110,101,99,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_ProviderSpiConnectionSettings]);
+DEFINE_CLSID!(ProviderSpiConnectionSettings: "Windows.Devices.Spi.Provider.ProviderSpiConnectionSettings");
 DEFINE_IID!(IID_IProviderSpiConnectionSettingsFactory, 1715825498, 3193, 17379, 159, 60, 229, 151, 128, 172, 24, 250);
 RT_INTERFACE!{static interface IProviderSpiConnectionSettingsFactory(IProviderSpiConnectionSettingsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IProviderSpiConnectionSettingsFactory] {
     fn Create(&self, chipSelectLine: i32, out: *mut *mut ProviderSpiConnectionSettings) -> HRESULT
@@ -2269,7 +2269,7 @@ impl SmartCardAppletIdGroup {
         <Self as RtActivatable<ISmartCardAppletIdGroupStatics>>::get_activation_factory().get_max_applet_ids()
     }}
 }
-DEFINE_CLSID!(SmartCardAppletIdGroup(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,65,112,112,108,101,116,73,100,71,114,111,117,112,0]) [CLSID_SmartCardAppletIdGroup]);
+DEFINE_CLSID!(SmartCardAppletIdGroup: "Windows.Devices.SmartCards.SmartCardAppletIdGroup");
 RT_ENUM! { enum SmartCardAppletIdGroupActivationPolicy: i32 {
     Disabled (SmartCardAppletIdGroupActivationPolicy_Disabled) = 0, ForegroundOverride (SmartCardAppletIdGroupActivationPolicy_ForegroundOverride) = 1, Enabled (SmartCardAppletIdGroupActivationPolicy_Enabled) = 2,
 }}
@@ -2398,7 +2398,7 @@ impl SmartCardAutomaticResponseApdu {
         <Self as RtActivatable<ISmartCardAutomaticResponseApduFactory>>::get_activation_factory().create(commandApdu, responseApdu)
     }}
 }
-DEFINE_CLSID!(SmartCardAutomaticResponseApdu(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,65,117,116,111,109,97,116,105,99,82,101,115,112,111,110,115,101,65,112,100,117,0]) [CLSID_SmartCardAutomaticResponseApdu]);
+DEFINE_CLSID!(SmartCardAutomaticResponseApdu: "Windows.Devices.SmartCards.SmartCardAutomaticResponseApdu");
 DEFINE_IID!(IID_ISmartCardAutomaticResponseApdu2, 1152301844, 21917, 17713, 78, 81, 137, 219, 111, 168, 165, 122);
 RT_INTERFACE!{interface ISmartCardAutomaticResponseApdu2(ISmartCardAutomaticResponseApdu2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardAutomaticResponseApdu2] {
     fn get_InputState(&self, out: *mut *mut super::super::foundation::IReference<u32>) -> HRESULT,
@@ -2609,7 +2609,7 @@ impl SmartCardCryptogramGenerator {
         <Self as RtActivatable<ISmartCardCryptogramGeneratorStatics2>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(SmartCardCryptogramGenerator(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,110,101,114,97,116,111,114,0]) [CLSID_SmartCardCryptogramGenerator]);
+DEFINE_CLSID!(SmartCardCryptogramGenerator: "Windows.Devices.SmartCards.SmartCardCryptogramGenerator");
 DEFINE_IID!(IID_ISmartCardCryptogramGenerator2, 1897310772, 23917, 19274, 150, 163, 239, 164, 125, 42, 126, 37);
 RT_INTERFACE!{interface ISmartCardCryptogramGenerator2(ISmartCardCryptogramGenerator2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramGenerator2] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -2690,7 +2690,7 @@ impl ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
 }
 RT_CLASS!{class SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {}
-DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,116,65,108,108,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,82,101,115,117,108,116,0]) [CLSID_SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult]);
+DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult: "Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult");
 DEFINE_IID!(IID_ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult, 1315605084, 38771, 18116, 163, 47, 177, 229, 67, 21, 158, 4);
 RT_INTERFACE!{interface ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult(ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResultVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult] {
     fn get_OperationStatus(&self, out: *mut SmartCardCryptogramGeneratorOperationStatus) -> HRESULT,
@@ -2710,7 +2710,7 @@ impl ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
 }
 RT_CLASS!{class SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {}
-DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,116,65,108,108,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,80,97,99,107,97,103,101,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,82,101,115,117,108,116,0]) [CLSID_SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult]);
+DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult: "Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult");
 DEFINE_IID!(IID_ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult, 2356996183, 42983, 18589, 185, 214, 54, 128, 97, 81, 80, 18);
 RT_INTERFACE!{interface ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult(ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResultVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult] {
     fn get_OperationStatus(&self, out: *mut SmartCardCryptogramGeneratorOperationStatus) -> HRESULT,
@@ -2730,7 +2730,7 @@ impl ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
 }
 RT_CLASS!{class SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {}
-DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,116,65,108,108,67,114,121,112,116,111,103,114,97,109,83,116,111,114,97,103,101,75,101,121,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,82,101,115,117,108,116,0]) [CLSID_SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult]);
+DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult: "Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult");
 DEFINE_IID!(IID_ISmartCardCryptogramMaterialCharacteristics, 4238001612, 49623, 16723, 146, 59, 162, 212, 60, 108, 141, 73);
 RT_INTERFACE!{interface ISmartCardCryptogramMaterialCharacteristics(ISmartCardCryptogramMaterialCharacteristicsVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramMaterialCharacteristics] {
     fn get_MaterialName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2786,7 +2786,7 @@ impl ISmartCardCryptogramMaterialCharacteristics {
 }
 RT_CLASS!{class SmartCardCryptogramMaterialCharacteristics: ISmartCardCryptogramMaterialCharacteristics}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramMaterialCharacteristics {}
-DEFINE_CLSID!(SmartCardCryptogramMaterialCharacteristics(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,0]) [CLSID_SmartCardCryptogramMaterialCharacteristics]);
+DEFINE_CLSID!(SmartCardCryptogramMaterialCharacteristics: "Windows.Devices.SmartCards.SmartCardCryptogramMaterialCharacteristics");
 DEFINE_IID!(IID_ISmartCardCryptogramMaterialPackageCharacteristics, 4290088479, 1682, 19527, 147, 207, 52, 217, 31, 157, 205, 0);
 RT_INTERFACE!{interface ISmartCardCryptogramMaterialPackageCharacteristics(ISmartCardCryptogramMaterialPackageCharacteristicsVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramMaterialPackageCharacteristics] {
     fn get_PackageName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2818,7 +2818,7 @@ impl ISmartCardCryptogramMaterialPackageCharacteristics {
 }
 RT_CLASS!{class SmartCardCryptogramMaterialPackageCharacteristics: ISmartCardCryptogramMaterialPackageCharacteristics}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramMaterialPackageCharacteristics {}
-DEFINE_CLSID!(SmartCardCryptogramMaterialPackageCharacteristics(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,80,97,99,107,97,103,101,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,0]) [CLSID_SmartCardCryptogramMaterialPackageCharacteristics]);
+DEFINE_CLSID!(SmartCardCryptogramMaterialPackageCharacteristics: "Windows.Devices.SmartCards.SmartCardCryptogramMaterialPackageCharacteristics");
 RT_ENUM! { enum SmartCardCryptogramMaterialPackageConfirmationResponseFormat: i32 {
     None (SmartCardCryptogramMaterialPackageConfirmationResponseFormat_None) = 0, VisaHmac (SmartCardCryptogramMaterialPackageConfirmationResponseFormat_VisaHmac) = 1,
 }}
@@ -2960,7 +2960,7 @@ impl ISmartCardCryptogramPlacementStep {
 }
 RT_CLASS!{class SmartCardCryptogramPlacementStep: ISmartCardCryptogramPlacementStep}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramPlacementStep {}
-DEFINE_CLSID!(SmartCardCryptogramPlacementStep(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,80,108,97,99,101,109,101,110,116,83,116,101,112,0]) [CLSID_SmartCardCryptogramPlacementStep]);
+DEFINE_CLSID!(SmartCardCryptogramPlacementStep: "Windows.Devices.SmartCards.SmartCardCryptogramPlacementStep");
 RT_ENUM! { enum SmartCardCryptogramStorageKeyAlgorithm: i32 {
     None (SmartCardCryptogramStorageKeyAlgorithm_None) = 0, Rsa2048 (SmartCardCryptogramStorageKeyAlgorithm_Rsa2048) = 1,
 }}
@@ -2998,7 +2998,7 @@ impl ISmartCardCryptogramStorageKeyCharacteristics {
 }
 RT_CLASS!{class SmartCardCryptogramStorageKeyCharacteristics: ISmartCardCryptogramStorageKeyCharacteristics}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramStorageKeyCharacteristics {}
-DEFINE_CLSID!(SmartCardCryptogramStorageKeyCharacteristics(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,83,116,111,114,97,103,101,75,101,121,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,0]) [CLSID_SmartCardCryptogramStorageKeyCharacteristics]);
+DEFINE_CLSID!(SmartCardCryptogramStorageKeyCharacteristics: "Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyCharacteristics");
 DEFINE_IID!(IID_ISmartCardCryptogramStorageKeyInfo, 2008084493, 45207, 20321, 162, 106, 149, 97, 99, 156, 156, 58);
 RT_INTERFACE!{interface ISmartCardCryptogramStorageKeyInfo(ISmartCardCryptogramStorageKeyInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramStorageKeyInfo] {
     fn get_OperationStatus(&self, out: *mut SmartCardCryptogramGeneratorOperationStatus) -> HRESULT,
@@ -3106,7 +3106,7 @@ impl SmartCardEmulator {
         <Self as RtActivatable<ISmartCardEmulatorStatics3>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(SmartCardEmulator(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,69,109,117,108,97,116,111,114,0]) [CLSID_SmartCardEmulator]);
+DEFINE_CLSID!(SmartCardEmulator: "Windows.Devices.SmartCards.SmartCardEmulator");
 DEFINE_IID!(IID_ISmartCardEmulator2, 4265590968, 34089, 16666, 128, 123, 72, 237, 194, 160, 171, 68);
 RT_INTERFACE!{interface ISmartCardEmulator2(ISmartCardEmulator2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardEmulator2] {
     fn add_ApduReceived(&self, value: *mut super::super::foundation::TypedEventHandler<SmartCardEmulator, SmartCardEmulatorApduReceivedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -3386,7 +3386,7 @@ impl ISmartCardPinPolicy {
 }
 RT_CLASS!{class SmartCardPinPolicy: ISmartCardPinPolicy}
 impl RtActivatable<IActivationFactory> for SmartCardPinPolicy {}
-DEFINE_CLSID!(SmartCardPinPolicy(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,80,105,110,80,111,108,105,99,121,0]) [CLSID_SmartCardPinPolicy]);
+DEFINE_CLSID!(SmartCardPinPolicy: "Windows.Devices.SmartCards.SmartCardPinPolicy");
 DEFINE_IID!(IID_ISmartCardPinResetDeferral, 415845036, 30725, 16388, 133, 228, 187, 239, 172, 143, 104, 132);
 RT_INTERFACE!{interface ISmartCardPinResetDeferral(ISmartCardPinResetDeferralVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardPinResetDeferral] {
     fn Complete(&self) -> HRESULT
@@ -3501,7 +3501,7 @@ impl SmartCardProvisioning {
         <Self as RtActivatable<ISmartCardProvisioningStatics2>>::get_activation_factory().request_attested_virtual_smart_card_creation_async_with_card_id(friendlyName, administrativeKey, pinPolicy, cardId)
     }}
 }
-DEFINE_CLSID!(SmartCardProvisioning(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,80,114,111,118,105,115,105,111,110,105,110,103,0]) [CLSID_SmartCardProvisioning]);
+DEFINE_CLSID!(SmartCardProvisioning: "Windows.Devices.SmartCards.SmartCardProvisioning");
 DEFINE_IID!(IID_ISmartCardProvisioning2, 285026539, 16249, 19302, 155, 124, 17, 193, 73, 183, 208, 188);
 RT_INTERFACE!{interface ISmartCardProvisioning2(ISmartCardProvisioning2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardProvisioning2] {
     fn GetAuthorityKeyContainerNameAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<HString>) -> HRESULT
@@ -3631,7 +3631,7 @@ impl SmartCardReader {
         <Self as RtActivatable<ISmartCardReaderStatics>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(SmartCardReader(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,82,101,97,100,101,114,0]) [CLSID_SmartCardReader]);
+DEFINE_CLSID!(SmartCardReader: "Windows.Devices.SmartCards.SmartCardReader");
 RT_ENUM! { enum SmartCardReaderKind: i32 {
     Any (SmartCardReaderKind_Any) = 0, Generic (SmartCardReaderKind_Generic) = 1, Tpm (SmartCardReaderKind_Tpm) = 2, Nfc (SmartCardReaderKind_Nfc) = 3, Uicc (SmartCardReaderKind_Uicc) = 4, EmbeddedSE (SmartCardReaderKind_EmbeddedSE) = 5,
 }}
@@ -3772,7 +3772,7 @@ impl Battery {
         <Self as RtActivatable<IBatteryStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(Battery(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,119,101,114,46,66,97,116,116,101,114,121,0]) [CLSID_Battery]);
+DEFINE_CLSID!(Battery: "Windows.Devices.Power.Battery");
 DEFINE_IID!(IID_IBatteryReport, 3380972602, 19987, 16906, 168, 208, 36, 241, 143, 57, 84, 1);
 RT_INTERFACE!{interface IBatteryReport(IBatteryReportVtbl): IInspectable(IInspectableVtbl) [IID_IBatteryReport] {
     fn get_ChargeRateInMilliwatts(&self, out: *mut *mut super::super::foundation::IReference<i32>) -> HRESULT,
@@ -3973,7 +3973,7 @@ impl ISmsAppMessage {
 }
 RT_CLASS!{class SmsAppMessage: ISmsAppMessage}
 impl RtActivatable<IActivationFactory> for SmsAppMessage {}
-DEFINE_CLSID!(SmsAppMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,65,112,112,77,101,115,115,97,103,101,0]) [CLSID_SmsAppMessage]);
+DEFINE_CLSID!(SmsAppMessage: "Windows.Devices.Sms.SmsAppMessage");
 DEFINE_IID!(IID_ISmsBinaryMessage, 1542776851, 15187, 19566, 182, 26, 216, 106, 99, 117, 86, 80);
 RT_INTERFACE!{interface ISmsBinaryMessage(ISmsBinaryMessageVtbl): IInspectable(IInspectableVtbl) [IID_ISmsBinaryMessage] {
     fn get_Format(&self, out: *mut SmsDataFormat) -> HRESULT,
@@ -4003,7 +4003,7 @@ impl ISmsBinaryMessage {
 }
 RT_CLASS!{class SmsBinaryMessage: ISmsBinaryMessage}
 impl RtActivatable<IActivationFactory> for SmsBinaryMessage {}
-DEFINE_CLSID!(SmsBinaryMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,66,105,110,97,114,121,77,101,115,115,97,103,101,0]) [CLSID_SmsBinaryMessage]);
+DEFINE_CLSID!(SmsBinaryMessage: "Windows.Devices.Sms.SmsBinaryMessage");
 DEFINE_IID!(IID_ISmsBroadcastMessage, 1974385649, 58551, 18548, 160, 156, 41, 86, 229, 146, 249, 87);
 RT_INTERFACE!{interface ISmsBroadcastMessage(ISmsBroadcastMessageVtbl): IInspectable(IInspectableVtbl) [IID_ISmsBroadcastMessage] {
     fn get_Timestamp(&self, out: *mut super::super::foundation::DateTime) -> HRESULT,
@@ -4156,7 +4156,7 @@ impl SmsDevice {
         <Self as RtActivatable<ISmsDeviceStatics2>>::get_activation_factory().from_network_account_id_async(networkAccountId)
     }}
 }
-DEFINE_CLSID!(SmsDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,68,101,118,105,99,101,0]) [CLSID_SmsDevice]);
+DEFINE_CLSID!(SmsDevice: "Windows.Devices.Sms.SmsDevice");
 DEFINE_IID!(IID_ISmsDevice2, 3179961363, 58658, 18123, 184, 213, 158, 173, 48, 251, 108, 71);
 RT_INTERFACE!{interface ISmsDevice2(ISmsDevice2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmsDevice2] {
     fn get_SmscAddress(&self, out: *mut HSTRING) -> HRESULT,
@@ -4242,7 +4242,7 @@ impl SmsDevice2 {
         <Self as RtActivatable<ISmsDevice2Statics>>::get_activation_factory().from_parent_id(parentDeviceId)
     }}
 }
-DEFINE_CLSID!(SmsDevice2(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,68,101,118,105,99,101,50,0]) [CLSID_SmsDevice2]);
+DEFINE_CLSID!(SmsDevice2: "Windows.Devices.Sms.SmsDevice2");
 DEFINE_IID!(IID_ISmsDevice2Statics, 1707574053, 4145, 18718, 143, 182, 239, 153, 145, 175, 227, 99);
 RT_INTERFACE!{static interface ISmsDevice2Statics(ISmsDevice2StaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISmsDevice2Statics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -4459,7 +4459,7 @@ impl SmsFilterRule {
         <Self as RtActivatable<ISmsFilterRuleFactory>>::get_activation_factory().create_filter_rule(messageType)
     }}
 }
-DEFINE_CLSID!(SmsFilterRule(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,70,105,108,116,101,114,82,117,108,101,0]) [CLSID_SmsFilterRule]);
+DEFINE_CLSID!(SmsFilterRule: "Windows.Devices.Sms.SmsFilterRule");
 DEFINE_IID!(IID_ISmsFilterRuleFactory, 12805384, 25238, 20265, 154, 173, 137, 32, 206, 186, 60, 232);
 RT_INTERFACE!{static interface ISmsFilterRuleFactory(ISmsFilterRuleFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISmsFilterRuleFactory] {
     fn CreateFilterRule(&self, messageType: SmsMessageType, out: *mut *mut SmsFilterRule) -> HRESULT
@@ -4495,7 +4495,7 @@ impl SmsFilterRules {
         <Self as RtActivatable<ISmsFilterRulesFactory>>::get_activation_factory().create_filter_rules(actionType)
     }}
 }
-DEFINE_CLSID!(SmsFilterRules(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,70,105,108,116,101,114,82,117,108,101,115,0]) [CLSID_SmsFilterRules]);
+DEFINE_CLSID!(SmsFilterRules: "Windows.Devices.Sms.SmsFilterRules");
 DEFINE_IID!(IID_ISmsFilterRulesFactory, 2694391021, 28206, 17712, 159, 222, 70, 93, 2, 238, 208, 14);
 RT_INTERFACE!{static interface ISmsFilterRulesFactory(ISmsFilterRulesFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISmsFilterRulesFactory] {
     fn CreateFilterRules(&self, actionType: SmsFilterActionType, out: *mut *mut SmsFilterRules) -> HRESULT
@@ -4691,7 +4691,7 @@ impl SmsMessageRegistration {
         <Self as RtActivatable<ISmsMessageRegistrationStatics>>::get_activation_factory().register(id, filterRules)
     }}
 }
-DEFINE_CLSID!(SmsMessageRegistration(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,77,101,115,115,97,103,101,82,101,103,105,115,116,114,97,116,105,111,110,0]) [CLSID_SmsMessageRegistration]);
+DEFINE_CLSID!(SmsMessageRegistration: "Windows.Devices.Sms.SmsMessageRegistration");
 DEFINE_IID!(IID_ISmsMessageRegistrationStatics, 1671451748, 10392, 18296, 160, 60, 111, 153, 73, 7, 214, 58);
 RT_INTERFACE!{static interface ISmsMessageRegistrationStatics(ISmsMessageRegistrationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISmsMessageRegistrationStatics] {
     fn get_AllRegistrations(&self, out: *mut *mut super::super::foundation::collections::IVectorView<SmsMessageRegistration>) -> HRESULT,
@@ -4936,7 +4936,7 @@ impl SmsTextMessage {
         <Self as RtActivatable<ISmsTextMessageStatics>>::get_activation_factory().from_binary_data(format, value)
     }}
 }
-DEFINE_CLSID!(SmsTextMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,84,101,120,116,77,101,115,115,97,103,101,0]) [CLSID_SmsTextMessage]);
+DEFINE_CLSID!(SmsTextMessage: "Windows.Devices.Sms.SmsTextMessage");
 DEFINE_IID!(IID_ISmsTextMessage2, 580966547, 17749, 18261, 181, 161, 231, 253, 132, 149, 95, 141);
 RT_INTERFACE!{interface ISmsTextMessage2(ISmsTextMessage2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmsTextMessage2] {
     fn get_Timestamp(&self, out: *mut super::super::foundation::DateTime) -> HRESULT,
@@ -5034,7 +5034,7 @@ impl ISmsTextMessage2 {
 }
 RT_CLASS!{class SmsTextMessage2: ISmsTextMessage2}
 impl RtActivatable<IActivationFactory> for SmsTextMessage2 {}
-DEFINE_CLSID!(SmsTextMessage2(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,84,101,120,116,77,101,115,115,97,103,101,50,0]) [CLSID_SmsTextMessage2]);
+DEFINE_CLSID!(SmsTextMessage2: "Windows.Devices.Sms.SmsTextMessage2");
 DEFINE_IID!(IID_ISmsTextMessageStatics, 2137572845, 15564, 18339, 140, 85, 56, 13, 59, 1, 8, 146);
 RT_INTERFACE!{static interface ISmsTextMessageStatics(ISmsTextMessageStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISmsTextMessageStatics] {
     fn FromBinaryMessage(&self, binaryMessage: *mut SmsBinaryMessage, out: *mut *mut SmsTextMessage) -> HRESULT,
@@ -5370,7 +5370,7 @@ impl AllJoynAboutDataView {
         <Self as RtActivatable<IAllJoynAboutDataViewStatics>>::get_activation_factory().get_data_by_session_port_with_language_async(uniqueName, busAttachment, sessionPort, language)
     }}
 }
-DEFINE_CLSID!(AllJoynAboutDataView(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,65,98,111,117,116,68,97,116,97,86,105,101,119,0]) [CLSID_AllJoynAboutDataView]);
+DEFINE_CLSID!(AllJoynAboutDataView: "Windows.Devices.AllJoyn.AllJoynAboutDataView");
 DEFINE_IID!(IID_IAllJoynAboutDataViewStatics, 1475196552, 3166, 16750, 136, 181, 57, 179, 45, 37, 196, 125);
 RT_INTERFACE!{static interface IAllJoynAboutDataViewStatics(IAllJoynAboutDataViewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynAboutDataViewStatics] {
     fn GetDataBySessionPortAsync(&self, uniqueName: HSTRING, busAttachment: *mut AllJoynBusAttachment, sessionPort: u16, out: *mut *mut super::super::foundation::IAsyncOperation<AllJoynAboutDataView>) -> HRESULT,
@@ -5445,7 +5445,7 @@ impl AllJoynAcceptSessionJoinerEventArgs {
         <Self as RtActivatable<IAllJoynAcceptSessionJoinerEventArgsFactory>>::get_activation_factory().create(uniqueName, sessionPort, trafficType, proximity, acceptSessionJoiner)
     }}
 }
-DEFINE_CLSID!(AllJoynAcceptSessionJoinerEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,65,99,99,101,112,116,83,101,115,115,105,111,110,74,111,105,110,101,114,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynAcceptSessionJoinerEventArgs]);
+DEFINE_CLSID!(AllJoynAcceptSessionJoinerEventArgs: "Windows.Devices.AllJoyn.AllJoynAcceptSessionJoinerEventArgs");
 DEFINE_IID!(IID_IAllJoynAcceptSessionJoinerEventArgsFactory, 3024313280, 24901, 17054, 132, 219, 213, 191, 231, 114, 177, 79);
 RT_INTERFACE!{static interface IAllJoynAcceptSessionJoinerEventArgsFactory(IAllJoynAcceptSessionJoinerEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynAcceptSessionJoinerEventArgsFactory] {
     fn Create(&self, uniqueName: HSTRING, sessionPort: u16, trafficType: AllJoynTrafficType, proximity: u8, acceptSessionJoiner: *mut IAllJoynAcceptSessionJoiner, out: *mut *mut AllJoynAcceptSessionJoinerEventArgs) -> HRESULT
@@ -5594,7 +5594,7 @@ impl AllJoynBusAttachment {
         <Self as RtActivatable<IAllJoynBusAttachmentStatics>>::get_activation_factory().get_watcher(requiredInterfaces)
     }}
 }
-DEFINE_CLSID!(AllJoynBusAttachment(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,66,117,115,65,116,116,97,99,104,109,101,110,116,0]) [CLSID_AllJoynBusAttachment]);
+DEFINE_CLSID!(AllJoynBusAttachment: "Windows.Devices.AllJoyn.AllJoynBusAttachment");
 DEFINE_IID!(IID_IAllJoynBusAttachment2, 880069406, 9064, 17330, 180, 62, 106, 58, 193, 39, 141, 152);
 RT_INTERFACE!{interface IAllJoynBusAttachment2(IAllJoynBusAttachment2Vtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynBusAttachment2] {
     fn GetAboutDataAsync(&self, serviceInfo: *mut AllJoynServiceInfo, out: *mut *mut super::super::foundation::IAsyncOperation<AllJoynAboutDataView>) -> HRESULT,
@@ -5738,7 +5738,7 @@ impl AllJoynBusObject {
         <Self as RtActivatable<IAllJoynBusObjectFactory>>::get_activation_factory().create_with_bus_attachment(objectPath, busAttachment)
     }}
 }
-DEFINE_CLSID!(AllJoynBusObject(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,66,117,115,79,98,106,101,99,116,0]) [CLSID_AllJoynBusObject]);
+DEFINE_CLSID!(AllJoynBusObject: "Windows.Devices.AllJoyn.AllJoynBusObject");
 DEFINE_IID!(IID_IAllJoynBusObjectFactory, 741318411, 36354, 20380, 172, 39, 234, 109, 173, 93, 59, 80);
 RT_INTERFACE!{static interface IAllJoynBusObjectFactory(IAllJoynBusObjectFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynBusObjectFactory] {
     fn Create(&self, objectPath: HSTRING, out: *mut *mut AllJoynBusObject) -> HRESULT,
@@ -5774,7 +5774,7 @@ impl AllJoynBusObjectStoppedEventArgs {
         <Self as RtActivatable<IAllJoynBusObjectStoppedEventArgsFactory>>::get_activation_factory().create(status)
     }}
 }
-DEFINE_CLSID!(AllJoynBusObjectStoppedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,66,117,115,79,98,106,101,99,116,83,116,111,112,112,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynBusObjectStoppedEventArgs]);
+DEFINE_CLSID!(AllJoynBusObjectStoppedEventArgs: "Windows.Devices.AllJoyn.AllJoynBusObjectStoppedEventArgs");
 DEFINE_IID!(IID_IAllJoynBusObjectStoppedEventArgsFactory, 1797455176, 53411, 16981, 149, 58, 71, 114, 180, 2, 128, 115);
 RT_INTERFACE!{static interface IAllJoynBusObjectStoppedEventArgsFactory(IAllJoynBusObjectStoppedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynBusObjectStoppedEventArgsFactory] {
     fn Create(&self, status: i32, out: *mut *mut AllJoynBusObjectStoppedEventArgs) -> HRESULT
@@ -5946,7 +5946,7 @@ impl AllJoynMessageInfo {
         <Self as RtActivatable<IAllJoynMessageInfoFactory>>::get_activation_factory().create(senderUniqueName)
     }}
 }
-DEFINE_CLSID!(AllJoynMessageInfo(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,77,101,115,115,97,103,101,73,110,102,111,0]) [CLSID_AllJoynMessageInfo]);
+DEFINE_CLSID!(AllJoynMessageInfo: "Windows.Devices.AllJoyn.AllJoynMessageInfo");
 DEFINE_IID!(IID_IAllJoynMessageInfoFactory, 879119402, 33417, 17364, 180, 168, 63, 77, 227, 89, 240, 67);
 RT_INTERFACE!{static interface IAllJoynMessageInfoFactory(IAllJoynMessageInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynMessageInfoFactory] {
     fn Create(&self, senderUniqueName: HSTRING, out: *mut *mut AllJoynMessageInfo) -> HRESULT
@@ -5986,7 +5986,7 @@ impl AllJoynProducerStoppedEventArgs {
         <Self as RtActivatable<IAllJoynProducerStoppedEventArgsFactory>>::get_activation_factory().create(status)
     }}
 }
-DEFINE_CLSID!(AllJoynProducerStoppedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,80,114,111,100,117,99,101,114,83,116,111,112,112,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynProducerStoppedEventArgs]);
+DEFINE_CLSID!(AllJoynProducerStoppedEventArgs: "Windows.Devices.AllJoyn.AllJoynProducerStoppedEventArgs");
 DEFINE_IID!(IID_IAllJoynProducerStoppedEventArgsFactory, 1448253793, 45593, 19822, 159, 120, 250, 63, 153, 250, 143, 229);
 RT_INTERFACE!{static interface IAllJoynProducerStoppedEventArgsFactory(IAllJoynProducerStoppedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynProducerStoppedEventArgsFactory] {
     fn Create(&self, status: i32, out: *mut *mut AllJoynProducerStoppedEventArgs) -> HRESULT
@@ -6032,7 +6032,7 @@ impl AllJoynServiceInfo {
         <Self as RtActivatable<IAllJoynServiceInfoStatics>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(AllJoynServiceInfo(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,114,118,105,99,101,73,110,102,111,0]) [CLSID_AllJoynServiceInfo]);
+DEFINE_CLSID!(AllJoynServiceInfo: "Windows.Devices.AllJoyn.AllJoynServiceInfo");
 DEFINE_IID!(IID_IAllJoynServiceInfoFactory, 1971444413, 65027, 20299, 148, 164, 240, 47, 220, 189, 17, 184);
 RT_INTERFACE!{static interface IAllJoynServiceInfoFactory(IAllJoynServiceInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynServiceInfoFactory] {
     fn Create(&self, uniqueName: HSTRING, objectPath: HSTRING, sessionPort: u16, out: *mut *mut AllJoynServiceInfo) -> HRESULT
@@ -6062,7 +6062,7 @@ impl AllJoynServiceInfoRemovedEventArgs {
         <Self as RtActivatable<IAllJoynServiceInfoRemovedEventArgsFactory>>::get_activation_factory().create(uniqueName)
     }}
 }
-DEFINE_CLSID!(AllJoynServiceInfoRemovedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,114,118,105,99,101,73,110,102,111,82,101,109,111,118,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynServiceInfoRemovedEventArgs]);
+DEFINE_CLSID!(AllJoynServiceInfoRemovedEventArgs: "Windows.Devices.AllJoyn.AllJoynServiceInfoRemovedEventArgs");
 DEFINE_IID!(IID_IAllJoynServiceInfoRemovedEventArgsFactory, 230655527, 39679, 18773, 146, 39, 105, 83, 186, 244, 21, 105);
 RT_INTERFACE!{static interface IAllJoynServiceInfoRemovedEventArgsFactory(IAllJoynServiceInfoRemovedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynServiceInfoRemovedEventArgsFactory] {
     fn Create(&self, uniqueName: HSTRING, out: *mut *mut AllJoynServiceInfoRemovedEventArgs) -> HRESULT
@@ -6151,7 +6151,7 @@ impl AllJoynSession {
         <Self as RtActivatable<IAllJoynSessionStatics>>::get_activation_factory().get_from_service_info_and_bus_attachment_async(serviceInfo, busAttachment)
     }}
 }
-DEFINE_CLSID!(AllJoynSession(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,115,115,105,111,110,0]) [CLSID_AllJoynSession]);
+DEFINE_CLSID!(AllJoynSession: "Windows.Devices.AllJoyn.AllJoynSession");
 DEFINE_IID!(IID_IAllJoynSessionJoinedEventArgs, 2661243856, 46551, 18373, 141, 171, 176, 64, 204, 25, 40, 113);
 RT_INTERFACE!{interface IAllJoynSessionJoinedEventArgs(IAllJoynSessionJoinedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynSessionJoinedEventArgs] {
     fn get_Session(&self, out: *mut *mut AllJoynSession) -> HRESULT
@@ -6170,7 +6170,7 @@ impl AllJoynSessionJoinedEventArgs {
         <Self as RtActivatable<IAllJoynSessionJoinedEventArgsFactory>>::get_activation_factory().create(session)
     }}
 }
-DEFINE_CLSID!(AllJoynSessionJoinedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,115,115,105,111,110,74,111,105,110,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynSessionJoinedEventArgs]);
+DEFINE_CLSID!(AllJoynSessionJoinedEventArgs: "Windows.Devices.AllJoyn.AllJoynSessionJoinedEventArgs");
 DEFINE_IID!(IID_IAllJoynSessionJoinedEventArgsFactory, 1747244681, 54987, 19870, 160, 158, 53, 128, 104, 112, 177, 127);
 RT_INTERFACE!{static interface IAllJoynSessionJoinedEventArgsFactory(IAllJoynSessionJoinedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynSessionJoinedEventArgsFactory] {
     fn Create(&self, session: *mut AllJoynSession, out: *mut *mut AllJoynSessionJoinedEventArgs) -> HRESULT
@@ -6200,7 +6200,7 @@ impl AllJoynSessionLostEventArgs {
         <Self as RtActivatable<IAllJoynSessionLostEventArgsFactory>>::get_activation_factory().create(reason)
     }}
 }
-DEFINE_CLSID!(AllJoynSessionLostEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,115,115,105,111,110,76,111,115,116,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynSessionLostEventArgs]);
+DEFINE_CLSID!(AllJoynSessionLostEventArgs: "Windows.Devices.AllJoyn.AllJoynSessionLostEventArgs");
 DEFINE_IID!(IID_IAllJoynSessionLostEventArgsFactory, 331087154, 54004, 18889, 152, 14, 40, 5, 225, 53, 134, 177);
 RT_INTERFACE!{static interface IAllJoynSessionLostEventArgsFactory(IAllJoynSessionLostEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynSessionLostEventArgsFactory] {
     fn Create(&self, reason: AllJoynSessionLostReason, out: *mut *mut AllJoynSessionLostEventArgs) -> HRESULT
@@ -6233,7 +6233,7 @@ impl AllJoynSessionMemberAddedEventArgs {
         <Self as RtActivatable<IAllJoynSessionMemberAddedEventArgsFactory>>::get_activation_factory().create(uniqueName)
     }}
 }
-DEFINE_CLSID!(AllJoynSessionMemberAddedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,115,115,105,111,110,77,101,109,98,101,114,65,100,100,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynSessionMemberAddedEventArgs]);
+DEFINE_CLSID!(AllJoynSessionMemberAddedEventArgs: "Windows.Devices.AllJoyn.AllJoynSessionMemberAddedEventArgs");
 DEFINE_IID!(IID_IAllJoynSessionMemberAddedEventArgsFactory, 874373970, 7475, 16545, 161, 211, 229, 119, 112, 32, 225, 241);
 RT_INTERFACE!{static interface IAllJoynSessionMemberAddedEventArgsFactory(IAllJoynSessionMemberAddedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynSessionMemberAddedEventArgsFactory] {
     fn Create(&self, uniqueName: HSTRING, out: *mut *mut AllJoynSessionMemberAddedEventArgs) -> HRESULT
@@ -6263,7 +6263,7 @@ impl AllJoynSessionMemberRemovedEventArgs {
         <Self as RtActivatable<IAllJoynSessionMemberRemovedEventArgsFactory>>::get_activation_factory().create(uniqueName)
     }}
 }
-DEFINE_CLSID!(AllJoynSessionMemberRemovedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,101,115,115,105,111,110,77,101,109,98,101,114,82,101,109,111,118,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynSessionMemberRemovedEventArgs]);
+DEFINE_CLSID!(AllJoynSessionMemberRemovedEventArgs: "Windows.Devices.AllJoyn.AllJoynSessionMemberRemovedEventArgs");
 DEFINE_IID!(IID_IAllJoynSessionMemberRemovedEventArgsFactory, 3302184424, 17080, 19303, 183, 87, 208, 207, 202, 213, 146, 128);
 RT_INTERFACE!{static interface IAllJoynSessionMemberRemovedEventArgsFactory(IAllJoynSessionMemberRemovedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynSessionMemberRemovedEventArgsFactory] {
     fn Create(&self, uniqueName: HSTRING, out: *mut *mut AllJoynSessionMemberRemovedEventArgs) -> HRESULT
@@ -6350,7 +6350,7 @@ impl AllJoynStatus {
         <Self as RtActivatable<IAllJoynStatusStatics>>::get_activation_factory().get_invalid_argument8()
     }}
 }
-DEFINE_CLSID!(AllJoynStatus(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,83,116,97,116,117,115,0]) [CLSID_AllJoynStatus]);
+DEFINE_CLSID!(AllJoynStatus: "Windows.Devices.AllJoyn.AllJoynStatus");
 DEFINE_IID!(IID_IAllJoynStatusStatics, 3501695358, 3369, 19881, 138, 198, 84, 197, 84, 190, 219, 197);
 RT_INTERFACE!{static interface IAllJoynStatusStatics(IAllJoynStatusStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynStatusStatics] {
     fn get_Ok(&self, out: *mut i32) -> HRESULT,
@@ -6485,7 +6485,7 @@ impl AllJoynWatcherStoppedEventArgs {
         <Self as RtActivatable<IAllJoynWatcherStoppedEventArgsFactory>>::get_activation_factory().create(status)
     }}
 }
-DEFINE_CLSID!(AllJoynWatcherStoppedEventArgs(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,65,108,108,74,111,121,110,46,65,108,108,74,111,121,110,87,97,116,99,104,101,114,83,116,111,112,112,101,100,69,118,101,110,116,65,114,103,115,0]) [CLSID_AllJoynWatcherStoppedEventArgs]);
+DEFINE_CLSID!(AllJoynWatcherStoppedEventArgs: "Windows.Devices.AllJoyn.AllJoynWatcherStoppedEventArgs");
 DEFINE_IID!(IID_IAllJoynWatcherStoppedEventArgsFactory, 2274338216, 11600, 18401, 144, 74, 32, 191, 13, 72, 199, 130);
 RT_INTERFACE!{static interface IAllJoynWatcherStoppedEventArgsFactory(IAllJoynWatcherStoppedEventArgsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynWatcherStoppedEventArgsFactory] {
     fn Create(&self, status: i32, out: *mut *mut AllJoynWatcherStoppedEventArgs) -> HRESULT
@@ -6611,7 +6611,7 @@ impl BluetoothAdapter {
         <Self as RtActivatable<IBluetoothAdapterStatics>>::get_activation_factory().get_default_async()
     }}
 }
-DEFINE_CLSID!(BluetoothAdapter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,65,100,97,112,116,101,114,0]) [CLSID_BluetoothAdapter]);
+DEFINE_CLSID!(BluetoothAdapter: "Windows.Devices.Bluetooth.BluetoothAdapter");
 DEFINE_IID!(IID_IBluetoothAdapterStatics, 2332228458, 44108, 18241, 134, 97, 142, 171, 125, 23, 234, 159);
 RT_INTERFACE!{static interface IBluetoothAdapterStatics(IBluetoothAdapterStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothAdapterStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -6680,7 +6680,7 @@ impl BluetoothClassOfDevice {
         <Self as RtActivatable<IBluetoothClassOfDeviceStatics>>::get_activation_factory().from_parts(majorClass, minorClass, serviceCapabilities)
     }}
 }
-DEFINE_CLSID!(BluetoothClassOfDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,67,108,97,115,115,79,102,68,101,118,105,99,101,0]) [CLSID_BluetoothClassOfDevice]);
+DEFINE_CLSID!(BluetoothClassOfDevice: "Windows.Devices.Bluetooth.BluetoothClassOfDevice");
 DEFINE_IID!(IID_IBluetoothClassOfDeviceStatics, 3831575997, 4002, 16748, 145, 180, 193, 228, 140, 160, 97, 193);
 RT_INTERFACE!{static interface IBluetoothClassOfDeviceStatics(IBluetoothClassOfDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothClassOfDeviceStatics] {
     fn FromRawValue(&self, rawValue: u32, out: *mut *mut BluetoothClassOfDevice) -> HRESULT,
@@ -6821,7 +6821,7 @@ impl BluetoothDevice {
         <Self as RtActivatable<IBluetoothDeviceStatics2>>::get_activation_factory().get_device_selector_from_class_of_device(classOfDevice)
     }}
 }
-DEFINE_CLSID!(BluetoothDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,68,101,118,105,99,101,0]) [CLSID_BluetoothDevice]);
+DEFINE_CLSID!(BluetoothDevice: "Windows.Devices.Bluetooth.BluetoothDevice");
 DEFINE_IID!(IID_IBluetoothDevice2, 20183380, 45398, 19920, 177, 245, 193, 27, 195, 26, 81, 99);
 RT_INTERFACE!{interface IBluetoothDevice2(IBluetoothDevice2Vtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothDevice2] {
     fn get_DeviceInformation(&self, out: *mut *mut super::enumeration::DeviceInformation) -> HRESULT
@@ -6915,7 +6915,7 @@ impl BluetoothDeviceId {
         <Self as RtActivatable<IBluetoothDeviceIdStatics>>::get_activation_factory().from_id(deviceId)
     }}
 }
-DEFINE_CLSID!(BluetoothDeviceId(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,68,101,118,105,99,101,73,100,0]) [CLSID_BluetoothDeviceId]);
+DEFINE_CLSID!(BluetoothDeviceId: "Windows.Devices.Bluetooth.BluetoothDeviceId");
 DEFINE_IID!(IID_IBluetoothDeviceIdStatics, 2810728039, 16123, 20273, 187, 194, 129, 14, 9, 151, 116, 4);
 RT_INTERFACE!{static interface IBluetoothDeviceIdStatics(IBluetoothDeviceIdStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothDeviceIdStatics] {
     fn FromId(&self, deviceId: HSTRING, out: *mut *mut BluetoothDeviceId) -> HRESULT
@@ -7028,7 +7028,7 @@ impl BluetoothLEAppearance {
         <Self as RtActivatable<IBluetoothLEAppearanceStatics>>::get_activation_factory().from_parts(appearanceCategory, appearanceSubCategory)
     }}
 }
-DEFINE_CLSID!(BluetoothLEAppearance(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,76,69,65,112,112,101,97,114,97,110,99,101,0]) [CLSID_BluetoothLEAppearance]);
+DEFINE_CLSID!(BluetoothLEAppearance: "Windows.Devices.Bluetooth.BluetoothLEAppearance");
 RT_CLASS!{static class BluetoothLEAppearanceCategories}
 impl RtActivatable<IBluetoothLEAppearanceCategoriesStatics> for BluetoothLEAppearanceCategories {}
 impl BluetoothLEAppearanceCategories {
@@ -7099,7 +7099,7 @@ impl BluetoothLEAppearanceCategories {
         <Self as RtActivatable<IBluetoothLEAppearanceCategoriesStatics>>::get_activation_factory().get_outdoor_sport_activity()
     }}
 }
-DEFINE_CLSID!(BluetoothLEAppearanceCategories(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,76,69,65,112,112,101,97,114,97,110,99,101,67,97,116,101,103,111,114,105,101,115,0]) [CLSID_BluetoothLEAppearanceCategories]);
+DEFINE_CLSID!(BluetoothLEAppearanceCategories: "Windows.Devices.Bluetooth.BluetoothLEAppearanceCategories");
 DEFINE_IID!(IID_IBluetoothLEAppearanceCategoriesStatics, 1833784574, 1130, 16773, 170, 182, 130, 76, 240, 97, 8, 97);
 RT_INTERFACE!{static interface IBluetoothLEAppearanceCategoriesStatics(IBluetoothLEAppearanceCategoriesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAppearanceCategoriesStatics] {
     fn get_Uncategorized(&self, out: *mut u16) -> HRESULT,
@@ -7342,7 +7342,7 @@ impl BluetoothLEAppearanceSubcategories {
         <Self as RtActivatable<IBluetoothLEAppearanceSubcategoriesStatics>>::get_activation_factory().get_location_navigation_pod()
     }}
 }
-DEFINE_CLSID!(BluetoothLEAppearanceSubcategories(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,76,69,65,112,112,101,97,114,97,110,99,101,83,117,98,99,97,116,101,103,111,114,105,101,115,0]) [CLSID_BluetoothLEAppearanceSubcategories]);
+DEFINE_CLSID!(BluetoothLEAppearanceSubcategories: "Windows.Devices.Bluetooth.BluetoothLEAppearanceSubcategories");
 DEFINE_IID!(IID_IBluetoothLEAppearanceSubcategoriesStatics, 3850085894, 8516, 16730, 131, 18, 113, 204, 242, 145, 248, 209);
 RT_INTERFACE!{static interface IBluetoothLEAppearanceSubcategoriesStatics(IBluetoothLEAppearanceSubcategoriesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAppearanceSubcategoriesStatics] {
     fn get_Generic(&self, out: *mut u16) -> HRESULT,
@@ -7625,7 +7625,7 @@ impl BluetoothLEDevice {
         <Self as RtActivatable<IBluetoothLEDeviceStatics2>>::get_activation_factory().from_bluetooth_address_with_bluetooth_address_type_async(bluetoothAddress, bluetoothAddressType)
     }}
 }
-DEFINE_CLSID!(BluetoothLEDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,76,69,68,101,118,105,99,101,0]) [CLSID_BluetoothLEDevice]);
+DEFINE_CLSID!(BluetoothLEDevice: "Windows.Devices.Bluetooth.BluetoothLEDevice");
 DEFINE_IID!(IID_IBluetoothLEDevice2, 653288115, 31470, 19761, 186, 186, 177, 185, 119, 95, 89, 22);
 RT_INTERFACE!{interface IBluetoothLEDevice2(IBluetoothLEDevice2Vtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEDevice2] {
     fn get_DeviceInformation(&self, out: *mut *mut super::enumeration::DeviceInformation) -> HRESULT,
@@ -7831,7 +7831,7 @@ impl IBluetoothSignalStrengthFilter {
 }
 RT_CLASS!{class BluetoothSignalStrengthFilter: IBluetoothSignalStrengthFilter}
 impl RtActivatable<IActivationFactory> for BluetoothSignalStrengthFilter {}
-DEFINE_CLSID!(BluetoothSignalStrengthFilter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,83,105,103,110,97,108,83,116,114,101,110,103,116,104,70,105,108,116,101,114,0]) [CLSID_BluetoothSignalStrengthFilter]);
+DEFINE_CLSID!(BluetoothSignalStrengthFilter: "Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter");
 RT_CLASS!{static class BluetoothUuidHelper}
 impl RtActivatable<IBluetoothUuidHelperStatics> for BluetoothUuidHelper {}
 impl BluetoothUuidHelper {
@@ -7842,7 +7842,7 @@ impl BluetoothUuidHelper {
         <Self as RtActivatable<IBluetoothUuidHelperStatics>>::get_activation_factory().try_get_short_id(uuid)
     }}
 }
-DEFINE_CLSID!(BluetoothUuidHelper(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,85,117,105,100,72,101,108,112,101,114,0]) [CLSID_BluetoothUuidHelper]);
+DEFINE_CLSID!(BluetoothUuidHelper: "Windows.Devices.Bluetooth.BluetoothUuidHelper");
 DEFINE_IID!(IID_IBluetoothUuidHelperStatics, 400493784, 53108, 19233, 175, 230, 245, 122, 17, 188, 222, 160);
 RT_INTERFACE!{static interface IBluetoothUuidHelperStatics(IBluetoothUuidHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothUuidHelperStatics] {
     fn FromShortId(&self, shortId: u32, out: *mut Guid) -> HRESULT,
@@ -7935,7 +7935,7 @@ impl RfcommDeviceService {
         <Self as RtActivatable<IRfcommDeviceServiceStatics2>>::get_activation_factory().get_device_selector_for_bluetooth_device_and_service_id_with_cache_mode(bluetoothDevice, serviceId, cacheMode)
     }}
 }
-DEFINE_CLSID!(RfcommDeviceService(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,82,102,99,111,109,109,46,82,102,99,111,109,109,68,101,118,105,99,101,83,101,114,118,105,99,101,0]) [CLSID_RfcommDeviceService]);
+DEFINE_CLSID!(RfcommDeviceService: "Windows.Devices.Bluetooth.Rfcomm.RfcommDeviceService");
 DEFINE_IID!(IID_IRfcommDeviceService2, 1399647508, 60365, 18942, 191, 159, 64, 239, 198, 137, 178, 13);
 RT_INTERFACE!{interface IRfcommDeviceService2(IRfcommDeviceService2Vtbl): IInspectable(IInspectableVtbl) [IID_IRfcommDeviceService2] {
     fn get_Device(&self, out: *mut *mut super::BluetoothDevice) -> HRESULT
@@ -8079,7 +8079,7 @@ impl RfcommServiceId {
         <Self as RtActivatable<IRfcommServiceIdStatics>>::get_activation_factory().get_generic_file_transfer()
     }}
 }
-DEFINE_CLSID!(RfcommServiceId(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,82,102,99,111,109,109,46,82,102,99,111,109,109,83,101,114,118,105,99,101,73,100,0]) [CLSID_RfcommServiceId]);
+DEFINE_CLSID!(RfcommServiceId: "Windows.Devices.Bluetooth.Rfcomm.RfcommServiceId");
 DEFINE_IID!(IID_IRfcommServiceIdStatics, 706191034, 43381, 18147, 181, 107, 8, 255, 215, 131, 165, 254);
 RT_INTERFACE!{static interface IRfcommServiceIdStatics(IRfcommServiceIdStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommServiceIdStatics] {
     fn FromUuid(&self, uuid: Guid, out: *mut *mut RfcommServiceId) -> HRESULT,
@@ -8169,7 +8169,7 @@ impl RfcommServiceProvider {
         <Self as RtActivatable<IRfcommServiceProviderStatics>>::get_activation_factory().create_async(serviceId)
     }}
 }
-DEFINE_CLSID!(RfcommServiceProvider(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,82,102,99,111,109,109,46,82,102,99,111,109,109,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,0]) [CLSID_RfcommServiceProvider]);
+DEFINE_CLSID!(RfcommServiceProvider: "Windows.Devices.Bluetooth.Rfcomm.RfcommServiceProvider");
 DEFINE_IID!(IID_IRfcommServiceProvider2, 1936449478, 15489, 19742, 186, 242, 221, 187, 129, 40, 69, 18);
 RT_INTERFACE!{interface IRfcommServiceProvider2(IRfcommServiceProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IRfcommServiceProvider2] {
     #[cfg(feature="windows-networking")] fn StartAdvertisingWithRadioDiscoverability(&self, listener: *mut ::rt::gen::windows::networking::sockets::StreamSocketListener, radioDiscoverable: bool) -> HRESULT
@@ -8302,7 +8302,7 @@ impl GattCharacteristic {
         <Self as RtActivatable<IGattCharacteristicStatics>>::get_activation_factory().convert_short_id_to_uuid(shortId)
     }}
 }
-DEFINE_CLSID!(GattCharacteristic(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,67,104,97,114,97,99,116,101,114,105,115,116,105,99,0]) [CLSID_GattCharacteristic]);
+DEFINE_CLSID!(GattCharacteristic: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristic");
 DEFINE_IID!(IID_IGattCharacteristic2, 2920985976, 60422, 18276, 183, 128, 152, 53, 161, 211, 93, 110);
 RT_INTERFACE!{interface IGattCharacteristic2(IGattCharacteristic2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristic2] {
     fn get_Service(&self, out: *mut *mut GattDeviceService) -> HRESULT,
@@ -8655,7 +8655,7 @@ impl GattCharacteristicUuids {
         <Self as RtActivatable<IGattCharacteristicUuidsStatics2>>::get_activation_factory().get_unread_alert_status()
     }}
 }
-DEFINE_CLSID!(GattCharacteristicUuids(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,67,104,97,114,97,99,116,101,114,105,115,116,105,99,85,117,105,100,115,0]) [CLSID_GattCharacteristicUuids]);
+DEFINE_CLSID!(GattCharacteristicUuids: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicUuids");
 DEFINE_IID!(IID_IGattCharacteristicUuidsStatics, 1492796806, 45534, 18188, 183, 222, 13, 17, 255, 68, 244, 183);
 RT_INTERFACE!{static interface IGattCharacteristicUuidsStatics(IGattCharacteristicUuidsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicUuidsStatics] {
     fn get_BatteryLevel(&self, out: *mut Guid) -> HRESULT,
@@ -9246,7 +9246,7 @@ impl GattDescriptor {
         <Self as RtActivatable<IGattDescriptorStatics>>::get_activation_factory().convert_short_id_to_uuid(shortId)
     }}
 }
-DEFINE_CLSID!(GattDescriptor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_GattDescriptor]);
+DEFINE_CLSID!(GattDescriptor: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptor");
 DEFINE_IID!(IID_IGattDescriptor2, 2404793657, 54832, 16492, 186, 17, 16, 205, 209, 107, 14, 94);
 RT_INTERFACE!{interface IGattDescriptor2(IGattDescriptor2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattDescriptor2] {
     #[cfg(feature="windows-storage")] fn WriteValueWithResultAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<GattWriteResult>) -> HRESULT
@@ -9315,7 +9315,7 @@ impl GattDescriptorUuids {
         <Self as RtActivatable<IGattDescriptorUuidsStatics>>::get_activation_factory().get_server_characteristic_configuration()
     }}
 }
-DEFINE_CLSID!(GattDescriptorUuids(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,68,101,115,99,114,105,112,116,111,114,85,117,105,100,115,0]) [CLSID_GattDescriptorUuids]);
+DEFINE_CLSID!(GattDescriptorUuids: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptorUuids");
 DEFINE_IID!(IID_IGattDescriptorUuidsStatics, 2801296078, 40188, 17137, 145, 133, 255, 55, 183, 81, 129, 211);
 RT_INTERFACE!{static interface IGattDescriptorUuidsStatics(IGattDescriptorUuidsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattDescriptorUuidsStatics] {
     fn get_CharacteristicAggregateFormat(&self, out: *mut Guid) -> HRESULT,
@@ -9424,7 +9424,7 @@ impl GattDeviceService {
         <Self as RtActivatable<IGattDeviceServiceStatics2>>::get_activation_factory().get_device_selector_for_bluetooth_device_id_and_uuid_with_cache_mode(bluetoothDeviceId, serviceUuid, cacheMode)
     }}
 }
-DEFINE_CLSID!(GattDeviceService(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,68,101,118,105,99,101,83,101,114,118,105,99,101,0]) [CLSID_GattDeviceService]);
+DEFINE_CLSID!(GattDeviceService: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceService");
 DEFINE_IID!(IID_IGattDeviceService2, 4233384459, 2829, 18184, 186, 224, 159, 253, 148, 137, 188, 89);
 RT_INTERFACE!{interface IGattDeviceService2(IGattDeviceService2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattDeviceService2] {
     fn get_Device(&self, out: *mut *mut super::BluetoothLEDevice) -> HRESULT,
@@ -9806,7 +9806,7 @@ impl IGattLocalCharacteristicParameters {
 }
 RT_CLASS!{class GattLocalCharacteristicParameters: IGattLocalCharacteristicParameters}
 impl RtActivatable<IActivationFactory> for GattLocalCharacteristicParameters {}
-DEFINE_CLSID!(GattLocalCharacteristicParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,76,111,99,97,108,67,104,97,114,97,99,116,101,114,105,115,116,105,99,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_GattLocalCharacteristicParameters]);
+DEFINE_CLSID!(GattLocalCharacteristicParameters: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristicParameters");
 DEFINE_IID!(IID_IGattLocalCharacteristicResult, 2037767835, 368, 17303, 150, 102, 146, 248, 99, 241, 46, 230);
 RT_INTERFACE!{interface IGattLocalCharacteristicResult(IGattLocalCharacteristicResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalCharacteristicResult] {
     fn get_Characteristic(&self, out: *mut *mut GattLocalCharacteristic) -> HRESULT,
@@ -9920,7 +9920,7 @@ impl IGattLocalDescriptorParameters {
 }
 RT_CLASS!{class GattLocalDescriptorParameters: IGattLocalDescriptorParameters}
 impl RtActivatable<IActivationFactory> for GattLocalDescriptorParameters {}
-DEFINE_CLSID!(GattLocalDescriptorParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,76,111,99,97,108,68,101,115,99,114,105,112,116,111,114,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_GattLocalDescriptorParameters]);
+DEFINE_CLSID!(GattLocalDescriptorParameters: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptorParameters");
 DEFINE_IID!(IID_IGattLocalDescriptorResult, 928485822, 12831, 17254, 191, 193, 59, 198, 184, 44, 121, 248);
 RT_INTERFACE!{interface IGattLocalDescriptorResult(IGattLocalDescriptorResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalDescriptorResult] {
     fn get_Descriptor(&self, out: *mut *mut GattLocalDescriptor) -> HRESULT,
@@ -10012,7 +10012,7 @@ impl GattPresentationFormat {
         <Self as RtActivatable<IGattPresentationFormatStatics2>>::get_activation_factory().from_parts(formatType, exponent, unit, namespaceId, description)
     }}
 }
-DEFINE_CLSID!(GattPresentationFormat(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,80,114,101,115,101,110,116,97,116,105,111,110,70,111,114,109,97,116,0]) [CLSID_GattPresentationFormat]);
+DEFINE_CLSID!(GattPresentationFormat: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattPresentationFormat");
 DEFINE_IID!(IID_IGattPresentationFormatStatics, 426573856, 64173, 17884, 174, 91, 42, 195, 24, 78, 132, 219);
 RT_INTERFACE!{static interface IGattPresentationFormatStatics(IGattPresentationFormatStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattPresentationFormatStatics] {
     fn get_BluetoothSigAssignedNumbers(&self, out: *mut u8) -> HRESULT
@@ -10120,7 +10120,7 @@ impl GattPresentationFormatTypes {
         <Self as RtActivatable<IGattPresentationFormatTypesStatics>>::get_activation_factory().get_struct()
     }}
 }
-DEFINE_CLSID!(GattPresentationFormatTypes(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,80,114,101,115,101,110,116,97,116,105,111,110,70,111,114,109,97,116,84,121,112,101,115,0]) [CLSID_GattPresentationFormatTypes]);
+DEFINE_CLSID!(GattPresentationFormatTypes: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattPresentationFormatTypes");
 DEFINE_IID!(IID_IGattPresentationFormatTypesStatics, 4210145802, 12474, 16540, 190, 247, 207, 251, 109, 3, 184, 251);
 RT_INTERFACE!{static interface IGattPresentationFormatTypesStatics(IGattPresentationFormatTypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattPresentationFormatTypesStatics] {
     fn get_Boolean(&self, out: *mut u8) -> HRESULT,
@@ -10346,7 +10346,7 @@ impl GattProtocolError {
         <Self as RtActivatable<IGattProtocolErrorStatics>>::get_activation_factory().get_insufficient_resources()
     }}
 }
-DEFINE_CLSID!(GattProtocolError(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,80,114,111,116,111,99,111,108,69,114,114,111,114,0]) [CLSID_GattProtocolError]);
+DEFINE_CLSID!(GattProtocolError: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattProtocolError");
 DEFINE_IID!(IID_IGattProtocolErrorStatics, 3393635781, 3788, 18441, 190, 163, 207, 121, 188, 153, 30, 55);
 RT_INTERFACE!{static interface IGattProtocolErrorStatics(IGattProtocolErrorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattProtocolErrorStatics] {
     fn get_InvalidHandle(&self, out: *mut u8) -> HRESULT,
@@ -10601,7 +10601,7 @@ impl IGattReliableWriteTransaction {
 }
 RT_CLASS!{class GattReliableWriteTransaction: IGattReliableWriteTransaction}
 impl RtActivatable<IActivationFactory> for GattReliableWriteTransaction {}
-DEFINE_CLSID!(GattReliableWriteTransaction(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,82,101,108,105,97,98,108,101,87,114,105,116,101,84,114,97,110,115,97,99,116,105,111,110,0]) [CLSID_GattReliableWriteTransaction]);
+DEFINE_CLSID!(GattReliableWriteTransaction: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattReliableWriteTransaction");
 DEFINE_IID!(IID_IGattReliableWriteTransaction2, 1360083335, 61202, 17967, 159, 178, 161, 164, 58, 103, 148, 22);
 RT_INTERFACE!{interface IGattReliableWriteTransaction2(IGattReliableWriteTransaction2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattReliableWriteTransaction2] {
     fn CommitWithResultAsync(&self, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<GattWriteResult>) -> HRESULT
@@ -10684,7 +10684,7 @@ impl GattServiceProvider {
         <Self as RtActivatable<IGattServiceProviderStatics>>::get_activation_factory().create_async(serviceUuid)
     }}
 }
-DEFINE_CLSID!(GattServiceProvider(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,0]) [CLSID_GattServiceProvider]);
+DEFINE_CLSID!(GattServiceProvider: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProvider");
 RT_ENUM! { enum GattServiceProviderAdvertisementStatus: i32 {
     Created (GattServiceProviderAdvertisementStatus_Created) = 0, Stopped (GattServiceProviderAdvertisementStatus_Stopped) = 1, Started (GattServiceProviderAdvertisementStatus_Started) = 2, Aborted (GattServiceProviderAdvertisementStatus_Aborted) = 3,
 }}
@@ -10735,7 +10735,7 @@ impl IGattServiceProviderAdvertisingParameters {
 }
 RT_CLASS!{class GattServiceProviderAdvertisingParameters: IGattServiceProviderAdvertisingParameters}
 impl RtActivatable<IActivationFactory> for GattServiceProviderAdvertisingParameters {}
-DEFINE_CLSID!(GattServiceProviderAdvertisingParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,65,100,118,101,114,116,105,115,105,110,103,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_GattServiceProviderAdvertisingParameters]);
+DEFINE_CLSID!(GattServiceProviderAdvertisingParameters: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderAdvertisingParameters");
 DEFINE_IID!(IID_IGattServiceProviderResult, 1984337624, 50494, 17036, 138, 72, 103, 175, 224, 44, 58, 230);
 RT_INTERFACE!{interface IGattServiceProviderResult(IGattServiceProviderResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProviderResult] {
     fn get_Error(&self, out: *mut super::BluetoothError) -> HRESULT,
@@ -10836,7 +10836,7 @@ impl GattServiceUuids {
         <Self as RtActivatable<IGattServiceUuidsStatics2>>::get_activation_factory().get_tx_power()
     }}
 }
-DEFINE_CLSID!(GattServiceUuids(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,83,101,114,118,105,99,101,85,117,105,100,115,0]) [CLSID_GattServiceUuids]);
+DEFINE_CLSID!(GattServiceUuids: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceUuids");
 DEFINE_IID!(IID_IGattServiceUuidsStatics, 1841655896, 39610, 17431, 184, 242, 220, 224, 22, 211, 78, 226);
 RT_INTERFACE!{static interface IGattServiceUuidsStatics(IGattServiceUuidsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceUuidsStatics] {
     fn get_Battery(&self, out: *mut Guid) -> HRESULT,
@@ -11048,7 +11048,7 @@ impl GattSession {
         <Self as RtActivatable<IGattSessionStatics>>::get_activation_factory().from_device_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(GattSession(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,83,101,115,115,105,111,110,0]) [CLSID_GattSession]);
+DEFINE_CLSID!(GattSession: "Windows.Devices.Bluetooth.GenericAttributeProfile.GattSession");
 DEFINE_IID!(IID_IGattSessionStatics, 778418524, 21407, 19895, 130, 168, 115, 189, 187, 247, 62, 191);
 RT_INTERFACE!{static interface IGattSessionStatics(IGattSessionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattSessionStatics] {
     fn FromDeviceIdAsync(&self, deviceId: *mut super::BluetoothDeviceId, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<GattSession>) -> HRESULT
@@ -11291,7 +11291,7 @@ impl IBluetoothLEAdvertisement {
 }
 RT_CLASS!{class BluetoothLEAdvertisement: IBluetoothLEAdvertisement}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisement {}
-DEFINE_CLSID!(BluetoothLEAdvertisement(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,0]) [CLSID_BluetoothLEAdvertisement]);
+DEFINE_CLSID!(BluetoothLEAdvertisement: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementBytePattern, 4227520498, 47557, 18952, 188, 81, 80, 47, 142, 246, 138, 121);
 RT_INTERFACE!{interface IBluetoothLEAdvertisementBytePattern(IBluetoothLEAdvertisementBytePatternVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementBytePattern] {
     fn get_DataType(&self, out: *mut u8) -> HRESULT,
@@ -11338,7 +11338,7 @@ impl BluetoothLEAdvertisementBytePattern {
         <Self as RtActivatable<IBluetoothLEAdvertisementBytePatternFactory>>::get_activation_factory().create(dataType, offset, data)
     }}
 }
-DEFINE_CLSID!(BluetoothLEAdvertisementBytePattern(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,66,121,116,101,80,97,116,116,101,114,110,0]) [CLSID_BluetoothLEAdvertisementBytePattern]);
+DEFINE_CLSID!(BluetoothLEAdvertisementBytePattern: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementBytePattern");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementBytePatternFactory, 3269610867, 64860, 20163, 190, 42, 156, 166, 250, 17, 183, 189);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementBytePatternFactory(IBluetoothLEAdvertisementBytePatternFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementBytePatternFactory] {
     #[cfg(feature="windows-storage")] fn Create(&self, dataType: u8, offset: i16, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEAdvertisementBytePattern) -> HRESULT
@@ -11385,7 +11385,7 @@ impl BluetoothLEAdvertisementDataSection {
         <Self as RtActivatable<IBluetoothLEAdvertisementDataSectionFactory>>::get_activation_factory().create(dataType, data)
     }}
 }
-DEFINE_CLSID!(BluetoothLEAdvertisementDataSection(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,68,97,116,97,83,101,99,116,105,111,110,0]) [CLSID_BluetoothLEAdvertisementDataSection]);
+DEFINE_CLSID!(BluetoothLEAdvertisementDataSection: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataSection");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementDataSectionFactory, 3886287170, 43077, 16453, 191, 126, 62, 153, 113, 219, 138, 107);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementDataSectionFactory(IBluetoothLEAdvertisementDataSectionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementDataSectionFactory] {
     #[cfg(feature="windows-storage")] fn Create(&self, dataType: u8, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEAdvertisementDataSection) -> HRESULT
@@ -11467,7 +11467,7 @@ impl BluetoothLEAdvertisementDataTypes {
         <Self as RtActivatable<IBluetoothLEAdvertisementDataTypesStatics>>::get_activation_factory().get_manufacturer_specific_data()
     }}
 }
-DEFINE_CLSID!(BluetoothLEAdvertisementDataTypes(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,68,97,116,97,84,121,112,101,115,0]) [CLSID_BluetoothLEAdvertisementDataTypes]);
+DEFINE_CLSID!(BluetoothLEAdvertisementDataTypes: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataTypes");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementDataTypesStatics, 1001801519, 1542, 17227, 167, 110, 116, 21, 159, 6, 132, 211);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementDataTypesStatics(IBluetoothLEAdvertisementDataTypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementDataTypesStatics] {
     fn get_Flags(&self, out: *mut u8) -> HRESULT,
@@ -11629,7 +11629,7 @@ impl IBluetoothLEAdvertisementFilter {
 }
 RT_CLASS!{class BluetoothLEAdvertisementFilter: IBluetoothLEAdvertisementFilter}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementFilter {}
-DEFINE_CLSID!(BluetoothLEAdvertisementFilter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,70,105,108,116,101,114,0]) [CLSID_BluetoothLEAdvertisementFilter]);
+DEFINE_CLSID!(BluetoothLEAdvertisementFilter: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFilter");
 RT_ENUM! { enum BluetoothLEAdvertisementFlags: u32 {
     None (BluetoothLEAdvertisementFlags_None) = 0, LimitedDiscoverableMode (BluetoothLEAdvertisementFlags_LimitedDiscoverableMode) = 1, GeneralDiscoverableMode (BluetoothLEAdvertisementFlags_GeneralDiscoverableMode) = 2, ClassicNotSupported (BluetoothLEAdvertisementFlags_ClassicNotSupported) = 4, DualModeControllerCapable (BluetoothLEAdvertisementFlags_DualModeControllerCapable) = 8, DualModeHostCapable (BluetoothLEAdvertisementFlags_DualModeHostCapable) = 16,
 }}
@@ -11679,7 +11679,7 @@ impl BluetoothLEAdvertisementPublisher {
         <Self as RtActivatable<IBluetoothLEAdvertisementPublisherFactory>>::get_activation_factory().create(advertisement)
     }}
 }
-DEFINE_CLSID!(BluetoothLEAdvertisementPublisher(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,80,117,98,108,105,115,104,101,114,0]) [CLSID_BluetoothLEAdvertisementPublisher]);
+DEFINE_CLSID!(BluetoothLEAdvertisementPublisher: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementPublisherFactory, 1549731422, 47203, 18817, 161, 175, 28, 84, 77, 139, 12, 13);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementPublisherFactory(IBluetoothLEAdvertisementPublisherFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementPublisherFactory] {
     fn Create(&self, advertisement: *mut BluetoothLEAdvertisement, out: *mut *mut BluetoothLEAdvertisementPublisher) -> HRESULT
@@ -11859,7 +11859,7 @@ impl BluetoothLEAdvertisementWatcher {
         <Self as RtActivatable<IBluetoothLEAdvertisementWatcherFactory>>::get_activation_factory().create(advertisementFilter)
     }}
 }
-DEFINE_CLSID!(BluetoothLEAdvertisementWatcher(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,87,97,116,99,104,101,114,0]) [CLSID_BluetoothLEAdvertisementWatcher]);
+DEFINE_CLSID!(BluetoothLEAdvertisementWatcher: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher");
 DEFINE_IID!(IID_IBluetoothLEAdvertisementWatcherFactory, 2595171670, 14764, 17726, 179, 42, 133, 198, 87, 224, 23, 241);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementWatcherFactory(IBluetoothLEAdvertisementWatcherFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementWatcherFactory] {
     fn Create(&self, advertisementFilter: *mut BluetoothLEAdvertisementFilter, out: *mut *mut BluetoothLEAdvertisementWatcher) -> HRESULT
@@ -11921,7 +11921,7 @@ impl BluetoothLEManufacturerData {
         <Self as RtActivatable<IBluetoothLEManufacturerDataFactory>>::get_activation_factory().create(companyId, data)
     }}
 }
-DEFINE_CLSID!(BluetoothLEManufacturerData(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,77,97,110,117,102,97,99,116,117,114,101,114,68,97,116,97,0]) [CLSID_BluetoothLEManufacturerData]);
+DEFINE_CLSID!(BluetoothLEManufacturerData: "Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData");
 DEFINE_IID!(IID_IBluetoothLEManufacturerDataFactory, 3231398392, 12698, 17438, 141, 229, 102, 168, 30, 135, 122, 108);
 RT_INTERFACE!{static interface IBluetoothLEManufacturerDataFactory(IBluetoothLEManufacturerDataFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEManufacturerDataFactory] {
     #[cfg(feature="windows-storage")] fn Create(&self, companyId: u16, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEManufacturerData) -> HRESULT
@@ -12054,7 +12054,7 @@ impl GattServiceProviderConnection {
         <Self as RtActivatable<IGattServiceProviderConnectionStatics>>::get_activation_factory().get_all_services()
     }}
 }
-DEFINE_CLSID!(GattServiceProviderConnection(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,97,99,107,103,114,111,117,110,100,46,71,97,116,116,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,67,111,110,110,101,99,116,105,111,110,0]) [CLSID_GattServiceProviderConnection]);
+DEFINE_CLSID!(GattServiceProviderConnection: "Windows.Devices.Bluetooth.Background.GattServiceProviderConnection");
 DEFINE_IID!(IID_IGattServiceProviderConnectionStatics, 1028693835, 2830, 17510, 184, 205, 110, 189, 218, 31, 161, 125);
 RT_INTERFACE!{static interface IGattServiceProviderConnectionStatics(IGattServiceProviderConnectionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProviderConnectionStatics] {
     fn get_AllServices(&self, out: *mut *mut ::rt::gen::windows::foundation::collections::IMapView<HString, GattServiceProviderConnection>) -> HRESULT
@@ -12223,7 +12223,7 @@ impl DeviceAccessInformation {
         <Self as RtActivatable<IDeviceAccessInformationStatics>>::get_activation_factory().create_from_device_class(deviceClass)
     }}
 }
-DEFINE_CLSID!(DeviceAccessInformation(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,68,101,118,105,99,101,65,99,99,101,115,115,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_DeviceAccessInformation]);
+DEFINE_CLSID!(DeviceAccessInformation: "Windows.Devices.Enumeration.DeviceAccessInformation");
 DEFINE_IID!(IID_IDeviceAccessInformationStatics, 1464587219, 24368, 17869, 138, 148, 114, 79, 229, 151, 48, 132);
 RT_INTERFACE!{static interface IDeviceAccessInformationStatics(IDeviceAccessInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceAccessInformationStatics] {
     fn CreateFromId(&self, deviceId: HSTRING, out: *mut *mut DeviceAccessInformation) -> HRESULT,
@@ -12382,7 +12382,7 @@ impl DeviceInformation {
         <Self as RtActivatable<IDeviceInformationStatics2>>::get_activation_factory().create_watcher_with_kind_aqs_filter_and_additional_properties(aqsFilter, additionalProperties, kind)
     }}
 }
-DEFINE_CLSID!(DeviceInformation(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,68,101,118,105,99,101,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_DeviceInformation]);
+DEFINE_CLSID!(DeviceInformation: "Windows.Devices.Enumeration.DeviceInformation");
 DEFINE_IID!(IID_IDeviceInformation2, 4048987704, 31127, 18649, 161, 12, 38, 157, 70, 83, 63, 72);
 RT_INTERFACE!{interface IDeviceInformation2(IDeviceInformation2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceInformation2] {
     fn get_Kind(&self, out: *mut DeviceInformationKind) -> HRESULT,
@@ -12475,7 +12475,7 @@ impl DeviceInformationPairing {
         <Self as RtActivatable<IDeviceInformationPairingStatics>>::get_activation_factory().try_register_for_all_inbound_pairing_requests(pairingKindsSupported)
     }}
 }
-DEFINE_CLSID!(DeviceInformationPairing(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,68,101,118,105,99,101,73,110,102,111,114,109,97,116,105,111,110,80,97,105,114,105,110,103,0]) [CLSID_DeviceInformationPairing]);
+DEFINE_CLSID!(DeviceInformationPairing: "Windows.Devices.Enumeration.DeviceInformationPairing");
 DEFINE_IID!(IID_IDeviceInformationPairing2, 4135981821, 2798, 17192, 133, 204, 28, 116, 43, 177, 121, 13);
 RT_INTERFACE!{interface IDeviceInformationPairing2(IDeviceInformationPairing2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceInformationPairing2] {
     fn get_ProtectionLevel(&self, out: *mut DevicePairingProtectionLevel) -> HRESULT,
@@ -12802,7 +12802,7 @@ impl IDevicePicker {
 }
 RT_CLASS!{class DevicePicker: IDevicePicker}
 impl RtActivatable<IActivationFactory> for DevicePicker {}
-DEFINE_CLSID!(DevicePicker(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,68,101,118,105,99,101,80,105,99,107,101,114,0]) [CLSID_DevicePicker]);
+DEFINE_CLSID!(DevicePicker: "Windows.Devices.Enumeration.DevicePicker");
 DEFINE_IID!(IID_IDevicePickerAppearance, 3868857030, 58919, 20184, 155, 108, 70, 10, 244, 69, 229, 109);
 RT_INTERFACE!{interface IDevicePickerAppearance(IDevicePickerAppearanceVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePickerAppearance] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -13153,7 +13153,7 @@ impl PnpObject {
         <Self as RtActivatable<IPnpObjectStatics>>::get_activation_factory().create_watcher_aqs_filter(type_, requestedProperties, aqsFilter)
     }}
 }
-DEFINE_CLSID!(PnpObject(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,80,110,112,46,80,110,112,79,98,106,101,99,116,0]) [CLSID_PnpObject]);
+DEFINE_CLSID!(PnpObject: "Windows.Devices.Enumeration.Pnp.PnpObject");
 RT_CLASS!{class PnpObjectCollection: ::rt::gen::windows::foundation::collections::IVectorView<PnpObject>}
 DEFINE_IID!(IID_IPnpObjectStatics, 3015911997, 53608, 18016, 187, 243, 167, 51, 177, 75, 110, 1);
 RT_INTERFACE!{static interface IPnpObjectStatics(IPnpObjectStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPnpObjectStatics] {
@@ -13398,7 +13398,7 @@ impl GeoboundingBox {
         <Self as RtActivatable<IGeoboundingBoxStatics>>::get_activation_factory().try_compute_with_altitude_reference_and_spatial_reference(positions, altitudeRefSystem, spatialReferenceId)
     }}
 }
-DEFINE_CLSID!(GeoboundingBox(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,98,111,117,110,100,105,110,103,66,111,120,0]) [CLSID_GeoboundingBox]);
+DEFINE_CLSID!(GeoboundingBox: "Windows.Devices.Geolocation.GeoboundingBox");
 DEFINE_IID!(IID_IGeoboundingBoxFactory, 1308337545, 1041, 19132, 179, 181, 91, 188, 203, 87, 217, 140);
 RT_INTERFACE!{static interface IGeoboundingBoxFactory(IGeoboundingBoxFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGeoboundingBoxFactory] {
     fn Create(&self, northwestCorner: BasicGeoposition, southeastCorner: BasicGeoposition, out: *mut *mut GeoboundingBox) -> HRESULT,
@@ -13475,7 +13475,7 @@ impl Geocircle {
         <Self as RtActivatable<IGeocircleFactory>>::get_activation_factory().create_with_altitude_reference_system_and_spatial_reference_id(position, radius, altitudeReferenceSystem, spatialReferenceId)
     }}
 }
-DEFINE_CLSID!(Geocircle(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,99,105,114,99,108,101,0]) [CLSID_Geocircle]);
+DEFINE_CLSID!(Geocircle: "Windows.Devices.Geolocation.Geocircle");
 DEFINE_IID!(IID_IGeocircleFactory, 2950058783, 29361, 20349, 135, 204, 78, 212, 201, 132, 156, 5);
 RT_INTERFACE!{static interface IGeocircleFactory(IGeocircleFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGeocircleFactory] {
     fn Create(&self, position: BasicGeoposition, radius: f64, out: *mut *mut Geocircle) -> HRESULT,
@@ -13721,7 +13721,7 @@ impl Geolocator {
         <Self as RtActivatable<IGeolocatorStatics2>>::get_activation_factory().get_default_geoposition()
     }}
 }
-DEFINE_CLSID!(Geolocator(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,108,111,99,97,116,111,114,0]) [CLSID_Geolocator]);
+DEFINE_CLSID!(Geolocator: "Windows.Devices.Geolocation.Geolocator");
 DEFINE_IID!(IID_IGeolocator2, 3518246509, 34961, 17332, 173, 54, 39, 198, 254, 154, 151, 177);
 RT_INTERFACE!{interface IGeolocator2(IGeolocator2Vtbl): IInspectable(IInspectableVtbl) [IID_IGeolocator2] {
     fn AllowFallbackToConsentlessPositions(&self) -> HRESULT
@@ -13817,7 +13817,7 @@ impl Geopath {
         <Self as RtActivatable<IGeopathFactory>>::get_activation_factory().create_with_altitude_reference_and_spatial_reference(positions, altitudeReferenceSystem, spatialReferenceId)
     }}
 }
-DEFINE_CLSID!(Geopath(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,112,97,116,104,0]) [CLSID_Geopath]);
+DEFINE_CLSID!(Geopath: "Windows.Devices.Geolocation.Geopath");
 DEFINE_IID!(IID_IGeopathFactory, 666806728, 51175, 17241, 155, 155, 252, 163, 224, 94, 245, 147);
 RT_INTERFACE!{static interface IGeopathFactory(IGeopathFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGeopathFactory] {
     fn Create(&self, positions: *mut super::super::foundation::collections::IIterable<BasicGeoposition>, out: *mut *mut Geopath) -> HRESULT,
@@ -13865,7 +13865,7 @@ impl Geopoint {
         <Self as RtActivatable<IGeopointFactory>>::get_activation_factory().create_with_altitude_reference_system_and_spatial_reference_id(position, altitudeReferenceSystem, spatialReferenceId)
     }}
 }
-DEFINE_CLSID!(Geopoint(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,112,111,105,110,116,0]) [CLSID_Geopoint]);
+DEFINE_CLSID!(Geopoint: "Windows.Devices.Geolocation.Geopoint");
 DEFINE_IID!(IID_IGeopointFactory, 3681258803, 30397, 20016, 138, 247, 168, 68, 220, 55, 183, 160);
 RT_INTERFACE!{static interface IGeopointFactory(IGeopointFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGeopointFactory] {
     fn Create(&self, position: BasicGeoposition, out: *mut *mut Geopoint) -> HRESULT,
@@ -14008,7 +14008,7 @@ impl GeovisitMonitor {
         <Self as RtActivatable<IGeovisitMonitorStatics>>::get_activation_factory().get_last_report_async()
     }}
 }
-DEFINE_CLSID!(GeovisitMonitor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,118,105,115,105,116,77,111,110,105,116,111,114,0]) [CLSID_GeovisitMonitor]);
+DEFINE_CLSID!(GeovisitMonitor: "Windows.Devices.Geolocation.GeovisitMonitor");
 DEFINE_IID!(IID_IGeovisitMonitorStatics, 3170465447, 48114, 19677, 149, 207, 85, 76, 130, 237, 251, 135);
 RT_INTERFACE!{static interface IGeovisitMonitorStatics(IGeovisitMonitorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGeovisitMonitorStatics] {
     fn GetLastReportAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<Geovisit>) -> HRESULT
@@ -14166,7 +14166,7 @@ impl Geofence {
         <Self as RtActivatable<IGeofenceFactory>>::get_activation_factory().create_with_monitor_states_dwell_time_start_time_and_duration(id, geoshape, monitoredStates, singleUse, dwellTime, startTime, duration)
     }}
 }
-DEFINE_CLSID!(Geofence(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,102,101,110,99,105,110,103,46,71,101,111,102,101,110,99,101,0]) [CLSID_Geofence]);
+DEFINE_CLSID!(Geofence: "Windows.Devices.Geolocation.Geofencing.Geofence");
 DEFINE_IID!(IID_IGeofenceFactory, 2216649291, 12895, 19344, 188, 167, 43, 128, 34, 169, 55, 150);
 RT_INTERFACE!{static interface IGeofenceFactory(IGeofenceFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGeofenceFactory] {
     fn Create(&self, id: HSTRING, geoshape: *mut super::IGeoshape, out: *mut *mut Geofence) -> HRESULT,
@@ -14254,7 +14254,7 @@ impl GeofenceMonitor {
         <Self as RtActivatable<IGeofenceMonitorStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(GeofenceMonitor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,71,101,111,108,111,99,97,116,105,111,110,46,71,101,111,102,101,110,99,105,110,103,46,71,101,111,102,101,110,99,101,77,111,110,105,116,111,114,0]) [CLSID_GeofenceMonitor]);
+DEFINE_CLSID!(GeofenceMonitor: "Windows.Devices.Geolocation.Geofencing.GeofenceMonitor");
 DEFINE_IID!(IID_IGeofenceMonitorStatics, 768815055, 32373, 18585, 172, 227, 43, 208, 166, 92, 206, 6);
 RT_INTERFACE!{static interface IGeofenceMonitorStatics(IGeofenceMonitorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGeofenceMonitorStatics] {
     fn get_Current(&self, out: *mut *mut GeofenceMonitor) -> HRESULT
@@ -14331,7 +14331,7 @@ impl KnownSimpleHapticsControllerWaveforms {
         <Self as RtActivatable<IKnownSimpleHapticsControllerWaveformsStatics>>::get_activation_factory().get_release()
     }}
 }
-DEFINE_CLSID!(KnownSimpleHapticsControllerWaveforms(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,72,97,112,116,105,99,115,46,75,110,111,119,110,83,105,109,112,108,101,72,97,112,116,105,99,115,67,111,110,116,114,111,108,108,101,114,87,97,118,101,102,111,114,109,115,0]) [CLSID_KnownSimpleHapticsControllerWaveforms]);
+DEFINE_CLSID!(KnownSimpleHapticsControllerWaveforms: "Windows.Devices.Haptics.KnownSimpleHapticsControllerWaveforms");
 DEFINE_IID!(IID_IKnownSimpleHapticsControllerWaveformsStatics, 1029144311, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{static interface IKnownSimpleHapticsControllerWaveformsStatics(IKnownSimpleHapticsControllerWaveformsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownSimpleHapticsControllerWaveformsStatics] {
     fn get_Click(&self, out: *mut u16) -> HRESULT,
@@ -14491,7 +14491,7 @@ impl VibrationDevice {
         <Self as RtActivatable<IVibrationDeviceStatics>>::get_activation_factory().find_all_async()
     }}
 }
-DEFINE_CLSID!(VibrationDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,72,97,112,116,105,99,115,46,86,105,98,114,97,116,105,111,110,68,101,118,105,99,101,0]) [CLSID_VibrationDevice]);
+DEFINE_CLSID!(VibrationDevice: "Windows.Devices.Haptics.VibrationDevice");
 DEFINE_IID!(IID_IVibrationDeviceStatics, 1407380973, 8848, 19145, 142, 179, 26, 132, 18, 46, 183, 28);
 RT_INTERFACE!{static interface IVibrationDeviceStatics(IVibrationDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IVibrationDeviceStatics] {
     fn RequestAccessAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<VibrationAccessStatus>) -> HRESULT,
@@ -14788,7 +14788,7 @@ impl HidDevice {
         <Self as RtActivatable<IHidDeviceStatics>>::get_activation_factory().from_id_async(deviceId, accessMode)
     }}
 }
-DEFINE_CLSID!(HidDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,72,117,109,97,110,73,110,116,101,114,102,97,99,101,68,101,118,105,99,101,46,72,105,100,68,101,118,105,99,101,0]) [CLSID_HidDevice]);
+DEFINE_CLSID!(HidDevice: "Windows.Devices.HumanInterfaceDevice.HidDevice");
 DEFINE_IID!(IID_IHidDeviceStatics, 2656666084, 38998, 16780, 159, 115, 119, 222, 12, 216, 87, 84);
 RT_INTERFACE!{static interface IHidDeviceStatics(IHidDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHidDeviceStatics] {
     fn GetDeviceSelector(&self, usagePage: u16, usageId: u16, out: *mut HSTRING) -> HRESULT,
@@ -15156,7 +15156,7 @@ impl IKeyboardCapabilities {
 }
 RT_CLASS!{class KeyboardCapabilities: IKeyboardCapabilities}
 impl RtActivatable<IActivationFactory> for KeyboardCapabilities {}
-DEFINE_CLSID!(KeyboardCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,75,101,121,98,111,97,114,100,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_KeyboardCapabilities]);
+DEFINE_CLSID!(KeyboardCapabilities: "Windows.Devices.Input.KeyboardCapabilities");
 DEFINE_IID!(IID_IMouseCapabilities, 3164987427, 32217, 19307, 154, 146, 85, 212, 60, 179, 143, 115);
 RT_INTERFACE!{interface IMouseCapabilities(IMouseCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IMouseCapabilities] {
     fn get_MousePresent(&self, out: *mut i32) -> HRESULT,
@@ -15194,7 +15194,7 @@ impl IMouseCapabilities {
 }
 RT_CLASS!{class MouseCapabilities: IMouseCapabilities}
 impl RtActivatable<IActivationFactory> for MouseCapabilities {}
-DEFINE_CLSID!(MouseCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,77,111,117,115,101,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_MouseCapabilities]);
+DEFINE_CLSID!(MouseCapabilities: "Windows.Devices.Input.MouseCapabilities");
 RT_STRUCT! { struct MouseDelta {
     X: i32, Y: i32,
 }}
@@ -15221,7 +15221,7 @@ impl MouseDevice {
         <Self as RtActivatable<IMouseDeviceStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(MouseDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,77,111,117,115,101,68,101,118,105,99,101,0]) [CLSID_MouseDevice]);
+DEFINE_CLSID!(MouseDevice: "Windows.Devices.Input.MouseDevice");
 DEFINE_IID!(IID_IMouseDeviceStatics, 1212846149, 28016, 18907, 142, 104, 70, 255, 189, 23, 211, 141);
 RT_INTERFACE!{static interface IMouseDeviceStatics(IMouseDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMouseDeviceStatics] {
     fn GetForCurrentView(&self, out: *mut *mut MouseDevice) -> HRESULT
@@ -15296,7 +15296,7 @@ impl PointerDevice {
         <Self as RtActivatable<IPointerDeviceStatics>>::get_activation_factory().get_pointer_devices()
     }}
 }
-DEFINE_CLSID!(PointerDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,80,111,105,110,116,101,114,68,101,118,105,99,101,0]) [CLSID_PointerDevice]);
+DEFINE_CLSID!(PointerDevice: "Windows.Devices.Input.PointerDevice");
 DEFINE_IID!(IID_IPointerDevice2, 4171682464, 50308, 18591, 174, 62, 48, 210, 238, 31, 253, 62);
 RT_INTERFACE!{interface IPointerDevice2(IPointerDevice2Vtbl): IInspectable(IInspectableVtbl) [IID_IPointerDevice2] {
     fn get_MaxPointersWithZDistance(&self, out: *mut u32) -> HRESULT
@@ -15350,7 +15350,7 @@ impl ITouchCapabilities {
 }
 RT_CLASS!{class TouchCapabilities: ITouchCapabilities}
 impl RtActivatable<IActivationFactory> for TouchCapabilities {}
-DEFINE_CLSID!(TouchCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,84,111,117,99,104,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_TouchCapabilities]);
+DEFINE_CLSID!(TouchCapabilities: "Windows.Devices.Input.TouchCapabilities");
 } // Windows.Devices.Input
 pub mod lights { // Windows.Devices.Lights
 use ::prelude::*;
@@ -15430,7 +15430,7 @@ impl Lamp {
         <Self as RtActivatable<ILampStatics>>::get_activation_factory().get_default_async()
     }}
 }
-DEFINE_CLSID!(Lamp(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,76,105,103,104,116,115,46,76,97,109,112,0]) [CLSID_Lamp]);
+DEFINE_CLSID!(Lamp: "Windows.Devices.Lights.Lamp");
 DEFINE_IID!(IID_ILampAvailabilityChangedEventArgs, 1332624877, 1954, 18845, 146, 96, 103, 227, 4, 83, 43, 164);
 RT_INTERFACE!{interface ILampAvailabilityChangedEventArgs(ILampAvailabilityChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILampAvailabilityChangedEventArgs] {
     fn get_IsAvailable(&self, out: *mut bool) -> HRESULT
@@ -15471,7 +15471,7 @@ pub mod midi { // Windows.Devices.Midi
 use ::prelude::*;
 RT_CLASS!{class MidiActiveSensingMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiActiveSensingMessage {}
-DEFINE_CLSID!(MidiActiveSensingMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,65,99,116,105,118,101,83,101,110,115,105,110,103,77,101,115,115,97,103,101,0]) [CLSID_MidiActiveSensingMessage]);
+DEFINE_CLSID!(MidiActiveSensingMessage: "Windows.Devices.Midi.MidiActiveSensingMessage");
 DEFINE_IID!(IID_IMidiChannelPressureMessage, 3189745760, 25268, 19794, 163, 126, 146, 229, 77, 53, 185, 9);
 RT_INTERFACE!{interface IMidiChannelPressureMessage(IMidiChannelPressureMessageVtbl): IInspectable(IInspectableVtbl) [IID_IMidiChannelPressureMessage] {
     fn get_Channel(&self, out: *mut u8) -> HRESULT,
@@ -15496,7 +15496,7 @@ impl MidiChannelPressureMessage {
         <Self as RtActivatable<IMidiChannelPressureMessageFactory>>::get_activation_factory().create_midi_channel_pressure_message(channel, pressure)
     }}
 }
-DEFINE_CLSID!(MidiChannelPressureMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,67,104,97,110,110,101,108,80,114,101,115,115,117,114,101,77,101,115,115,97,103,101,0]) [CLSID_MidiChannelPressureMessage]);
+DEFINE_CLSID!(MidiChannelPressureMessage: "Windows.Devices.Midi.MidiChannelPressureMessage");
 DEFINE_IID!(IID_IMidiChannelPressureMessageFactory, 1645800751, 8836, 16682, 148, 207, 16, 251, 4, 132, 44, 108);
 RT_INTERFACE!{static interface IMidiChannelPressureMessageFactory(IMidiChannelPressureMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiChannelPressureMessageFactory] {
     fn CreateMidiChannelPressureMessage(&self, channel: u8, pressure: u8, out: *mut *mut MidiChannelPressureMessage) -> HRESULT
@@ -15510,7 +15510,7 @@ impl IMidiChannelPressureMessageFactory {
 }
 RT_CLASS!{class MidiContinueMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiContinueMessage {}
-DEFINE_CLSID!(MidiContinueMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,67,111,110,116,105,110,117,101,77,101,115,115,97,103,101,0]) [CLSID_MidiContinueMessage]);
+DEFINE_CLSID!(MidiContinueMessage: "Windows.Devices.Midi.MidiContinueMessage");
 DEFINE_IID!(IID_IMidiControlChangeMessage, 3085000579, 30733, 16479, 183, 129, 62, 21, 152, 201, 127, 64);
 RT_INTERFACE!{interface IMidiControlChangeMessage(IMidiControlChangeMessageVtbl): IInspectable(IInspectableVtbl) [IID_IMidiControlChangeMessage] {
     fn get_Channel(&self, out: *mut u8) -> HRESULT,
@@ -15541,7 +15541,7 @@ impl MidiControlChangeMessage {
         <Self as RtActivatable<IMidiControlChangeMessageFactory>>::get_activation_factory().create_midi_control_change_message(channel, controller, controlValue)
     }}
 }
-DEFINE_CLSID!(MidiControlChangeMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,67,111,110,116,114,111,108,67,104,97,110,103,101,77,101,115,115,97,103,101,0]) [CLSID_MidiControlChangeMessage]);
+DEFINE_CLSID!(MidiControlChangeMessage: "Windows.Devices.Midi.MidiControlChangeMessage");
 DEFINE_IID!(IID_IMidiControlChangeMessageFactory, 716260129, 38252, 18093, 151, 82, 248, 127, 85, 5, 47, 227);
 RT_INTERFACE!{static interface IMidiControlChangeMessageFactory(IMidiControlChangeMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiControlChangeMessageFactory] {
     fn CreateMidiControlChangeMessage(&self, channel: u8, controller: u8, controlValue: u8, out: *mut *mut MidiControlChangeMessage) -> HRESULT
@@ -15585,7 +15585,7 @@ impl MidiInPort {
         <Self as RtActivatable<IMidiInPortStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(MidiInPort(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,73,110,80,111,114,116,0]) [CLSID_MidiInPort]);
+DEFINE_CLSID!(MidiInPort: "Windows.Devices.Midi.MidiInPort");
 DEFINE_IID!(IID_IMidiInPortStatics, 1153710556, 26623, 19054, 139, 172, 253, 182, 97, 12, 242, 150);
 RT_INTERFACE!{static interface IMidiInPortStatics(IMidiInPortStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMidiInPortStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<MidiInPort>) -> HRESULT,
@@ -15672,7 +15672,7 @@ impl MidiNoteOffMessage {
         <Self as RtActivatable<IMidiNoteOffMessageFactory>>::get_activation_factory().create_midi_note_off_message(channel, note, velocity)
     }}
 }
-DEFINE_CLSID!(MidiNoteOffMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,78,111,116,101,79,102,102,77,101,115,115,97,103,101,0]) [CLSID_MidiNoteOffMessage]);
+DEFINE_CLSID!(MidiNoteOffMessage: "Windows.Devices.Midi.MidiNoteOffMessage");
 DEFINE_IID!(IID_IMidiNoteOffMessageFactory, 2796699872, 42825, 16991, 138, 244, 164, 217, 121, 204, 21, 181);
 RT_INTERFACE!{static interface IMidiNoteOffMessageFactory(IMidiNoteOffMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiNoteOffMessageFactory] {
     fn CreateMidiNoteOffMessage(&self, channel: u8, note: u8, velocity: u8, out: *mut *mut MidiNoteOffMessage) -> HRESULT
@@ -15714,7 +15714,7 @@ impl MidiNoteOnMessage {
         <Self as RtActivatable<IMidiNoteOnMessageFactory>>::get_activation_factory().create_midi_note_on_message(channel, note, velocity)
     }}
 }
-DEFINE_CLSID!(MidiNoteOnMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,78,111,116,101,79,110,77,101,115,115,97,103,101,0]) [CLSID_MidiNoteOnMessage]);
+DEFINE_CLSID!(MidiNoteOnMessage: "Windows.Devices.Midi.MidiNoteOnMessage");
 DEFINE_IID!(IID_IMidiNoteOnMessageFactory, 2604826784, 22977, 16910, 181, 23, 21, 161, 10, 169, 96, 107);
 RT_INTERFACE!{static interface IMidiNoteOnMessageFactory(IMidiNoteOnMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiNoteOnMessageFactory] {
     fn CreateMidiNoteOnMessage(&self, channel: u8, note: u8, velocity: u8, out: *mut *mut MidiNoteOnMessage) -> HRESULT
@@ -15758,7 +15758,7 @@ impl MidiOutPort {
         <Self as RtActivatable<IMidiOutPortStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(MidiOutPort(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,79,117,116,80,111,114,116,0]) [CLSID_MidiOutPort]);
+DEFINE_CLSID!(MidiOutPort: "Windows.Devices.Midi.MidiOutPort");
 DEFINE_IID!(IID_IMidiOutPortStatics, 106742761, 3976, 17547, 155, 100, 169, 88, 38, 198, 91, 143);
 RT_INTERFACE!{static interface IMidiOutPortStatics(IMidiOutPortStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMidiOutPortStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<IMidiOutPort>) -> HRESULT,
@@ -15800,7 +15800,7 @@ impl MidiPitchBendChangeMessage {
         <Self as RtActivatable<IMidiPitchBendChangeMessageFactory>>::get_activation_factory().create_midi_pitch_bend_change_message(channel, bend)
     }}
 }
-DEFINE_CLSID!(MidiPitchBendChangeMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,80,105,116,99,104,66,101,110,100,67,104,97,110,103,101,77,101,115,115,97,103,101,0]) [CLSID_MidiPitchBendChangeMessage]);
+DEFINE_CLSID!(MidiPitchBendChangeMessage: "Windows.Devices.Midi.MidiPitchBendChangeMessage");
 DEFINE_IID!(IID_IMidiPitchBendChangeMessageFactory, 4126072661, 53192, 18726, 179, 14, 163, 98, 35, 147, 48, 108);
 RT_INTERFACE!{static interface IMidiPitchBendChangeMessageFactory(IMidiPitchBendChangeMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiPitchBendChangeMessageFactory] {
     fn CreateMidiPitchBendChangeMessage(&self, channel: u8, bend: u16, out: *mut *mut MidiPitchBendChangeMessage) -> HRESULT
@@ -15842,7 +15842,7 @@ impl MidiPolyphonicKeyPressureMessage {
         <Self as RtActivatable<IMidiPolyphonicKeyPressureMessageFactory>>::get_activation_factory().create_midi_polyphonic_key_pressure_message(channel, note, pressure)
     }}
 }
-DEFINE_CLSID!(MidiPolyphonicKeyPressureMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,80,111,108,121,112,104,111,110,105,99,75,101,121,80,114,101,115,115,117,114,101,77,101,115,115,97,103,101,0]) [CLSID_MidiPolyphonicKeyPressureMessage]);
+DEFINE_CLSID!(MidiPolyphonicKeyPressureMessage: "Windows.Devices.Midi.MidiPolyphonicKeyPressureMessage");
 DEFINE_IID!(IID_IMidiPolyphonicKeyPressureMessageFactory, 3918481470, 50355, 19922, 145, 124, 227, 73, 129, 90, 27, 59);
 RT_INTERFACE!{static interface IMidiPolyphonicKeyPressureMessageFactory(IMidiPolyphonicKeyPressureMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiPolyphonicKeyPressureMessageFactory] {
     fn CreateMidiPolyphonicKeyPressureMessage(&self, channel: u8, note: u8, pressure: u8, out: *mut *mut MidiPolyphonicKeyPressureMessage) -> HRESULT
@@ -15878,7 +15878,7 @@ impl MidiProgramChangeMessage {
         <Self as RtActivatable<IMidiProgramChangeMessageFactory>>::get_activation_factory().create_midi_program_change_message(channel, program)
     }}
 }
-DEFINE_CLSID!(MidiProgramChangeMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,80,114,111,103,114,97,109,67,104,97,110,103,101,77,101,115,115,97,103,101,0]) [CLSID_MidiProgramChangeMessage]);
+DEFINE_CLSID!(MidiProgramChangeMessage: "Windows.Devices.Midi.MidiProgramChangeMessage");
 DEFINE_IID!(IID_IMidiProgramChangeMessageFactory, 3601875847, 21067, 16644, 156, 153, 101, 114, 191, 210, 226, 97);
 RT_INTERFACE!{static interface IMidiProgramChangeMessageFactory(IMidiProgramChangeMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiProgramChangeMessageFactory] {
     fn CreateMidiProgramChangeMessage(&self, channel: u8, program: u8, out: *mut *mut MidiProgramChangeMessage) -> HRESULT
@@ -15908,7 +15908,7 @@ impl MidiSongPositionPointerMessage {
         <Self as RtActivatable<IMidiSongPositionPointerMessageFactory>>::get_activation_factory().create_midi_song_position_pointer_message(beats)
     }}
 }
-DEFINE_CLSID!(MidiSongPositionPointerMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,111,110,103,80,111,115,105,116,105,111,110,80,111,105,110,116,101,114,77,101,115,115,97,103,101,0]) [CLSID_MidiSongPositionPointerMessage]);
+DEFINE_CLSID!(MidiSongPositionPointerMessage: "Windows.Devices.Midi.MidiSongPositionPointerMessage");
 DEFINE_IID!(IID_IMidiSongPositionPointerMessageFactory, 2617305494, 61707, 20458, 179, 149, 245, 214, 207, 128, 246, 78);
 RT_INTERFACE!{static interface IMidiSongPositionPointerMessageFactory(IMidiSongPositionPointerMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiSongPositionPointerMessageFactory] {
     fn CreateMidiSongPositionPointerMessage(&self, beats: u16, out: *mut *mut MidiSongPositionPointerMessage) -> HRESULT
@@ -15938,7 +15938,7 @@ impl MidiSongSelectMessage {
         <Self as RtActivatable<IMidiSongSelectMessageFactory>>::get_activation_factory().create_midi_song_select_message(song)
     }}
 }
-DEFINE_CLSID!(MidiSongSelectMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,111,110,103,83,101,108,101,99,116,77,101,115,115,97,103,101,0]) [CLSID_MidiSongSelectMessage]);
+DEFINE_CLSID!(MidiSongSelectMessage: "Windows.Devices.Midi.MidiSongSelectMessage");
 DEFINE_IID!(IID_IMidiSongSelectMessageFactory, 2223536356, 34632, 16681, 166, 108, 160, 84, 147, 247, 93, 170);
 RT_INTERFACE!{static interface IMidiSongSelectMessageFactory(IMidiSongSelectMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiSongSelectMessageFactory] {
     fn CreateMidiSongSelectMessage(&self, song: u8, out: *mut *mut MidiSongSelectMessage) -> HRESULT
@@ -15952,10 +15952,10 @@ impl IMidiSongSelectMessageFactory {
 }
 RT_CLASS!{class MidiStartMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiStartMessage {}
-DEFINE_CLSID!(MidiStartMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,116,97,114,116,77,101,115,115,97,103,101,0]) [CLSID_MidiStartMessage]);
+DEFINE_CLSID!(MidiStartMessage: "Windows.Devices.Midi.MidiStartMessage");
 RT_CLASS!{class MidiStopMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiStopMessage {}
-DEFINE_CLSID!(MidiStopMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,116,111,112,77,101,115,115,97,103,101,0]) [CLSID_MidiStopMessage]);
+DEFINE_CLSID!(MidiStopMessage: "Windows.Devices.Midi.MidiStopMessage");
 DEFINE_IID!(IID_IMidiSynthesizer, 4040824158, 56208, 16479, 184, 174, 33, 210, 225, 127, 46, 69);
 RT_INTERFACE!{interface IMidiSynthesizer(IMidiSynthesizerVtbl): IInspectable(IInspectableVtbl) [IID_IMidiSynthesizer] {
     fn get_AudioDevice(&self, out: *mut *mut super::enumeration::DeviceInformation) -> HRESULT,
@@ -15991,7 +15991,7 @@ impl MidiSynthesizer {
         <Self as RtActivatable<IMidiSynthesizerStatics>>::get_activation_factory().is_synthesizer(midiDevice)
     }}
 }
-DEFINE_CLSID!(MidiSynthesizer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,121,110,116,104,101,115,105,122,101,114,0]) [CLSID_MidiSynthesizer]);
+DEFINE_CLSID!(MidiSynthesizer: "Windows.Devices.Midi.MidiSynthesizer");
 DEFINE_IID!(IID_IMidiSynthesizerStatics, 1109715624, 26153, 19819, 170, 143, 212, 82, 26, 90, 49, 206);
 RT_INTERFACE!{static interface IMidiSynthesizerStatics(IMidiSynthesizerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMidiSynthesizerStatics] {
     fn CreateAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<MidiSynthesizer>) -> HRESULT,
@@ -16022,7 +16022,7 @@ impl MidiSystemExclusiveMessage {
         <Self as RtActivatable<IMidiSystemExclusiveMessageFactory>>::get_activation_factory().create_midi_system_exclusive_message(rawData)
     }}
 }
-DEFINE_CLSID!(MidiSystemExclusiveMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,121,115,116,101,109,69,120,99,108,117,115,105,118,101,77,101,115,115,97,103,101,0]) [CLSID_MidiSystemExclusiveMessage]);
+DEFINE_CLSID!(MidiSystemExclusiveMessage: "Windows.Devices.Midi.MidiSystemExclusiveMessage");
 DEFINE_IID!(IID_IMidiSystemExclusiveMessageFactory, 138273314, 15220, 17184, 155, 66, 12, 168, 84, 95, 138, 36);
 RT_INTERFACE!{static interface IMidiSystemExclusiveMessageFactory(IMidiSystemExclusiveMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiSystemExclusiveMessageFactory] {
     #[cfg(feature="windows-storage")] fn CreateMidiSystemExclusiveMessage(&self, rawData: *mut super::super::storage::streams::IBuffer, out: *mut *mut MidiSystemExclusiveMessage) -> HRESULT
@@ -16036,7 +16036,7 @@ impl IMidiSystemExclusiveMessageFactory {
 }
 RT_CLASS!{class MidiSystemResetMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiSystemResetMessage {}
-DEFINE_CLSID!(MidiSystemResetMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,121,115,116,101,109,82,101,115,101,116,77,101,115,115,97,103,101,0]) [CLSID_MidiSystemResetMessage]);
+DEFINE_CLSID!(MidiSystemResetMessage: "Windows.Devices.Midi.MidiSystemResetMessage");
 DEFINE_IID!(IID_IMidiTimeCodeMessage, 200738941, 64099, 18972, 141, 235, 192, 232, 119, 150, 166, 215);
 RT_INTERFACE!{interface IMidiTimeCodeMessage(IMidiTimeCodeMessageVtbl): IInspectable(IInspectableVtbl) [IID_IMidiTimeCodeMessage] {
     fn get_FrameType(&self, out: *mut u8) -> HRESULT,
@@ -16061,7 +16061,7 @@ impl MidiTimeCodeMessage {
         <Self as RtActivatable<IMidiTimeCodeMessageFactory>>::get_activation_factory().create_midi_time_code_message(frameType, values)
     }}
 }
-DEFINE_CLSID!(MidiTimeCodeMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,84,105,109,101,67,111,100,101,77,101,115,115,97,103,101,0]) [CLSID_MidiTimeCodeMessage]);
+DEFINE_CLSID!(MidiTimeCodeMessage: "Windows.Devices.Midi.MidiTimeCodeMessage");
 DEFINE_IID!(IID_IMidiTimeCodeMessageFactory, 3945830853, 30492, 16606, 185, 97, 23, 90, 116, 137, 168, 94);
 RT_INTERFACE!{static interface IMidiTimeCodeMessageFactory(IMidiTimeCodeMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMidiTimeCodeMessageFactory] {
     fn CreateMidiTimeCodeMessage(&self, frameType: u8, values: u8, out: *mut *mut MidiTimeCodeMessage) -> HRESULT
@@ -16075,10 +16075,10 @@ impl IMidiTimeCodeMessageFactory {
 }
 RT_CLASS!{class MidiTimingClockMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiTimingClockMessage {}
-DEFINE_CLSID!(MidiTimingClockMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,84,105,109,105,110,103,67,108,111,99,107,77,101,115,115,97,103,101,0]) [CLSID_MidiTimingClockMessage]);
+DEFINE_CLSID!(MidiTimingClockMessage: "Windows.Devices.Midi.MidiTimingClockMessage");
 RT_CLASS!{class MidiTuneRequestMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiTuneRequestMessage {}
-DEFINE_CLSID!(MidiTuneRequestMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,84,117,110,101,82,101,113,117,101,115,116,77,101,115,115,97,103,101,0]) [CLSID_MidiTuneRequestMessage]);
+DEFINE_CLSID!(MidiTuneRequestMessage: "Windows.Devices.Midi.MidiTuneRequestMessage");
 } // Windows.Devices.Midi
 pub mod perception { // Windows.Devices.Perception
 use ::prelude::*;
@@ -16098,7 +16098,7 @@ impl KnownCameraIntrinsicsProperties {
         <Self as RtActivatable<IKnownCameraIntrinsicsPropertiesStatics>>::get_activation_factory().get_tangential_distortion()
     }}
 }
-DEFINE_CLSID!(KnownCameraIntrinsicsProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,67,97,109,101,114,97,73,110,116,114,105,110,115,105,99,115,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownCameraIntrinsicsProperties]);
+DEFINE_CLSID!(KnownCameraIntrinsicsProperties: "Windows.Devices.Perception.KnownCameraIntrinsicsProperties");
 DEFINE_IID!(IID_IKnownCameraIntrinsicsPropertiesStatics, 146815352, 17274, 19863, 166, 99, 253, 49, 149, 96, 2, 73);
 RT_INTERFACE!{static interface IKnownCameraIntrinsicsPropertiesStatics(IKnownCameraIntrinsicsPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownCameraIntrinsicsPropertiesStatics] {
     fn get_FocalLength(&self, out: *mut HSTRING) -> HRESULT,
@@ -16141,7 +16141,7 @@ impl KnownPerceptionColorFrameSourceProperties {
         <Self as RtActivatable<IKnownPerceptionColorFrameSourcePropertiesStatics>>::get_activation_factory().get_exposure_compensation()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionColorFrameSourceProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,67,111,108,111,114,70,114,97,109,101,83,111,117,114,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownPerceptionColorFrameSourceProperties]);
+DEFINE_CLSID!(KnownPerceptionColorFrameSourceProperties: "Windows.Devices.Perception.KnownPerceptionColorFrameSourceProperties");
 DEFINE_IID!(IID_IKnownPerceptionColorFrameSourcePropertiesStatics, 1576127650, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 75);
 RT_INTERFACE!{static interface IKnownPerceptionColorFrameSourcePropertiesStatics(IKnownPerceptionColorFrameSourcePropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionColorFrameSourcePropertiesStatics] {
     fn get_Exposure(&self, out: *mut HSTRING) -> HRESULT,
@@ -16175,7 +16175,7 @@ impl KnownPerceptionDepthFrameSourceProperties {
         <Self as RtActivatable<IKnownPerceptionDepthFrameSourcePropertiesStatics>>::get_activation_factory().get_max_depth()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionDepthFrameSourceProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,68,101,112,116,104,70,114,97,109,101,83,111,117,114,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownPerceptionDepthFrameSourceProperties]);
+DEFINE_CLSID!(KnownPerceptionDepthFrameSourceProperties: "Windows.Devices.Perception.KnownPerceptionDepthFrameSourceProperties");
 DEFINE_IID!(IID_IKnownPerceptionDepthFrameSourcePropertiesStatics, 1576127650, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 74);
 RT_INTERFACE!{static interface IKnownPerceptionDepthFrameSourcePropertiesStatics(IKnownPerceptionDepthFrameSourcePropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionDepthFrameSourcePropertiesStatics] {
     fn get_MinDepth(&self, out: *mut HSTRING) -> HRESULT,
@@ -16216,7 +16216,7 @@ impl KnownPerceptionFrameSourceProperties {
         <Self as RtActivatable<IKnownPerceptionFrameSourcePropertiesStatics2>>::get_activation_factory().get_device_id()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionFrameSourceProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,70,114,97,109,101,83,111,117,114,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownPerceptionFrameSourceProperties]);
+DEFINE_CLSID!(KnownPerceptionFrameSourceProperties: "Windows.Devices.Perception.KnownPerceptionFrameSourceProperties");
 DEFINE_IID!(IID_IKnownPerceptionFrameSourcePropertiesStatics, 1576127650, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 71);
 RT_INTERFACE!{static interface IKnownPerceptionFrameSourcePropertiesStatics(IKnownPerceptionFrameSourcePropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionFrameSourcePropertiesStatics] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -16288,7 +16288,7 @@ impl KnownPerceptionInfraredFrameSourceProperties {
         <Self as RtActivatable<IKnownPerceptionInfraredFrameSourcePropertiesStatics>>::get_activation_factory().get_interleaved_illumination_enabled()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionInfraredFrameSourceProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,73,110,102,114,97,114,101,100,70,114,97,109,101,83,111,117,114,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownPerceptionInfraredFrameSourceProperties]);
+DEFINE_CLSID!(KnownPerceptionInfraredFrameSourceProperties: "Windows.Devices.Perception.KnownPerceptionInfraredFrameSourceProperties");
 DEFINE_IID!(IID_IKnownPerceptionInfraredFrameSourcePropertiesStatics, 1576127650, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 73);
 RT_INTERFACE!{static interface IKnownPerceptionInfraredFrameSourcePropertiesStatics(IKnownPerceptionInfraredFrameSourcePropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionInfraredFrameSourcePropertiesStatics] {
     fn get_Exposure(&self, out: *mut HSTRING) -> HRESULT,
@@ -16355,7 +16355,7 @@ impl KnownPerceptionVideoFrameSourceProperties {
         <Self as RtActivatable<IKnownPerceptionVideoFrameSourcePropertiesStatics>>::get_activation_factory().get_camera_intrinsics()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionVideoFrameSourceProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,86,105,100,101,111,70,114,97,109,101,83,111,117,114,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownPerceptionVideoFrameSourceProperties]);
+DEFINE_CLSID!(KnownPerceptionVideoFrameSourceProperties: "Windows.Devices.Perception.KnownPerceptionVideoFrameSourceProperties");
 DEFINE_IID!(IID_IKnownPerceptionVideoFrameSourcePropertiesStatics, 1576127650, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 72);
 RT_INTERFACE!{static interface IKnownPerceptionVideoFrameSourcePropertiesStatics(IKnownPerceptionVideoFrameSourcePropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionVideoFrameSourcePropertiesStatics] {
     fn get_VideoProfile(&self, out: *mut HSTRING) -> HRESULT,
@@ -16410,7 +16410,7 @@ impl KnownPerceptionVideoProfileProperties {
         <Self as RtActivatable<IKnownPerceptionVideoProfilePropertiesStatics>>::get_activation_factory().get_frame_duration()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionVideoProfileProperties(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,86,105,100,101,111,80,114,111,102,105,108,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownPerceptionVideoProfileProperties]);
+DEFINE_CLSID!(KnownPerceptionVideoProfileProperties: "Windows.Devices.Perception.KnownPerceptionVideoProfileProperties");
 DEFINE_IID!(IID_IKnownPerceptionVideoProfilePropertiesStatics, 2399724263, 23158, 17379, 161, 58, 218, 61, 145, 169, 239, 152);
 RT_INTERFACE!{static interface IKnownPerceptionVideoProfilePropertiesStatics(IKnownPerceptionVideoProfilePropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionVideoProfilePropertiesStatics] {
     fn get_BitmapPixelFormat(&self, out: *mut HSTRING) -> HRESULT,
@@ -16707,7 +16707,7 @@ impl PerceptionColorFrameSource {
         <Self as RtActivatable<IPerceptionColorFrameSourceStatics>>::get_activation_factory().request_access_async()
     }}
 }
-DEFINE_CLSID!(PerceptionColorFrameSource(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,101,114,99,101,112,116,105,111,110,67,111,108,111,114,70,114,97,109,101,83,111,117,114,99,101,0]) [CLSID_PerceptionColorFrameSource]);
+DEFINE_CLSID!(PerceptionColorFrameSource: "Windows.Devices.Perception.PerceptionColorFrameSource");
 DEFINE_IID!(IID_IPerceptionColorFrameSource2, 4169140453, 22065, 17901, 173, 152, 140, 106, 160, 76, 251, 145);
 RT_INTERFACE!{interface IPerceptionColorFrameSource2(IPerceptionColorFrameSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionColorFrameSource2] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT
@@ -17180,7 +17180,7 @@ impl PerceptionDepthFrameSource {
         <Self as RtActivatable<IPerceptionDepthFrameSourceStatics>>::get_activation_factory().request_access_async()
     }}
 }
-DEFINE_CLSID!(PerceptionDepthFrameSource(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,101,114,99,101,112,116,105,111,110,68,101,112,116,104,70,114,97,109,101,83,111,117,114,99,101,0]) [CLSID_PerceptionDepthFrameSource]);
+DEFINE_CLSID!(PerceptionDepthFrameSource: "Windows.Devices.Perception.PerceptionDepthFrameSource");
 DEFINE_IID!(IID_IPerceptionDepthFrameSource2, 3822206254, 28204, 20077, 145, 217, 112, 76, 216, 223, 247, 157);
 RT_INTERFACE!{interface IPerceptionDepthFrameSource2(IPerceptionDepthFrameSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrameSource2] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT
@@ -17614,7 +17614,7 @@ impl PerceptionInfraredFrameSource {
         <Self as RtActivatable<IPerceptionInfraredFrameSourceStatics>>::get_activation_factory().request_access_async()
     }}
 }
-DEFINE_CLSID!(PerceptionInfraredFrameSource(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,101,114,99,101,112,116,105,111,110,73,110,102,114,97,114,101,100,70,114,97,109,101,83,111,117,114,99,101,0]) [CLSID_PerceptionInfraredFrameSource]);
+DEFINE_CLSID!(PerceptionInfraredFrameSource: "Windows.Devices.Perception.PerceptionInfraredFrameSource");
 DEFINE_IID!(IID_IPerceptionInfraredFrameSource2, 3704936344, 19211, 17152, 141, 133, 65, 8, 23, 250, 160, 50);
 RT_INTERFACE!{interface IPerceptionInfraredFrameSource2(IPerceptionInfraredFrameSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionInfraredFrameSource2] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT
@@ -17804,7 +17804,7 @@ impl KnownPerceptionFrameKind {
         <Self as RtActivatable<IKnownPerceptionFrameKindStatics>>::get_activation_factory().get_infrared()
     }}
 }
-DEFINE_CLSID!(KnownPerceptionFrameKind(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,75,110,111,119,110,80,101,114,99,101,112,116,105,111,110,70,114,97,109,101,75,105,110,100,0]) [CLSID_KnownPerceptionFrameKind]);
+DEFINE_CLSID!(KnownPerceptionFrameKind: "Windows.Devices.Perception.Provider.KnownPerceptionFrameKind");
 DEFINE_IID!(IID_IKnownPerceptionFrameKindStatics, 988172758, 38505, 16646, 159, 174, 72, 53, 193, 185, 97, 4);
 RT_INTERFACE!{static interface IKnownPerceptionFrameKindStatics(IKnownPerceptionFrameKindStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownPerceptionFrameKindStatics] {
     fn get_Color(&self, out: *mut HSTRING) -> HRESULT,
@@ -17846,7 +17846,7 @@ impl PerceptionControlGroup {
         <Self as RtActivatable<IPerceptionControlGroupFactory>>::get_activation_factory().create(ids)
     }}
 }
-DEFINE_CLSID!(PerceptionControlGroup(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,67,111,110,116,114,111,108,71,114,111,117,112,0]) [CLSID_PerceptionControlGroup]);
+DEFINE_CLSID!(PerceptionControlGroup: "Windows.Devices.Perception.Provider.PerceptionControlGroup");
 DEFINE_IID!(IID_IPerceptionControlGroupFactory, 790295264, 47857, 17723, 190, 212, 205, 157, 70, 25, 21, 76);
 RT_INTERFACE!{static interface IPerceptionControlGroupFactory(IPerceptionControlGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionControlGroupFactory] {
     fn Create(&self, ids: *mut ::rt::gen::windows::foundation::collections::IIterable<HString>, out: *mut *mut PerceptionControlGroup) -> HRESULT
@@ -17888,7 +17888,7 @@ impl PerceptionCorrelation {
         <Self as RtActivatable<IPerceptionCorrelationFactory>>::get_activation_factory().create(targetId, position, orientation)
     }}
 }
-DEFINE_CLSID!(PerceptionCorrelation(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,67,111,114,114,101,108,97,116,105,111,110,0]) [CLSID_PerceptionCorrelation]);
+DEFINE_CLSID!(PerceptionCorrelation: "Windows.Devices.Perception.Provider.PerceptionCorrelation");
 DEFINE_IID!(IID_IPerceptionCorrelationFactory, 3567698981, 10372, 19087, 129, 52, 40, 53, 215, 40, 108, 191);
 RT_INTERFACE!{static interface IPerceptionCorrelationFactory(IPerceptionCorrelationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionCorrelationFactory] {
     fn Create(&self, targetId: HSTRING, position: ::rt::gen::windows::foundation::numerics::Vector3, orientation: ::rt::gen::windows::foundation::numerics::Quaternion, out: *mut *mut PerceptionCorrelation) -> HRESULT
@@ -17918,7 +17918,7 @@ impl PerceptionCorrelationGroup {
         <Self as RtActivatable<IPerceptionCorrelationGroupFactory>>::get_activation_factory().create(relativeLocations)
     }}
 }
-DEFINE_CLSID!(PerceptionCorrelationGroup(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,67,111,114,114,101,108,97,116,105,111,110,71,114,111,117,112,0]) [CLSID_PerceptionCorrelationGroup]);
+DEFINE_CLSID!(PerceptionCorrelationGroup: "Windows.Devices.Perception.Provider.PerceptionCorrelationGroup");
 DEFINE_IID!(IID_IPerceptionCorrelationGroupFactory, 2113806472, 25567, 18669, 131, 177, 74, 184, 41, 19, 41, 149);
 RT_INTERFACE!{static interface IPerceptionCorrelationGroupFactory(IPerceptionCorrelationGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionCorrelationGroupFactory] {
     fn Create(&self, relativeLocations: *mut ::rt::gen::windows::foundation::collections::IIterable<PerceptionCorrelation>, out: *mut *mut PerceptionCorrelationGroup) -> HRESULT
@@ -17948,7 +17948,7 @@ impl PerceptionFaceAuthenticationGroup {
         <Self as RtActivatable<IPerceptionFaceAuthenticationGroupFactory>>::get_activation_factory().create(ids, startHandler, stopHandler)
     }}
 }
-DEFINE_CLSID!(PerceptionFaceAuthenticationGroup(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,70,97,99,101,65,117,116,104,101,110,116,105,99,97,116,105,111,110,71,114,111,117,112,0]) [CLSID_PerceptionFaceAuthenticationGroup]);
+DEFINE_CLSID!(PerceptionFaceAuthenticationGroup: "Windows.Devices.Perception.Provider.PerceptionFaceAuthenticationGroup");
 DEFINE_IID!(IID_IPerceptionFaceAuthenticationGroupFactory, 3867805140, 46604, 16628, 188, 185, 242, 77, 70, 70, 115, 32);
 RT_INTERFACE!{static interface IPerceptionFaceAuthenticationGroupFactory(IPerceptionFaceAuthenticationGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionFaceAuthenticationGroupFactory] {
     fn Create(&self, ids: *mut ::rt::gen::windows::foundation::collections::IIterable<HString>, startHandler: *mut PerceptionStartFaceAuthenticationHandler, stopHandler: *mut PerceptionStopFaceAuthenticationHandler, out: *mut *mut PerceptionFaceAuthenticationGroup) -> HRESULT
@@ -18089,7 +18089,7 @@ impl IPerceptionFrameProviderInfo {
 }
 RT_CLASS!{class PerceptionFrameProviderInfo: IPerceptionFrameProviderInfo}
 impl RtActivatable<IActivationFactory> for PerceptionFrameProviderInfo {}
-DEFINE_CLSID!(PerceptionFrameProviderInfo(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,70,114,97,109,101,80,114,111,118,105,100,101,114,73,110,102,111,0]) [CLSID_PerceptionFrameProviderInfo]);
+DEFINE_CLSID!(PerceptionFrameProviderInfo: "Windows.Devices.Perception.Provider.PerceptionFrameProviderInfo");
 DEFINE_IID!(IID_IPerceptionFrameProviderManager, 2841234951, 60115, 13279, 142, 193, 185, 36, 171, 224, 25, 196);
 RT_INTERFACE!{interface IPerceptionFrameProviderManager(IPerceptionFrameProviderManagerVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionFrameProviderManager] {
     fn GetFrameProvider(&self, frameProviderInfo: *mut PerceptionFrameProviderInfo, out: *mut *mut IPerceptionFrameProvider) -> HRESULT
@@ -18135,7 +18135,7 @@ impl PerceptionFrameProviderManagerService {
         <Self as RtActivatable<IPerceptionFrameProviderManagerServiceStatics>>::get_activation_factory().publish_frame_for_provider(provider, frame)
     }}
 }
-DEFINE_CLSID!(PerceptionFrameProviderManagerService(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,70,114,97,109,101,80,114,111,118,105,100,101,114,77,97,110,97,103,101,114,83,101,114,118,105,99,101,0]) [CLSID_PerceptionFrameProviderManagerService]);
+DEFINE_CLSID!(PerceptionFrameProviderManagerService: "Windows.Devices.Perception.Provider.PerceptionFrameProviderManagerService");
 DEFINE_IID!(IID_IPerceptionFrameProviderManagerServiceStatics, 2927855334, 51929, 17241, 143, 150, 142, 174, 81, 129, 5, 38);
 RT_INTERFACE!{static interface IPerceptionFrameProviderManagerServiceStatics(IPerceptionFrameProviderManagerServiceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionFrameProviderManagerServiceStatics] {
     fn RegisterFrameProviderInfo(&self, manager: *mut IPerceptionFrameProviderManager, frameProviderInfo: *mut PerceptionFrameProviderInfo) -> HRESULT,
@@ -18271,7 +18271,7 @@ impl PerceptionVideoFrameAllocator {
         <Self as RtActivatable<IPerceptionVideoFrameAllocatorFactory>>::get_activation_factory().create(maxOutstandingFrameCountForWrite, format, resolution, alpha)
     }}
 }
-DEFINE_CLSID!(PerceptionVideoFrameAllocator(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,86,105,100,101,111,70,114,97,109,101,65,108,108,111,99,97,116,111,114,0]) [CLSID_PerceptionVideoFrameAllocator]);
+DEFINE_CLSID!(PerceptionVideoFrameAllocator: "Windows.Devices.Perception.Provider.PerceptionVideoFrameAllocator");
 DEFINE_IID!(IID_IPerceptionVideoFrameAllocatorFactory, 442020065, 59674, 18462, 184, 118, 168, 158, 43, 188, 107, 51);
 RT_INTERFACE!{static interface IPerceptionVideoFrameAllocatorFactory(IPerceptionVideoFrameAllocatorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionVideoFrameAllocatorFactory] {
     #[cfg(feature="windows-graphics")] fn Create(&self, maxOutstandingFrameCountForWrite: u32, format: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, resolution: ::rt::gen::windows::foundation::Size, alpha: ::rt::gen::windows::graphics::imaging::BitmapAlphaMode, out: *mut *mut PerceptionVideoFrameAllocator) -> HRESULT
@@ -18375,7 +18375,7 @@ impl BarcodeScanner {
         <Self as RtActivatable<IBarcodeScannerStatics2>>::get_activation_factory().get_device_selector_with_connection_types(connectionTypes)
     }}
 }
-DEFINE_CLSID!(BarcodeScanner(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,66,97,114,99,111,100,101,83,99,97,110,110,101,114,0]) [CLSID_BarcodeScanner]);
+DEFINE_CLSID!(BarcodeScanner: "Windows.Devices.PointOfService.BarcodeScanner");
 DEFINE_IID!(IID_IBarcodeScanner2, 2300662119, 36078, 17261, 137, 171, 141, 251, 67, 187, 66, 134);
 RT_INTERFACE!{interface IBarcodeScanner2(IBarcodeScanner2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScanner2] {
     fn get_VideoDeviceId(&self, out: *mut HSTRING) -> HRESULT
@@ -18845,7 +18845,7 @@ impl BarcodeSymbologies {
         <Self as RtActivatable<IBarcodeSymbologiesStatics2>>::get_activation_factory().get_gs1_dwcode()
     }}
 }
-DEFINE_CLSID!(BarcodeSymbologies(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,66,97,114,99,111,100,101,83,121,109,98,111,108,111,103,105,101,115,0]) [CLSID_BarcodeSymbologies]);
+DEFINE_CLSID!(BarcodeSymbologies: "Windows.Devices.PointOfService.BarcodeSymbologies");
 DEFINE_IID!(IID_IBarcodeSymbologiesStatics, 3397732795, 1746, 17396, 164, 75, 198, 32, 103, 159, 216, 208);
 RT_INTERFACE!{static interface IBarcodeSymbologiesStatics(IBarcodeSymbologiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeSymbologiesStatics] {
     fn get_Unknown(&self, out: *mut u32) -> HRESULT,
@@ -19589,7 +19589,7 @@ impl CashDrawer {
         <Self as RtActivatable<ICashDrawerStatics2>>::get_activation_factory().get_device_selector_with_connection_types(connectionTypes)
     }}
 }
-DEFINE_CLSID!(CashDrawer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,67,97,115,104,68,114,97,119,101,114,0]) [CLSID_CashDrawer]);
+DEFINE_CLSID!(CashDrawer: "Windows.Devices.PointOfService.CashDrawer");
 DEFINE_IID!(IID_ICashDrawerCapabilities, 197582347, 59623, 19231, 177, 209, 62, 80, 26, 208, 130, 71);
 RT_INTERFACE!{interface ICashDrawerCapabilities(ICashDrawerCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_ICashDrawerCapabilities] {
     fn get_PowerReportingType(&self, out: *mut UnifiedPosPowerReportingType) -> HRESULT,
@@ -20159,7 +20159,7 @@ impl ClaimedLineDisplay {
         <Self as RtActivatable<IClaimedLineDisplayStatics>>::get_activation_factory().get_device_selector_with_connection_types(connectionTypes)
     }}
 }
-DEFINE_CLSID!(ClaimedLineDisplay(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,67,108,97,105,109,101,100,76,105,110,101,68,105,115,112,108,97,121,0]) [CLSID_ClaimedLineDisplay]);
+DEFINE_CLSID!(ClaimedLineDisplay: "Windows.Devices.PointOfService.ClaimedLineDisplay");
 DEFINE_IID!(IID_IClaimedLineDisplay2, 2736551405, 16885, 20086, 160, 116, 121, 94, 71, 164, 110, 151);
 RT_INTERFACE!{interface IClaimedLineDisplay2(IClaimedLineDisplay2Vtbl): IInspectable(IInspectableVtbl) [IID_IClaimedLineDisplay2] {
     fn GetStatisticsAsync(&self, statisticsCategories: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut super::super::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -21056,7 +21056,7 @@ impl LineDisplay {
         <Self as RtActivatable<ILineDisplayStatics2>>::get_activation_factory().get_statistics_category_selector()
     }}
 }
-DEFINE_CLSID!(LineDisplay(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,76,105,110,101,68,105,115,112,108,97,121,0]) [CLSID_LineDisplay]);
+DEFINE_CLSID!(LineDisplay: "Windows.Devices.PointOfService.LineDisplay");
 DEFINE_IID!(IID_ILineDisplay2, 3264652840, 61252, 16627, 189, 28, 176, 76, 106, 92, 220, 125);
 RT_INTERFACE!{interface ILineDisplay2(ILineDisplay2Vtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplay2] {
     fn CheckPowerStatusAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<LineDisplayPowerStatus>) -> HRESULT
@@ -21771,7 +21771,7 @@ impl MagneticStripeReader {
         <Self as RtActivatable<IMagneticStripeReaderStatics2>>::get_activation_factory().get_device_selector_with_connection_types(connectionTypes)
     }}
 }
-DEFINE_CLSID!(MagneticStripeReader(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,77,97,103,110,101,116,105,99,83,116,114,105,112,101,82,101,97,100,101,114,0]) [CLSID_MagneticStripeReader]);
+DEFINE_CLSID!(MagneticStripeReader: "Windows.Devices.PointOfService.MagneticStripeReader");
 DEFINE_IID!(IID_IMagneticStripeReaderAamvaCardDataReceivedEventArgs, 172735825, 49942, 18704, 135, 243, 122, 98, 186, 134, 45, 49);
 RT_INTERFACE!{interface IMagneticStripeReaderAamvaCardDataReceivedEventArgs(IMagneticStripeReaderAamvaCardDataReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMagneticStripeReaderAamvaCardDataReceivedEventArgs] {
     fn get_Report(&self, out: *mut *mut MagneticStripeReaderReport) -> HRESULT,
@@ -22046,7 +22046,7 @@ impl MagneticStripeReaderCardTypes {
         <Self as RtActivatable<IMagneticStripeReaderCardTypesStatics>>::get_activation_factory().get_extended_base()
     }}
 }
-DEFINE_CLSID!(MagneticStripeReaderCardTypes(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,77,97,103,110,101,116,105,99,83,116,114,105,112,101,82,101,97,100,101,114,67,97,114,100,84,121,112,101,115,0]) [CLSID_MagneticStripeReaderCardTypes]);
+DEFINE_CLSID!(MagneticStripeReaderCardTypes: "Windows.Devices.PointOfService.MagneticStripeReaderCardTypes");
 DEFINE_IID!(IID_IMagneticStripeReaderCardTypesStatics, 1385114717, 10630, 18255, 132, 84, 124, 205, 5, 146, 141, 95);
 RT_INTERFACE!{static interface IMagneticStripeReaderCardTypesStatics(IMagneticStripeReaderCardTypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMagneticStripeReaderCardTypesStatics] {
     fn get_Unknown(&self, out: *mut u32) -> HRESULT,
@@ -22089,7 +22089,7 @@ impl MagneticStripeReaderEncryptionAlgorithms {
         <Self as RtActivatable<IMagneticStripeReaderEncryptionAlgorithmsStatics>>::get_activation_factory().get_extended_base()
     }}
 }
-DEFINE_CLSID!(MagneticStripeReaderEncryptionAlgorithms(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,77,97,103,110,101,116,105,99,83,116,114,105,112,101,82,101,97,100,101,114,69,110,99,114,121,112,116,105,111,110,65,108,103,111,114,105,116,104,109,115,0]) [CLSID_MagneticStripeReaderEncryptionAlgorithms]);
+DEFINE_CLSID!(MagneticStripeReaderEncryptionAlgorithms: "Windows.Devices.PointOfService.MagneticStripeReaderEncryptionAlgorithms");
 DEFINE_IID!(IID_IMagneticStripeReaderEncryptionAlgorithmsStatics, 1404400464, 50139, 18260, 156, 0, 65, 57, 35, 116, 161, 9);
 RT_INTERFACE!{static interface IMagneticStripeReaderEncryptionAlgorithmsStatics(IMagneticStripeReaderEncryptionAlgorithmsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMagneticStripeReaderEncryptionAlgorithmsStatics] {
     fn get_None(&self, out: *mut u32) -> HRESULT,
@@ -22399,7 +22399,7 @@ impl PosPrinter {
         <Self as RtActivatable<IPosPrinterStatics2>>::get_activation_factory().get_device_selector_with_connection_types(connectionTypes)
     }}
 }
-DEFINE_CLSID!(PosPrinter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,80,111,115,80,114,105,110,116,101,114,0]) [CLSID_PosPrinter]);
+DEFINE_CLSID!(PosPrinter: "Windows.Devices.PointOfService.PosPrinter");
 RT_ENUM! { enum PosPrinterAlignment: i32 {
     Left (PosPrinterAlignment_Left) = 0, Center (PosPrinterAlignment_Center) = 1, Right (PosPrinterAlignment_Right) = 2,
 }}
@@ -22488,7 +22488,7 @@ impl PosPrinterCharacterSetIds {
         <Self as RtActivatable<IPosPrinterCharacterSetIdsStatics>>::get_activation_factory().get_ansi()
     }}
 }
-DEFINE_CLSID!(PosPrinterCharacterSetIds(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,80,111,115,80,114,105,110,116,101,114,67,104,97,114,97,99,116,101,114,83,101,116,73,100,115,0]) [CLSID_PosPrinterCharacterSetIds]);
+DEFINE_CLSID!(PosPrinterCharacterSetIds: "Windows.Devices.PointOfService.PosPrinterCharacterSetIds");
 DEFINE_IID!(IID_IPosPrinterCharacterSetIdsStatics, 1550884607, 28826, 20455, 178, 21, 6, 167, 72, 163, 139, 57);
 RT_INTERFACE!{static interface IPosPrinterCharacterSetIdsStatics(IPosPrinterCharacterSetIdsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPosPrinterCharacterSetIdsStatics] {
     fn get_Utf16LE(&self, out: *mut u32) -> HRESULT,
@@ -22885,7 +22885,7 @@ impl Radio {
         <Self as RtActivatable<IRadioStatics>>::get_activation_factory().request_access_async()
     }}
 }
-DEFINE_CLSID!(Radio(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,82,97,100,105,111,115,46,82,97,100,105,111,0]) [CLSID_Radio]);
+DEFINE_CLSID!(Radio: "Windows.Devices.Radios.Radio");
 RT_ENUM! { enum RadioAccessStatus: i32 {
     Unspecified (RadioAccessStatus_Unspecified) = 0, Allowed (RadioAccessStatus_Allowed) = 1, DeniedByUser (RadioAccessStatus_DeniedByUser) = 2, DeniedBySystem (RadioAccessStatus_DeniedBySystem) = 3,
 }}
@@ -22995,7 +22995,7 @@ impl Accelerometer {
         <Self as RtActivatable<IAccelerometerStatics3>>::get_activation_factory().get_device_selector(readingType)
     }}
 }
-DEFINE_CLSID!(Accelerometer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,65,99,99,101,108,101,114,111,109,101,116,101,114,0]) [CLSID_Accelerometer]);
+DEFINE_CLSID!(Accelerometer: "Windows.Devices.Sensors.Accelerometer");
 DEFINE_IID!(IID_IAccelerometer2, 3908080366, 18788, 16410, 182, 2, 34, 13, 113, 83, 198, 10);
 RT_INTERFACE!{interface IAccelerometer2(IAccelerometer2Vtbl): IInspectable(IInspectableVtbl) [IID_IAccelerometer2] {
     #[cfg(feature="windows-graphics")] fn put_ReadingTransform(&self, value: super::super::graphics::display::DisplayOrientations) -> HRESULT,
@@ -23240,7 +23240,7 @@ impl ActivitySensor {
         <Self as RtActivatable<IActivitySensorStatics>>::get_activation_factory().get_system_history_with_duration_async(fromTime, duration)
     }}
 }
-DEFINE_CLSID!(ActivitySensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,65,99,116,105,118,105,116,121,83,101,110,115,111,114,0]) [CLSID_ActivitySensor]);
+DEFINE_CLSID!(ActivitySensor: "Windows.Devices.Sensors.ActivitySensor");
 DEFINE_IID!(IID_IActivitySensorReading, 2232572566, 5234, 16546, 178, 174, 225, 239, 41, 34, 108, 120);
 RT_INTERFACE!{interface IActivitySensorReading(IActivitySensorReadingVtbl): IInspectable(IInspectableVtbl) [IID_IActivitySensorReading] {
     fn get_Timestamp(&self, out: *mut super::super::foundation::DateTime) -> HRESULT,
@@ -23394,7 +23394,7 @@ impl Altimeter {
         <Self as RtActivatable<IAltimeterStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(Altimeter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,65,108,116,105,109,101,116,101,114,0]) [CLSID_Altimeter]);
+DEFINE_CLSID!(Altimeter: "Windows.Devices.Sensors.Altimeter");
 DEFINE_IID!(IID_IAltimeter2, 3376880633, 10973, 18677, 159, 8, 61, 12, 118, 96, 217, 56);
 RT_INTERFACE!{interface IAltimeter2(IAltimeter2Vtbl): IInspectable(IInspectableVtbl) [IID_IAltimeter2] {
     fn put_ReportLatency(&self, value: u32) -> HRESULT,
@@ -23534,7 +23534,7 @@ impl Barometer {
         <Self as RtActivatable<IBarometerStatics2>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(Barometer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,66,97,114,111,109,101,116,101,114,0]) [CLSID_Barometer]);
+DEFINE_CLSID!(Barometer: "Windows.Devices.Sensors.Barometer");
 DEFINE_IID!(IID_IBarometer2, 851231768, 16107, 19716, 149, 116, 118, 51, 168, 120, 31, 159);
 RT_INTERFACE!{interface IBarometer2(IBarometer2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarometer2] {
     fn put_ReportLatency(&self, value: u32) -> HRESULT,
@@ -23685,7 +23685,7 @@ impl Compass {
         <Self as RtActivatable<ICompassStatics2>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(Compass(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,67,111,109,112,97,115,115,0]) [CLSID_Compass]);
+DEFINE_CLSID!(Compass: "Windows.Devices.Sensors.Compass");
 DEFINE_IID!(IID_ICompass2, 921857289, 51159, 17231, 180, 97, 151, 157, 223, 194, 50, 47);
 RT_INTERFACE!{interface ICompass2(ICompass2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompass2] {
     #[cfg(feature="windows-graphics")] fn put_ReadingTransform(&self, value: super::super::graphics::display::DisplayOrientations) -> HRESULT,
@@ -23880,7 +23880,7 @@ impl Gyrometer {
         <Self as RtActivatable<IGyrometerStatics2>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(Gyrometer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,71,121,114,111,109,101,116,101,114,0]) [CLSID_Gyrometer]);
+DEFINE_CLSID!(Gyrometer: "Windows.Devices.Sensors.Gyrometer");
 DEFINE_IID!(IID_IGyrometer2, 1675568195, 36072, 16835, 172, 68, 134, 152, 129, 11, 85, 127);
 RT_INTERFACE!{interface IGyrometer2(IGyrometer2Vtbl): IInspectable(IInspectableVtbl) [IID_IGyrometer2] {
     #[cfg(feature="windows-graphics")] fn put_ReadingTransform(&self, value: super::super::graphics::display::DisplayOrientations) -> HRESULT,
@@ -24078,7 +24078,7 @@ impl Inclinometer {
         <Self as RtActivatable<IInclinometerStatics4>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(Inclinometer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,73,110,99,108,105,110,111,109,101,116,101,114,0]) [CLSID_Inclinometer]);
+DEFINE_CLSID!(Inclinometer: "Windows.Devices.Sensors.Inclinometer");
 DEFINE_IID!(IID_IInclinometer2, 43987859, 10418, 17912, 187, 22, 97, 232, 106, 127, 174, 110);
 RT_INTERFACE!{interface IInclinometer2(IInclinometer2Vtbl): IInspectable(IInspectableVtbl) [IID_IInclinometer2] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -24309,7 +24309,7 @@ impl LightSensor {
         <Self as RtActivatable<ILightSensorStatics2>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(LightSensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,76,105,103,104,116,83,101,110,115,111,114,0]) [CLSID_LightSensor]);
+DEFINE_CLSID!(LightSensor: "Windows.Devices.Sensors.LightSensor");
 DEFINE_IID!(IID_ILightSensor2, 1214981352, 43340, 16528, 143, 72, 9, 247, 130, 169, 247, 213);
 RT_INTERFACE!{interface ILightSensor2(ILightSensor2Vtbl): IInspectable(IInspectableVtbl) [IID_ILightSensor2] {
     fn put_ReportLatency(&self, value: u32) -> HRESULT,
@@ -24471,7 +24471,7 @@ impl Magnetometer {
         <Self as RtActivatable<IMagnetometerStatics2>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(Magnetometer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,77,97,103,110,101,116,111,109,101,116,101,114,0]) [CLSID_Magnetometer]);
+DEFINE_CLSID!(Magnetometer: "Windows.Devices.Sensors.Magnetometer");
 DEFINE_IID!(IID_IMagnetometer2, 3026545797, 9974, 17483, 169, 226, 162, 63, 150, 108, 211, 104);
 RT_INTERFACE!{interface IMagnetometer2(IMagnetometer2Vtbl): IInspectable(IInspectableVtbl) [IID_IMagnetometer2] {
     #[cfg(feature="windows-graphics")] fn put_ReadingTransform(&self, value: super::super::graphics::display::DisplayOrientations) -> HRESULT,
@@ -24684,7 +24684,7 @@ impl OrientationSensor {
         <Self as RtActivatable<IOrientationSensorStatics4>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(OrientationSensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,79,114,105,101,110,116,97,116,105,111,110,83,101,110,115,111,114,0]) [CLSID_OrientationSensor]);
+DEFINE_CLSID!(OrientationSensor: "Windows.Devices.Sensors.OrientationSensor");
 DEFINE_IID!(IID_IOrientationSensor2, 227691769, 12063, 18889, 128, 66, 74, 24, 19, 214, 119, 96);
 RT_INTERFACE!{interface IOrientationSensor2(IOrientationSensor2Vtbl): IInspectable(IInspectableVtbl) [IID_IOrientationSensor2] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -24936,7 +24936,7 @@ impl Pedometer {
         <Self as RtActivatable<IPedometerStatics2>>::get_activation_factory().get_readings_from_trigger_details(triggerDetails)
     }}
 }
-DEFINE_CLSID!(Pedometer(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,80,101,100,111,109,101,116,101,114,0]) [CLSID_Pedometer]);
+DEFINE_CLSID!(Pedometer: "Windows.Devices.Sensors.Pedometer");
 DEFINE_IID!(IID_IPedometer2, 3852732127, 11137, 19165, 178, 255, 119, 171, 108, 152, 186, 25);
 RT_INTERFACE!{interface IPedometer2(IPedometer2Vtbl): IInspectable(IInspectableVtbl) [IID_IPedometer2] {
     fn GetCurrentReadings(&self, out: *mut *mut super::super::foundation::collections::IMapView<PedometerStepKind, PedometerReading>) -> HRESULT
@@ -24955,7 +24955,7 @@ impl PedometerDataThreshold {
         <Self as RtActivatable<IPedometerDataThresholdFactory>>::get_activation_factory().create(sensor, stepGoal)
     }}
 }
-DEFINE_CLSID!(PedometerDataThreshold(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,80,101,100,111,109,101,116,101,114,68,97,116,97,84,104,114,101,115,104,111,108,100,0]) [CLSID_PedometerDataThreshold]);
+DEFINE_CLSID!(PedometerDataThreshold: "Windows.Devices.Sensors.PedometerDataThreshold");
 DEFINE_IID!(IID_IPedometerDataThresholdFactory, 3417149264, 31316, 18027, 144, 16, 119, 161, 98, 252, 165, 215);
 RT_INTERFACE!{static interface IPedometerDataThresholdFactory(IPedometerDataThresholdFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPedometerDataThresholdFactory] {
     fn Create(&self, sensor: *mut Pedometer, stepGoal: i32, out: *mut *mut PedometerDataThreshold) -> HRESULT
@@ -25118,7 +25118,7 @@ impl ProximitySensor {
         <Self as RtActivatable<IProximitySensorStatics2>>::get_activation_factory().get_readings_from_trigger_details(triggerDetails)
     }}
 }
-DEFINE_CLSID!(ProximitySensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,80,114,111,120,105,109,105,116,121,83,101,110,115,111,114,0]) [CLSID_ProximitySensor]);
+DEFINE_CLSID!(ProximitySensor: "Windows.Devices.Sensors.ProximitySensor");
 RT_CLASS!{class ProximitySensorDataThreshold: ISensorDataThreshold}
 impl RtActivatable<IProximitySensorDataThresholdFactory> for ProximitySensorDataThreshold {}
 impl ProximitySensorDataThreshold {
@@ -25126,7 +25126,7 @@ impl ProximitySensorDataThreshold {
         <Self as RtActivatable<IProximitySensorDataThresholdFactory>>::get_activation_factory().create(sensor)
     }}
 }
-DEFINE_CLSID!(ProximitySensorDataThreshold(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,80,114,111,120,105,109,105,116,121,83,101,110,115,111,114,68,97,116,97,84,104,114,101,115,104,111,108,100,0]) [CLSID_ProximitySensorDataThreshold]);
+DEFINE_CLSID!(ProximitySensorDataThreshold: "Windows.Devices.Sensors.ProximitySensorDataThreshold");
 DEFINE_IID!(IID_IProximitySensorDataThresholdFactory, 2421866785, 27943, 19155, 157, 181, 100, 103, 242, 165, 173, 157);
 RT_INTERFACE!{static interface IProximitySensorDataThresholdFactory(IProximitySensorDataThresholdFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IProximitySensorDataThresholdFactory] {
     fn Create(&self, sensor: *mut ProximitySensor, out: *mut *mut ProximitySensorDataThreshold) -> HRESULT
@@ -25356,7 +25356,7 @@ impl SimpleOrientationSensor {
         <Self as RtActivatable<ISimpleOrientationSensorStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(SimpleOrientationSensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,83,105,109,112,108,101,79,114,105,101,110,116,97,116,105,111,110,83,101,110,115,111,114,0]) [CLSID_SimpleOrientationSensor]);
+DEFINE_CLSID!(SimpleOrientationSensor: "Windows.Devices.Sensors.SimpleOrientationSensor");
 DEFINE_IID!(IID_ISimpleOrientationSensor2, 2725750680, 34928, 17726, 139, 214, 184, 245, 216, 215, 148, 27);
 RT_INTERFACE!{interface ISimpleOrientationSensor2(ISimpleOrientationSensor2Vtbl): IInspectable(IInspectableVtbl) [IID_ISimpleOrientationSensor2] {
     #[cfg(feature="windows-graphics")] fn put_ReadingTransform(&self, value: super::super::graphics::display::DisplayOrientations) -> HRESULT,
@@ -25470,7 +25470,7 @@ impl CustomSensor {
         <Self as RtActivatable<ICustomSensorStatics>>::get_activation_factory().from_id_async(sensorId)
     }}
 }
-DEFINE_CLSID!(CustomSensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,67,117,115,116,111,109,46,67,117,115,116,111,109,83,101,110,115,111,114,0]) [CLSID_CustomSensor]);
+DEFINE_CLSID!(CustomSensor: "Windows.Devices.Sensors.Custom.CustomSensor");
 DEFINE_IID!(IID_ICustomSensor2, 551235857, 60504, 19871, 191, 189, 231, 120, 37, 8, 133, 16);
 RT_INTERFACE!{interface ICustomSensor2(ICustomSensor2Vtbl): IInspectable(IInspectableVtbl) [IID_ICustomSensor2] {
     fn put_ReportLatency(&self, value: u32) -> HRESULT,
@@ -25788,7 +25788,7 @@ impl SerialDevice {
         <Self as RtActivatable<ISerialDeviceStatics>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(SerialDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,114,105,97,108,67,111,109,109,117,110,105,99,97,116,105,111,110,46,83,101,114,105,97,108,68,101,118,105,99,101,0]) [CLSID_SerialDevice]);
+DEFINE_CLSID!(SerialDevice: "Windows.Devices.SerialCommunication.SerialDevice");
 DEFINE_IID!(IID_ISerialDeviceStatics, 93080176, 2102, 18835, 174, 26, 182, 26, 227, 190, 5, 107);
 RT_INTERFACE!{static interface ISerialDeviceStatics(ISerialDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISerialDeviceStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -26028,7 +26028,7 @@ impl UsbConfigurationDescriptor {
         <Self as RtActivatable<IUsbConfigurationDescriptorStatics>>::get_activation_factory().parse(descriptor)
     }}
 }
-DEFINE_CLSID!(UsbConfigurationDescriptor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,67,111,110,102,105,103,117,114,97,116,105,111,110,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_UsbConfigurationDescriptor]);
+DEFINE_CLSID!(UsbConfigurationDescriptor: "Windows.Devices.Usb.UsbConfigurationDescriptor");
 DEFINE_IID!(IID_IUsbConfigurationDescriptorStatics, 1112337811, 59200, 16545, 146, 189, 218, 18, 14, 160, 73, 20);
 RT_INTERFACE!{static interface IUsbConfigurationDescriptorStatics(IUsbConfigurationDescriptorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUsbConfigurationDescriptorStatics] {
     fn TryParse(&self, descriptor: *mut UsbDescriptor, parsed: *mut *mut UsbConfigurationDescriptor, out: *mut bool) -> HRESULT,
@@ -26100,7 +26100,7 @@ impl IUsbControlRequestType {
 }
 RT_CLASS!{class UsbControlRequestType: IUsbControlRequestType}
 impl RtActivatable<IActivationFactory> for UsbControlRequestType {}
-DEFINE_CLSID!(UsbControlRequestType(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,67,111,110,116,114,111,108,82,101,113,117,101,115,116,84,121,112,101,0]) [CLSID_UsbControlRequestType]);
+DEFINE_CLSID!(UsbControlRequestType: "Windows.Devices.Usb.UsbControlRequestType");
 RT_ENUM! { enum UsbControlTransferType: i32 {
     Standard (UsbControlTransferType_Standard) = 0, Class (UsbControlTransferType_Class) = 1, Vendor (UsbControlTransferType_Vendor) = 2,
 }}
@@ -26196,7 +26196,7 @@ impl UsbDevice {
         <Self as RtActivatable<IUsbDeviceStatics>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(UsbDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,68,101,118,105,99,101,0]) [CLSID_UsbDevice]);
+DEFINE_CLSID!(UsbDevice: "Windows.Devices.Usb.UsbDevice");
 DEFINE_IID!(IID_IUsbDeviceClass, 85541625, 33886, 18411, 177, 42, 56, 242, 246, 23, 175, 231);
 RT_INTERFACE!{interface IUsbDeviceClass(IUsbDeviceClassVtbl): IInspectable(IInspectableVtbl) [IID_IUsbDeviceClass] {
     fn get_ClassCode(&self, out: *mut u8) -> HRESULT,
@@ -26237,7 +26237,7 @@ impl IUsbDeviceClass {
 }
 RT_CLASS!{class UsbDeviceClass: IUsbDeviceClass}
 impl RtActivatable<IActivationFactory> for UsbDeviceClass {}
-DEFINE_CLSID!(UsbDeviceClass(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,68,101,118,105,99,101,67,108,97,115,115,0]) [CLSID_UsbDeviceClass]);
+DEFINE_CLSID!(UsbDeviceClass: "Windows.Devices.Usb.UsbDeviceClass");
 DEFINE_IID!(IID_IUsbDeviceClasses, 1752143197, 39826, 19248, 151, 129, 194, 44, 85, 172, 53, 203);
 RT_INTERFACE!{interface IUsbDeviceClasses(IUsbDeviceClassesVtbl): IInspectable(IInspectableVtbl) [IID_IUsbDeviceClasses] {
     
@@ -26273,7 +26273,7 @@ impl UsbDeviceClasses {
         <Self as RtActivatable<IUsbDeviceClassesStatics>>::get_activation_factory().get_vendor_specific()
     }}
 }
-DEFINE_CLSID!(UsbDeviceClasses(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,68,101,118,105,99,101,67,108,97,115,115,101,115,0]) [CLSID_UsbDeviceClasses]);
+DEFINE_CLSID!(UsbDeviceClasses: "Windows.Devices.Usb.UsbDeviceClasses");
 DEFINE_IID!(IID_IUsbDeviceClassesStatics, 2987066663, 50560, 17817, 161, 101, 152, 27, 79, 208, 50, 48);
 RT_INTERFACE!{static interface IUsbDeviceClassesStatics(IUsbDeviceClassesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUsbDeviceClassesStatics] {
     fn get_CdcControl(&self, out: *mut *mut UsbDeviceClass) -> HRESULT,
@@ -26467,7 +26467,7 @@ impl UsbEndpointDescriptor {
         <Self as RtActivatable<IUsbEndpointDescriptorStatics>>::get_activation_factory().parse(descriptor)
     }}
 }
-DEFINE_CLSID!(UsbEndpointDescriptor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,69,110,100,112,111,105,110,116,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_UsbEndpointDescriptor]);
+DEFINE_CLSID!(UsbEndpointDescriptor: "Windows.Devices.Usb.UsbEndpointDescriptor");
 DEFINE_IID!(IID_IUsbEndpointDescriptorStatics, 3364925953, 39530, 18782, 168, 44, 41, 91, 158, 112, 129, 6);
 RT_INTERFACE!{static interface IUsbEndpointDescriptorStatics(IUsbEndpointDescriptorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUsbEndpointDescriptorStatics] {
     fn TryParse(&self, descriptor: *mut UsbDescriptor, parsed: *mut *mut UsbEndpointDescriptor, out: *mut bool) -> HRESULT,
@@ -26581,7 +26581,7 @@ impl UsbInterfaceDescriptor {
         <Self as RtActivatable<IUsbInterfaceDescriptorStatics>>::get_activation_factory().parse(descriptor)
     }}
 }
-DEFINE_CLSID!(UsbInterfaceDescriptor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,73,110,116,101,114,102,97,99,101,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_UsbInterfaceDescriptor]);
+DEFINE_CLSID!(UsbInterfaceDescriptor: "Windows.Devices.Usb.UsbInterfaceDescriptor");
 DEFINE_IID!(IID_IUsbInterfaceDescriptorStatics, 3813318645, 30678, 18614, 176, 190, 22, 198, 66, 35, 22, 254);
 RT_INTERFACE!{static interface IUsbInterfaceDescriptorStatics(IUsbInterfaceDescriptorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterfaceDescriptorStatics] {
     fn TryParse(&self, descriptor: *mut UsbDescriptor, parsed: *mut *mut UsbInterfaceDescriptor, out: *mut bool) -> HRESULT,
@@ -26860,7 +26860,7 @@ impl UsbSetupPacket {
         <Self as RtActivatable<IUsbSetupPacketFactory>>::get_activation_factory().create_with_eight_byte_buffer(eightByteBuffer)
     }}
 }
-DEFINE_CLSID!(UsbSetupPacket(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,83,101,116,117,112,80,97,99,107,101,116,0]) [CLSID_UsbSetupPacket]);
+DEFINE_CLSID!(UsbSetupPacket: "Windows.Devices.Usb.UsbSetupPacket");
 DEFINE_IID!(IID_IUsbSetupPacketFactory, 3374677328, 6958, 19009, 162, 167, 51, 143, 12, 239, 60, 20);
 RT_INTERFACE!{static interface IUsbSetupPacketFactory(IUsbSetupPacketFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IUsbSetupPacketFactory] {
     #[cfg(feature="windows-storage")] fn CreateWithEightByteBuffer(&self, eightByteBuffer: *mut super::super::storage::streams::IBuffer, out: *mut *mut UsbSetupPacket) -> HRESULT
@@ -26960,7 +26960,7 @@ impl WiFiAdapter {
         <Self as RtActivatable<IWiFiAdapterStatics>>::get_activation_factory().request_access_async()
     }}
 }
-DEFINE_CLSID!(WiFiAdapter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,46,87,105,70,105,65,100,97,112,116,101,114,0]) [CLSID_WiFiAdapter]);
+DEFINE_CLSID!(WiFiAdapter: "Windows.Devices.WiFi.WiFiAdapter");
 DEFINE_IID!(IID_IWiFiAdapter2, 1539592221, 33252, 17725, 148, 48, 31, 202, 251, 173, 214, 182);
 RT_INTERFACE!{interface IWiFiAdapter2(IWiFiAdapter2Vtbl): IInspectable(IInspectableVtbl) [IID_IWiFiAdapter2] {
     fn GetWpsConfigurationAsync(&self, availableNetwork: *mut WiFiAvailableNetwork, out: *mut *mut super::super::foundation::IAsyncOperation<WiFiWpsConfigurationResult>) -> HRESULT,
@@ -27251,7 +27251,7 @@ impl IWiFiDirectAdvertisementPublisher {
 }
 RT_CLASS!{class WiFiDirectAdvertisementPublisher: IWiFiDirectAdvertisementPublisher}
 impl RtActivatable<IActivationFactory> for WiFiDirectAdvertisementPublisher {}
-DEFINE_CLSID!(WiFiDirectAdvertisementPublisher(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,65,100,118,101,114,116,105,115,101,109,101,110,116,80,117,98,108,105,115,104,101,114,0]) [CLSID_WiFiDirectAdvertisementPublisher]);
+DEFINE_CLSID!(WiFiDirectAdvertisementPublisher: "Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisher");
 RT_ENUM! { enum WiFiDirectAdvertisementPublisherStatus: i32 {
     Created (WiFiDirectAdvertisementPublisherStatus_Created) = 0, Started (WiFiDirectAdvertisementPublisherStatus_Started) = 1, Stopped (WiFiDirectAdvertisementPublisherStatus_Stopped) = 2, Aborted (WiFiDirectAdvertisementPublisherStatus_Aborted) = 3,
 }}
@@ -27294,7 +27294,7 @@ impl IWiFiDirectConnectionListener {
 }
 RT_CLASS!{class WiFiDirectConnectionListener: IWiFiDirectConnectionListener}
 impl RtActivatable<IActivationFactory> for WiFiDirectConnectionListener {}
-DEFINE_CLSID!(WiFiDirectConnectionListener(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,67,111,110,110,101,99,116,105,111,110,76,105,115,116,101,110,101,114,0]) [CLSID_WiFiDirectConnectionListener]);
+DEFINE_CLSID!(WiFiDirectConnectionListener: "Windows.Devices.WiFiDirect.WiFiDirectConnectionListener");
 DEFINE_IID!(IID_IWiFiDirectConnectionParameters, 3001373701, 22274, 19222, 160, 44, 187, 205, 33, 239, 96, 152);
 RT_INTERFACE!{interface IWiFiDirectConnectionParameters(IWiFiDirectConnectionParametersVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectConnectionParameters] {
     fn get_GroupOwnerIntent(&self, out: *mut i16) -> HRESULT,
@@ -27319,7 +27319,7 @@ impl WiFiDirectConnectionParameters {
         <Self as RtActivatable<IWiFiDirectConnectionParametersStatics>>::get_activation_factory().get_device_pairing_kinds(configurationMethod)
     }}
 }
-DEFINE_CLSID!(WiFiDirectConnectionParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,67,111,110,110,101,99,116,105,111,110,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_WiFiDirectConnectionParameters]);
+DEFINE_CLSID!(WiFiDirectConnectionParameters: "Windows.Devices.WiFiDirect.WiFiDirectConnectionParameters");
 DEFINE_IID!(IID_IWiFiDirectConnectionParameters2, 2872774590, 43650, 17588, 136, 200, 227, 5, 107, 137, 128, 29);
 RT_INTERFACE!{interface IWiFiDirectConnectionParameters2(IWiFiDirectConnectionParameters2Vtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectConnectionParameters2] {
     fn get_PreferenceOrderedConfigurationMethods(&self, out: *mut *mut super::super::foundation::collections::IVector<WiFiDirectConfigurationMethod>) -> HRESULT,
@@ -27431,7 +27431,7 @@ impl WiFiDirectDevice {
         <Self as RtActivatable<IWiFiDirectDeviceStatics2>>::get_activation_factory().from_id_async(deviceId, connectionParameters)
     }}
 }
-DEFINE_CLSID!(WiFiDirectDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,68,101,118,105,99,101,0]) [CLSID_WiFiDirectDevice]);
+DEFINE_CLSID!(WiFiDirectDevice: "Windows.Devices.WiFiDirect.WiFiDirectDevice");
 RT_ENUM! { enum WiFiDirectDeviceSelectorType: i32 {
     DeviceInterface (WiFiDirectDeviceSelectorType_DeviceInterface) = 0, AssociationEndpoint (WiFiDirectDeviceSelectorType_AssociationEndpoint) = 1,
 }}
@@ -27521,7 +27521,7 @@ impl WiFiDirectInformationElement {
         <Self as RtActivatable<IWiFiDirectInformationElementStatics>>::get_activation_factory().create_from_device_information(deviceInformation)
     }}
 }
-DEFINE_CLSID!(WiFiDirectInformationElement(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,73,110,102,111,114,109,97,116,105,111,110,69,108,101,109,101,110,116,0]) [CLSID_WiFiDirectInformationElement]);
+DEFINE_CLSID!(WiFiDirectInformationElement: "Windows.Devices.WiFiDirect.WiFiDirectInformationElement");
 DEFINE_IID!(IID_IWiFiDirectInformationElementStatics, 3687853846, 4517, 20064, 140, 170, 52, 119, 33, 72, 55, 138);
 RT_INTERFACE!{static interface IWiFiDirectInformationElementStatics(IWiFiDirectInformationElementStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectInformationElementStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -27674,7 +27674,7 @@ impl WiFiDirectService {
         <Self as RtActivatable<IWiFiDirectServiceStatics>>::get_activation_factory().from_id_async(deviceId)
     }}
 }
-DEFINE_CLSID!(WiFiDirectService(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,83,101,114,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,83,101,114,118,105,99,101,0]) [CLSID_WiFiDirectService]);
+DEFINE_CLSID!(WiFiDirectService: "Windows.Devices.WiFiDirect.Services.WiFiDirectService");
 RT_ENUM! { enum WiFiDirectServiceAdvertisementStatus: i32 {
     Created (WiFiDirectServiceAdvertisementStatus_Created) = 0, Started (WiFiDirectServiceAdvertisementStatus_Started) = 1, Stopped (WiFiDirectServiceAdvertisementStatus_Stopped) = 2, Aborted (WiFiDirectServiceAdvertisementStatus_Aborted) = 3,
 }}
@@ -27845,7 +27845,7 @@ impl WiFiDirectServiceAdvertiser {
         <Self as RtActivatable<IWiFiDirectServiceAdvertiserFactory>>::get_activation_factory().create_wi_fi_direct_service_advertiser(serviceName)
     }}
 }
-DEFINE_CLSID!(WiFiDirectServiceAdvertiser(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,83,101,114,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,83,101,114,118,105,99,101,65,100,118,101,114,116,105,115,101,114,0]) [CLSID_WiFiDirectServiceAdvertiser]);
+DEFINE_CLSID!(WiFiDirectServiceAdvertiser: "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser");
 DEFINE_IID!(IID_IWiFiDirectServiceAdvertiserFactory, 822520845, 46150, 20243, 159, 154, 138, 233, 37, 254, 186, 43);
 RT_INTERFACE!{static interface IWiFiDirectServiceAdvertiserFactory(IWiFiDirectServiceAdvertiserFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceAdvertiserFactory] {
     fn CreateWiFiDirectServiceAdvertiser(&self, serviceName: HSTRING, out: *mut *mut WiFiDirectServiceAdvertiser) -> HRESULT
@@ -28107,7 +28107,7 @@ impl ServiceDevice {
         <Self as RtActivatable<IServiceDeviceStatics>>::get_activation_factory().get_device_selector_from_service_id(serviceId)
     }}
 }
-DEFINE_CLSID!(ServiceDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,114,116,97,98,108,101,46,83,101,114,118,105,99,101,68,101,118,105,99,101,0]) [CLSID_ServiceDevice]);
+DEFINE_CLSID!(ServiceDevice: "Windows.Devices.Portable.ServiceDevice");
 DEFINE_IID!(IID_IServiceDeviceStatics, 2827097313, 22983, 18976, 171, 166, 159, 103, 7, 147, 114, 48);
 RT_INTERFACE!{static interface IServiceDeviceStatics(IServiceDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IServiceDeviceStatics] {
     fn GetDeviceSelector(&self, serviceType: ServiceDeviceType, out: *mut HSTRING) -> HRESULT,
@@ -28138,7 +28138,7 @@ impl StorageDevice {
         <Self as RtActivatable<IStorageDeviceStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(StorageDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,114,116,97,98,108,101,46,83,116,111,114,97,103,101,68,101,118,105,99,101,0]) [CLSID_StorageDevice]);
+DEFINE_CLSID!(StorageDevice: "Windows.Devices.Portable.StorageDevice");
 DEFINE_IID!(IID_IStorageDeviceStatics, 1590576366, 6947, 19922, 134, 82, 188, 22, 79, 0, 49, 40);
 RT_INTERFACE!{static interface IStorageDeviceStatics(IStorageDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageDeviceStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -28229,7 +28229,7 @@ impl ImageScanner {
         <Self as RtActivatable<IImageScannerStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(ImageScanner(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,99,97,110,110,101,114,115,46,73,109,97,103,101,83,99,97,110,110,101,114,0]) [CLSID_ImageScanner]);
+DEFINE_CLSID!(ImageScanner: "Windows.Devices.Scanners.ImageScanner");
 RT_CLASS!{class ImageScannerAutoConfiguration: IImageScannerFormatConfiguration}
 RT_ENUM! { enum ImageScannerAutoCroppingMode: i32 {
     Disabled (ImageScannerAutoCroppingMode_Disabled) = 0, SingleRegion (ImageScannerAutoCroppingMode_SingleRegion) = 1, MultipleRegion (ImageScannerAutoCroppingMode_MultipleRegion) = 2,

--- a/src/rt/gen/windows/foundation.rs
+++ b/src/rt/gen/windows/foundation.rs
@@ -233,7 +233,7 @@ impl Deferral {
         <Self as RtActivatable<IDeferralFactory>>::get_activation_factory().create(handler)
     }}
 }
-DEFINE_CLSID!(Deferral(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,101,102,101,114,114,97,108,0]) [CLSID_Deferral]);
+DEFINE_CLSID!(Deferral: "Windows.Foundation.Deferral");
 DEFINE_IID!(IID_DeferralCompletedHandler, 3979518834, 62408, 20394, 156, 251, 71, 1, 72, 218, 56, 136);
 RT_DELEGATE!{delegate DeferralCompletedHandler(DeferralCompletedHandlerVtbl, DeferralCompletedHandlerImpl) [IID_DeferralCompletedHandler] {
     fn Invoke(&self) -> HRESULT
@@ -300,7 +300,7 @@ impl MemoryBuffer {
         <Self as RtActivatable<IMemoryBufferFactory>>::get_activation_factory().create(capacity)
     }}
 }
-DEFINE_CLSID!(MemoryBuffer(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,77,101,109,111,114,121,66,117,102,102,101,114,0]) [CLSID_MemoryBuffer]);
+DEFINE_CLSID!(MemoryBuffer: "Windows.Foundation.MemoryBuffer");
 DEFINE_IID!(IID_IMemoryBufferFactory, 4223982891, 9307, 4580, 175, 152, 104, 148, 35, 38, 12, 248);
 RT_INTERFACE!{static interface IMemoryBufferFactory(IMemoryBufferFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMemoryBufferFactory] {
     fn Create(&self, capacity: u32, out: *mut *mut MemoryBuffer) -> HRESULT
@@ -700,7 +700,7 @@ impl PropertyValue {
         <Self as RtActivatable<IPropertyValueStatics>>::get_activation_factory().create_rect_array(value)
     }}
 }
-DEFINE_CLSID!(PropertyValue(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,80,114,111,112,101,114,116,121,86,97,108,117,101,0]) [CLSID_PropertyValue]);
+DEFINE_CLSID!(PropertyValue: "Windows.Foundation.PropertyValue");
 DEFINE_IID!(IID_IPropertyValueStatics, 1654381512, 55602, 20468, 150, 185, 141, 150, 197, 193, 232, 88);
 RT_INTERFACE!{static interface IPropertyValueStatics(IPropertyValueStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPropertyValueStatics] {
     fn CreateEmpty(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -1009,7 +1009,7 @@ impl Uri {
         <Self as RtActivatable<IUriEscapeStatics>>::get_activation_factory().escape_component(toEscape)
     }}
 }
-DEFINE_CLSID!(Uri(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,85,114,105,0]) [CLSID_Uri]);
+DEFINE_CLSID!(Uri: "Windows.Foundation.Uri");
 DEFINE_IID!(IID_IUriEscapeStatics, 3251909306, 51236, 17490, 167, 253, 81, 43, 195, 187, 233, 161);
 RT_INTERFACE!{static interface IUriEscapeStatics(IUriEscapeStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUriEscapeStatics] {
     fn UnescapeComponent(&self, toUnescape: HSTRING, out: *mut HSTRING) -> HRESULT,
@@ -1175,7 +1175,7 @@ impl WwwFormUrlDecoder {
         <Self as RtActivatable<IWwwFormUrlDecoderRuntimeClassFactory>>::get_activation_factory().create_www_form_url_decoder(query)
     }}
 }
-DEFINE_CLSID!(WwwFormUrlDecoder(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,87,119,119,70,111,114,109,85,114,108,68,101,99,111,100,101,114,0]) [CLSID_WwwFormUrlDecoder]);
+DEFINE_CLSID!(WwwFormUrlDecoder: "Windows.Foundation.WwwFormUrlDecoder");
 DEFINE_IID!(IID_IWwwFormUrlDecoderEntry, 308180017, 63096, 20110, 182, 112, 32, 169, 176, 108, 81, 45);
 RT_INTERFACE!{interface IWwwFormUrlDecoderEntry(IWwwFormUrlDecoderEntryVtbl): IInspectable(IInspectableVtbl) [IID_IWwwFormUrlDecoderEntry] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -3352,13 +3352,13 @@ RT_INTERFACE!{interface IPropertySet(IPropertySetVtbl): IInspectable(IInspectabl
 }}
 RT_CLASS!{class PropertySet: IPropertySet}
 impl RtActivatable<IActivationFactory> for PropertySet {}
-DEFINE_CLSID!(PropertySet(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,67,111,108,108,101,99,116,105,111,110,115,46,80,114,111,112,101,114,116,121,83,101,116,0]) [CLSID_PropertySet]);
+DEFINE_CLSID!(PropertySet: "Windows.Foundation.Collections.PropertySet");
 RT_CLASS!{class StringMap: IMap<HString, HString>}
 impl RtActivatable<IActivationFactory> for StringMap {}
-DEFINE_CLSID!(StringMap(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,67,111,108,108,101,99,116,105,111,110,115,46,83,116,114,105,110,103,77,97,112,0]) [CLSID_StringMap]);
+DEFINE_CLSID!(StringMap: "Windows.Foundation.Collections.StringMap");
 RT_CLASS!{class ValueSet: IPropertySet}
 impl RtActivatable<IActivationFactory> for ValueSet {}
-DEFINE_CLSID!(ValueSet(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,67,111,108,108,101,99,116,105,111,110,115,46,86,97,108,117,101,83,101,116,0]) [CLSID_ValueSet]);
+DEFINE_CLSID!(ValueSet: "Windows.Foundation.Collections.ValueSet");
 DEFINE_IID!(IID_IVector, 2436052969, 4513, 17221, 163, 162, 78, 127, 149, 110, 34, 45);
 RT_INTERFACE!{interface IVector<T>(IVectorVtbl): IInspectable(IInspectableVtbl) [IID_IVector] {
     fn GetAt(&self, index: u32, out: *mut T::Abi) -> HRESULT,
@@ -5346,7 +5346,7 @@ impl ApiInformation {
         <Self as RtActivatable<IApiInformationStatics>>::get_activation_factory().is_api_contract_present_by_major_and_minor(contractName, majorVersion, minorVersion)
     }}
 }
-DEFINE_CLSID!(ApiInformation(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,77,101,116,97,100,97,116,97,46,65,112,105,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_ApiInformation]);
+DEFINE_CLSID!(ApiInformation: "Windows.Foundation.Metadata.ApiInformation");
 DEFINE_IID!(IID_IApiInformationStatics, 2574531070, 63105, 18961, 180, 22, 193, 58, 71, 232, 186, 54);
 RT_INTERFACE!{static interface IApiInformationStatics(IApiInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IApiInformationStatics] {
     fn IsTypePresent(&self, typeName: HSTRING, out: *mut bool) -> HRESULT,
@@ -5464,7 +5464,7 @@ impl AsyncCausalityTracer {
         <Self as RtActivatable<IAsyncCausalityTracerStatics>>::get_activation_factory().remove_tracing_status_changed(cookie)
     }}
 }
-DEFINE_CLSID!(AsyncCausalityTracer(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,65,115,121,110,99,67,97,117,115,97,108,105,116,121,84,114,97,99,101,114,0]) [CLSID_AsyncCausalityTracer]);
+DEFINE_CLSID!(AsyncCausalityTracer: "Windows.Foundation.Diagnostics.AsyncCausalityTracer");
 DEFINE_IID!(IID_IAsyncCausalityTracerStatics, 1350896422, 9854, 17691, 168, 144, 171, 106, 55, 2, 69, 238);
 RT_INTERFACE!{static interface IAsyncCausalityTracerStatics(IAsyncCausalityTracerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAsyncCausalityTracerStatics] {
     fn TraceOperationCreation(&self, traceLevel: CausalityTraceLevel, source: CausalitySource, platformId: Guid, operationId: u64, operationName: HSTRING, relatedContext: u64) -> HRESULT,
@@ -5548,7 +5548,7 @@ impl ErrorDetails {
         <Self as RtActivatable<IErrorDetailsStatics>>::get_activation_factory().create_from_hresult_async(errorCode)
     }}
 }
-DEFINE_CLSID!(ErrorDetails(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,69,114,114,111,114,68,101,116,97,105,108,115,0]) [CLSID_ErrorDetails]);
+DEFINE_CLSID!(ErrorDetails: "Windows.Foundation.Diagnostics.ErrorDetails");
 DEFINE_IID!(IID_IErrorDetailsStatics, 3077584720, 2845, 18120, 170, 14, 75, 129, 120, 228, 252, 233);
 RT_INTERFACE!{static interface IErrorDetailsStatics(IErrorDetailsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IErrorDetailsStatics] {
     fn CreateFromHResultAsync(&self, errorCode: i32, out: *mut *mut super::IAsyncOperation<ErrorDetails>) -> HRESULT
@@ -5630,7 +5630,7 @@ impl FileLoggingSession {
         <Self as RtActivatable<IFileLoggingSessionFactory>>::get_activation_factory().create(name)
     }}
 }
-DEFINE_CLSID!(FileLoggingSession(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,70,105,108,101,76,111,103,103,105,110,103,83,101,115,115,105,111,110,0]) [CLSID_FileLoggingSession]);
+DEFINE_CLSID!(FileLoggingSession: "Windows.Foundation.Diagnostics.FileLoggingSession");
 DEFINE_IID!(IID_IFileLoggingSessionFactory, 4003499470, 33863, 19882, 145, 51, 18, 235, 70, 246, 151, 212);
 RT_INTERFACE!{static interface IFileLoggingSessionFactory(IFileLoggingSessionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IFileLoggingSessionFactory] {
     fn Create(&self, name: HSTRING, out: *mut *mut FileLoggingSession) -> HRESULT
@@ -5681,7 +5681,7 @@ impl LoggingActivity {
         <Self as RtActivatable<ILoggingActivityFactory>>::get_activation_factory().create_logging_activity_with_level(activityName, loggingChannel, level)
     }}
 }
-DEFINE_CLSID!(LoggingActivity(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,65,99,116,105,118,105,116,121,0]) [CLSID_LoggingActivity]);
+DEFINE_CLSID!(LoggingActivity: "Windows.Foundation.Diagnostics.LoggingActivity");
 DEFINE_IID!(IID_ILoggingActivity2, 650287112, 25378, 17770, 175, 130, 128, 200, 100, 47, 23, 139);
 RT_INTERFACE!{interface ILoggingActivity2(ILoggingActivity2Vtbl): IInspectable(IInspectableVtbl) [IID_ILoggingActivity2] {
     fn get_Channel(&self, out: *mut *mut LoggingChannel) -> HRESULT,
@@ -5793,7 +5793,7 @@ impl LoggingChannel {
         <Self as RtActivatable<ILoggingChannelFactory2>>::get_activation_factory().create_with_options_and_id(name, options, id)
     }}
 }
-DEFINE_CLSID!(LoggingChannel(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,67,104,97,110,110,101,108,0]) [CLSID_LoggingChannel]);
+DEFINE_CLSID!(LoggingChannel: "Windows.Foundation.Diagnostics.LoggingChannel");
 DEFINE_IID!(IID_ILoggingChannel2, 2672573683, 2988, 17829, 158, 51, 186, 243, 243, 162, 70, 165);
 RT_INTERFACE!{interface ILoggingChannel2(ILoggingChannel2Vtbl): IInspectable(IInspectableVtbl) [IID_ILoggingChannel2] {
     fn get_Id(&self, out: *mut Guid) -> HRESULT
@@ -5857,7 +5857,7 @@ impl LoggingChannelOptions {
         <Self as RtActivatable<ILoggingChannelOptionsFactory>>::get_activation_factory().create(group)
     }}
 }
-DEFINE_CLSID!(LoggingChannelOptions(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,67,104,97,110,110,101,108,79,112,116,105,111,110,115,0]) [CLSID_LoggingChannelOptions]);
+DEFINE_CLSID!(LoggingChannelOptions: "Windows.Foundation.Diagnostics.LoggingChannelOptions");
 DEFINE_IID!(IID_ILoggingChannelOptionsFactory, 2838581722, 32687, 16785, 135, 85, 94, 134, 220, 101, 216, 150);
 RT_INTERFACE!{static interface ILoggingChannelOptionsFactory(ILoggingChannelOptionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILoggingChannelOptionsFactory] {
     fn Create(&self, group: Guid, out: *mut *mut LoggingChannelOptions) -> HRESULT
@@ -6454,7 +6454,7 @@ impl ILoggingFields {
 }
 RT_CLASS!{class LoggingFields: ILoggingFields}
 impl RtActivatable<IActivationFactory> for LoggingFields {}
-DEFINE_CLSID!(LoggingFields(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,70,105,101,108,100,115,0]) [CLSID_LoggingFields]);
+DEFINE_CLSID!(LoggingFields: "Windows.Foundation.Diagnostics.LoggingFields");
 RT_ENUM! { enum LoggingLevel: i32 {
     Verbose (LoggingLevel_Verbose) = 0, Information (LoggingLevel_Information) = 1, Warning (LoggingLevel_Warning) = 2, Error (LoggingLevel_Error) = 3, Critical (LoggingLevel_Critical) = 4,
 }}
@@ -6540,7 +6540,7 @@ impl LoggingOptions {
         <Self as RtActivatable<ILoggingOptionsFactory>>::get_activation_factory().create_with_keywords(keywords)
     }}
 }
-DEFINE_CLSID!(LoggingOptions(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,79,112,116,105,111,110,115,0]) [CLSID_LoggingOptions]);
+DEFINE_CLSID!(LoggingOptions: "Windows.Foundation.Diagnostics.LoggingOptions");
 DEFINE_IID!(IID_ILoggingOptionsFactory, 3608397515, 39083, 17995, 159, 34, 163, 38, 132, 120, 54, 138);
 RT_INTERFACE!{static interface ILoggingOptionsFactory(ILoggingOptionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILoggingOptionsFactory] {
     fn CreateWithKeywords(&self, keywords: i64, out: *mut *mut LoggingOptions) -> HRESULT
@@ -6592,7 +6592,7 @@ impl LoggingSession {
         <Self as RtActivatable<ILoggingSessionFactory>>::get_activation_factory().create(name)
     }}
 }
-DEFINE_CLSID!(LoggingSession(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,83,101,115,115,105,111,110,0]) [CLSID_LoggingSession]);
+DEFINE_CLSID!(LoggingSession: "Windows.Foundation.Diagnostics.LoggingSession");
 DEFINE_IID!(IID_ILoggingSessionFactory, 1318289125, 22781, 17888, 140, 47, 161, 50, 239, 249, 92, 30);
 RT_INTERFACE!{static interface ILoggingSessionFactory(ILoggingSessionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILoggingSessionFactory] {
     fn Create(&self, name: HSTRING, out: *mut *mut LoggingSession) -> HRESULT
@@ -6673,7 +6673,7 @@ impl ILoggingTarget {
 }
 RT_CLASS!{class RuntimeBrokerErrorSettings: IErrorReportingSettings}
 impl RtActivatable<IActivationFactory> for RuntimeBrokerErrorSettings {}
-DEFINE_CLSID!(RuntimeBrokerErrorSettings(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,82,117,110,116,105,109,101,66,114,111,107,101,114,69,114,114,111,114,83,101,116,116,105,110,103,115,0]) [CLSID_RuntimeBrokerErrorSettings]);
+DEFINE_CLSID!(RuntimeBrokerErrorSettings: "Windows.Foundation.Diagnostics.RuntimeBrokerErrorSettings");
 DEFINE_IID!(IID_ITracingStatusChangedEventArgs, 1091270417, 65339, 18303, 156, 154, 210, 239, 218, 48, 45, 195);
 RT_INTERFACE!{interface ITracingStatusChangedEventArgs(ITracingStatusChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITracingStatusChangedEventArgs] {
     fn get_Enabled(&self, out: *mut bool) -> HRESULT,

--- a/src/rt/gen/windows/gaming.rs
+++ b/src/rt/gen/windows/gaming.rs
@@ -22,7 +22,7 @@ impl GameBar {
         <Self as RtActivatable<IGameBarStatics>>::get_activation_factory().get_is_input_redirected()
     }}
 }
-DEFINE_CLSID!(GameBar(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,85,73,46,71,97,109,101,66,97,114,0]) [CLSID_GameBar]);
+DEFINE_CLSID!(GameBar: "Windows.Gaming.UI.GameBar");
 DEFINE_IID!(IID_IGameBarStatics, 498705042, 52344, 16755, 190, 69, 182, 30, 103, 40, 62, 167);
 RT_INTERFACE!{static interface IGameBarStatics(IGameBarStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameBarStatics] {
     fn add_VisibilityChanged(&self, handler: *mut super::super::foundation::EventHandler<IInspectable>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -129,7 +129,7 @@ impl GameChatOverlay {
         <Self as RtActivatable<IGameChatOverlayStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(GameChatOverlay(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,85,73,46,71,97,109,101,67,104,97,116,79,118,101,114,108,97,121,0]) [CLSID_GameChatOverlay]);
+DEFINE_CLSID!(GameChatOverlay: "Windows.Gaming.UI.GameChatOverlay");
 DEFINE_IID!(IID_IGameChatOverlayMessageSource, 504853399, 23035, 20303, 142, 154, 128, 172, 248, 23, 116, 60);
 RT_INTERFACE!{interface IGameChatOverlayMessageSource(IGameChatOverlayMessageSourceVtbl): IInspectable(IInspectableVtbl) [IID_IGameChatOverlayMessageSource] {
     fn add_MessageReceived(&self, handler: *mut super::super::foundation::TypedEventHandler<GameChatOverlayMessageSource, GameChatMessageReceivedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -153,7 +153,7 @@ impl IGameChatOverlayMessageSource {
 }
 RT_CLASS!{class GameChatOverlayMessageSource: IGameChatOverlayMessageSource}
 impl RtActivatable<IActivationFactory> for GameChatOverlayMessageSource {}
-DEFINE_CLSID!(GameChatOverlayMessageSource(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,85,73,46,71,97,109,101,67,104,97,116,79,118,101,114,108,97,121,77,101,115,115,97,103,101,83,111,117,114,99,101,0]) [CLSID_GameChatOverlayMessageSource]);
+DEFINE_CLSID!(GameChatOverlayMessageSource: "Windows.Gaming.UI.GameChatOverlayMessageSource");
 RT_ENUM! { enum GameChatOverlayPosition: i32 {
     BottomCenter (GameChatOverlayPosition_BottomCenter) = 0, BottomLeft (GameChatOverlayPosition_BottomLeft) = 1, BottomRight (GameChatOverlayPosition_BottomRight) = 2, MiddleRight (GameChatOverlayPosition_MiddleRight) = 3, MiddleLeft (GameChatOverlayPosition_MiddleLeft) = 4, TopCenter (GameChatOverlayPosition_TopCenter) = 5, TopLeft (GameChatOverlayPosition_TopLeft) = 6, TopRight (GameChatOverlayPosition_TopRight) = 7,
 }}
@@ -186,7 +186,7 @@ impl GameMonitor {
         <Self as RtActivatable<IGameMonitorStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(GameMonitor(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,85,73,46,71,97,109,101,77,111,110,105,116,111,114,0]) [CLSID_GameMonitor]);
+DEFINE_CLSID!(GameMonitor: "Windows.Gaming.UI.GameMonitor");
 RT_ENUM! { enum GameMonitoringPermission: i32 {
     Allowed (GameMonitoringPermission_Allowed) = 0, DeniedByUser (GameMonitoringPermission_DeniedByUser) = 1, DeniedBySystem (GameMonitoringPermission_DeniedBySystem) = 2,
 }}
@@ -261,7 +261,7 @@ impl ArcadeStick {
         <Self as RtActivatable<IArcadeStickStatics2>>::get_activation_factory().from_game_controller(gameController)
     }}
 }
-DEFINE_CLSID!(ArcadeStick(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,65,114,99,97,100,101,83,116,105,99,107,0]) [CLSID_ArcadeStick]);
+DEFINE_CLSID!(ArcadeStick: "Windows.Gaming.Input.ArcadeStick");
 RT_ENUM! { enum ArcadeStickButtons: u32 {
     None (ArcadeStickButtons_None) = 0, StickUp (ArcadeStickButtons_StickUp) = 1, StickDown (ArcadeStickButtons_StickDown) = 2, StickLeft (ArcadeStickButtons_StickLeft) = 4, StickRight (ArcadeStickButtons_StickRight) = 8, Action1 (ArcadeStickButtons_Action1) = 16, Action2 (ArcadeStickButtons_Action2) = 32, Action3 (ArcadeStickButtons_Action3) = 64, Action4 (ArcadeStickButtons_Action4) = 128, Action5 (ArcadeStickButtons_Action5) = 256, Action6 (ArcadeStickButtons_Action6) = 512, Special1 (ArcadeStickButtons_Special1) = 1024, Special2 (ArcadeStickButtons_Special2) = 2048,
 }}
@@ -357,7 +357,7 @@ impl FlightStick {
         <Self as RtActivatable<IFlightStickStatics>>::get_activation_factory().from_game_controller(gameController)
     }}
 }
-DEFINE_CLSID!(FlightStick(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,108,105,103,104,116,83,116,105,99,107,0]) [CLSID_FlightStick]);
+DEFINE_CLSID!(FlightStick: "Windows.Gaming.Input.FlightStick");
 RT_ENUM! { enum FlightStickButtons: u32 {
     None (FlightStickButtons_None) = 0, FirePrimary (FlightStickButtons_FirePrimary) = 1, FireSecondary (FlightStickButtons_FireSecondary) = 2,
 }}
@@ -524,7 +524,7 @@ impl Gamepad {
         <Self as RtActivatable<IGamepadStatics2>>::get_activation_factory().from_game_controller(gameController)
     }}
 }
-DEFINE_CLSID!(Gamepad(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,71,97,109,101,112,97,100,0]) [CLSID_Gamepad]);
+DEFINE_CLSID!(Gamepad: "Windows.Gaming.Input.Gamepad");
 DEFINE_IID!(IID_IGamepad2, 1008110013, 22805, 16965, 176, 192, 200, 159, 174, 3, 8, 255);
 RT_INTERFACE!{interface IGamepad2(IGamepad2Vtbl): IInspectable(IInspectableVtbl) [IID_IGamepad2] {
     fn GetButtonLabel(&self, button: GamepadButtons, out: *mut GameControllerButtonLabel) -> HRESULT
@@ -686,7 +686,7 @@ impl RacingWheel {
         <Self as RtActivatable<IRacingWheelStatics2>>::get_activation_factory().from_game_controller(gameController)
     }}
 }
-DEFINE_CLSID!(RacingWheel(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,82,97,99,105,110,103,87,104,101,101,108,0]) [CLSID_RacingWheel]);
+DEFINE_CLSID!(RacingWheel: "Windows.Gaming.Input.RacingWheel");
 RT_ENUM! { enum RacingWheelButtons: u32 {
     None (RacingWheelButtons_None) = 0, PreviousGear (RacingWheelButtons_PreviousGear) = 1, NextGear (RacingWheelButtons_NextGear) = 2, DPadUp (RacingWheelButtons_DPadUp) = 4, DPadDown (RacingWheelButtons_DPadDown) = 8, DPadLeft (RacingWheelButtons_DPadLeft) = 16, DPadRight (RacingWheelButtons_DPadRight) = 32, Button1 (RacingWheelButtons_Button1) = 64, Button2 (RacingWheelButtons_Button2) = 128, Button3 (RacingWheelButtons_Button3) = 256, Button4 (RacingWheelButtons_Button4) = 512, Button5 (RacingWheelButtons_Button5) = 1024, Button6 (RacingWheelButtons_Button6) = 2048, Button7 (RacingWheelButtons_Button7) = 4096, Button8 (RacingWheelButtons_Button8) = 8192, Button9 (RacingWheelButtons_Button9) = 16384, Button10 (RacingWheelButtons_Button10) = 32768, Button11 (RacingWheelButtons_Button11) = 65536, Button12 (RacingWheelButtons_Button12) = 131072, Button13 (RacingWheelButtons_Button13) = 262144, Button14 (RacingWheelButtons_Button14) = 524288, Button15 (RacingWheelButtons_Button15) = 1048576, Button16 (RacingWheelButtons_Button16) = 2097152,
 }}
@@ -818,7 +818,7 @@ impl RawGameController {
         <Self as RtActivatable<IRawGameControllerStatics>>::get_activation_factory().from_game_controller(gameController)
     }}
 }
-DEFINE_CLSID!(RawGameController(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,82,97,119,71,97,109,101,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_RawGameController]);
+DEFINE_CLSID!(RawGameController: "Windows.Gaming.Input.RawGameController");
 DEFINE_IID!(IID_IRawGameController2, 1136705589, 47987, 18262, 167, 135, 62, 214, 190, 166, 23, 189);
 RT_INTERFACE!{interface IRawGameController2(IRawGameController2Vtbl): IInspectable(IInspectableVtbl) [IID_IRawGameController2] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -931,7 +931,7 @@ impl UINavigationController {
         <Self as RtActivatable<IUINavigationControllerStatics2>>::get_activation_factory().from_game_controller(gameController)
     }}
 }
-DEFINE_CLSID!(UINavigationController(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,85,73,78,97,118,105,103,97,116,105,111,110,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_UINavigationController]);
+DEFINE_CLSID!(UINavigationController: "Windows.Gaming.Input.UINavigationController");
 DEFINE_IID!(IID_IUINavigationControllerStatics, 789877514, 63224, 19016, 141, 137, 148, 120, 108, 202, 12, 46);
 RT_INTERFACE!{static interface IUINavigationControllerStatics(IUINavigationControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUINavigationControllerStatics] {
     fn add_UINavigationControllerAdded(&self, value: *mut super::super::foundation::EventHandler<UINavigationController>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -1019,7 +1019,7 @@ impl GameControllerFactoryManager {
         <Self as RtActivatable<IGameControllerFactoryManagerStatics2>>::get_activation_factory().try_get_factory_controller_from_game_controller(factory, gameController)
     }}
 }
-DEFINE_CLSID!(GameControllerFactoryManager(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,67,117,115,116,111,109,46,71,97,109,101,67,111,110,116,114,111,108,108,101,114,70,97,99,116,111,114,121,77,97,110,97,103,101,114,0]) [CLSID_GameControllerFactoryManager]);
+DEFINE_CLSID!(GameControllerFactoryManager: "Windows.Gaming.Input.Custom.GameControllerFactoryManager");
 DEFINE_IID!(IID_IGameControllerFactoryManagerStatics, 919299811, 53409, 18822, 162, 76, 64, 177, 55, 222, 186, 158);
 RT_INTERFACE!{static interface IGameControllerFactoryManagerStatics(IGameControllerFactoryManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameControllerFactoryManagerStatics] {
     fn RegisterCustomFactoryForGipInterface(&self, factory: *mut ICustomGameControllerFactory, interfaceId: Guid) -> HRESULT,
@@ -1270,7 +1270,7 @@ impl ConditionForceEffect {
         <Self as RtActivatable<IConditionForceEffectFactory>>::get_activation_factory().create_instance(effectKind)
     }}
 }
-DEFINE_CLSID!(ConditionForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,67,111,110,100,105,116,105,111,110,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_ConditionForceEffect]);
+DEFINE_CLSID!(ConditionForceEffect: "Windows.Gaming.Input.ForceFeedback.ConditionForceEffect");
 DEFINE_IID!(IID_IConditionForceEffectFactory, 2443809380, 6160, 20150, 167, 115, 191, 211, 184, 205, 219, 171);
 RT_INTERFACE!{static interface IConditionForceEffectFactory(IConditionForceEffectFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IConditionForceEffectFactory] {
     fn CreateInstance(&self, effectKind: ConditionForceEffectKind, out: *mut *mut ConditionForceEffect) -> HRESULT
@@ -1302,7 +1302,7 @@ impl IConstantForceEffect {
 }
 RT_CLASS!{class ConstantForceEffect: IForceFeedbackEffect}
 impl RtActivatable<IActivationFactory> for ConstantForceEffect {}
-DEFINE_CLSID!(ConstantForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,67,111,110,115,116,97,110,116,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_ConstantForceEffect]);
+DEFINE_CLSID!(ConstantForceEffect: "Windows.Gaming.Input.ForceFeedback.ConstantForceEffect");
 DEFINE_IID!(IID_IForceFeedbackEffect, 2709502476, 10980, 18626, 128, 99, 234, 189, 7, 119, 203, 137);
 RT_INTERFACE!{interface IForceFeedbackEffect(IForceFeedbackEffectVtbl): IInspectable(IInspectableVtbl) [IID_IForceFeedbackEffect] {
     fn get_Gain(&self, out: *mut f64) -> HRESULT,
@@ -1452,7 +1452,7 @@ impl PeriodicForceEffect {
         <Self as RtActivatable<IPeriodicForceEffectFactory>>::get_activation_factory().create_instance(effectKind)
     }}
 }
-DEFINE_CLSID!(PeriodicForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,80,101,114,105,111,100,105,99,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_PeriodicForceEffect]);
+DEFINE_CLSID!(PeriodicForceEffect: "Windows.Gaming.Input.ForceFeedback.PeriodicForceEffect");
 DEFINE_IID!(IID_IPeriodicForceEffectFactory, 1868753690, 38993, 18299, 179, 24, 53, 236, 170, 21, 7, 15);
 RT_INTERFACE!{static interface IPeriodicForceEffectFactory(IPeriodicForceEffectFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPeriodicForceEffectFactory] {
     fn CreateInstance(&self, effectKind: PeriodicForceEffectKind, out: *mut *mut PeriodicForceEffect) -> HRESULT
@@ -1484,7 +1484,7 @@ impl IRampForceEffect {
 }
 RT_CLASS!{class RampForceEffect: IForceFeedbackEffect}
 impl RtActivatable<IActivationFactory> for RampForceEffect {}
-DEFINE_CLSID!(RampForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,82,97,109,112,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_RampForceEffect]);
+DEFINE_CLSID!(RampForceEffect: "Windows.Gaming.Input.ForceFeedback.RampForceEffect");
 } // Windows.Gaming.Input.ForceFeedback
 pub mod preview { // Windows.Gaming.Input.Preview
 use ::prelude::*;
@@ -1498,7 +1498,7 @@ impl GameControllerProviderInfo {
         <Self as RtActivatable<IGameControllerProviderInfoStatics>>::get_activation_factory().get_provider_id(provider)
     }}
 }
-DEFINE_CLSID!(GameControllerProviderInfo(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,71,97,109,101,67,111,110,116,114,111,108,108,101,114,80,114,111,118,105,100,101,114,73,110,102,111,0]) [CLSID_GameControllerProviderInfo]);
+DEFINE_CLSID!(GameControllerProviderInfo: "Windows.Gaming.Input.Preview.GameControllerProviderInfo");
 DEFINE_IID!(IID_IGameControllerProviderInfoStatics, 199354053, 55741, 17646, 131, 98, 72, 139, 46, 70, 75, 251);
 RT_INTERFACE!{static interface IGameControllerProviderInfoStatics(IGameControllerProviderInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameControllerProviderInfoStatics] {
     fn GetParentProviderId(&self, provider: *mut super::custom::IGameControllerProvider, out: *mut HSTRING) -> HRESULT,
@@ -1800,7 +1800,7 @@ impl GameSaveProvider {
         <Self as RtActivatable<IGameSaveProviderStatics>>::get_activation_factory().get_sync_on_demand_for_user_async(user, serviceConfigId)
     }}
 }
-DEFINE_CLSID!(GameSaveProvider(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,88,98,111,120,76,105,118,101,46,83,116,111,114,97,103,101,46,71,97,109,101,83,97,118,101,80,114,111,118,105,100,101,114,0]) [CLSID_GameSaveProvider]);
+DEFINE_CLSID!(GameSaveProvider: "Windows.Gaming.XboxLive.Storage.GameSaveProvider");
 DEFINE_IID!(IID_IGameSaveProviderGetResult, 985204758, 54163, 19813, 172, 22, 65, 195, 230, 122, 185, 69);
 RT_INTERFACE!{interface IGameSaveProviderGetResult(IGameSaveProviderGetResultVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveProviderGetResult] {
     fn get_Status(&self, out: *mut GameSaveErrorStatus) -> HRESULT,
@@ -1876,7 +1876,7 @@ impl GameList {
         <Self as RtActivatable<IGameListStatics2>>::get_activation_factory().unmerge_entry_async(mergedEntry)
     }}
 }
-DEFINE_CLSID!(GameList(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,80,114,101,118,105,101,119,46,71,97,109,101,115,69,110,117,109,101,114,97,116,105,111,110,46,71,97,109,101,76,105,115,116,0]) [CLSID_GameList]);
+DEFINE_CLSID!(GameList: "Windows.Gaming.Preview.GamesEnumeration.GameList");
 RT_ENUM! { enum GameListCategory: i32 {
     Candidate (GameListCategory_Candidate) = 0, ConfirmedBySystem (GameListCategory_ConfirmedBySystem) = 1, ConfirmedByUser (GameListCategory_ConfirmedByUser) = 2,
 }}
@@ -2193,7 +2193,7 @@ impl GameModeUserConfiguration {
         <Self as RtActivatable<IGameModeUserConfigurationStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(GameModeUserConfiguration(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,80,114,101,118,105,101,119,46,71,97,109,101,115,69,110,117,109,101,114,97,116,105,111,110,46,71,97,109,101,77,111,100,101,85,115,101,114,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_GameModeUserConfiguration]);
+DEFINE_CLSID!(GameModeUserConfiguration: "Windows.Gaming.Preview.GamesEnumeration.GameModeUserConfiguration");
 DEFINE_IID!(IID_IGameModeUserConfigurationStatics, 1850792316, 26346, 18318, 164, 161, 245, 124, 14, 141, 0, 231);
 RT_INTERFACE!{static interface IGameModeUserConfigurationStatics(IGameModeUserConfigurationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameModeUserConfigurationStatics] {
     fn GetDefault(&self, out: *mut *mut GameModeUserConfiguration) -> HRESULT

--- a/src/rt/gen/windows/globalization.rs
+++ b/src/rt/gen/windows/globalization.rs
@@ -15,7 +15,7 @@ impl ApplicationLanguages {
         <Self as RtActivatable<IApplicationLanguagesStatics>>::get_activation_factory().get_manifest_languages()
     }}
 }
-DEFINE_CLSID!(ApplicationLanguages(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,65,112,112,108,105,99,97,116,105,111,110,76,97,110,103,117,97,103,101,115,0]) [CLSID_ApplicationLanguages]);
+DEFINE_CLSID!(ApplicationLanguages: "Windows.Globalization.ApplicationLanguages");
 DEFINE_IID!(IID_IApplicationLanguagesStatics, 1974732871, 2636, 19090, 149, 101, 253, 99, 201, 95, 122, 237);
 RT_INTERFACE!{static interface IApplicationLanguagesStatics(IApplicationLanguagesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationLanguagesStatics] {
     fn get_PrimaryLanguageOverride(&self, out: *mut HSTRING) -> HRESULT,
@@ -625,7 +625,7 @@ impl Calendar {
         <Self as RtActivatable<ICalendarFactory2>>::get_activation_factory().create_calendar_with_time_zone(languages, calendar, clock, timeZoneId)
     }}
 }
-DEFINE_CLSID!(Calendar(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,67,97,108,101,110,100,97,114,0]) [CLSID_Calendar]);
+DEFINE_CLSID!(Calendar: "Windows.Globalization.Calendar");
 DEFINE_IID!(IID_ICalendarFactory, 2213905426, 58731, 19573, 166, 110, 15, 99, 213, 119, 88, 166);
 RT_INTERFACE!{static interface ICalendarFactory(ICalendarFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICalendarFactory] {
     fn CreateCalendarDefaultCalendarAndClock(&self, languages: *mut super::foundation::collections::IIterable<HString>, out: *mut *mut Calendar) -> HRESULT,
@@ -705,7 +705,7 @@ impl CalendarIdentifiers {
         <Self as RtActivatable<ICalendarIdentifiersStatics3>>::get_activation_factory().get_vietnamese_lunar()
     }}
 }
-DEFINE_CLSID!(CalendarIdentifiers(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,67,97,108,101,110,100,97,114,73,100,101,110,116,105,102,105,101,114,115,0]) [CLSID_CalendarIdentifiers]);
+DEFINE_CLSID!(CalendarIdentifiers: "Windows.Globalization.CalendarIdentifiers");
 DEFINE_IID!(IID_ICalendarIdentifiersStatics, 2154119016, 11442, 19487, 181, 144, 240, 245, 43, 244, 253, 26);
 RT_INTERFACE!{static interface ICalendarIdentifiersStatics(ICalendarIdentifiersStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICalendarIdentifiersStatics] {
     fn get_Gregorian(&self, out: *mut HSTRING) -> HRESULT,
@@ -821,7 +821,7 @@ impl ClockIdentifiers {
         <Self as RtActivatable<IClockIdentifiersStatics>>::get_activation_factory().get_twenty_four_hour()
     }}
 }
-DEFINE_CLSID!(ClockIdentifiers(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,67,108,111,99,107,73,100,101,110,116,105,102,105,101,114,115,0]) [CLSID_ClockIdentifiers]);
+DEFINE_CLSID!(ClockIdentifiers: "Windows.Globalization.ClockIdentifiers");
 DEFINE_IID!(IID_IClockIdentifiersStatics, 1379403195, 4844, 20355, 188, 49, 177, 180, 55, 107, 8, 8);
 RT_INTERFACE!{static interface IClockIdentifiersStatics(IClockIdentifiersStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IClockIdentifiersStatics] {
     fn get_TwelveHour(&self, out: *mut HSTRING) -> HRESULT,
@@ -1318,7 +1318,7 @@ impl CurrencyIdentifiers {
         <Self as RtActivatable<ICurrencyIdentifiersStatics2>>::get_activation_factory().get_byn()
     }}
 }
-DEFINE_CLSID!(CurrencyIdentifiers(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,67,117,114,114,101,110,99,121,73,100,101,110,116,105,102,105,101,114,115,0]) [CLSID_CurrencyIdentifiers]);
+DEFINE_CLSID!(CurrencyIdentifiers: "Windows.Globalization.CurrencyIdentifiers");
 DEFINE_IID!(IID_ICurrencyIdentifiersStatics, 2669480219, 54662, 18707, 155, 106, 169, 189, 45, 193, 40, 116);
 RT_INTERFACE!{static interface ICurrencyIdentifiersStatics(ICurrencyIdentifiersStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICurrencyIdentifiersStatics] {
     fn get_AED(&self, out: *mut HSTRING) -> HRESULT,
@@ -2339,7 +2339,7 @@ impl GeographicRegion {
         <Self as RtActivatable<IGeographicRegionStatics>>::get_activation_factory().is_supported(geographicRegionCode)
     }}
 }
-DEFINE_CLSID!(GeographicRegion(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,71,101,111,103,114,97,112,104,105,99,82,101,103,105,111,110,0]) [CLSID_GeographicRegion]);
+DEFINE_CLSID!(GeographicRegion: "Windows.Globalization.GeographicRegion");
 DEFINE_IID!(IID_IGeographicRegionFactory, 1396855408, 30644, 17003, 133, 159, 129, 225, 157, 81, 37, 70);
 RT_INTERFACE!{static interface IGeographicRegionFactory(IGeographicRegionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IGeographicRegionFactory] {
     fn CreateGeographicRegion(&self, geographicRegionCode: HSTRING, out: *mut *mut GeographicRegion) -> HRESULT
@@ -2396,7 +2396,7 @@ impl JapanesePhoneticAnalyzer {
         <Self as RtActivatable<IJapanesePhoneticAnalyzerStatics>>::get_activation_factory().get_words_with_mono_ruby_option(input, monoRuby)
     }}
 }
-DEFINE_CLSID!(JapanesePhoneticAnalyzer(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,74,97,112,97,110,101,115,101,80,104,111,110,101,116,105,99,65,110,97,108,121,122,101,114,0]) [CLSID_JapanesePhoneticAnalyzer]);
+DEFINE_CLSID!(JapanesePhoneticAnalyzer: "Windows.Globalization.JapanesePhoneticAnalyzer");
 DEFINE_IID!(IID_IJapanesePhoneticAnalyzerStatics, 2292948624, 37854, 16818, 180, 213, 142, 219, 34, 127, 209, 194);
 RT_INTERFACE!{static interface IJapanesePhoneticAnalyzerStatics(IJapanesePhoneticAnalyzerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IJapanesePhoneticAnalyzerStatics] {
     fn GetWords(&self, input: HSTRING, out: *mut *mut super::foundation::collections::IVectorView<JapanesePhoneme>) -> HRESULT,
@@ -2461,7 +2461,7 @@ impl Language {
         <Self as RtActivatable<ILanguageStatics2>>::get_activation_factory().try_set_input_method_language_tag(languageTag)
     }}
 }
-DEFINE_CLSID!(Language(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,76,97,110,103,117,97,103,101,0]) [CLSID_Language]);
+DEFINE_CLSID!(Language: "Windows.Globalization.Language");
 DEFINE_IID!(IID_ILanguageExtensionSubtags, 2105388869, 13965, 17252, 133, 43, 222, 201, 39, 3, 123, 133);
 RT_INTERFACE!{interface ILanguageExtensionSubtags(ILanguageExtensionSubtagsVtbl): IInspectable(IInspectableVtbl) [IID_ILanguageExtensionSubtags] {
     fn GetExtensionSubtags(&self, singleton: HSTRING, out: *mut *mut super::foundation::collections::IVectorView<HString>) -> HRESULT
@@ -2661,7 +2661,7 @@ impl NumeralSystemIdentifiers {
         <Self as RtActivatable<INumeralSystemIdentifiersStatics2>>::get_activation_factory().get_zmth_mono()
     }}
 }
-DEFINE_CLSID!(NumeralSystemIdentifiers(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,101,114,97,108,83,121,115,116,101,109,73,100,101,110,116,105,102,105,101,114,115,0]) [CLSID_NumeralSystemIdentifiers]);
+DEFINE_CLSID!(NumeralSystemIdentifiers: "Windows.Globalization.NumeralSystemIdentifiers");
 DEFINE_IID!(IID_INumeralSystemIdentifiersStatics, 2781242051, 26825, 19773, 183, 101, 151, 32, 41, 226, 29, 236);
 RT_INTERFACE!{static interface INumeralSystemIdentifiersStatics(INumeralSystemIdentifiersStaticsVtbl): IInspectable(IInspectableVtbl) [IID_INumeralSystemIdentifiersStatics] {
     fn get_Arab(&self, out: *mut HSTRING) -> HRESULT,
@@ -3107,7 +3107,7 @@ impl LanguageFontGroup {
         <Self as RtActivatable<ILanguageFontGroupFactory>>::get_activation_factory().create_language_font_group(languageTag)
     }}
 }
-DEFINE_CLSID!(LanguageFontGroup(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,70,111,110,116,115,46,76,97,110,103,117,97,103,101,70,111,110,116,71,114,111,117,112,0]) [CLSID_LanguageFontGroup]);
+DEFINE_CLSID!(LanguageFontGroup: "Windows.Globalization.Fonts.LanguageFontGroup");
 DEFINE_IID!(IID_ILanguageFontGroupFactory, 4239305831, 20087, 18887, 184, 86, 221, 233, 52, 252, 115, 91);
 RT_INTERFACE!{static interface ILanguageFontGroupFactory(ILanguageFontGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILanguageFontGroupFactory] {
     fn CreateLanguageFontGroup(&self, languageTag: HSTRING, out: *mut *mut LanguageFontGroup) -> HRESULT
@@ -3177,7 +3177,7 @@ impl PhoneNumberFormatter {
         <Self as RtActivatable<IPhoneNumberFormatterStatics>>::get_activation_factory().wrap_with_left_to_right_markers(number)
     }}
 }
-DEFINE_CLSID!(PhoneNumberFormatter(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,80,104,111,110,101,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,80,104,111,110,101,78,117,109,98,101,114,70,111,114,109,97,116,116,101,114,0]) [CLSID_PhoneNumberFormatter]);
+DEFINE_CLSID!(PhoneNumberFormatter: "Windows.Globalization.PhoneNumberFormatting.PhoneNumberFormatter");
 DEFINE_IID!(IID_IPhoneNumberFormatterStatics, 1554446641, 34009, 16715, 171, 78, 160, 85, 44, 135, 134, 2);
 RT_INTERFACE!{static interface IPhoneNumberFormatterStatics(IPhoneNumberFormatterStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneNumberFormatterStatics] {
     fn TryCreate(&self, regionCode: HSTRING, phoneNumber: *mut *mut PhoneNumberFormatter) -> HRESULT,
@@ -3274,7 +3274,7 @@ impl PhoneNumberInfo {
         <Self as RtActivatable<IPhoneNumberInfoStatics>>::get_activation_factory().try_parse_with_region(input, regionCode)
     }}
 }
-DEFINE_CLSID!(PhoneNumberInfo(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,80,104,111,110,101,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,80,104,111,110,101,78,117,109,98,101,114,73,110,102,111,0]) [CLSID_PhoneNumberInfo]);
+DEFINE_CLSID!(PhoneNumberInfo: "Windows.Globalization.PhoneNumberFormatting.PhoneNumberInfo");
 DEFINE_IID!(IID_IPhoneNumberInfoFactory, 2181216612, 44458, 19711, 143, 207, 23, 231, 81, 106, 40, 255);
 RT_INTERFACE!{static interface IPhoneNumberInfoFactory(IPhoneNumberInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneNumberInfoFactory] {
     fn Create(&self, number: HSTRING, out: *mut *mut PhoneNumberInfo) -> HRESULT
@@ -3465,7 +3465,7 @@ impl DateTimeFormatter {
         <Self as RtActivatable<IDateTimeFormatterStatics>>::get_activation_factory().get_short_time()
     }}
 }
-DEFINE_CLSID!(DateTimeFormatter(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,68,97,116,101,84,105,109,101,70,111,114,109,97,116,116,105,110,103,46,68,97,116,101,84,105,109,101,70,111,114,109,97,116,116,101,114,0]) [CLSID_DateTimeFormatter]);
+DEFINE_CLSID!(DateTimeFormatter: "Windows.Globalization.DateTimeFormatting.DateTimeFormatter");
 DEFINE_IID!(IID_IDateTimeFormatter2, 667490950, 48554, 20432, 158, 54, 103, 29, 90, 165, 238, 3);
 RT_INTERFACE!{interface IDateTimeFormatter2(IDateTimeFormatter2Vtbl): IInspectable(IInspectableVtbl) [IID_IDateTimeFormatter2] {
     fn FormatUsingTimeZone(&self, datetime: super::super::foundation::DateTime, timeZoneId: HSTRING, out: *mut HSTRING) -> HRESULT
@@ -3603,7 +3603,7 @@ impl CurrencyFormatter {
         <Self as RtActivatable<ICurrencyFormatterFactory>>::get_activation_factory().create_currency_formatter_code_context(currencyCode, languages, geographicRegion)
     }}
 }
-DEFINE_CLSID!(CurrencyFormatter(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,67,117,114,114,101,110,99,121,70,111,114,109,97,116,116,101,114,0]) [CLSID_CurrencyFormatter]);
+DEFINE_CLSID!(CurrencyFormatter: "Windows.Globalization.NumberFormatting.CurrencyFormatter");
 DEFINE_IID!(IID_ICurrencyFormatter2, 120336157, 59322, 16791, 146, 14, 36, 124, 146, 247, 222, 166);
 RT_INTERFACE!{interface ICurrencyFormatter2(ICurrencyFormatter2Vtbl): IInspectable(IInspectableVtbl) [IID_ICurrencyFormatter2] {
     fn get_Mode(&self, out: *mut CurrencyFormatterMode) -> HRESULT,
@@ -3653,7 +3653,7 @@ impl DecimalFormatter {
         <Self as RtActivatable<IDecimalFormatterFactory>>::get_activation_factory().create_decimal_formatter(languages, geographicRegion)
     }}
 }
-DEFINE_CLSID!(DecimalFormatter(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,68,101,99,105,109,97,108,70,111,114,109,97,116,116,101,114,0]) [CLSID_DecimalFormatter]);
+DEFINE_CLSID!(DecimalFormatter: "Windows.Globalization.NumberFormatting.DecimalFormatter");
 DEFINE_IID!(IID_IDecimalFormatterFactory, 218205338, 58259, 18104, 184, 48, 122, 105, 200, 248, 159, 187);
 RT_INTERFACE!{static interface IDecimalFormatterFactory(IDecimalFormatterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDecimalFormatterFactory] {
     fn CreateDecimalFormatter(&self, languages: *mut super::super::foundation::collections::IIterable<HString>, geographicRegion: HSTRING, out: *mut *mut DecimalFormatter) -> HRESULT
@@ -3694,7 +3694,7 @@ impl IIncrementNumberRounder {
 }
 RT_CLASS!{class IncrementNumberRounder: INumberRounder}
 impl RtActivatable<IActivationFactory> for IncrementNumberRounder {}
-DEFINE_CLSID!(IncrementNumberRounder(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,73,110,99,114,101,109,101,110,116,78,117,109,98,101,114,82,111,117,110,100,101,114,0]) [CLSID_IncrementNumberRounder]);
+DEFINE_CLSID!(IncrementNumberRounder: "Windows.Globalization.NumberFormatting.IncrementNumberRounder");
 DEFINE_IID!(IID_INumberFormatter, 2768272457, 30326, 19895, 134, 49, 27, 111, 242, 101, 202, 169);
 RT_INTERFACE!{interface INumberFormatter(INumberFormatterVtbl): IInspectable(IInspectableVtbl) [IID_INumberFormatter] {
     fn FormatInt(&self, value: i64, out: *mut HSTRING) -> HRESULT,
@@ -3947,7 +3947,7 @@ impl NumeralSystemTranslator {
         <Self as RtActivatable<INumeralSystemTranslatorFactory>>::get_activation_factory().create(languages)
     }}
 }
-DEFINE_CLSID!(NumeralSystemTranslator(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,78,117,109,101,114,97,108,83,121,115,116,101,109,84,114,97,110,115,108,97,116,111,114,0]) [CLSID_NumeralSystemTranslator]);
+DEFINE_CLSID!(NumeralSystemTranslator: "Windows.Globalization.NumberFormatting.NumeralSystemTranslator");
 DEFINE_IID!(IID_INumeralSystemTranslatorFactory, 2519779546, 14063, 19848, 168, 92, 111, 13, 152, 214, 32, 166);
 RT_INTERFACE!{static interface INumeralSystemTranslatorFactory(INumeralSystemTranslatorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INumeralSystemTranslatorFactory] {
     fn Create(&self, languages: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut NumeralSystemTranslator) -> HRESULT
@@ -3967,7 +3967,7 @@ impl PercentFormatter {
         <Self as RtActivatable<IPercentFormatterFactory>>::get_activation_factory().create_percent_formatter(languages, geographicRegion)
     }}
 }
-DEFINE_CLSID!(PercentFormatter(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,80,101,114,99,101,110,116,70,111,114,109,97,116,116,101,114,0]) [CLSID_PercentFormatter]);
+DEFINE_CLSID!(PercentFormatter: "Windows.Globalization.NumberFormatting.PercentFormatter");
 DEFINE_IID!(IID_IPercentFormatterFactory, 3078785775, 65236, 16408, 166, 226, 224, 153, 97, 224, 55, 101);
 RT_INTERFACE!{static interface IPercentFormatterFactory(IPercentFormatterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPercentFormatterFactory] {
     fn CreatePercentFormatter(&self, languages: *mut super::super::foundation::collections::IIterable<HString>, geographicRegion: HSTRING, out: *mut *mut PercentFormatter) -> HRESULT
@@ -3987,7 +3987,7 @@ impl PermilleFormatter {
         <Self as RtActivatable<IPermilleFormatterFactory>>::get_activation_factory().create_permille_formatter(languages, geographicRegion)
     }}
 }
-DEFINE_CLSID!(PermilleFormatter(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,80,101,114,109,105,108,108,101,70,111,114,109,97,116,116,101,114,0]) [CLSID_PermilleFormatter]);
+DEFINE_CLSID!(PermilleFormatter: "Windows.Globalization.NumberFormatting.PermilleFormatter");
 DEFINE_IID!(IID_IPermilleFormatterFactory, 725071020, 58936, 20181, 169, 152, 98, 246, 176, 106, 73, 174);
 RT_INTERFACE!{static interface IPermilleFormatterFactory(IPermilleFormatterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPermilleFormatterFactory] {
     fn CreatePermilleFormatter(&self, languages: *mut super::super::foundation::collections::IIterable<HString>, geographicRegion: HSTRING, out: *mut *mut PermilleFormatter) -> HRESULT
@@ -4047,7 +4047,7 @@ impl ISignificantDigitsNumberRounder {
 }
 RT_CLASS!{class SignificantDigitsNumberRounder: INumberRounder}
 impl RtActivatable<IActivationFactory> for SignificantDigitsNumberRounder {}
-DEFINE_CLSID!(SignificantDigitsNumberRounder(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,83,105,103,110,105,102,105,99,97,110,116,68,105,103,105,116,115,78,117,109,98,101,114,82,111,117,110,100,101,114,0]) [CLSID_SignificantDigitsNumberRounder]);
+DEFINE_CLSID!(SignificantDigitsNumberRounder: "Windows.Globalization.NumberFormatting.SignificantDigitsNumberRounder");
 DEFINE_IID!(IID_ISignificantDigitsOption, 491650269, 11587, 20200, 187, 241, 193, 178, 106, 113, 26, 88);
 RT_INTERFACE!{interface ISignificantDigitsOption(ISignificantDigitsOptionVtbl): IInspectable(IInspectableVtbl) [IID_ISignificantDigitsOption] {
     fn get_SignificantDigits(&self, out: *mut i32) -> HRESULT,
@@ -4104,7 +4104,7 @@ impl CharacterGroupings {
         <Self as RtActivatable<ICharacterGroupingsFactory>>::get_activation_factory().create(language)
     }}
 }
-DEFINE_CLSID!(CharacterGroupings(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,67,111,108,108,97,116,105,111,110,46,67,104,97,114,97,99,116,101,114,71,114,111,117,112,105,110,103,115,0]) [CLSID_CharacterGroupings]);
+DEFINE_CLSID!(CharacterGroupings: "Windows.Globalization.Collation.CharacterGroupings");
 DEFINE_IID!(IID_ICharacterGroupingsFactory, 2582290393, 34925, 17409, 159, 152, 105, 200, 45, 76, 47, 120);
 RT_INTERFACE!{static interface ICharacterGroupingsFactory(ICharacterGroupingsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICharacterGroupingsFactory] {
     fn Create(&self, language: HSTRING, out: *mut *mut CharacterGroupings) -> HRESULT

--- a/src/rt/gen/windows/graphics.rs
+++ b/src/rt/gen/windows/graphics.rs
@@ -36,7 +36,7 @@ impl Print3DManager {
         <Self as RtActivatable<IPrint3DManagerStatics>>::get_activation_factory().show_print_uiasync()
     }}
 }
-DEFINE_CLSID!(Print3DManager(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,51,68,77,97,110,97,103,101,114,0]) [CLSID_Print3DManager]);
+DEFINE_CLSID!(Print3DManager: "Windows.Graphics.Printing3D.Print3DManager");
 DEFINE_IID!(IID_IPrint3DManagerStatics, 250727166, 43437, 19464, 169, 23, 29, 31, 134, 62, 171, 203);
 RT_INTERFACE!{static interface IPrint3DManagerStatics(IPrint3DManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DManagerStatics] {
     fn GetForCurrentView(&self, out: *mut *mut Print3DManager) -> HRESULT,
@@ -256,7 +256,7 @@ impl Printing3D3MFPackage {
         <Self as RtActivatable<IPrinting3D3MFPackageStatics>>::get_activation_factory().load_async(value)
     }}
 }
-DEFINE_CLSID!(Printing3D3MFPackage(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,51,77,70,80,97,99,107,97,103,101,0]) [CLSID_Printing3D3MFPackage]);
+DEFINE_CLSID!(Printing3D3MFPackage: "Windows.Graphics.Printing3D.Printing3D3MFPackage");
 DEFINE_IID!(IID_IPrinting3D3MFPackage2, 2522643140, 37835, 17456, 146, 184, 120, 156, 212, 84, 248, 131);
 RT_INTERFACE!{interface IPrinting3D3MFPackage2(IPrinting3D3MFPackage2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3D3MFPackage2] {
     fn get_Compression(&self, out: *mut Printing3DPackageCompression) -> HRESULT,
@@ -322,7 +322,7 @@ impl Printing3DBaseMaterial {
         <Self as RtActivatable<IPrinting3DBaseMaterialStatics>>::get_activation_factory().get_pla()
     }}
 }
-DEFINE_CLSID!(Printing3DBaseMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,66,97,115,101,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DBaseMaterial]);
+DEFINE_CLSID!(Printing3DBaseMaterial: "Windows.Graphics.Printing3D.Printing3DBaseMaterial");
 DEFINE_IID!(IID_IPrinting3DBaseMaterialGroup, 2498785464, 9493, 19085, 161, 240, 208, 252, 19, 208, 96, 33);
 RT_INTERFACE!{interface IPrinting3DBaseMaterialGroup(IPrinting3DBaseMaterialGroupVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DBaseMaterialGroup] {
     fn get_Bases(&self, out: *mut *mut super::super::foundation::collections::IVector<Printing3DBaseMaterial>) -> HRESULT,
@@ -347,7 +347,7 @@ impl Printing3DBaseMaterialGroup {
         <Self as RtActivatable<IPrinting3DBaseMaterialGroupFactory>>::get_activation_factory().create(materialGroupId)
     }}
 }
-DEFINE_CLSID!(Printing3DBaseMaterialGroup(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,66,97,115,101,77,97,116,101,114,105,97,108,71,114,111,117,112,0]) [CLSID_Printing3DBaseMaterialGroup]);
+DEFINE_CLSID!(Printing3DBaseMaterialGroup: "Windows.Graphics.Printing3D.Printing3DBaseMaterialGroup");
 DEFINE_IID!(IID_IPrinting3DBaseMaterialGroupFactory, 1544898268, 34455, 16787, 151, 107, 132, 187, 65, 22, 229, 191);
 RT_INTERFACE!{static interface IPrinting3DBaseMaterialGroupFactory(IPrinting3DBaseMaterialGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DBaseMaterialGroupFactory] {
     fn Create(&self, materialGroupId: u32, out: *mut *mut Printing3DBaseMaterialGroup) -> HRESULT
@@ -400,7 +400,7 @@ impl IPrinting3DColorMaterial {
 }
 RT_CLASS!{class Printing3DColorMaterial: IPrinting3DColorMaterial}
 impl RtActivatable<IActivationFactory> for Printing3DColorMaterial {}
-DEFINE_CLSID!(Printing3DColorMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,108,111,114,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DColorMaterial]);
+DEFINE_CLSID!(Printing3DColorMaterial: "Windows.Graphics.Printing3D.Printing3DColorMaterial");
 DEFINE_IID!(IID_IPrinting3DColorMaterial2, 4205897810, 2799, 17641, 157, 221, 54, 238, 234, 90, 205, 68);
 RT_INTERFACE!{interface IPrinting3DColorMaterial2(IPrinting3DColorMaterial2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DColorMaterial2] {
     #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut super::super::ui::Color) -> HRESULT,
@@ -441,7 +441,7 @@ impl Printing3DColorMaterialGroup {
         <Self as RtActivatable<IPrinting3DColorMaterialGroupFactory>>::get_activation_factory().create(materialGroupId)
     }}
 }
-DEFINE_CLSID!(Printing3DColorMaterialGroup(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,108,111,114,77,97,116,101,114,105,97,108,71,114,111,117,112,0]) [CLSID_Printing3DColorMaterialGroup]);
+DEFINE_CLSID!(Printing3DColorMaterialGroup: "Windows.Graphics.Printing3D.Printing3DColorMaterialGroup");
 DEFINE_IID!(IID_IPrinting3DColorMaterialGroupFactory, 1909689709, 45546, 19035, 188, 84, 25, 198, 95, 61, 240, 68);
 RT_INTERFACE!{static interface IPrinting3DColorMaterialGroupFactory(IPrinting3DColorMaterialGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DColorMaterialGroupFactory] {
     fn Create(&self, materialGroupId: u32, out: *mut *mut Printing3DColorMaterialGroup) -> HRESULT
@@ -521,7 +521,7 @@ impl IPrinting3DComponent {
 }
 RT_CLASS!{class Printing3DComponent: IPrinting3DComponent}
 impl RtActivatable<IActivationFactory> for Printing3DComponent {}
-DEFINE_CLSID!(Printing3DComponent(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,110,101,110,116,0]) [CLSID_Printing3DComponent]);
+DEFINE_CLSID!(Printing3DComponent: "Windows.Graphics.Printing3D.Printing3DComponent");
 DEFINE_IID!(IID_IPrinting3DComponentWithMatrix, 846852917, 3824, 17771, 154, 33, 73, 190, 190, 139, 81, 194);
 RT_INTERFACE!{interface IPrinting3DComponentWithMatrix(IPrinting3DComponentWithMatrixVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DComponentWithMatrix] {
     fn get_Component(&self, out: *mut *mut Printing3DComponent) -> HRESULT,
@@ -551,7 +551,7 @@ impl IPrinting3DComponentWithMatrix {
 }
 RT_CLASS!{class Printing3DComponentWithMatrix: IPrinting3DComponentWithMatrix}
 impl RtActivatable<IActivationFactory> for Printing3DComponentWithMatrix {}
-DEFINE_CLSID!(Printing3DComponentWithMatrix(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,110,101,110,116,87,105,116,104,77,97,116,114,105,120,0]) [CLSID_Printing3DComponentWithMatrix]);
+DEFINE_CLSID!(Printing3DComponentWithMatrix: "Windows.Graphics.Printing3D.Printing3DComponentWithMatrix");
 DEFINE_IID!(IID_IPrinting3DCompositeMaterial, 1176647901, 22062, 20332, 136, 45, 244, 216, 65, 253, 99, 199);
 RT_INTERFACE!{interface IPrinting3DCompositeMaterial(IPrinting3DCompositeMaterialVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DCompositeMaterial] {
     fn get_Values(&self, out: *mut *mut super::super::foundation::collections::IVector<f64>) -> HRESULT
@@ -565,7 +565,7 @@ impl IPrinting3DCompositeMaterial {
 }
 RT_CLASS!{class Printing3DCompositeMaterial: IPrinting3DCompositeMaterial}
 impl RtActivatable<IActivationFactory> for Printing3DCompositeMaterial {}
-DEFINE_CLSID!(Printing3DCompositeMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,115,105,116,101,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DCompositeMaterial]);
+DEFINE_CLSID!(Printing3DCompositeMaterial: "Windows.Graphics.Printing3D.Printing3DCompositeMaterial");
 DEFINE_IID!(IID_IPrinting3DCompositeMaterialGroup, 2375314011, 16625, 18797, 165, 251, 52, 10, 90, 103, 142, 48);
 RT_INTERFACE!{interface IPrinting3DCompositeMaterialGroup(IPrinting3DCompositeMaterialGroupVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DCompositeMaterialGroup] {
     fn get_Composites(&self, out: *mut *mut super::super::foundation::collections::IVector<Printing3DCompositeMaterial>) -> HRESULT,
@@ -596,7 +596,7 @@ impl Printing3DCompositeMaterialGroup {
         <Self as RtActivatable<IPrinting3DCompositeMaterialGroupFactory>>::get_activation_factory().create(materialGroupId)
     }}
 }
-DEFINE_CLSID!(Printing3DCompositeMaterialGroup(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,115,105,116,101,77,97,116,101,114,105,97,108,71,114,111,117,112,0]) [CLSID_Printing3DCompositeMaterialGroup]);
+DEFINE_CLSID!(Printing3DCompositeMaterialGroup: "Windows.Graphics.Printing3D.Printing3DCompositeMaterialGroup");
 DEFINE_IID!(IID_IPrinting3DCompositeMaterialGroup2, 115895650, 32059, 16865, 148, 76, 186, 253, 228, 85, 84, 131);
 RT_INTERFACE!{interface IPrinting3DCompositeMaterialGroup2(IPrinting3DCompositeMaterialGroup2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DCompositeMaterialGroup2] {
     fn get_BaseMaterialGroup(&self, out: *mut *mut Printing3DBaseMaterialGroup) -> HRESULT,
@@ -664,7 +664,7 @@ impl IPrinting3DFaceReductionOptions {
 }
 RT_CLASS!{class Printing3DFaceReductionOptions: IPrinting3DFaceReductionOptions}
 impl RtActivatable<IActivationFactory> for Printing3DFaceReductionOptions {}
-DEFINE_CLSID!(Printing3DFaceReductionOptions(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,70,97,99,101,82,101,100,117,99,116,105,111,110,79,112,116,105,111,110,115,0]) [CLSID_Printing3DFaceReductionOptions]);
+DEFINE_CLSID!(Printing3DFaceReductionOptions: "Windows.Graphics.Printing3D.Printing3DFaceReductionOptions");
 DEFINE_IID!(IID_IPrinting3DMaterial, 932033110, 60770, 18770, 184, 91, 3, 86, 125, 124, 70, 94);
 RT_INTERFACE!{interface IPrinting3DMaterial(IPrinting3DMaterialVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DMaterial] {
     fn get_BaseGroups(&self, out: *mut *mut super::super::foundation::collections::IVector<Printing3DBaseMaterialGroup>) -> HRESULT,
@@ -702,7 +702,7 @@ impl IPrinting3DMaterial {
 }
 RT_CLASS!{class Printing3DMaterial: IPrinting3DMaterial}
 impl RtActivatable<IActivationFactory> for Printing3DMaterial {}
-DEFINE_CLSID!(Printing3DMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DMaterial]);
+DEFINE_CLSID!(Printing3DMaterial: "Windows.Graphics.Printing3D.Printing3DMaterial");
 DEFINE_IID!(IID_IPrinting3DMesh, 422482140, 552, 11777, 188, 32, 197, 41, 12, 191, 50, 196);
 RT_INTERFACE!{interface IPrinting3DMesh(IPrinting3DMeshVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DMesh] {
     fn get_VertexCount(&self, out: *mut u32) -> HRESULT,
@@ -842,7 +842,7 @@ impl IPrinting3DMesh {
 }
 RT_CLASS!{class Printing3DMesh: IPrinting3DMesh}
 impl RtActivatable<IActivationFactory> for Printing3DMesh {}
-DEFINE_CLSID!(Printing3DMesh(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,101,115,104,0]) [CLSID_Printing3DMesh]);
+DEFINE_CLSID!(Printing3DMesh: "Windows.Graphics.Printing3D.Printing3DMesh");
 RT_ENUM! { enum Printing3DMeshVerificationMode: i32 {
     FindFirstError (Printing3DMeshVerificationMode_FindFirstError) = 0, FindAllErrors (Printing3DMeshVerificationMode_FindAllErrors) = 1,
 }}
@@ -963,7 +963,7 @@ impl IPrinting3DModel {
 }
 RT_CLASS!{class Printing3DModel: IPrinting3DModel}
 impl RtActivatable<IActivationFactory> for Printing3DModel {}
-DEFINE_CLSID!(Printing3DModel(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,111,100,101,108,0]) [CLSID_Printing3DModel]);
+DEFINE_CLSID!(Printing3DModel: "Windows.Graphics.Printing3D.Printing3DModel");
 DEFINE_IID!(IID_IPrinting3DModel2, 3374344647, 51265, 18419, 168, 78, 161, 73, 253, 8, 182, 87);
 RT_INTERFACE!{interface IPrinting3DModel2(IPrinting3DModel2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DModel2] {
     fn TryPartialRepairAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -1045,7 +1045,7 @@ impl IPrinting3DModelTexture {
 }
 RT_CLASS!{class Printing3DModelTexture: IPrinting3DModelTexture}
 impl RtActivatable<IActivationFactory> for Printing3DModelTexture {}
-DEFINE_CLSID!(Printing3DModelTexture(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,111,100,101,108,84,101,120,116,117,114,101,0]) [CLSID_Printing3DModelTexture]);
+DEFINE_CLSID!(Printing3DModelTexture: "Windows.Graphics.Printing3D.Printing3DModelTexture");
 RT_ENUM! { enum Printing3DModelUnit: i32 {
     Meter (Printing3DModelUnit_Meter) = 0, Micron (Printing3DModelUnit_Micron) = 1, Millimeter (Printing3DModelUnit_Millimeter) = 2, Centimeter (Printing3DModelUnit_Centimeter) = 3, Inch (Printing3DModelUnit_Inch) = 4, Foot (Printing3DModelUnit_Foot) = 5,
 }}
@@ -1062,7 +1062,7 @@ impl IPrinting3DMultiplePropertyMaterial {
 }
 RT_CLASS!{class Printing3DMultiplePropertyMaterial: IPrinting3DMultiplePropertyMaterial}
 impl RtActivatable<IActivationFactory> for Printing3DMultiplePropertyMaterial {}
-DEFINE_CLSID!(Printing3DMultiplePropertyMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,117,108,116,105,112,108,101,80,114,111,112,101,114,116,121,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DMultiplePropertyMaterial]);
+DEFINE_CLSID!(Printing3DMultiplePropertyMaterial: "Windows.Graphics.Printing3D.Printing3DMultiplePropertyMaterial");
 DEFINE_IID!(IID_IPrinting3DMultiplePropertyMaterialGroup, 4036298009, 44729, 17685, 163, 155, 160, 136, 251, 187, 39, 124);
 RT_INTERFACE!{interface IPrinting3DMultiplePropertyMaterialGroup(IPrinting3DMultiplePropertyMaterialGroupVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DMultiplePropertyMaterialGroup] {
     fn get_MultipleProperties(&self, out: *mut *mut super::super::foundation::collections::IVector<Printing3DMultiplePropertyMaterial>) -> HRESULT,
@@ -1093,7 +1093,7 @@ impl Printing3DMultiplePropertyMaterialGroup {
         <Self as RtActivatable<IPrinting3DMultiplePropertyMaterialGroupFactory>>::get_activation_factory().create(materialGroupId)
     }}
 }
-DEFINE_CLSID!(Printing3DMultiplePropertyMaterialGroup(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,117,108,116,105,112,108,101,80,114,111,112,101,114,116,121,77,97,116,101,114,105,97,108,71,114,111,117,112,0]) [CLSID_Printing3DMultiplePropertyMaterialGroup]);
+DEFINE_CLSID!(Printing3DMultiplePropertyMaterialGroup: "Windows.Graphics.Printing3D.Printing3DMultiplePropertyMaterialGroup");
 DEFINE_IID!(IID_IPrinting3DMultiplePropertyMaterialGroupFactory, 842930542, 54470, 17694, 168, 20, 77, 120, 162, 16, 254, 83);
 RT_INTERFACE!{static interface IPrinting3DMultiplePropertyMaterialGroupFactory(IPrinting3DMultiplePropertyMaterialGroupFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DMultiplePropertyMaterialGroupFactory] {
     fn Create(&self, materialGroupId: u32, out: *mut *mut Printing3DMultiplePropertyMaterialGroup) -> HRESULT
@@ -1151,7 +1151,7 @@ impl IPrinting3DTexture2CoordMaterial {
 }
 RT_CLASS!{class Printing3DTexture2CoordMaterial: IPrinting3DTexture2CoordMaterial}
 impl RtActivatable<IActivationFactory> for Printing3DTexture2CoordMaterial {}
-DEFINE_CLSID!(Printing3DTexture2CoordMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,84,101,120,116,117,114,101,50,67,111,111,114,100,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DTexture2CoordMaterial]);
+DEFINE_CLSID!(Printing3DTexture2CoordMaterial: "Windows.Graphics.Printing3D.Printing3DTexture2CoordMaterial");
 DEFINE_IID!(IID_IPrinting3DTexture2CoordMaterialGroup, 1652391079, 28048, 20409, 159, 196, 159, 239, 243, 223, 168, 146);
 RT_INTERFACE!{interface IPrinting3DTexture2CoordMaterialGroup(IPrinting3DTexture2CoordMaterialGroupVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DTexture2CoordMaterialGroup] {
     fn get_Texture2Coords(&self, out: *mut *mut super::super::foundation::collections::IVector<Printing3DTexture2CoordMaterial>) -> HRESULT,
@@ -1176,7 +1176,7 @@ impl Printing3DTexture2CoordMaterialGroup {
         <Self as RtActivatable<IPrinting3DTexture2CoordMaterialGroupFactory>>::get_activation_factory().create(materialGroupId)
     }}
 }
-DEFINE_CLSID!(Printing3DTexture2CoordMaterialGroup(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,84,101,120,116,117,114,101,50,67,111,111,114,100,77,97,116,101,114,105,97,108,71,114,111,117,112,0]) [CLSID_Printing3DTexture2CoordMaterialGroup]);
+DEFINE_CLSID!(Printing3DTexture2CoordMaterialGroup: "Windows.Graphics.Printing3D.Printing3DTexture2CoordMaterialGroup");
 DEFINE_IID!(IID_IPrinting3DTexture2CoordMaterialGroup2, 1778113466, 45358, 17051, 131, 134, 223, 82, 132, 246, 232, 15);
 RT_INTERFACE!{interface IPrinting3DTexture2CoordMaterialGroup2(IPrinting3DTexture2CoordMaterialGroup2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DTexture2CoordMaterialGroup2] {
     fn get_Texture(&self, out: *mut *mut Printing3DModelTexture) -> HRESULT,
@@ -1238,7 +1238,7 @@ impl IPrinting3DTextureResource {
 }
 RT_CLASS!{class Printing3DTextureResource: IPrinting3DTextureResource}
 impl RtActivatable<IActivationFactory> for Printing3DTextureResource {}
-DEFINE_CLSID!(Printing3DTextureResource(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,84,101,120,116,117,114,101,82,101,115,111,117,114,99,101,0]) [CLSID_Printing3DTextureResource]);
+DEFINE_CLSID!(Printing3DTextureResource: "Windows.Graphics.Printing3D.Printing3DTextureResource");
 } // Windows.Graphics.Printing3D
 pub mod display { // Windows.Graphics.Display
 use ::prelude::*;
@@ -1337,7 +1337,7 @@ impl BrightnessOverride {
         <Self as RtActivatable<IBrightnessOverrideStatics>>::get_activation_factory().save_for_system_async(value)
     }}
 }
-DEFINE_CLSID!(BrightnessOverride(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,68,105,115,112,108,97,121,46,66,114,105,103,104,116,110,101,115,115,79,118,101,114,114,105,100,101,0]) [CLSID_BrightnessOverride]);
+DEFINE_CLSID!(BrightnessOverride: "Windows.Graphics.Display.BrightnessOverride");
 DEFINE_IID!(IID_IBrightnessOverrideStatics, 61323757, 57841, 19048, 161, 31, 148, 106, 216, 206, 83, 147);
 RT_INTERFACE!{static interface IBrightnessOverrideStatics(IBrightnessOverrideStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBrightnessOverrideStatics] {
     fn GetDefaultForSystem(&self, out: *mut *mut BrightnessOverride) -> HRESULT,
@@ -1484,7 +1484,7 @@ impl DisplayInformation {
         <Self as RtActivatable<IDisplayInformationStatics>>::get_activation_factory().remove_display_contents_invalidated(token)
     }}
 }
-DEFINE_CLSID!(DisplayInformation(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,68,105,115,112,108,97,121,46,68,105,115,112,108,97,121,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_DisplayInformation]);
+DEFINE_CLSID!(DisplayInformation: "Windows.Graphics.Display.DisplayInformation");
 DEFINE_IID!(IID_IDisplayInformation2, 1305280545, 64209, 19342, 142, 223, 119, 88, 135, 184, 191, 25);
 RT_INTERFACE!{interface IDisplayInformation2(IDisplayInformation2Vtbl): IInspectable(IInspectableVtbl) [IID_IDisplayInformation2] {
     fn get_RawPixelsPerViewPixel(&self, out: *mut f64) -> HRESULT
@@ -1618,7 +1618,7 @@ impl DisplayProperties {
         <Self as RtActivatable<IDisplayPropertiesStatics>>::get_activation_factory().remove_display_contents_invalidated(token)
     }}
 }
-DEFINE_CLSID!(DisplayProperties(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,68,105,115,112,108,97,121,46,68,105,115,112,108,97,121,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_DisplayProperties]);
+DEFINE_CLSID!(DisplayProperties: "Windows.Graphics.Display.DisplayProperties");
 DEFINE_IID!(IID_DisplayPropertiesEventHandler, 3688729345, 61857, 18129, 158, 227, 84, 59, 204, 153, 89, 128);
 RT_DELEGATE!{delegate DisplayPropertiesEventHandler(DisplayPropertiesEventHandlerVtbl, DisplayPropertiesEventHandlerImpl) [IID_DisplayPropertiesEventHandler] {
     fn Invoke(&self, sender: *mut IInspectable) -> HRESULT
@@ -1810,7 +1810,7 @@ impl HdmiDisplayInformation {
         <Self as RtActivatable<IHdmiDisplayInformationStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(HdmiDisplayInformation(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,68,105,115,112,108,97,121,46,67,111,114,101,46,72,100,109,105,68,105,115,112,108,97,121,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_HdmiDisplayInformation]);
+DEFINE_CLSID!(HdmiDisplayInformation: "Windows.Graphics.Display.Core.HdmiDisplayInformation");
 DEFINE_IID!(IID_IHdmiDisplayInformationStatics, 1827058272, 62506, 18965, 145, 76, 123, 142, 42, 90, 101, 223);
 RT_INTERFACE!{static interface IHdmiDisplayInformationStatics(IHdmiDisplayInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHdmiDisplayInformationStatics] {
     fn GetForCurrentView(&self, out: *mut *mut HdmiDisplayInformation) -> HRESULT
@@ -2027,7 +2027,7 @@ impl BitmapDecoder {
         <Self as RtActivatable<IBitmapDecoderStatics>>::get_activation_factory().create_with_id_async(decoderId, stream)
     }}
 }
-DEFINE_CLSID!(BitmapDecoder(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,68,101,99,111,100,101,114,0]) [CLSID_BitmapDecoder]);
+DEFINE_CLSID!(BitmapDecoder: "Windows.Graphics.Imaging.BitmapDecoder");
 DEFINE_IID!(IID_IBitmapDecoderStatics, 1133300518, 48367, 20117, 186, 214, 35, 168, 34, 229, 141, 1);
 RT_INTERFACE!{static interface IBitmapDecoderStatics(IBitmapDecoderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapDecoderStatics] {
     fn get_BmpDecoderId(&self, out: *mut Guid) -> HRESULT,
@@ -2215,7 +2215,7 @@ impl BitmapEncoder {
         <Self as RtActivatable<IBitmapEncoderStatics>>::get_activation_factory().create_for_in_place_property_encoding_async(bitmapDecoder)
     }}
 }
-DEFINE_CLSID!(BitmapEncoder(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,69,110,99,111,100,101,114,0]) [CLSID_BitmapEncoder]);
+DEFINE_CLSID!(BitmapEncoder: "Windows.Graphics.Imaging.BitmapEncoder");
 DEFINE_IID!(IID_IBitmapEncoderStatics, 2806208167, 42212, 20153, 142, 64, 86, 77, 231, 225, 204, 178);
 RT_INTERFACE!{static interface IBitmapEncoderStatics(IBitmapEncoderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapEncoderStatics] {
     fn get_BmpEncoderId(&self, out: *mut Guid) -> HRESULT,
@@ -2439,7 +2439,7 @@ impl IBitmapPropertiesView {
 RT_CLASS!{class BitmapPropertiesView: IBitmapPropertiesView}
 RT_CLASS!{class BitmapPropertySet: super::super::foundation::collections::IMap<HString, BitmapTypedValue>}
 impl RtActivatable<IActivationFactory> for BitmapPropertySet {}
-DEFINE_CLSID!(BitmapPropertySet(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,80,114,111,112,101,114,116,121,83,101,116,0]) [CLSID_BitmapPropertySet]);
+DEFINE_CLSID!(BitmapPropertySet: "Windows.Graphics.Imaging.BitmapPropertySet");
 RT_ENUM! { enum BitmapRotation: i32 {
     None (BitmapRotation_None) = 0, Clockwise90Degrees (BitmapRotation_Clockwise90Degrees) = 1, Clockwise180Degrees (BitmapRotation_Clockwise180Degrees) = 2, Clockwise270Degrees (BitmapRotation_Clockwise270Degrees) = 3,
 }}
@@ -2519,7 +2519,7 @@ impl IBitmapTransform {
 }
 RT_CLASS!{class BitmapTransform: IBitmapTransform}
 impl RtActivatable<IActivationFactory> for BitmapTransform {}
-DEFINE_CLSID!(BitmapTransform(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,84,114,97,110,115,102,111,114,109,0]) [CLSID_BitmapTransform]);
+DEFINE_CLSID!(BitmapTransform: "Windows.Graphics.Imaging.BitmapTransform");
 DEFINE_IID!(IID_IBitmapTypedValue, 3447735465, 9283, 16384, 176, 205, 121, 49, 108, 86, 245, 137);
 RT_INTERFACE!{interface IBitmapTypedValue(IBitmapTypedValueVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapTypedValue] {
     fn get_Value(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -2544,7 +2544,7 @@ impl BitmapTypedValue {
         <Self as RtActivatable<IBitmapTypedValueFactory>>::get_activation_factory().create(value, type_)
     }}
 }
-DEFINE_CLSID!(BitmapTypedValue(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,84,121,112,101,100,86,97,108,117,101,0]) [CLSID_BitmapTypedValue]);
+DEFINE_CLSID!(BitmapTypedValue: "Windows.Graphics.Imaging.BitmapTypedValue");
 DEFINE_IID!(IID_IBitmapTypedValueFactory, 2463872409, 52755, 18107, 149, 69, 203, 58, 63, 99, 235, 139);
 RT_INTERFACE!{static interface IBitmapTypedValueFactory(IBitmapTypedValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapTypedValueFactory] {
     fn Create(&self, value: *mut IInspectable, type_: super::super::foundation::PropertyType, out: *mut *mut BitmapTypedValue) -> HRESULT
@@ -2700,7 +2700,7 @@ impl SoftwareBitmap {
         <Self as RtActivatable<ISoftwareBitmapStatics>>::get_activation_factory().create_copy_with_alpha_from_surface_async(surface, alpha)
     }}
 }
-DEFINE_CLSID!(SoftwareBitmap(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,83,111,102,116,119,97,114,101,66,105,116,109,97,112,0]) [CLSID_SoftwareBitmap]);
+DEFINE_CLSID!(SoftwareBitmap: "Windows.Graphics.Imaging.SoftwareBitmap");
 DEFINE_IID!(IID_ISoftwareBitmapFactory, 3382700905, 11618, 19783, 166, 179, 79, 219, 106, 7, 253, 248);
 RT_INTERFACE!{static interface ISoftwareBitmapFactory(ISoftwareBitmapFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISoftwareBitmapFactory] {
     fn Create(&self, format: BitmapPixelFormat, width: i32, height: i32, out: *mut *mut SoftwareBitmap) -> HRESULT,
@@ -2848,7 +2848,7 @@ impl PrintManager {
         <Self as RtActivatable<IPrintManagerStatic2>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(PrintManager(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,46,80,114,105,110,116,77,97,110,97,103,101,114,0]) [CLSID_PrintManager]);
+DEFINE_CLSID!(PrintManager: "Windows.Graphics.Printing.PrintManager");
 DEFINE_IID!(IID_IPrintManagerStatic, 1477991885, 58932, 18004, 132, 240, 224, 21, 42, 130, 23, 172);
 RT_INTERFACE!{static interface IPrintManagerStatic(IPrintManagerStaticVtbl): IInspectable(IInspectableVtbl) [IID_IPrintManagerStatic] {
     fn GetForCurrentView(&self, out: *mut *mut PrintManager) -> HRESULT,
@@ -2951,7 +2951,7 @@ impl IPrintPageInfo {
 }
 RT_CLASS!{class PrintPageInfo: IPrintPageInfo}
 impl RtActivatable<IActivationFactory> for PrintPageInfo {}
-DEFINE_CLSID!(PrintPageInfo(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,46,80,114,105,110,116,80,97,103,101,73,110,102,111,0]) [CLSID_PrintPageInfo]);
+DEFINE_CLSID!(PrintPageInfo: "Windows.Graphics.Printing.PrintPageInfo");
 RT_ENUM! { enum PrintQuality: i32 {
     Default (PrintQuality_Default) = 0, NotAvailable (PrintQuality_NotAvailable) = 1, PrinterCustom (PrintQuality_PrinterCustom) = 2, Automatic (PrintQuality_Automatic) = 3, Draft (PrintQuality_Draft) = 4, Fax (PrintQuality_Fax) = 5, High (PrintQuality_High) = 6, Normal (PrintQuality_Normal) = 7, Photographic (PrintQuality_Photographic) = 8, Text (PrintQuality_Text) = 9,
 }}
@@ -3418,7 +3418,7 @@ impl StandardPrintTaskOptions {
         <Self as RtActivatable<IStandardPrintTaskOptionsStatic2>>::get_activation_factory().get_bordering()
     }}
 }
-DEFINE_CLSID!(StandardPrintTaskOptions(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,46,83,116,97,110,100,97,114,100,80,114,105,110,116,84,97,115,107,79,112,116,105,111,110,115,0]) [CLSID_StandardPrintTaskOptions]);
+DEFINE_CLSID!(StandardPrintTaskOptions: "Windows.Graphics.Printing.StandardPrintTaskOptions");
 DEFINE_IID!(IID_IStandardPrintTaskOptionsStatic, 3024633126, 3536, 19668, 186, 255, 147, 15, 199, 214, 165, 116);
 RT_INTERFACE!{static interface IStandardPrintTaskOptionsStatic(IStandardPrintTaskOptionsStaticVtbl): IInspectable(IInspectableVtbl) [IID_IStandardPrintTaskOptionsStatic] {
     fn get_MediaSize(&self, out: *mut HSTRING) -> HRESULT,
@@ -3743,7 +3743,7 @@ impl PrintTaskOptionDetails {
         <Self as RtActivatable<IPrintTaskOptionDetailsStatic>>::get_activation_factory().get_from_print_task_options(printTaskOptions)
     }}
 }
-DEFINE_CLSID!(PrintTaskOptionDetails(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,46,79,112,116,105,111,110,68,101,116,97,105,108,115,46,80,114,105,110,116,84,97,115,107,79,112,116,105,111,110,68,101,116,97,105,108,115,0]) [CLSID_PrintTaskOptionDetails]);
+DEFINE_CLSID!(PrintTaskOptionDetails: "Windows.Graphics.Printing.OptionDetails.PrintTaskOptionDetails");
 DEFINE_IID!(IID_IPrintTaskOptionDetailsStatic, 324903315, 2401, 19310, 135, 102, 241, 59, 127, 188, 205, 88);
 RT_INTERFACE!{static interface IPrintTaskOptionDetailsStatic(IPrintTaskOptionDetailsStaticVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskOptionDetailsStatic] {
     fn GetFromPrintTaskOptions(&self, printTaskOptions: *mut super::PrintTaskOptions, out: *mut *mut PrintTaskOptionDetails) -> HRESULT
@@ -4940,7 +4940,7 @@ impl HolographicDisplay {
         <Self as RtActivatable<IHolographicDisplayStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(HolographicDisplay(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,72,111,108,111,103,114,97,112,104,105,99,46,72,111,108,111,103,114,97,112,104,105,99,68,105,115,112,108,97,121,0]) [CLSID_HolographicDisplay]);
+DEFINE_CLSID!(HolographicDisplay: "Windows.Graphics.Holographic.HolographicDisplay");
 DEFINE_IID!(IID_IHolographicDisplay2, 1974222722, 59221, 17260, 141, 150, 77, 50, 209, 49, 71, 62);
 RT_INTERFACE!{interface IHolographicDisplay2(IHolographicDisplay2Vtbl): IInspectable(IInspectableVtbl) [IID_IHolographicDisplay2] {
     fn get_RefreshRate(&self, out: *mut f64) -> HRESULT
@@ -5083,7 +5083,7 @@ impl HolographicQuadLayer {
         <Self as RtActivatable<IHolographicQuadLayerFactory>>::get_activation_factory().create_with_pixel_format(size, pixelFormat)
     }}
 }
-DEFINE_CLSID!(HolographicQuadLayer(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,72,111,108,111,103,114,97,112,104,105,99,46,72,111,108,111,103,114,97,112,104,105,99,81,117,97,100,76,97,121,101,114,0]) [CLSID_HolographicQuadLayer]);
+DEFINE_CLSID!(HolographicQuadLayer: "Windows.Graphics.Holographic.HolographicQuadLayer");
 DEFINE_IID!(IID_IHolographicQuadLayerFactory, 2792700147, 23060, 23056, 72, 154, 69, 80, 101, 179, 123, 118);
 RT_INTERFACE!{static interface IHolographicQuadLayerFactory(IHolographicQuadLayerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicQuadLayerFactory] {
     fn Create(&self, size: super::super::foundation::Size, out: *mut *mut HolographicQuadLayer) -> HRESULT,
@@ -5210,7 +5210,7 @@ impl HolographicSpace {
         <Self as RtActivatable<IHolographicSpaceStatics3>>::get_activation_factory().get_is_configured()
     }}
 }
-DEFINE_CLSID!(HolographicSpace(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,72,111,108,111,103,114,97,112,104,105,99,46,72,111,108,111,103,114,97,112,104,105,99,83,112,97,99,101,0]) [CLSID_HolographicSpace]);
+DEFINE_CLSID!(HolographicSpace: "Windows.Graphics.Holographic.HolographicSpace");
 DEFINE_IID!(IID_IHolographicSpaceCameraAddedEventArgs, 1492245045, 48051, 15503, 153, 61, 108, 128, 231, 254, 185, 159);
 RT_INTERFACE!{interface IHolographicSpaceCameraAddedEventArgs(IHolographicSpaceCameraAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicSpaceCameraAddedEventArgs] {
     fn get_Camera(&self, out: *mut *mut HolographicCamera) -> HRESULT,

--- a/src/rt/gen/windows/management.rs
+++ b/src/rt/gen/windows/management.rs
@@ -78,7 +78,7 @@ impl IMdmAlert {
 }
 RT_CLASS!{class MdmAlert: IMdmAlert}
 impl RtActivatable<IActivationFactory> for MdmAlert {}
-DEFINE_CLSID!(MdmAlert(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,77,100,109,65,108,101,114,116,0]) [CLSID_MdmAlert]);
+DEFINE_CLSID!(MdmAlert: "Windows.Management.MdmAlert");
 RT_ENUM! { enum MdmAlertDataType: i32 {
     String (MdmAlertDataType_String) = 0, Base64 (MdmAlertDataType_Base64) = 1, Boolean (MdmAlertDataType_Boolean) = 2, Integer (MdmAlertDataType_Integer) = 3,
 }}
@@ -154,7 +154,7 @@ impl MdmSessionManager {
         <Self as RtActivatable<IMdmSessionManagerStatics>>::get_activation_factory().get_session_by_id(sessionId)
     }}
 }
-DEFINE_CLSID!(MdmSessionManager(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,77,100,109,83,101,115,115,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MdmSessionManager]);
+DEFINE_CLSID!(MdmSessionManager: "Windows.Management.MdmSessionManager");
 DEFINE_IID!(IID_IMdmSessionManagerStatics, 3477789017, 63301, 19321, 155, 92, 222, 11, 248, 239, 228, 75);
 RT_INTERFACE!{static interface IMdmSessionManagerStatics(IMdmSessionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMdmSessionManagerStatics] {
     fn get_SessionIds(&self, out: *mut *mut super::foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -340,7 +340,7 @@ impl IPackageManager {
 }
 RT_CLASS!{class PackageManager: IPackageManager}
 impl RtActivatable<IActivationFactory> for PackageManager {}
-DEFINE_CLSID!(PackageManager(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,68,101,112,108,111,121,109,101,110,116,46,80,97,99,107,97,103,101,77,97,110,97,103,101,114,0]) [CLSID_PackageManager]);
+DEFINE_CLSID!(PackageManager: "Windows.Management.Deployment.PackageManager");
 DEFINE_IID!(IID_IPackageManager2, 4155166861, 2112, 18162, 181, 216, 202, 212, 118, 147, 160, 149);
 RT_INTERFACE!{interface IPackageManager2(IPackageManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IPackageManager2] {
     fn RemovePackageWithOptionsAsync(&self, packageFullName: HSTRING, removalOptions: RemovalOptions, out: *mut *mut super::super::foundation::IAsyncOperationWithProgress<DeploymentResult, DeploymentProgress>) -> HRESULT,
@@ -791,7 +791,7 @@ impl ClassicAppManager {
         <Self as RtActivatable<IClassicAppManagerStatics>>::get_activation_factory().find_installed_app(appUninstallKey)
     }}
 }
-DEFINE_CLSID!(ClassicAppManager(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,68,101,112,108,111,121,109,101,110,116,46,80,114,101,118,105,101,119,46,67,108,97,115,115,105,99,65,112,112,77,97,110,97,103,101,114,0]) [CLSID_ClassicAppManager]);
+DEFINE_CLSID!(ClassicAppManager: "Windows.Management.Deployment.Preview.ClassicAppManager");
 DEFINE_IID!(IID_IClassicAppManagerStatics, 3808089704, 34860, 20275, 176, 53, 13, 247, 185, 13, 103, 230);
 RT_INTERFACE!{static interface IClassicAppManagerStatics(IClassicAppManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IClassicAppManagerStatics] {
     fn FindInstalledApp(&self, appUninstallKey: HSTRING, out: *mut *mut InstalledClassicAppInfo) -> HRESULT
@@ -836,7 +836,7 @@ impl ApplicationDataManager {
         <Self as RtActivatable<IApplicationDataManagerStatics>>::get_activation_factory().create_for_package_family(packageFamilyName)
     }}
 }
-DEFINE_CLSID!(ApplicationDataManager(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,67,111,114,101,46,65,112,112,108,105,99,97,116,105,111,110,68,97,116,97,77,97,110,97,103,101,114,0]) [CLSID_ApplicationDataManager]);
+DEFINE_CLSID!(ApplicationDataManager: "Windows.Management.Core.ApplicationDataManager");
 DEFINE_IID!(IID_IApplicationDataManagerStatics, 504914659, 27022, 18849, 151, 82, 222, 233, 73, 37, 185, 179);
 RT_INTERFACE!{static interface IApplicationDataManagerStatics(IApplicationDataManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationDataManagerStatics] {
     #[cfg(feature="windows-storage")] fn CreateForPackageFamily(&self, packageFamilyName: HSTRING, out: *mut *mut super::super::storage::ApplicationData) -> HRESULT
@@ -861,7 +861,7 @@ impl NamedPolicy {
         <Self as RtActivatable<INamedPolicyStatics>>::get_activation_factory().get_policy_from_path_for_user(user, area, name)
     }}
 }
-DEFINE_CLSID!(NamedPolicy(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,80,111,108,105,99,105,101,115,46,78,97,109,101,100,80,111,108,105,99,121,0]) [CLSID_NamedPolicy]);
+DEFINE_CLSID!(NamedPolicy: "Windows.Management.Policies.NamedPolicy");
 DEFINE_IID!(IID_INamedPolicyData, 953987480, 38316, 16503, 166, 67, 128, 120, 202, 226, 100, 0);
 RT_INTERFACE!{interface INamedPolicyData(INamedPolicyDataVtbl): IInspectable(IInspectableVtbl) [IID_INamedPolicyData] {
     fn get_Area(&self, out: *mut HSTRING) -> HRESULT,
@@ -1019,7 +1019,7 @@ impl MdmPolicy {
         <Self as RtActivatable<IMdmPolicyStatics2>>::get_activation_factory().get_messaging_sync_policy()
     }}
 }
-DEFINE_CLSID!(MdmPolicy(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,87,111,114,107,112,108,97,99,101,46,77,100,109,80,111,108,105,99,121,0]) [CLSID_MdmPolicy]);
+DEFINE_CLSID!(MdmPolicy: "Windows.Management.Workplace.MdmPolicy");
 DEFINE_IID!(IID_IMdmPolicyStatics2, 3382474022, 980, 18937, 169, 147, 67, 239, 204, 210, 101, 196);
 RT_INTERFACE!{static interface IMdmPolicyStatics2(IMdmPolicyStatics2Vtbl): IInspectable(IInspectableVtbl) [IID_IMdmPolicyStatics2] {
     fn GetMessagingSyncPolicy(&self, out: *mut MessagingSyncPolicy) -> HRESULT
@@ -1041,7 +1041,7 @@ impl WorkplaceSettings {
         <Self as RtActivatable<IWorkplaceSettingsStatics>>::get_activation_factory().get_is_microsoft_account_optional()
     }}
 }
-DEFINE_CLSID!(WorkplaceSettings(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,87,111,114,107,112,108,97,99,101,46,87,111,114,107,112,108,97,99,101,83,101,116,116,105,110,103,115,0]) [CLSID_WorkplaceSettings]);
+DEFINE_CLSID!(WorkplaceSettings: "Windows.Management.Workplace.WorkplaceSettings");
 DEFINE_IID!(IID_IWorkplaceSettingsStatics, 3831984125, 11666, 19464, 186, 212, 246, 89, 11, 84, 166, 211);
 RT_INTERFACE!{static interface IWorkplaceSettingsStatics(IWorkplaceSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWorkplaceSettingsStatics] {
     fn get_IsMicrosoftAccountOptional(&self, out: *mut bool) -> HRESULT

--- a/src/rt/gen/windows/media.rs
+++ b/src/rt/gen/windows/media.rs
@@ -43,7 +43,7 @@ impl AudioFrame {
         <Self as RtActivatable<IAudioFrameFactory>>::get_activation_factory().create(capacity)
     }}
 }
-DEFINE_CLSID!(AudioFrame(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,70,114,97,109,101,0]) [CLSID_AudioFrame]);
+DEFINE_CLSID!(AudioFrame: "Windows.Media.AudioFrame");
 DEFINE_IID!(IID_IAudioFrameFactory, 2443774686, 9250, 16550, 185, 173, 48, 208, 36, 4, 49, 125);
 RT_INTERFACE!{static interface IAudioFrameFactory(IAudioFrameFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAudioFrameFactory] {
     fn Create(&self, capacity: u32, out: *mut *mut AudioFrame) -> HRESULT
@@ -388,7 +388,7 @@ impl MediaControl {
         <Self as RtActivatable<IMediaControl>>::get_activation_factory().get_album_art()
     }}
 }
-DEFINE_CLSID!(MediaControl(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,67,111,110,116,114,111,108,0]) [CLSID_MediaControl]);
+DEFINE_CLSID!(MediaControl: "Windows.Media.MediaControl");
 DEFINE_IID!(IID_IMediaExtension, 126963992, 17887, 17451, 138, 63, 247, 130, 106, 99, 112, 171);
 RT_INTERFACE!{interface IMediaExtension(IMediaExtensionVtbl): IInspectable(IInspectableVtbl) [IID_IMediaExtension] {
     fn SetProperties(&self, configuration: *mut super::foundation::collections::IPropertySet) -> HRESULT
@@ -466,7 +466,7 @@ impl IMediaExtensionManager {
 }
 RT_CLASS!{class MediaExtensionManager: IMediaExtensionManager}
 impl RtActivatable<IActivationFactory> for MediaExtensionManager {}
-DEFINE_CLSID!(MediaExtensionManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,69,120,116,101,110,115,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MediaExtensionManager]);
+DEFINE_CLSID!(MediaExtensionManager: "Windows.Media.MediaExtensionManager");
 DEFINE_IID!(IID_IMediaExtensionManager2, 1540276039, 16451, 20461, 172, 175, 84, 236, 41, 223, 177, 247);
 RT_INTERFACE!{interface IMediaExtensionManager2(IMediaExtensionManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaExtensionManager2] {
     #[cfg(feature="windows-applicationmodel")] fn RegisterMediaExtensionForAppService(&self, extension: *mut IMediaExtension, connection: *mut super::applicationmodel::appservice::AppServiceConnection) -> HRESULT
@@ -585,7 +585,7 @@ impl MediaMarkerTypes {
         <Self as RtActivatable<IMediaMarkerTypesStatics>>::get_activation_factory().get_bookmark()
     }}
 }
-DEFINE_CLSID!(MediaMarkerTypes(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,77,97,114,107,101,114,84,121,112,101,115,0]) [CLSID_MediaMarkerTypes]);
+DEFINE_CLSID!(MediaMarkerTypes: "Windows.Media.MediaMarkerTypes");
 DEFINE_IID!(IID_IMediaMarkerTypesStatics, 3139010624, 18479, 18243, 136, 50, 69, 133, 56, 33, 236, 224);
 RT_INTERFACE!{static interface IMediaMarkerTypesStatics(IMediaMarkerTypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaMarkerTypesStatics] {
     fn get_Bookmark(&self, out: *mut HSTRING) -> HRESULT
@@ -690,7 +690,7 @@ impl IMediaTimelineController {
 }
 RT_CLASS!{class MediaTimelineController: IMediaTimelineController}
 impl RtActivatable<IActivationFactory> for MediaTimelineController {}
-DEFINE_CLSID!(MediaTimelineController(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,84,105,109,101,108,105,110,101,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_MediaTimelineController]);
+DEFINE_CLSID!(MediaTimelineController: "Windows.Media.MediaTimelineController");
 DEFINE_IID!(IID_IMediaTimelineController2, 4017416760, 40562, 19961, 131, 85, 110, 144, 200, 27, 186, 221);
 RT_INTERFACE!{interface IMediaTimelineController2(IMediaTimelineController2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaTimelineController2] {
     fn get_Duration(&self, out: *mut *mut super::foundation::IReference<super::foundation::TimeSpan>) -> HRESULT,
@@ -1063,7 +1063,7 @@ impl SystemMediaTransportControls {
         <Self as RtActivatable<ISystemMediaTransportControlsStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(SystemMediaTransportControls(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,121,115,116,101,109,77,101,100,105,97,84,114,97,110,115,112,111,114,116,67,111,110,116,114,111,108,115,0]) [CLSID_SystemMediaTransportControls]);
+DEFINE_CLSID!(SystemMediaTransportControls: "Windows.Media.SystemMediaTransportControls");
 DEFINE_IID!(IID_ISystemMediaTransportControls2, 3935884022, 32572, 19186, 165, 134, 114, 136, 152, 8, 239, 177);
 RT_INTERFACE!{interface ISystemMediaTransportControls2(ISystemMediaTransportControls2Vtbl): IInspectable(IInspectableVtbl) [IID_ISystemMediaTransportControls2] {
     fn get_AutoRepeatMode(&self, out: *mut MediaPlaybackAutoRepeatMode) -> HRESULT,
@@ -1330,7 +1330,7 @@ impl ISystemMediaTransportControlsTimelineProperties {
 }
 RT_CLASS!{class SystemMediaTransportControlsTimelineProperties: ISystemMediaTransportControlsTimelineProperties}
 impl RtActivatable<IActivationFactory> for SystemMediaTransportControlsTimelineProperties {}
-DEFINE_CLSID!(SystemMediaTransportControlsTimelineProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,121,115,116,101,109,77,101,100,105,97,84,114,97,110,115,112,111,114,116,67,111,110,116,114,111,108,115,84,105,109,101,108,105,110,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_SystemMediaTransportControlsTimelineProperties]);
+DEFINE_CLSID!(SystemMediaTransportControlsTimelineProperties: "Windows.Media.SystemMediaTransportControlsTimelineProperties");
 DEFINE_IID!(IID_IVideoDisplayProperties, 1443495345, 23853, 18546, 129, 112, 69, 222, 229, 188, 47, 92);
 RT_INTERFACE!{interface IVideoDisplayProperties(IVideoDisplayPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IVideoDisplayProperties] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -1377,7 +1377,7 @@ impl VideoEffects {
         <Self as RtActivatable<IVideoEffectsStatics>>::get_activation_factory().get_video_stabilization()
     }}
 }
-DEFINE_CLSID!(VideoEffects(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,86,105,100,101,111,69,102,102,101,99,116,115,0]) [CLSID_VideoEffects]);
+DEFINE_CLSID!(VideoEffects: "Windows.Media.VideoEffects");
 DEFINE_IID!(IID_IVideoEffectsStatics, 533571048, 47857, 17697, 152, 12, 59, 206, 187, 68, 207, 56);
 RT_INTERFACE!{static interface IVideoEffectsStatics(IVideoEffectsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IVideoEffectsStatics] {
     fn get_VideoStabilization(&self, out: *mut HSTRING) -> HRESULT
@@ -1422,7 +1422,7 @@ impl VideoFrame {
         <Self as RtActivatable<IVideoFrameFactory>>::get_activation_factory().create_with_alpha(format, width, height, alpha)
     }}
 }
-DEFINE_CLSID!(VideoFrame(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,86,105,100,101,111,70,114,97,109,101,0]) [CLSID_VideoFrame]);
+DEFINE_CLSID!(VideoFrame: "Windows.Media.VideoFrame");
 DEFINE_IID!(IID_IVideoFrameFactory, 21720425, 8744, 19602, 146, 255, 80, 195, 128, 211, 231, 118);
 RT_INTERFACE!{static interface IVideoFrameFactory(IVideoFrameFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVideoFrameFactory] {
     #[cfg(feature="windows-graphics")] fn Create(&self, format: super::graphics::imaging::BitmapPixelFormat, width: i32, height: i32, out: *mut *mut VideoFrame) -> HRESULT,
@@ -2051,7 +2051,7 @@ impl AppBroadcastManager {
         <Self as RtActivatable<IAppBroadcastManagerStatics>>::get_activation_factory().apply_provider_settings(value)
     }}
 }
-DEFINE_CLSID!(AppBroadcastManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,65,112,112,66,114,111,97,100,99,97,115,116,77,97,110,97,103,101,114,0]) [CLSID_AppBroadcastManager]);
+DEFINE_CLSID!(AppBroadcastManager: "Windows.Media.Capture.AppBroadcastManager");
 DEFINE_IID!(IID_IAppBroadcastManagerStatics, 911081867, 7758, 16671, 171, 62, 146, 149, 152, 68, 193, 86);
 RT_INTERFACE!{static interface IAppBroadcastManagerStatics(IAppBroadcastManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastManagerStatics] {
     fn GetGlobalSettings(&self, out: *mut *mut AppBroadcastGlobalSettings) -> HRESULT,
@@ -2169,7 +2169,7 @@ impl AppBroadcastPlugInManager {
         <Self as RtActivatable<IAppBroadcastPlugInManagerStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(AppBroadcastPlugInManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,65,112,112,66,114,111,97,100,99,97,115,116,80,108,117,103,73,110,77,97,110,97,103,101,114,0]) [CLSID_AppBroadcastPlugInManager]);
+DEFINE_CLSID!(AppBroadcastPlugInManager: "Windows.Media.Capture.AppBroadcastPlugInManager");
 DEFINE_IID!(IID_IAppBroadcastPlugInManagerStatics, 4066663456, 23670, 19676, 147, 100, 130, 254, 158, 182, 83, 77);
 RT_INTERFACE!{static interface IAppBroadcastPlugInManagerStatics(IAppBroadcastPlugInManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPlugInManagerStatics] {
     fn GetDefault(&self, out: *mut *mut AppBroadcastPlugInManager) -> HRESULT,
@@ -3052,7 +3052,7 @@ impl AppCapture {
         <Self as RtActivatable<IAppCaptureStatics2>>::get_activation_factory().set_allowed_async(allowed)
     }}
 }
-DEFINE_CLSID!(AppCapture(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,65,112,112,67,97,112,116,117,114,101,0]) [CLSID_AppCapture]);
+DEFINE_CLSID!(AppCapture: "Windows.Media.Capture.AppCapture");
 DEFINE_IID!(IID_IAppCaptureAlternateShortcutKeys, 434692335, 9068, 16633, 179, 143, 155, 125, 214, 93, 28, 204);
 RT_INTERFACE!{interface IAppCaptureAlternateShortcutKeys(IAppCaptureAlternateShortcutKeysVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureAlternateShortcutKeys] {
     #[cfg(feature="windows-system")] fn put_ToggleGameBarKey(&self, value: super::super::system::VirtualKey) -> HRESULT,
@@ -3282,7 +3282,7 @@ impl AppCaptureManager {
         <Self as RtActivatable<IAppCaptureManagerStatics>>::get_activation_factory().apply_settings(appCaptureSettings)
     }}
 }
-DEFINE_CLSID!(AppCaptureManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,65,112,112,67,97,112,116,117,114,101,77,97,110,97,103,101,114,0]) [CLSID_AppCaptureManager]);
+DEFINE_CLSID!(AppCaptureManager: "Windows.Media.Capture.AppCaptureManager");
 DEFINE_IID!(IID_IAppCaptureManagerStatics, 2107522727, 25218, 18229, 141, 78, 170, 69, 249, 15, 103, 35);
 RT_INTERFACE!{static interface IAppCaptureManagerStatics(IAppCaptureManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureManagerStatics] {
     fn GetCurrentSettings(&self, out: *mut *mut AppCaptureSettings) -> HRESULT,
@@ -3366,7 +3366,7 @@ impl IAppCaptureMetadataWriter {
 }
 RT_CLASS!{class AppCaptureMetadataWriter: IAppCaptureMetadataWriter}
 impl RtActivatable<IActivationFactory> for AppCaptureMetadataWriter {}
-DEFINE_CLSID!(AppCaptureMetadataWriter(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,65,112,112,67,97,112,116,117,114,101,77,101,116,97,100,97,116,97,87,114,105,116,101,114,0]) [CLSID_AppCaptureMetadataWriter]);
+DEFINE_CLSID!(AppCaptureMetadataWriter: "Windows.Media.Capture.AppCaptureMetadataWriter");
 RT_ENUM! { enum AppCaptureMicrophoneCaptureState: i32 {
     Stopped (AppCaptureMicrophoneCaptureState_Stopped) = 0, Started (AppCaptureMicrophoneCaptureState_Started) = 1, Failed (AppCaptureMicrophoneCaptureState_Failed) = 2,
 }}
@@ -3957,7 +3957,7 @@ impl ICameraCaptureUI {
 }
 RT_CLASS!{class CameraCaptureUI: ICameraCaptureUI}
 impl RtActivatable<IActivationFactory> for CameraCaptureUI {}
-DEFINE_CLSID!(CameraCaptureUI(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,67,97,109,101,114,97,67,97,112,116,117,114,101,85,73,0]) [CLSID_CameraCaptureUI]);
+DEFINE_CLSID!(CameraCaptureUI: "Windows.Media.Capture.CameraCaptureUI");
 RT_ENUM! { enum CameraCaptureUIMaxPhotoResolution: i32 {
     HighestAvailable (CameraCaptureUIMaxPhotoResolution_HighestAvailable) = 0, VerySmallQvga (CameraCaptureUIMaxPhotoResolution_VerySmallQvga) = 1, SmallVga (CameraCaptureUIMaxPhotoResolution_SmallVga) = 2, MediumXga (CameraCaptureUIMaxPhotoResolution_MediumXga) = 3, Large3M (CameraCaptureUIMaxPhotoResolution_Large3M) = 4, VeryLarge5M (CameraCaptureUIMaxPhotoResolution_VeryLarge5M) = 5,
 }}
@@ -4091,7 +4091,7 @@ impl CameraOptionsUI {
         <Self as RtActivatable<ICameraOptionsUIStatics>>::get_activation_factory().show(mediaCapture)
     }}
 }
-DEFINE_CLSID!(CameraOptionsUI(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,67,97,109,101,114,97,79,112,116,105,111,110,115,85,73,0]) [CLSID_CameraOptionsUI]);
+DEFINE_CLSID!(CameraOptionsUI: "Windows.Media.Capture.CameraOptionsUI");
 DEFINE_IID!(IID_ICameraOptionsUIStatics, 990731828, 14598, 19325, 148, 108, 123, 222, 132, 68, 153, 174);
 RT_INTERFACE!{static interface ICameraOptionsUIStatics(ICameraOptionsUIStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICameraOptionsUIStatics] {
     fn Show(&self, mediaCapture: *mut MediaCapture) -> HRESULT
@@ -4354,7 +4354,7 @@ impl GameBarServicesManager {
         <Self as RtActivatable<IGameBarServicesManagerStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(GameBarServicesManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,71,97,109,101,66,97,114,83,101,114,118,105,99,101,115,77,97,110,97,103,101,114,0]) [CLSID_GameBarServicesManager]);
+DEFINE_CLSID!(GameBarServicesManager: "Windows.Media.Capture.GameBarServicesManager");
 DEFINE_IID!(IID_IGameBarServicesManagerGameBarServicesCreatedEventArgs, 3991780764, 5182, 18851, 165, 234, 11, 25, 149, 200, 212, 110);
 RT_INTERFACE!{interface IGameBarServicesManagerGameBarServicesCreatedEventArgs(IGameBarServicesManagerGameBarServicesCreatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGameBarServicesManagerGameBarServicesCreatedEventArgs] {
     fn get_GameBarServices(&self, out: *mut *mut GameBarServices) -> HRESULT
@@ -4701,7 +4701,7 @@ impl MediaCapture {
         <Self as RtActivatable<IMediaCaptureStatics>>::get_activation_factory().find_known_video_profiles(videoDeviceId, name)
     }}
 }
-DEFINE_CLSID!(MediaCapture(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,77,101,100,105,97,67,97,112,116,117,114,101,0]) [CLSID_MediaCapture]);
+DEFINE_CLSID!(MediaCapture: "Windows.Media.Capture.MediaCapture");
 DEFINE_IID!(IID_IMediaCapture2, 2630255200, 32161, 16451, 182, 82, 33, 184, 135, 141, 175, 249);
 RT_INTERFACE!{interface IMediaCapture2(IMediaCapture2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaCapture2] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -5046,7 +5046,7 @@ impl IMediaCaptureInitializationSettings {
 }
 RT_CLASS!{class MediaCaptureInitializationSettings: IMediaCaptureInitializationSettings}
 impl RtActivatable<IActivationFactory> for MediaCaptureInitializationSettings {}
-DEFINE_CLSID!(MediaCaptureInitializationSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,77,101,100,105,97,67,97,112,116,117,114,101,73,110,105,116,105,97,108,105,122,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_MediaCaptureInitializationSettings]);
+DEFINE_CLSID!(MediaCaptureInitializationSettings: "Windows.Media.Capture.MediaCaptureInitializationSettings");
 DEFINE_IID!(IID_IMediaCaptureInitializationSettings2, 1078855206, 51676, 17385, 174, 228, 230, 191, 27, 87, 180, 76);
 RT_INTERFACE!{interface IMediaCaptureInitializationSettings2(IMediaCaptureInitializationSettings2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureInitializationSettings2] {
     fn put_MediaCategory(&self, value: MediaCategory) -> HRESULT,
@@ -5998,7 +5998,7 @@ impl MediaFrameSourceGroup {
         <Self as RtActivatable<IMediaFrameSourceGroupStatics>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(MediaFrameSourceGroup(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,70,114,97,109,101,115,46,77,101,100,105,97,70,114,97,109,101,83,111,117,114,99,101,71,114,111,117,112,0]) [CLSID_MediaFrameSourceGroup]);
+DEFINE_CLSID!(MediaFrameSourceGroup: "Windows.Media.Capture.Frames.MediaFrameSourceGroup");
 DEFINE_IID!(IID_IMediaFrameSourceGroupStatics, 474529733, 17263, 17672, 148, 207, 213, 216, 183, 50, 100, 69);
 RT_INTERFACE!{static interface IMediaFrameSourceGroupStatics(IMediaFrameSourceGroupStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameSourceGroupStatics] {
     fn FindAllAsync(&self, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<::rt::gen::windows::foundation::collections::IVectorView<MediaFrameSourceGroup>>) -> HRESULT,
@@ -6370,7 +6370,7 @@ impl AppRecordingManager {
         <Self as RtActivatable<IAppRecordingManagerStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(AppRecordingManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,112,112,82,101,99,111,114,100,105,110,103,46,65,112,112,82,101,99,111,114,100,105,110,103,77,97,110,97,103,101,114,0]) [CLSID_AppRecordingManager]);
+DEFINE_CLSID!(AppRecordingManager: "Windows.Media.AppRecording.AppRecordingManager");
 DEFINE_IID!(IID_IAppRecordingManagerStatics, 1357318647, 14542, 19411, 157, 178, 231, 43, 190, 157, 225, 29);
 RT_INTERFACE!{static interface IAppRecordingManagerStatics(IAppRecordingManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppRecordingManagerStatics] {
     fn GetDefault(&self, out: *mut *mut AppRecordingManager) -> HRESULT
@@ -6575,7 +6575,7 @@ impl IAppBroadcastingMonitor {
 }
 RT_CLASS!{class AppBroadcastingMonitor: IAppBroadcastingMonitor}
 impl RtActivatable<IActivationFactory> for AppBroadcastingMonitor {}
-DEFINE_CLSID!(AppBroadcastingMonitor(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,112,112,66,114,111,97,100,99,97,115,116,105,110,103,46,65,112,112,66,114,111,97,100,99,97,115,116,105,110,103,77,111,110,105,116,111,114,0]) [CLSID_AppBroadcastingMonitor]);
+DEFINE_CLSID!(AppBroadcastingMonitor: "Windows.Media.AppBroadcasting.AppBroadcastingMonitor");
 DEFINE_IID!(IID_IAppBroadcastingStatus, 304473311, 929, 17144, 139, 128, 201, 34, 140, 217, 207, 46);
 RT_INTERFACE!{interface IAppBroadcastingStatus(IAppBroadcastingStatusVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastingStatus] {
     fn get_CanStartBroadcast(&self, out: *mut bool) -> HRESULT,
@@ -6674,7 +6674,7 @@ impl AppBroadcastingUI {
         <Self as RtActivatable<IAppBroadcastingUIStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(AppBroadcastingUI(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,112,112,66,114,111,97,100,99,97,115,116,105,110,103,46,65,112,112,66,114,111,97,100,99,97,115,116,105,110,103,85,73,0]) [CLSID_AppBroadcastingUI]);
+DEFINE_CLSID!(AppBroadcastingUI: "Windows.Media.AppBroadcasting.AppBroadcastingUI");
 DEFINE_IID!(IID_IAppBroadcastingUIStatics, 1437116317, 9163, 17785, 156, 52, 136, 111, 224, 44, 4, 90);
 RT_INTERFACE!{static interface IAppBroadcastingUIStatics(IAppBroadcastingUIStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastingUIStatics] {
     fn GetDefault(&self, out: *mut *mut AppBroadcastingUI) -> HRESULT,
@@ -7093,7 +7093,7 @@ impl AudioGraph {
         <Self as RtActivatable<IAudioGraphStatics>>::get_activation_factory().create_async(settings)
     }}
 }
-DEFINE_CLSID!(AudioGraph(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,71,114,97,112,104,0]) [CLSID_AudioGraph]);
+DEFINE_CLSID!(AudioGraph: "Windows.Media.Audio.AudioGraph");
 DEFINE_IID!(IID_IAudioGraph2, 1313618901, 20417, 17910, 169, 71, 60, 211, 143, 79, 216, 57);
 RT_INTERFACE!{interface IAudioGraph2(IAudioGraph2Vtbl): IInspectable(IInspectableVtbl) [IID_IAudioGraph2] {
     fn CreateFrameInputNodeWithFormatAndEmitter(&self, encodingProperties: *mut super::mediaproperties::AudioEncodingProperties, emitter: *mut AudioNodeEmitter, out: *mut *mut AudioFrameInputNode) -> HRESULT,
@@ -7238,7 +7238,7 @@ impl AudioGraphSettings {
         <Self as RtActivatable<IAudioGraphSettingsFactory>>::get_activation_factory().create(audioRenderCategory)
     }}
 }
-DEFINE_CLSID!(AudioGraphSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,71,114,97,112,104,83,101,116,116,105,110,103,115,0]) [CLSID_AudioGraphSettings]);
+DEFINE_CLSID!(AudioGraphSettings: "Windows.Media.Audio.AudioGraphSettings");
 DEFINE_IID!(IID_IAudioGraphSettingsFactory, 2782469318, 49899, 19041, 162, 20, 29, 102, 215, 95, 131, 218);
 RT_INTERFACE!{static interface IAudioGraphSettingsFactory(IAudioGraphSettingsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAudioGraphSettingsFactory] {
     fn Create(&self, audioRenderCategory: super::render::AudioRenderCategory, out: *mut *mut AudioGraphSettings) -> HRESULT
@@ -7474,7 +7474,7 @@ impl AudioNodeEmitter {
         <Self as RtActivatable<IAudioNodeEmitterFactory>>::get_activation_factory().create_audio_node_emitter(shape, decayModel, settings)
     }}
 }
-DEFINE_CLSID!(AudioNodeEmitter(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,78,111,100,101,69,109,105,116,116,101,114,0]) [CLSID_AudioNodeEmitter]);
+DEFINE_CLSID!(AudioNodeEmitter: "Windows.Media.Audio.AudioNodeEmitter");
 DEFINE_IID!(IID_IAudioNodeEmitter2, 1253502667, 60457, 18424, 129, 140, 182, 182, 96, 165, 174, 177);
 RT_INTERFACE!{interface IAudioNodeEmitter2(IAudioNodeEmitter2Vtbl): IInspectable(IInspectableVtbl) [IID_IAudioNodeEmitter2] {
     fn get_SpatialAudioModel(&self, out: *mut SpatialAudioModel) -> HRESULT,
@@ -7557,7 +7557,7 @@ impl AudioNodeEmitterDecayModel {
         <Self as RtActivatable<IAudioNodeEmitterDecayModelStatics>>::get_activation_factory().create_custom(minGain, maxGain)
     }}
 }
-DEFINE_CLSID!(AudioNodeEmitterDecayModel(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,78,111,100,101,69,109,105,116,116,101,114,68,101,99,97,121,77,111,100,101,108,0]) [CLSID_AudioNodeEmitterDecayModel]);
+DEFINE_CLSID!(AudioNodeEmitterDecayModel: "Windows.Media.Audio.AudioNodeEmitterDecayModel");
 DEFINE_IID!(IID_IAudioNodeEmitterDecayModelStatics, 3346562216, 61816, 17967, 188, 129, 141, 213, 203, 229, 218, 232);
 RT_INTERFACE!{static interface IAudioNodeEmitterDecayModelStatics(IAudioNodeEmitterDecayModelStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAudioNodeEmitterDecayModelStatics] {
     fn CreateNatural(&self, minGain: f64, maxGain: f64, unityGainDistance: f64, cutoffDistance: f64, out: *mut *mut AudioNodeEmitterDecayModel) -> HRESULT,
@@ -7634,7 +7634,7 @@ impl AudioNodeEmitterShape {
         <Self as RtActivatable<IAudioNodeEmitterShapeStatics>>::get_activation_factory().create_omnidirectional()
     }}
 }
-DEFINE_CLSID!(AudioNodeEmitterShape(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,78,111,100,101,69,109,105,116,116,101,114,83,104,97,112,101,0]) [CLSID_AudioNodeEmitterShape]);
+DEFINE_CLSID!(AudioNodeEmitterShape: "Windows.Media.Audio.AudioNodeEmitterShape");
 RT_ENUM! { enum AudioNodeEmitterShapeKind: i32 {
     Omnidirectional (AudioNodeEmitterShapeKind_Omnidirectional) = 0, Cone (AudioNodeEmitterShapeKind_Cone) = 1,
 }}
@@ -7706,7 +7706,7 @@ impl IAudioNodeListener {
 }
 RT_CLASS!{class AudioNodeListener: IAudioNodeListener}
 impl RtActivatable<IActivationFactory> for AudioNodeListener {}
-DEFINE_CLSID!(AudioNodeListener(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,78,111,100,101,76,105,115,116,101,110,101,114,0]) [CLSID_AudioNodeListener]);
+DEFINE_CLSID!(AudioNodeListener: "Windows.Media.Audio.AudioNodeListener");
 DEFINE_IID!(IID_IAudioNodeWithListener, 235901052, 31231, 17732, 158, 235, 1, 37, 123, 21, 16, 90);
 RT_INTERFACE!{interface IAudioNodeWithListener(IAudioNodeWithListenerVtbl): IInspectable(IInspectableVtbl) [IID_IAudioNodeWithListener] {
     fn put_Listener(&self, value: *mut AudioNodeListener) -> HRESULT,
@@ -7859,7 +7859,7 @@ impl EchoEffectDefinition {
         <Self as RtActivatable<IEchoEffectDefinitionFactory>>::get_activation_factory().create(audioGraph)
     }}
 }
-DEFINE_CLSID!(EchoEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,69,99,104,111,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_EchoEffectDefinition]);
+DEFINE_CLSID!(EchoEffectDefinition: "Windows.Media.Audio.EchoEffectDefinition");
 DEFINE_IID!(IID_IEchoEffectDefinitionFactory, 223224407, 43762, 20102, 165, 76, 251, 121, 219, 143, 108, 18);
 RT_INTERFACE!{static interface IEchoEffectDefinitionFactory(IEchoEffectDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEchoEffectDefinitionFactory] {
     fn Create(&self, audioGraph: *mut AudioGraph, out: *mut *mut EchoEffectDefinition) -> HRESULT
@@ -7928,7 +7928,7 @@ impl EqualizerEffectDefinition {
         <Self as RtActivatable<IEqualizerEffectDefinitionFactory>>::get_activation_factory().create(audioGraph)
     }}
 }
-DEFINE_CLSID!(EqualizerEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,69,113,117,97,108,105,122,101,114,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_EqualizerEffectDefinition]);
+DEFINE_CLSID!(EqualizerEffectDefinition: "Windows.Media.Audio.EqualizerEffectDefinition");
 DEFINE_IID!(IID_IEqualizerEffectDefinitionFactory, 3532091332, 54288, 20149, 158, 105, 201, 170, 18, 119, 234, 240);
 RT_INTERFACE!{static interface IEqualizerEffectDefinitionFactory(IEqualizerEffectDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEqualizerEffectDefinitionFactory] {
     fn Create(&self, audioGraph: *mut AudioGraph, out: *mut *mut EqualizerEffectDefinition) -> HRESULT
@@ -7986,7 +7986,7 @@ impl LimiterEffectDefinition {
         <Self as RtActivatable<ILimiterEffectDefinitionFactory>>::get_activation_factory().create(audioGraph)
     }}
 }
-DEFINE_CLSID!(LimiterEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,76,105,109,105,116,101,114,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_LimiterEffectDefinition]);
+DEFINE_CLSID!(LimiterEffectDefinition: "Windows.Media.Audio.LimiterEffectDefinition");
 DEFINE_IID!(IID_ILimiterEffectDefinitionFactory, 3971671793, 25087, 17903, 184, 245, 72, 101, 154, 87, 199, 45);
 RT_INTERFACE!{static interface ILimiterEffectDefinitionFactory(ILimiterEffectDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ILimiterEffectDefinitionFactory] {
     fn Create(&self, audioGraph: *mut AudioGraph, out: *mut *mut LimiterEffectDefinition) -> HRESULT
@@ -8266,7 +8266,7 @@ impl ReverbEffectDefinition {
         <Self as RtActivatable<IReverbEffectDefinitionFactory>>::get_activation_factory().create(audioGraph)
     }}
 }
-DEFINE_CLSID!(ReverbEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,82,101,118,101,114,98,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_ReverbEffectDefinition]);
+DEFINE_CLSID!(ReverbEffectDefinition: "Windows.Media.Audio.ReverbEffectDefinition");
 DEFINE_IID!(IID_IReverbEffectDefinitionFactory, 2815806462, 4107, 20464, 157, 166, 220, 78, 5, 167, 89, 240);
 RT_INTERFACE!{static interface IReverbEffectDefinitionFactory(IReverbEffectDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IReverbEffectDefinitionFactory] {
     fn Create(&self, audioGraph: *mut AudioGraph, out: *mut *mut ReverbEffectDefinition) -> HRESULT
@@ -8423,7 +8423,7 @@ impl CastingDevice {
         <Self as RtActivatable<ICastingDeviceStatics>>::get_activation_factory().device_info_supports_casting_async(device)
     }}
 }
-DEFINE_CLSID!(CastingDevice(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,115,116,105,110,103,46,67,97,115,116,105,110,103,68,101,118,105,99,101,0]) [CLSID_CastingDevice]);
+DEFINE_CLSID!(CastingDevice: "Windows.Media.Casting.CastingDevice");
 DEFINE_IID!(IID_ICastingDevicePicker, 3704854820, 1425, 18878, 170, 203, 75, 130, 238, 117, 106, 149);
 RT_INTERFACE!{interface ICastingDevicePicker(ICastingDevicePickerVtbl): IInspectable(IInspectableVtbl) [IID_ICastingDevicePicker] {
     fn get_Filter(&self, out: *mut *mut CastingDevicePickerFilter) -> HRESULT,
@@ -8482,7 +8482,7 @@ impl ICastingDevicePicker {
 }
 RT_CLASS!{class CastingDevicePicker: ICastingDevicePicker}
 impl RtActivatable<IActivationFactory> for CastingDevicePicker {}
-DEFINE_CLSID!(CastingDevicePicker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,115,116,105,110,103,46,67,97,115,116,105,110,103,68,101,118,105,99,101,80,105,99,107,101,114,0]) [CLSID_CastingDevicePicker]);
+DEFINE_CLSID!(CastingDevicePicker: "Windows.Media.Casting.CastingDevicePicker");
 DEFINE_IID!(IID_ICastingDevicePickerFilter, 3196871068, 46435, 17236, 174, 51, 159, 218, 173, 140, 98, 145);
 RT_INTERFACE!{interface ICastingDevicePickerFilter(ICastingDevicePickerFilterVtbl): IInspectable(IInspectableVtbl) [IID_ICastingDevicePickerFilter] {
     fn get_SupportsAudio(&self, out: *mut bool) -> HRESULT,
@@ -8616,7 +8616,7 @@ impl AudioStreamDescriptor {
         <Self as RtActivatable<IAudioStreamDescriptorFactory>>::get_activation_factory().create(encodingProperties)
     }}
 }
-DEFINE_CLSID!(AudioStreamDescriptor(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,65,117,100,105,111,83,116,114,101,97,109,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_AudioStreamDescriptor]);
+DEFINE_CLSID!(AudioStreamDescriptor: "Windows.Media.Core.AudioStreamDescriptor");
 DEFINE_IID!(IID_IAudioStreamDescriptor2, 778629622, 42056, 18811, 136, 64, 133, 8, 38, 101, 172, 249);
 RT_INTERFACE!{interface IAudioStreamDescriptor2(IAudioStreamDescriptor2Vtbl): IInspectable(IInspectableVtbl) [IID_IAudioStreamDescriptor2] {
     fn put_LeadingEncoderPadding(&self, value: *mut super::super::foundation::IReference<u32>) -> HRESULT,
@@ -8756,7 +8756,7 @@ impl IChapterCue {
 }
 RT_CLASS!{class ChapterCue: IChapterCue}
 impl RtActivatable<IActivationFactory> for ChapterCue {}
-DEFINE_CLSID!(ChapterCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,67,104,97,112,116,101,114,67,117,101,0]) [CLSID_ChapterCue]);
+DEFINE_CLSID!(ChapterCue: "Windows.Media.Core.ChapterCue");
 RT_ENUM! { enum CodecCategory: i32 {
     Encoder (CodecCategory_Encoder) = 0, Decoder (CodecCategory_Decoder) = 1,
 }}
@@ -8812,7 +8812,7 @@ impl ICodecQuery {
 }
 RT_CLASS!{class CodecQuery: ICodecQuery}
 impl RtActivatable<IActivationFactory> for CodecQuery {}
-DEFINE_CLSID!(CodecQuery(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,67,111,100,101,99,81,117,101,114,121,0]) [CLSID_CodecQuery]);
+DEFINE_CLSID!(CodecQuery: "Windows.Media.Core.CodecQuery");
 RT_CLASS!{static class CodecSubtypes}
 impl RtActivatable<ICodecSubtypesStatics> for CodecSubtypes {}
 impl CodecSubtypes {
@@ -8970,7 +8970,7 @@ impl CodecSubtypes {
         <Self as RtActivatable<ICodecSubtypesStatics>>::get_activation_factory().get_audio_format_wmaudio_v9()
     }}
 }
-DEFINE_CLSID!(CodecSubtypes(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,67,111,100,101,99,83,117,98,116,121,112,101,115,0]) [CLSID_CodecSubtypes]);
+DEFINE_CLSID!(CodecSubtypes: "Windows.Media.Core.CodecSubtypes");
 DEFINE_IID!(IID_ICodecSubtypesStatics, 2792015090, 34955, 16932, 140, 246, 42, 141, 78, 176, 35, 130);
 RT_INTERFACE!{static interface ICodecSubtypesStatics(ICodecSubtypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICodecSubtypesStatics] {
     fn get_VideoFormatDV25(&self, out: *mut HSTRING) -> HRESULT,
@@ -9300,7 +9300,7 @@ impl IDataCue {
 }
 RT_CLASS!{class DataCue: IDataCue}
 impl RtActivatable<IActivationFactory> for DataCue {}
-DEFINE_CLSID!(DataCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,68,97,116,97,67,117,101,0]) [CLSID_DataCue]);
+DEFINE_CLSID!(DataCue: "Windows.Media.Core.DataCue");
 DEFINE_IID!(IID_IDataCue2, 3159759637, 38386, 18920, 150, 241, 141, 213, 218, 198, 141, 147);
 RT_INTERFACE!{interface IDataCue2(IDataCue2Vtbl): IInspectable(IInspectableVtbl) [IID_IDataCue2] {
     fn get_Properties(&self, out: *mut *mut super::super::foundation::collections::PropertySet) -> HRESULT
@@ -9392,7 +9392,7 @@ impl IFaceDetectionEffectDefinition {
 }
 RT_CLASS!{class FaceDetectionEffectDefinition: super::effects::IVideoEffectDefinition}
 impl RtActivatable<IActivationFactory> for FaceDetectionEffectDefinition {}
-DEFINE_CLSID!(FaceDetectionEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,70,97,99,101,68,101,116,101,99,116,105,111,110,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_FaceDetectionEffectDefinition]);
+DEFINE_CLSID!(FaceDetectionEffectDefinition: "Windows.Media.Core.FaceDetectionEffectDefinition");
 DEFINE_IID!(IID_IFaceDetectionEffectFrame, 2326825363, 24008, 17531, 162, 71, 82, 112, 189, 128, 46, 206);
 RT_INTERFACE!{interface IFaceDetectionEffectFrame(IFaceDetectionEffectFrameVtbl): IInspectable(IInspectableVtbl) [IID_IFaceDetectionEffectFrame] {
     fn get_DetectedFaces(&self, out: *mut *mut super::super::foundation::collections::IVectorView<super::faceanalysis::DetectedFace>) -> HRESULT
@@ -9483,7 +9483,7 @@ impl IImageCue {
 }
 RT_CLASS!{class ImageCue: IImageCue}
 impl RtActivatable<IActivationFactory> for ImageCue {}
-DEFINE_CLSID!(ImageCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,73,109,97,103,101,67,117,101,0]) [CLSID_ImageCue]);
+DEFINE_CLSID!(ImageCue: "Windows.Media.Core.ImageCue");
 DEFINE_IID!(IID_IInitializeMediaStreamSourceRequestedEventArgs, 633095649, 39688, 19502, 168, 85, 69, 66, 241, 167, 93, 235);
 RT_INTERFACE!{interface IInitializeMediaStreamSourceRequestedEventArgs(IInitializeMediaStreamSourceRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IInitializeMediaStreamSourceRequestedEventArgs] {
     fn get_Source(&self, out: *mut *mut MediaStreamSource) -> HRESULT,
@@ -9522,7 +9522,7 @@ impl LowLightFusion {
         <Self as RtActivatable<ILowLightFusionStatics>>::get_activation_factory().fuse_async(frameSet)
     }}
 }
-DEFINE_CLSID!(LowLightFusion(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,76,111,119,76,105,103,104,116,70,117,115,105,111,110,0]) [CLSID_LowLightFusion]);
+DEFINE_CLSID!(LowLightFusion: "Windows.Media.Core.LowLightFusion");
 DEFINE_IID!(IID_ILowLightFusionResult, 2028846645, 10144, 17120, 156, 211, 115, 141, 32, 137, 222, 156);
 RT_INTERFACE!{interface ILowLightFusionResult(ILowLightFusionResultVtbl): IInspectable(IInspectableVtbl) [IID_ILowLightFusionResult] {
     #[cfg(feature="windows-graphics")] fn get_Frame(&self, out: *mut *mut super::super::graphics::imaging::SoftwareBitmap) -> HRESULT
@@ -9593,7 +9593,7 @@ impl IMediaBinder {
 }
 RT_CLASS!{class MediaBinder: IMediaBinder}
 impl RtActivatable<IActivationFactory> for MediaBinder {}
-DEFINE_CLSID!(MediaBinder(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,101,100,105,97,66,105,110,100,101,114,0]) [CLSID_MediaBinder]);
+DEFINE_CLSID!(MediaBinder: "Windows.Media.Core.MediaBinder");
 DEFINE_IID!(IID_IMediaBindingEventArgs, 3055333978, 7021, 17968, 168, 109, 47, 8, 55, 247, 18, 229);
 RT_INTERFACE!{interface IMediaBindingEventArgs(IMediaBindingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBindingEventArgs] {
     fn add_Canceled(&self, handler: *mut super::super::foundation::TypedEventHandler<MediaBindingEventArgs, IInspectable>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -9746,7 +9746,7 @@ impl MediaSource {
         <Self as RtActivatable<IMediaSourceStatics3>>::get_activation_factory().create_from_media_frame_source(frameSource)
     }}
 }
-DEFINE_CLSID!(MediaSource(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,101,100,105,97,83,111,117,114,99,101,0]) [CLSID_MediaSource]);
+DEFINE_CLSID!(MediaSource: "Windows.Media.Core.MediaSource");
 DEFINE_IID!(IID_IMediaSource2, 783683656, 25951, 19511, 184, 19, 180, 228, 93, 250, 10, 190);
 RT_INTERFACE!{interface IMediaSource2(IMediaSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaSource2] {
     fn add_OpenOperationCompleted(&self, handler: *mut super::super::foundation::TypedEventHandler<MediaSource, MediaSourceOpenOperationCompletedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -9883,7 +9883,7 @@ impl MediaSourceAppServiceConnection {
         <Self as RtActivatable<IMediaSourceAppServiceConnectionFactory>>::get_activation_factory().create(appServiceConnection)
     }}
 }
-DEFINE_CLSID!(MediaSourceAppServiceConnection(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,101,100,105,97,83,111,117,114,99,101,65,112,112,83,101,114,118,105,99,101,67,111,110,110,101,99,116,105,111,110,0]) [CLSID_MediaSourceAppServiceConnection]);
+DEFINE_CLSID!(MediaSourceAppServiceConnection: "Windows.Media.Core.MediaSourceAppServiceConnection");
 DEFINE_IID!(IID_IMediaSourceAppServiceConnectionFactory, 1706627819, 32953, 17657, 156, 30, 225, 32, 246, 217, 40, 56);
 RT_INTERFACE!{static interface IMediaSourceAppServiceConnectionFactory(IMediaSourceAppServiceConnectionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMediaSourceAppServiceConnectionFactory] {
     #[cfg(feature="windows-applicationmodel")] fn Create(&self, appServiceConnection: *mut super::super::applicationmodel::appservice::AppServiceConnection, out: *mut *mut MediaSourceAppServiceConnection) -> HRESULT
@@ -10165,7 +10165,7 @@ impl MediaStreamSample {
         <Self as RtActivatable<IMediaStreamSampleStatics>>::get_activation_factory().create_from_stream_async(stream, count, timestamp)
     }}
 }
-DEFINE_CLSID!(MediaStreamSample(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,101,100,105,97,83,116,114,101,97,109,83,97,109,112,108,101,0]) [CLSID_MediaStreamSample]);
+DEFINE_CLSID!(MediaStreamSample: "Windows.Media.Core.MediaStreamSample");
 RT_CLASS!{class MediaStreamSamplePropertySet: super::super::foundation::collections::IMap<Guid, IInspectable>}
 DEFINE_IID!(IID_IMediaStreamSampleProtectionProperties, 1320714898, 60639, 18750, 132, 29, 221, 74, 221, 124, 172, 162);
 RT_INTERFACE!{interface IMediaStreamSampleProtectionProperties(IMediaStreamSampleProtectionPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSampleProtectionProperties] {
@@ -10384,7 +10384,7 @@ impl MediaStreamSource {
         <Self as RtActivatable<IMediaStreamSourceFactory>>::get_activation_factory().create_from_descriptors(descriptor, descriptor2)
     }}
 }
-DEFINE_CLSID!(MediaStreamSource(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,101,100,105,97,83,116,114,101,97,109,83,111,117,114,99,101,0]) [CLSID_MediaStreamSource]);
+DEFINE_CLSID!(MediaStreamSource: "Windows.Media.Core.MediaStreamSource");
 DEFINE_IID!(IID_IMediaStreamSource2, 3965046957, 11882, 20340, 173, 187, 181, 98, 209, 83, 56, 73);
 RT_INTERFACE!{interface IMediaStreamSource2(IMediaStreamSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSource2] {
     fn add_SampleRendered(&self, handler: *mut super::super::foundation::TypedEventHandler<MediaStreamSource, MediaStreamSourceSampleRenderedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -10958,7 +10958,7 @@ impl MseStreamSource {
         <Self as RtActivatable<IMseStreamSourceStatics>>::get_activation_factory().is_content_type_supported(contentType)
     }}
 }
-DEFINE_CLSID!(MseStreamSource(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,115,101,83,116,114,101,97,109,83,111,117,114,99,101,0]) [CLSID_MseStreamSource]);
+DEFINE_CLSID!(MseStreamSource: "Windows.Media.Core.MseStreamSource");
 DEFINE_IID!(IID_IMseStreamSource2, 1727364407, 63975, 16778, 156, 222, 160, 32, 233, 86, 85, 43);
 RT_INTERFACE!{interface IMseStreamSource2(IMseStreamSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IMseStreamSource2] {
     fn get_LiveSeekableRange(&self, out: *mut *mut super::super::foundation::IReference<MseTimeRange>) -> HRESULT,
@@ -11025,7 +11025,7 @@ impl ISceneAnalysisEffect {
 RT_CLASS!{class SceneAnalysisEffect: ISceneAnalysisEffect}
 RT_CLASS!{class SceneAnalysisEffectDefinition: super::effects::IVideoEffectDefinition}
 impl RtActivatable<IActivationFactory> for SceneAnalysisEffectDefinition {}
-DEFINE_CLSID!(SceneAnalysisEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,83,99,101,110,101,65,110,97,108,121,115,105,115,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_SceneAnalysisEffectDefinition]);
+DEFINE_CLSID!(SceneAnalysisEffectDefinition: "Windows.Media.Core.SceneAnalysisEffectDefinition");
 DEFINE_IID!(IID_ISceneAnalysisEffectFrame, 3635482188, 32729, 17121, 133, 235, 101, 114, 194, 151, 201, 135);
 RT_INTERFACE!{interface ISceneAnalysisEffectFrame(ISceneAnalysisEffectFrameVtbl): IInspectable(IInspectableVtbl) [IID_ISceneAnalysisEffectFrame] {
     fn get_FrameControlValues(&self, out: *mut *mut super::capture::CapturedFrameControlValues) -> HRESULT,
@@ -11137,7 +11137,7 @@ impl ISpeechCue {
 }
 RT_CLASS!{class SpeechCue: ISpeechCue}
 impl RtActivatable<IActivationFactory> for SpeechCue {}
-DEFINE_CLSID!(SpeechCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,83,112,101,101,99,104,67,117,101,0]) [CLSID_SpeechCue]);
+DEFINE_CLSID!(SpeechCue: "Windows.Media.Core.SpeechCue");
 RT_ENUM! { enum TimedMetadataKind: i32 {
     Caption (TimedMetadataKind_Caption) = 0, Chapter (TimedMetadataKind_Chapter) = 1, Custom (TimedMetadataKind_Custom) = 2, Data (TimedMetadataKind_Data) = 3, Description (TimedMetadataKind_Description) = 4, Subtitle (TimedMetadataKind_Subtitle) = 5, ImageSubtitle (TimedMetadataKind_ImageSubtitle) = 6, Speech (TimedMetadataKind_Speech) = 7,
 }}
@@ -11220,7 +11220,7 @@ impl TimedMetadataTrack {
         <Self as RtActivatable<ITimedMetadataTrackFactory>>::get_activation_factory().create(id, language, kind)
     }}
 }
-DEFINE_CLSID!(TimedMetadataTrack(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,77,101,116,97,100,97,116,97,84,114,97,99,107,0]) [CLSID_TimedMetadataTrack]);
+DEFINE_CLSID!(TimedMetadataTrack: "Windows.Media.Core.TimedMetadataTrack");
 DEFINE_IID!(IID_ITimedMetadataTrack2, 565491272, 40861, 16570, 168, 243, 26, 146, 117, 58, 239, 11);
 RT_INTERFACE!{interface ITimedMetadataTrack2(ITimedMetadataTrack2Vtbl): IInspectable(IInspectableVtbl) [IID_ITimedMetadataTrack2] {
     fn get_PlaybackItem(&self, out: *mut *mut super::playback::MediaPlaybackItem) -> HRESULT,
@@ -11328,7 +11328,7 @@ impl ITimedTextCue {
 }
 RT_CLASS!{class TimedTextCue: ITimedTextCue}
 impl RtActivatable<IActivationFactory> for TimedTextCue {}
-DEFINE_CLSID!(TimedTextCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,67,117,101,0]) [CLSID_TimedTextCue]);
+DEFINE_CLSID!(TimedTextCue: "Windows.Media.Core.TimedTextCue");
 RT_ENUM! { enum TimedTextDisplayAlignment: i32 {
     Before (TimedTextDisplayAlignment_Before) = 0, After (TimedTextDisplayAlignment_After) = 1, Center (TimedTextDisplayAlignment_Center) = 2,
 }}
@@ -11365,7 +11365,7 @@ impl ITimedTextLine {
 }
 RT_CLASS!{class TimedTextLine: ITimedTextLine}
 impl RtActivatable<IActivationFactory> for TimedTextLine {}
-DEFINE_CLSID!(TimedTextLine(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,76,105,110,101,0]) [CLSID_TimedTextLine]);
+DEFINE_CLSID!(TimedTextLine: "Windows.Media.Core.TimedTextLine");
 RT_ENUM! { enum TimedTextLineAlignment: i32 {
     Start (TimedTextLineAlignment_Start) = 0, End (TimedTextLineAlignment_End) = 1, Center (TimedTextLineAlignment_Center) = 2,
 }}
@@ -11516,7 +11516,7 @@ impl ITimedTextRegion {
 }
 RT_CLASS!{class TimedTextRegion: ITimedTextRegion}
 impl RtActivatable<IActivationFactory> for TimedTextRegion {}
-DEFINE_CLSID!(TimedTextRegion(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,82,101,103,105,111,110,0]) [CLSID_TimedTextRegion]);
+DEFINE_CLSID!(TimedTextRegion: "Windows.Media.Core.TimedTextRegion");
 RT_ENUM! { enum TimedTextScrollMode: i32 {
     Popon (TimedTextScrollMode_Popon) = 0, Rollup (TimedTextScrollMode_Rollup) = 1,
 }}
@@ -11568,7 +11568,7 @@ impl TimedTextSource {
         <Self as RtActivatable<ITimedTextSourceStatics2>>::get_activation_factory().create_from_uri_with_index_and_language(uri, indexUri, defaultLanguage)
     }}
 }
-DEFINE_CLSID!(TimedTextSource(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,83,111,117,114,99,101,0]) [CLSID_TimedTextSource]);
+DEFINE_CLSID!(TimedTextSource: "Windows.Media.Core.TimedTextSource");
 DEFINE_IID!(IID_ITimedTextSourceResolveResultEventArgs, 1217428636, 56536, 19507, 154, 211, 108, 220, 231, 177, 197, 102);
 RT_INTERFACE!{interface ITimedTextSourceResolveResultEventArgs(ITimedTextSourceResolveResultEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITimedTextSourceResolveResultEventArgs] {
     fn get_Error(&self, out: *mut *mut TimedMetadataTrackError) -> HRESULT,
@@ -11794,7 +11794,7 @@ impl ITimedTextStyle {
 }
 RT_CLASS!{class TimedTextStyle: ITimedTextStyle}
 impl RtActivatable<IActivationFactory> for TimedTextStyle {}
-DEFINE_CLSID!(TimedTextStyle(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,83,116,121,108,101,0]) [CLSID_TimedTextStyle]);
+DEFINE_CLSID!(TimedTextStyle: "Windows.Media.Core.TimedTextStyle");
 DEFINE_IID!(IID_ITimedTextStyle2, 1700743469, 24849, 18311, 137, 204, 104, 111, 236, 229, 126, 20);
 RT_INTERFACE!{interface ITimedTextStyle2(ITimedTextStyle2Vtbl): IInspectable(IInspectableVtbl) [IID_ITimedTextStyle2] {
     fn get_FontStyle(&self, out: *mut TimedTextFontStyle) -> HRESULT,
@@ -11884,7 +11884,7 @@ impl ITimedTextSubformat {
 }
 RT_CLASS!{class TimedTextSubformat: ITimedTextSubformat}
 impl RtActivatable<IActivationFactory> for TimedTextSubformat {}
-DEFINE_CLSID!(TimedTextSubformat(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,83,117,98,102,111,114,109,97,116,0]) [CLSID_TimedTextSubformat]);
+DEFINE_CLSID!(TimedTextSubformat: "Windows.Media.Core.TimedTextSubformat");
 RT_ENUM! { enum TimedTextUnit: i32 {
     Pixels (TimedTextUnit_Pixels) = 0, Percentage (TimedTextUnit_Percentage) = 1,
 }}
@@ -11933,7 +11933,7 @@ impl IVideoStabilizationEffect {
 RT_CLASS!{class VideoStabilizationEffect: IVideoStabilizationEffect}
 RT_CLASS!{class VideoStabilizationEffectDefinition: super::effects::IVideoEffectDefinition}
 impl RtActivatable<IActivationFactory> for VideoStabilizationEffectDefinition {}
-DEFINE_CLSID!(VideoStabilizationEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,86,105,100,101,111,83,116,97,98,105,108,105,122,97,116,105,111,110,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_VideoStabilizationEffectDefinition]);
+DEFINE_CLSID!(VideoStabilizationEffectDefinition: "Windows.Media.Core.VideoStabilizationEffectDefinition");
 DEFINE_IID!(IID_IVideoStabilizationEffectEnabledChangedEventArgs, 410976040, 26555, 18195, 185, 0, 65, 104, 218, 22, 69, 41);
 RT_INTERFACE!{interface IVideoStabilizationEffectEnabledChangedEventArgs(IVideoStabilizationEffectEnabledChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVideoStabilizationEffectEnabledChangedEventArgs] {
     fn get_Reason(&self, out: *mut VideoStabilizationEffectEnabledChangedReason) -> HRESULT
@@ -11967,7 +11967,7 @@ impl VideoStreamDescriptor {
         <Self as RtActivatable<IVideoStreamDescriptorFactory>>::get_activation_factory().create(encodingProperties)
     }}
 }
-DEFINE_CLSID!(VideoStreamDescriptor(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,86,105,100,101,111,83,116,114,101,97,109,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_VideoStreamDescriptor]);
+DEFINE_CLSID!(VideoStreamDescriptor: "Windows.Media.Core.VideoStreamDescriptor");
 DEFINE_IID!(IID_IVideoStreamDescriptorFactory, 1229911761, 47989, 17362, 158, 94, 123, 121, 163, 175, 206, 212);
 RT_INTERFACE!{static interface IVideoStreamDescriptorFactory(IVideoStreamDescriptorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVideoStreamDescriptorFactory] {
     fn Create(&self, encodingProperties: *mut super::mediaproperties::VideoEncodingProperties, out: *mut *mut VideoStreamDescriptor) -> HRESULT
@@ -12065,7 +12065,7 @@ impl SoundLevelBroker {
         <Self as RtActivatable<ISoundLevelBrokerStatics>>::get_activation_factory().remove_sound_level_changed(token)
     }}
 }
-DEFINE_CLSID!(SoundLevelBroker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,80,114,101,118,105,101,119,46,83,111,117,110,100,76,101,118,101,108,66,114,111,107,101,114,0]) [CLSID_SoundLevelBroker]);
+DEFINE_CLSID!(SoundLevelBroker: "Windows.Media.Core.Preview.SoundLevelBroker");
 DEFINE_IID!(IID_ISoundLevelBrokerStatics, 1784887649, 56301, 17996, 160, 154, 51, 65, 47, 92, 170, 63);
 RT_INTERFACE!{static interface ISoundLevelBrokerStatics(ISoundLevelBrokerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISoundLevelBrokerStatics] {
     fn get_SoundLevel(&self, out: *mut super::super::SoundLevel) -> HRESULT,
@@ -12110,7 +12110,7 @@ impl IAdvancedPhotoCaptureSettings {
 }
 RT_CLASS!{class AdvancedPhotoCaptureSettings: IAdvancedPhotoCaptureSettings}
 impl RtActivatable<IActivationFactory> for AdvancedPhotoCaptureSettings {}
-DEFINE_CLSID!(AdvancedPhotoCaptureSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,65,100,118,97,110,99,101,100,80,104,111,116,111,67,97,112,116,117,114,101,83,101,116,116,105,110,103,115,0]) [CLSID_AdvancedPhotoCaptureSettings]);
+DEFINE_CLSID!(AdvancedPhotoCaptureSettings: "Windows.Media.Devices.AdvancedPhotoCaptureSettings");
 DEFINE_IID!(IID_IAdvancedPhotoControl, 3316733062, 36865, 18050, 147, 9, 104, 234, 224, 8, 14, 236);
 RT_INTERFACE!{interface IAdvancedPhotoControl(IAdvancedPhotoControlVtbl): IInspectable(IInspectableVtbl) [IID_IAdvancedPhotoControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -12462,7 +12462,7 @@ impl AudioDeviceModulesManager {
         <Self as RtActivatable<IAudioDeviceModulesManagerFactory>>::get_activation_factory().create(deviceId)
     }}
 }
-DEFINE_CLSID!(AudioDeviceModulesManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,65,117,100,105,111,68,101,118,105,99,101,77,111,100,117,108,101,115,77,97,110,97,103,101,114,0]) [CLSID_AudioDeviceModulesManager]);
+DEFINE_CLSID!(AudioDeviceModulesManager: "Windows.Media.Devices.AudioDeviceModulesManager");
 DEFINE_IID!(IID_IAudioDeviceModulesManagerFactory, 2377135728, 58957, 18291, 150, 192, 188, 126, 191, 14, 6, 63);
 RT_INTERFACE!{static interface IAudioDeviceModulesManagerFactory(IAudioDeviceModulesManagerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAudioDeviceModulesManagerFactory] {
     fn Create(&self, deviceId: HSTRING, out: *mut *mut AudioDeviceModulesManager) -> HRESULT
@@ -12589,7 +12589,7 @@ impl CallControl {
         <Self as RtActivatable<ICallControlStatics>>::get_activation_factory().from_id(deviceId)
     }}
 }
-DEFINE_CLSID!(CallControl(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,67,97,108,108,67,111,110,116,114,111,108,0]) [CLSID_CallControl]);
+DEFINE_CLSID!(CallControl: "Windows.Media.Devices.CallControl");
 DEFINE_IID!(IID_CallControlEventHandler, 1500476831, 20703, 17492, 188, 99, 77, 61, 1, 182, 25, 88);
 RT_DELEGATE!{delegate CallControlEventHandler(CallControlEventHandlerVtbl, CallControlEventHandlerImpl) [IID_CallControlEventHandler] {
     fn Invoke(&self, sender: *mut CallControl) -> HRESULT
@@ -13099,7 +13099,7 @@ impl IFocusSettings {
 }
 RT_CLASS!{class FocusSettings: IFocusSettings}
 impl RtActivatable<IActivationFactory> for FocusSettings {}
-DEFINE_CLSID!(FocusSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,70,111,99,117,115,83,101,116,116,105,110,103,115,0]) [CLSID_FocusSettings]);
+DEFINE_CLSID!(FocusSettings: "Windows.Media.Devices.FocusSettings");
 DEFINE_IID!(IID_IHdrVideoControl, 1440277200, 12480, 17343, 155, 154, 151, 153, 215, 12, 237, 148);
 RT_INTERFACE!{interface IHdrVideoControl(IHdrVideoControlVtbl): IInspectable(IInspectableVtbl) [IID_IHdrVideoControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -13431,7 +13431,7 @@ impl MediaDevice {
         <Self as RtActivatable<IMediaDeviceStatics>>::get_activation_factory().remove_default_audio_render_device_changed(cookie)
     }}
 }
-DEFINE_CLSID!(MediaDevice(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,77,101,100,105,97,68,101,118,105,99,101,0]) [CLSID_MediaDevice]);
+DEFINE_CLSID!(MediaDevice: "Windows.Media.Devices.MediaDevice");
 DEFINE_IID!(IID_IMediaDeviceControl, 4020821929, 28533, 18531, 186, 11, 88, 63, 48, 54, 180, 222);
 RT_INTERFACE!{interface IMediaDeviceControl(IMediaDeviceControlVtbl): IInspectable(IInspectableVtbl) [IID_IMediaDeviceControl] {
     fn get_Capabilities(&self, out: *mut *mut MediaDeviceControlCapabilities) -> HRESULT,
@@ -13746,7 +13746,7 @@ impl IRegionOfInterest {
 }
 RT_CLASS!{class RegionOfInterest: IRegionOfInterest}
 impl RtActivatable<IActivationFactory> for RegionOfInterest {}
-DEFINE_CLSID!(RegionOfInterest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,82,101,103,105,111,110,79,102,73,110,116,101,114,101,115,116,0]) [CLSID_RegionOfInterest]);
+DEFINE_CLSID!(RegionOfInterest: "Windows.Media.Devices.RegionOfInterest");
 DEFINE_IID!(IID_IRegionOfInterest2, 436087441, 29610, 19793, 138, 157, 86, 204, 247, 219, 127, 84);
 RT_INTERFACE!{interface IRegionOfInterest2(IRegionOfInterest2Vtbl): IInspectable(IInspectableVtbl) [IID_IRegionOfInterest2] {
     fn get_Type(&self, out: *mut RegionOfInterestType) -> HRESULT,
@@ -14160,7 +14160,7 @@ impl IZoomSettings {
 }
 RT_CLASS!{class ZoomSettings: IZoomSettings}
 impl RtActivatable<IActivationFactory> for ZoomSettings {}
-DEFINE_CLSID!(ZoomSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,90,111,111,109,83,101,116,116,105,110,103,115,0]) [CLSID_ZoomSettings]);
+DEFINE_CLSID!(ZoomSettings: "Windows.Media.Devices.ZoomSettings");
 RT_ENUM! { enum ZoomTransitionMode: i32 {
     Auto (ZoomTransitionMode_Auto) = 0, Direct (ZoomTransitionMode_Direct) = 1, Smooth (ZoomTransitionMode_Smooth) = 2,
 }}
@@ -14391,7 +14391,7 @@ impl IFrameController {
 }
 RT_CLASS!{class FrameController: IFrameController}
 impl RtActivatable<IActivationFactory> for FrameController {}
-DEFINE_CLSID!(FrameController(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,67,111,114,101,46,70,114,97,109,101,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_FrameController]);
+DEFINE_CLSID!(FrameController: "Windows.Media.Devices.Core.FrameController");
 DEFINE_IID!(IID_IFrameController2, 13876341, 55420, 18523, 138, 9, 92, 53, 133, 104, 180, 39);
 RT_INTERFACE!{interface IFrameController2(IFrameController2Vtbl): IInspectable(IInspectableVtbl) [IID_IFrameController2] {
     fn get_FlashControl(&self, out: *mut *mut FrameFlashControl) -> HRESULT
@@ -14834,7 +14834,7 @@ impl DialDevice {
         <Self as RtActivatable<IDialDeviceStatics>>::get_activation_factory().device_info_supports_dial_async(device)
     }}
 }
-DEFINE_CLSID!(DialDevice(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,105,97,108,80,114,111,116,111,99,111,108,46,68,105,97,108,68,101,118,105,99,101,0]) [CLSID_DialDevice]);
+DEFINE_CLSID!(DialDevice: "Windows.Media.DialProtocol.DialDevice");
 DEFINE_IID!(IID_IDialDevice2, 3132617685, 23547, 20154, 139, 50, 181, 124, 92, 94, 229, 201);
 RT_INTERFACE!{interface IDialDevice2(IDialDevice2Vtbl): IInspectable(IInspectableVtbl) [IID_IDialDevice2] {
     fn get_FriendlyName(&self, out: *mut HSTRING) -> HRESULT,
@@ -14942,7 +14942,7 @@ impl IDialDevicePicker {
 }
 RT_CLASS!{class DialDevicePicker: IDialDevicePicker}
 impl RtActivatable<IActivationFactory> for DialDevicePicker {}
-DEFINE_CLSID!(DialDevicePicker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,105,97,108,80,114,111,116,111,99,111,108,46,68,105,97,108,68,101,118,105,99,101,80,105,99,107,101,114,0]) [CLSID_DialDevicePicker]);
+DEFINE_CLSID!(DialDevicePicker: "Windows.Media.DialProtocol.DialDevicePicker");
 DEFINE_IID!(IID_IDialDevicePickerFilter, 3246166970, 34496, 18525, 184, 214, 15, 154, 143, 100, 21, 144);
 RT_INTERFACE!{interface IDialDevicePickerFilter(IDialDevicePickerFilterVtbl): IInspectable(IInspectableVtbl) [IID_IDialDevicePickerFilter] {
     fn get_SupportedAppNames(&self, out: *mut *mut super::super::foundation::collections::IVector<HString>) -> HRESULT
@@ -15026,7 +15026,7 @@ impl DialReceiverApp {
         <Self as RtActivatable<IDialReceiverAppStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(DialReceiverApp(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,105,97,108,80,114,111,116,111,99,111,108,46,68,105,97,108,82,101,99,101,105,118,101,114,65,112,112,0]) [CLSID_DialReceiverApp]);
+DEFINE_CLSID!(DialReceiverApp: "Windows.Media.DialProtocol.DialReceiverApp");
 DEFINE_IID!(IID_IDialReceiverAppStatics, 1394096700, 19510, 19714, 178, 138, 242, 169, 218, 56, 236, 82);
 RT_INTERFACE!{static interface IDialReceiverAppStatics(IDialReceiverAppStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDialReceiverAppStatics] {
     fn get_Current(&self, out: *mut *mut DialReceiverApp) -> HRESULT
@@ -15103,7 +15103,7 @@ impl AudioEffectDefinition {
         <Self as RtActivatable<IAudioEffectDefinitionFactory>>::get_activation_factory().create_with_properties(activatableClassId, props)
     }}
 }
-DEFINE_CLSID!(AudioEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,102,102,101,99,116,115,46,65,117,100,105,111,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_AudioEffectDefinition]);
+DEFINE_CLSID!(AudioEffectDefinition: "Windows.Media.Effects.AudioEffectDefinition");
 DEFINE_IID!(IID_IAudioEffectDefinitionFactory, 2384307782, 59141, 17901, 138, 43, 252, 78, 79, 64, 90, 151);
 RT_INTERFACE!{static interface IAudioEffectDefinitionFactory(IAudioEffectDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAudioEffectDefinitionFactory] {
     fn Create(&self, activatableClassId: HSTRING, out: *mut *mut AudioEffectDefinition) -> HRESULT,
@@ -15137,7 +15137,7 @@ impl AudioEffectsManager {
         <Self as RtActivatable<IAudioEffectsManagerStatics>>::get_activation_factory().create_audio_capture_effects_manager_with_mode(deviceId, category, mode)
     }}
 }
-DEFINE_CLSID!(AudioEffectsManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,102,102,101,99,116,115,46,65,117,100,105,111,69,102,102,101,99,116,115,77,97,110,97,103,101,114,0]) [CLSID_AudioEffectsManager]);
+DEFINE_CLSID!(AudioEffectsManager: "Windows.Media.Effects.AudioEffectsManager");
 DEFINE_IID!(IID_IAudioEffectsManagerStatics, 1715497988, 34554, 18380, 163, 21, 244, 137, 216, 195, 254, 16);
 RT_INTERFACE!{static interface IAudioEffectsManagerStatics(IAudioEffectsManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAudioEffectsManagerStatics] {
     fn CreateAudioRenderEffectsManager(&self, deviceId: HSTRING, category: super::render::AudioRenderCategory, out: *mut *mut AudioRenderEffectsManager) -> HRESULT,
@@ -15434,7 +15434,7 @@ impl VideoCompositorDefinition {
         <Self as RtActivatable<IVideoCompositorDefinitionFactory>>::get_activation_factory().create_with_properties(activatableClassId, props)
     }}
 }
-DEFINE_CLSID!(VideoCompositorDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,102,102,101,99,116,115,46,86,105,100,101,111,67,111,109,112,111,115,105,116,111,114,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_VideoCompositorDefinition]);
+DEFINE_CLSID!(VideoCompositorDefinition: "Windows.Media.Effects.VideoCompositorDefinition");
 DEFINE_IID!(IID_IVideoCompositorDefinitionFactory, 1130822928, 26808, 19794, 137, 182, 2, 169, 104, 204, 168, 153);
 RT_INTERFACE!{static interface IVideoCompositorDefinitionFactory(IVideoCompositorDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVideoCompositorDefinitionFactory] {
     fn Create(&self, activatableClassId: HSTRING, out: *mut *mut VideoCompositorDefinition) -> HRESULT,
@@ -15479,7 +15479,7 @@ impl VideoEffectDefinition {
         <Self as RtActivatable<IVideoEffectDefinitionFactory>>::get_activation_factory().create_with_properties(activatableClassId, props)
     }}
 }
-DEFINE_CLSID!(VideoEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,102,102,101,99,116,115,46,86,105,100,101,111,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_VideoEffectDefinition]);
+DEFINE_CLSID!(VideoEffectDefinition: "Windows.Media.Effects.VideoEffectDefinition");
 DEFINE_IID!(IID_IVideoEffectDefinitionFactory, 2168691534, 28211, 17039, 157, 33, 181, 170, 254, 247, 97, 124);
 RT_INTERFACE!{static interface IVideoEffectDefinitionFactory(IVideoEffectDefinitionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVideoEffectDefinitionFactory] {
     fn Create(&self, activatableClassId: HSTRING, out: *mut *mut VideoEffectDefinition) -> HRESULT,
@@ -15572,7 +15572,7 @@ impl IVideoTransformEffectDefinition {
 }
 RT_CLASS!{class VideoTransformEffectDefinition: IVideoEffectDefinition}
 impl RtActivatable<IActivationFactory> for VideoTransformEffectDefinition {}
-DEFINE_CLSID!(VideoTransformEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,102,102,101,99,116,115,46,86,105,100,101,111,84,114,97,110,115,102,111,114,109,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_VideoTransformEffectDefinition]);
+DEFINE_CLSID!(VideoTransformEffectDefinition: "Windows.Media.Effects.VideoTransformEffectDefinition");
 } // Windows.Media.Effects
 pub mod editing { // Windows.Media.Editing
 use ::prelude::*;
@@ -15671,7 +15671,7 @@ impl BackgroundAudioTrack {
         <Self as RtActivatable<IBackgroundAudioTrackStatics>>::get_activation_factory().create_from_file_async(file)
     }}
 }
-DEFINE_CLSID!(BackgroundAudioTrack(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,100,105,116,105,110,103,46,66,97,99,107,103,114,111,117,110,100,65,117,100,105,111,84,114,97,99,107,0]) [CLSID_BackgroundAudioTrack]);
+DEFINE_CLSID!(BackgroundAudioTrack: "Windows.Media.Editing.BackgroundAudioTrack");
 DEFINE_IID!(IID_IBackgroundAudioTrackStatics, 3652305111, 53272, 17064, 165, 89, 203, 77, 158, 151, 230, 100);
 RT_INTERFACE!{static interface IBackgroundAudioTrackStatics(IBackgroundAudioTrackStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundAudioTrackStatics] {
     fn CreateFromEmbeddedAudioTrack(&self, embeddedAudioTrack: *mut EmbeddedAudioTrack, out: *mut *mut BackgroundAudioTrack) -> HRESULT,
@@ -15827,7 +15827,7 @@ impl MediaClip {
         <Self as RtActivatable<IMediaClipStatics2>>::get_activation_factory().create_from_surface(surface, originalDuration)
     }}
 }
-DEFINE_CLSID!(MediaClip(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,100,105,116,105,110,103,46,77,101,100,105,97,67,108,105,112,0]) [CLSID_MediaClip]);
+DEFINE_CLSID!(MediaClip: "Windows.Media.Editing.MediaClip");
 DEFINE_IID!(IID_IMediaClipStatics, 4198509416, 37519, 17348, 188, 110, 120, 58, 26, 53, 150, 86);
 RT_INTERFACE!{static interface IMediaClipStatics(IMediaClipStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaClipStatics] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
@@ -15972,7 +15972,7 @@ impl MediaComposition {
         <Self as RtActivatable<IMediaCompositionStatics>>::get_activation_factory().load_async(file)
     }}
 }
-DEFINE_CLSID!(MediaComposition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,100,105,116,105,110,103,46,77,101,100,105,97,67,111,109,112,111,115,105,116,105,111,110,0]) [CLSID_MediaComposition]);
+DEFINE_CLSID!(MediaComposition: "Windows.Media.Editing.MediaComposition");
 DEFINE_IID!(IID_IMediaComposition2, 2778616690, 9062, 18732, 190, 200, 230, 223, 186, 109, 2, 129);
 RT_INTERFACE!{interface IMediaComposition2(IMediaComposition2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaComposition2] {
     fn get_OverlayLayers(&self, out: *mut *mut super::super::foundation::collections::IVector<MediaOverlayLayer>) -> HRESULT
@@ -16066,7 +16066,7 @@ impl MediaOverlay {
         <Self as RtActivatable<IMediaOverlayFactory>>::get_activation_factory().create_with_position_and_opacity(clip, position, opacity)
     }}
 }
-DEFINE_CLSID!(MediaOverlay(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,100,105,116,105,110,103,46,77,101,100,105,97,79,118,101,114,108,97,121,0]) [CLSID_MediaOverlay]);
+DEFINE_CLSID!(MediaOverlay: "Windows.Media.Editing.MediaOverlay");
 DEFINE_IID!(IID_IMediaOverlayFactory, 3045360266, 24968, 20367, 162, 224, 170, 85, 45, 89, 142, 24);
 RT_INTERFACE!{static interface IMediaOverlayFactory(IMediaOverlayFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMediaOverlayFactory] {
     fn Create(&self, clip: *mut MediaClip, out: *mut *mut MediaOverlay) -> HRESULT,
@@ -16115,7 +16115,7 @@ impl MediaOverlayLayer {
         <Self as RtActivatable<IMediaOverlayLayerFactory>>::get_activation_factory().create_with_compositor_definition(compositorDefinition)
     }}
 }
-DEFINE_CLSID!(MediaOverlayLayer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,100,105,116,105,110,103,46,77,101,100,105,97,79,118,101,114,108,97,121,76,97,121,101,114,0]) [CLSID_MediaOverlayLayer]);
+DEFINE_CLSID!(MediaOverlayLayer: "Windows.Media.Editing.MediaOverlayLayer");
 DEFINE_IID!(IID_IMediaOverlayLayerFactory, 2491200627, 41886, 17250, 171, 191, 159, 139, 80, 112, 160, 98);
 RT_INTERFACE!{static interface IMediaOverlayLayerFactory(IMediaOverlayLayerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMediaOverlayLayerFactory] {
     fn CreateWithCompositorDefinition(&self, compositorDefinition: *mut super::effects::IVideoCompositorDefinition, out: *mut *mut MediaOverlayLayer) -> HRESULT
@@ -16209,7 +16209,7 @@ impl FaceDetector {
         <Self as RtActivatable<IFaceDetectorStatics>>::get_activation_factory().get_is_supported()
     }}
 }
-DEFINE_CLSID!(FaceDetector(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,70,97,99,101,65,110,97,108,121,115,105,115,46,70,97,99,101,68,101,116,101,99,116,111,114,0]) [CLSID_FaceDetector]);
+DEFINE_CLSID!(FaceDetector: "Windows.Media.FaceAnalysis.FaceDetector");
 DEFINE_IID!(IID_IFaceDetectorStatics, 3154390375, 36935, 13302, 136, 27, 103, 70, 193, 178, 24, 184);
 RT_INTERFACE!{static interface IFaceDetectorStatics(IFaceDetectorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFaceDetectorStatics] {
     fn CreateAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<FaceDetector>) -> HRESULT,
@@ -16290,7 +16290,7 @@ impl FaceTracker {
         <Self as RtActivatable<IFaceTrackerStatics>>::get_activation_factory().get_is_supported()
     }}
 }
-DEFINE_CLSID!(FaceTracker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,70,97,99,101,65,110,97,108,121,115,105,115,46,70,97,99,101,84,114,97,99,107,101,114,0]) [CLSID_FaceTracker]);
+DEFINE_CLSID!(FaceTracker: "Windows.Media.FaceAnalysis.FaceTracker");
 DEFINE_IID!(IID_IFaceTrackerStatics, 3915551128, 6145, 16293, 147, 46, 49, 215, 103, 175, 108, 77);
 RT_INTERFACE!{static interface IFaceTrackerStatics(IFaceTrackerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFaceTrackerStatics] {
     fn CreateAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<FaceTracker>) -> HRESULT,
@@ -16835,7 +16835,7 @@ impl PhotoImportManager {
         <Self as RtActivatable<IPhotoImportManagerStatics>>::get_activation_factory().get_pending_operations()
     }}
 }
-DEFINE_CLSID!(PhotoImportManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,73,109,112,111,114,116,46,80,104,111,116,111,73,109,112,111,114,116,77,97,110,97,103,101,114,0]) [CLSID_PhotoImportManager]);
+DEFINE_CLSID!(PhotoImportManager: "Windows.Media.Import.PhotoImportManager");
 DEFINE_IID!(IID_IPhotoImportManagerStatics, 661753917, 41030, 20230, 155, 156, 191, 214, 98, 232, 50, 135);
 RT_INTERFACE!{static interface IPhotoImportManagerStatics(IPhotoImportManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportManagerStatics] {
     fn IsSupportedAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -17152,7 +17152,7 @@ impl PhotoImportSource {
         <Self as RtActivatable<IPhotoImportSourceStatics>>::get_activation_factory().from_folder_async(sourceRootFolder)
     }}
 }
-DEFINE_CLSID!(PhotoImportSource(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,73,109,112,111,114,116,46,80,104,111,116,111,73,109,112,111,114,116,83,111,117,114,99,101,0]) [CLSID_PhotoImportSource]);
+DEFINE_CLSID!(PhotoImportSource: "Windows.Media.Import.PhotoImportSource");
 DEFINE_IID!(IID_IPhotoImportSourceStatics, 86566278, 13016, 18044, 140, 238, 35, 161, 178, 244, 62, 133);
 RT_INTERFACE!{static interface IPhotoImportSourceStatics(IPhotoImportSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportSourceStatics] {
     fn FromIdAsync(&self, sourceId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<PhotoImportSource>) -> HRESULT,
@@ -17314,7 +17314,7 @@ impl OcrEngine {
         <Self as RtActivatable<IOcrEngineStatics>>::get_activation_factory().try_create_from_user_profile_languages()
     }}
 }
-DEFINE_CLSID!(OcrEngine(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,79,99,114,46,79,99,114,69,110,103,105,110,101,0]) [CLSID_OcrEngine]);
+DEFINE_CLSID!(OcrEngine: "Windows.Media.Ocr.OcrEngine");
 DEFINE_IID!(IID_IOcrEngineStatics, 1543481434, 13188, 13632, 153, 64, 105, 145, 32, 212, 40, 168);
 RT_INTERFACE!{static interface IOcrEngineStatics(IOcrEngineStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IOcrEngineStatics] {
     fn get_MaxImageDimension(&self, out: *mut u32) -> HRESULT,
@@ -17450,7 +17450,7 @@ impl BackgroundMediaPlayer {
         <Self as RtActivatable<IBackgroundMediaPlayerStatics>>::get_activation_factory().shutdown()
     }}
 }
-DEFINE_CLSID!(BackgroundMediaPlayer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,66,97,99,107,103,114,111,117,110,100,77,101,100,105,97,80,108,97,121,101,114,0]) [CLSID_BackgroundMediaPlayer]);
+DEFINE_CLSID!(BackgroundMediaPlayer: "Windows.Media.Playback.BackgroundMediaPlayer");
 DEFINE_IID!(IID_IBackgroundMediaPlayerStatics, 2238569409, 22007, 18207, 160, 242, 104, 172, 76, 144, 69, 146);
 RT_INTERFACE!{static interface IBackgroundMediaPlayerStatics(IBackgroundMediaPlayerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundMediaPlayerStatics] {
     fn get_Current(&self, out: *mut *mut MediaPlayer) -> HRESULT,
@@ -17587,7 +17587,7 @@ impl MediaBreak {
         <Self as RtActivatable<IMediaBreakFactory>>::get_activation_factory().create_with_presentation_position(insertionMethod, presentationPosition)
     }}
 }
-DEFINE_CLSID!(MediaBreak(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,77,101,100,105,97,66,114,101,97,107,0]) [CLSID_MediaBreak]);
+DEFINE_CLSID!(MediaBreak: "Windows.Media.Playback.MediaBreak");
 DEFINE_IID!(IID_IMediaBreakEndedEventArgs, 850997878, 7261, 20462, 135, 50, 35, 109, 195, 168, 133, 128);
 RT_INTERFACE!{interface IMediaBreakEndedEventArgs(IMediaBreakEndedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBreakEndedEventArgs] {
     fn get_MediaBreak(&self, out: *mut *mut MediaBreak) -> HRESULT
@@ -18435,7 +18435,7 @@ impl MediaPlaybackItem {
         <Self as RtActivatable<IMediaPlaybackItemStatics>>::get_activation_factory().find_from_media_source(source)
     }}
 }
-DEFINE_CLSID!(MediaPlaybackItem(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,77,101,100,105,97,80,108,97,121,98,97,99,107,73,116,101,109,0]) [CLSID_MediaPlaybackItem]);
+DEFINE_CLSID!(MediaPlaybackItem: "Windows.Media.Playback.MediaPlaybackItem");
 DEFINE_IID!(IID_IMediaPlaybackItem2, 3629764977, 55279, 19329, 172, 31, 244, 4, 147, 203, 176, 145);
 RT_INTERFACE!{interface IMediaPlaybackItem2(IMediaPlaybackItem2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackItem2] {
     fn get_BreakSchedule(&self, out: *mut *mut MediaBreakSchedule) -> HRESULT,
@@ -18705,7 +18705,7 @@ impl IMediaPlaybackList {
 }
 RT_CLASS!{class MediaPlaybackList: IMediaPlaybackList}
 impl RtActivatable<IActivationFactory> for MediaPlaybackList {}
-DEFINE_CLSID!(MediaPlaybackList(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,77,101,100,105,97,80,108,97,121,98,97,99,107,76,105,115,116,0]) [CLSID_MediaPlaybackList]);
+DEFINE_CLSID!(MediaPlaybackList: "Windows.Media.Playback.MediaPlaybackList");
 DEFINE_IID!(IID_IMediaPlaybackList2, 235517048, 24586, 17012, 161, 75, 11, 103, 35, 208, 244, 139);
 RT_INTERFACE!{interface IMediaPlaybackList2(IMediaPlaybackList2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackList2] {
     fn get_MaxPrefetchTime(&self, out: *mut *mut super::super::foundation::IReference<super::super::foundation::TimeSpan>) -> HRESULT,
@@ -19419,7 +19419,7 @@ impl IMediaPlayer {
 }
 RT_CLASS!{class MediaPlayer: IMediaPlayer}
 impl RtActivatable<IActivationFactory> for MediaPlayer {}
-DEFINE_CLSID!(MediaPlayer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,77,101,100,105,97,80,108,97,121,101,114,0]) [CLSID_MediaPlayer]);
+DEFINE_CLSID!(MediaPlayer: "Windows.Media.Playback.MediaPlayer");
 DEFINE_IID!(IID_IMediaPlayer2, 1015288344, 8483, 20421, 144, 130, 47, 136, 63, 119, 189, 245);
 RT_INTERFACE!{interface IMediaPlayer2(IMediaPlayer2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlayer2] {
     fn get_SystemMediaTransportControls(&self, out: *mut *mut super::SystemMediaTransportControls) -> HRESULT,
@@ -19861,7 +19861,7 @@ impl PlaybackMediaMarker {
         <Self as RtActivatable<IPlaybackMediaMarkerFactory>>::get_activation_factory().create(value, mediaMarketType, text)
     }}
 }
-DEFINE_CLSID!(PlaybackMediaMarker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,80,108,97,121,98,97,99,107,77,101,100,105,97,77,97,114,107,101,114,0]) [CLSID_PlaybackMediaMarker]);
+DEFINE_CLSID!(PlaybackMediaMarker: "Windows.Media.Playback.PlaybackMediaMarker");
 DEFINE_IID!(IID_IPlaybackMediaMarkerFactory, 2354252408, 57518, 19994, 168, 200, 226, 63, 152, 42, 147, 123);
 RT_INTERFACE!{static interface IPlaybackMediaMarkerFactory(IPlaybackMediaMarkerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPlaybackMediaMarkerFactory] {
     fn CreateFromTime(&self, value: super::super::foundation::TimeSpan, out: *mut *mut PlaybackMediaMarker) -> HRESULT,
@@ -20138,7 +20138,7 @@ impl PlayToManager {
         <Self as RtActivatable<IPlayToManagerStatics>>::get_activation_factory().show_play_to_ui()
     }}
 }
-DEFINE_CLSID!(PlayToManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,84,111,46,80,108,97,121,84,111,77,97,110,97,103,101,114,0]) [CLSID_PlayToManager]);
+DEFINE_CLSID!(PlayToManager: "Windows.Media.PlayTo.PlayToManager");
 DEFINE_IID!(IID_IPlayToManagerStatics, 1692838023, 14722, 20283, 186, 32, 97, 85, 228, 53, 50, 91);
 RT_INTERFACE!{static interface IPlayToManagerStatics(IPlayToManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToManagerStatics] {
     fn GetForCurrentView(&self, out: *mut *mut PlayToManager) -> HRESULT,
@@ -20383,7 +20383,7 @@ impl IPlayToReceiver {
 }
 RT_CLASS!{class PlayToReceiver: IPlayToReceiver}
 impl RtActivatable<IActivationFactory> for PlayToReceiver {}
-DEFINE_CLSID!(PlayToReceiver(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,84,111,46,80,108,97,121,84,111,82,101,99,101,105,118,101,114,0]) [CLSID_PlayToReceiver]);
+DEFINE_CLSID!(PlayToReceiver: "Windows.Media.PlayTo.PlayToReceiver");
 DEFINE_IID!(IID_IPlayToSource, 2131986952, 64439, 19209, 131, 86, 170, 95, 78, 51, 92, 49);
 RT_INTERFACE!{interface IPlayToSource(IPlayToSourceVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToSource] {
     fn get_Connection(&self, out: *mut *mut PlayToConnection) -> HRESULT,
@@ -20634,7 +20634,7 @@ impl ComponentRenewal {
         <Self as RtActivatable<IComponentRenewalStatics>>::get_activation_factory().renew_system_components_async(information)
     }}
 }
-DEFINE_CLSID!(ComponentRenewal(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,67,111,109,112,111,110,101,110,116,82,101,110,101,119,97,108,0]) [CLSID_ComponentRenewal]);
+DEFINE_CLSID!(ComponentRenewal: "Windows.Media.Protection.ComponentRenewal");
 DEFINE_IID!(IID_IComponentRenewalStatics, 1878773095, 46997, 18629, 139, 123, 167, 196, 239, 226, 2, 227);
 RT_INTERFACE!{static interface IComponentRenewalStatics(IComponentRenewalStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IComponentRenewalStatics] {
     fn RenewSystemComponentsAsync(&self, information: *mut RevocationAndRenewalInformation, out: *mut *mut super::super::foundation::IAsyncOperationWithProgress<RenewalStatus, u32>) -> HRESULT
@@ -20688,7 +20688,7 @@ impl IHdcpSession {
 }
 RT_CLASS!{class HdcpSession: IHdcpSession}
 impl RtActivatable<IActivationFactory> for HdcpSession {}
-DEFINE_CLSID!(HdcpSession(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,72,100,99,112,83,101,115,115,105,111,110,0]) [CLSID_HdcpSession]);
+DEFINE_CLSID!(HdcpSession: "Windows.Media.Protection.HdcpSession");
 RT_ENUM! { enum HdcpSetProtectionResult: i32 {
     Success (HdcpSetProtectionResult_Success) = 0, TimedOut (HdcpSetProtectionResult_TimedOut) = 1, NotSupported (HdcpSetProtectionResult_NotSupported) = 2, UnknownFailure (HdcpSetProtectionResult_UnknownFailure) = 3,
 }}
@@ -20738,7 +20738,7 @@ impl IMediaProtectionManager {
 }
 RT_CLASS!{class MediaProtectionManager: IMediaProtectionManager}
 impl RtActivatable<IActivationFactory> for MediaProtectionManager {}
-DEFINE_CLSID!(MediaProtectionManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,77,101,100,105,97,80,114,111,116,101,99,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MediaProtectionManager]);
+DEFINE_CLSID!(MediaProtectionManager: "Windows.Media.Protection.MediaProtectionManager");
 DEFINE_IID!(IID_IMediaProtectionPMPServer, 202445350, 31526, 19761, 149, 187, 156, 27, 8, 239, 127, 192);
 RT_INTERFACE!{interface IMediaProtectionPMPServer(IMediaProtectionPMPServerVtbl): IInspectable(IInspectableVtbl) [IID_IMediaProtectionPMPServer] {
     fn get_Properties(&self, out: *mut *mut super::super::foundation::collections::IPropertySet) -> HRESULT
@@ -20757,7 +20757,7 @@ impl MediaProtectionPMPServer {
         <Self as RtActivatable<IMediaProtectionPMPServerFactory>>::get_activation_factory().create_pmpserver(pProperties)
     }}
 }
-DEFINE_CLSID!(MediaProtectionPMPServer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,77,101,100,105,97,80,114,111,116,101,99,116,105,111,110,80,77,80,83,101,114,118,101,114,0]) [CLSID_MediaProtectionPMPServer]);
+DEFINE_CLSID!(MediaProtectionPMPServer: "Windows.Media.Protection.MediaProtectionPMPServer");
 DEFINE_IID!(IID_IMediaProtectionPMPServerFactory, 1613532766, 63442, 18558, 175, 145, 219, 196, 37, 43, 33, 130);
 RT_INTERFACE!{static interface IMediaProtectionPMPServerFactory(IMediaProtectionPMPServerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMediaProtectionPMPServerFactory] {
     fn CreatePMPServer(&self, pProperties: *mut super::super::foundation::collections::IPropertySet, out: *mut *mut MediaProtectionPMPServer) -> HRESULT
@@ -20810,7 +20810,7 @@ impl IProtectionCapabilities {
 }
 RT_CLASS!{class ProtectionCapabilities: IProtectionCapabilities}
 impl RtActivatable<IActivationFactory> for ProtectionCapabilities {}
-DEFINE_CLSID!(ProtectionCapabilities(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,114,111,116,101,99,116,105,111,110,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_ProtectionCapabilities]);
+DEFINE_CLSID!(ProtectionCapabilities: "Windows.Media.Protection.ProtectionCapabilities");
 RT_ENUM! { enum ProtectionCapabilityResult: i32 {
     NotSupported (ProtectionCapabilityResult_NotSupported) = 0, Maybe (ProtectionCapabilityResult_Maybe) = 1, Probably (ProtectionCapabilityResult_Probably) = 2,
 }}
@@ -21018,7 +21018,7 @@ impl NDClient {
         <Self as RtActivatable<INDClientFactory>>::get_activation_factory().create_instance(downloadEngine, streamParser, pMessenger)
     }}
 }
-DEFINE_CLSID!(NDClient(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,67,108,105,101,110,116,0]) [CLSID_NDClient]);
+DEFINE_CLSID!(NDClient: "Windows.Media.Protection.PlayReady.NDClient");
 DEFINE_IID!(IID_INDClientFactory, 1045683554, 65256, 17695, 176, 212, 247, 6, 204, 163, 224, 55);
 RT_INTERFACE!{static interface INDClientFactory(INDClientFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INDClientFactory] {
     fn CreateInstance(&self, downloadEngine: *mut INDDownloadEngine, streamParser: *mut INDStreamParser, pMessenger: *mut INDMessenger, out: *mut *mut NDClient) -> HRESULT
@@ -21083,7 +21083,7 @@ impl NDCustomData {
         <Self as RtActivatable<INDCustomDataFactory>>::get_activation_factory().create_instance(customDataTypeIDBytes, customDataBytes)
     }}
 }
-DEFINE_CLSID!(NDCustomData(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,67,117,115,116,111,109,68,97,116,97,0]) [CLSID_NDCustomData]);
+DEFINE_CLSID!(NDCustomData: "Windows.Media.Protection.PlayReady.NDCustomData");
 DEFINE_IID!(IID_INDCustomDataFactory, 3595830699, 13348, 18483, 140, 154, 175, 95, 222, 178, 40, 114);
 RT_INTERFACE!{static interface INDCustomDataFactory(INDCustomDataFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INDCustomDataFactory] {
     fn CreateInstance(&self, customDataTypeIDBytesSize: u32, customDataTypeIDBytes: *mut u8, customDataBytesSize: u32, customDataBytes: *mut u8, out: *mut *mut NDCustomData) -> HRESULT
@@ -21186,7 +21186,7 @@ impl INDDownloadEngineNotifier {
 }
 RT_CLASS!{class NDDownloadEngineNotifier: INDDownloadEngineNotifier}
 impl RtActivatable<IActivationFactory> for NDDownloadEngineNotifier {}
-DEFINE_CLSID!(NDDownloadEngineNotifier(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,68,111,119,110,108,111,97,100,69,110,103,105,110,101,78,111,116,105,102,105,101,114,0]) [CLSID_NDDownloadEngineNotifier]);
+DEFINE_CLSID!(NDDownloadEngineNotifier: "Windows.Media.Protection.PlayReady.NDDownloadEngineNotifier");
 DEFINE_IID!(IID_INDLicenseFetchCompletedEventArgs, 518195738, 4530, 17752, 136, 101, 227, 165, 22, 146, 37, 23);
 RT_INTERFACE!{interface INDLicenseFetchCompletedEventArgs(INDLicenseFetchCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_INDLicenseFetchCompletedEventArgs] {
     fn get_ResponseCustomData(&self, out: *mut *mut INDCustomData) -> HRESULT
@@ -21233,7 +21233,7 @@ impl NDLicenseFetchDescriptor {
         <Self as RtActivatable<INDLicenseFetchDescriptorFactory>>::get_activation_factory().create_instance(contentIDType, contentIDBytes, licenseFetchChallengeCustomData)
     }}
 }
-DEFINE_CLSID!(NDLicenseFetchDescriptor(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,76,105,99,101,110,115,101,70,101,116,99,104,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_NDLicenseFetchDescriptor]);
+DEFINE_CLSID!(NDLicenseFetchDescriptor: "Windows.Media.Protection.PlayReady.NDLicenseFetchDescriptor");
 DEFINE_IID!(IID_INDLicenseFetchDescriptorFactory, 3489862146, 53164, 20224, 174, 106, 151, 175, 128, 184, 72, 242);
 RT_INTERFACE!{static interface INDLicenseFetchDescriptorFactory(INDLicenseFetchDescriptorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INDLicenseFetchDescriptorFactory] {
     fn CreateInstance(&self, contentIDType: NDContentIDType, contentIDBytesSize: u32, contentIDBytes: *mut u8, licenseFetchChallengeCustomData: *mut INDCustomData, out: *mut *mut NDLicenseFetchDescriptor) -> HRESULT
@@ -21368,7 +21368,7 @@ impl INDStorageFileHelper {
 }
 RT_CLASS!{class NDStorageFileHelper: INDStorageFileHelper}
 impl RtActivatable<IActivationFactory> for NDStorageFileHelper {}
-DEFINE_CLSID!(NDStorageFileHelper(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,83,116,111,114,97,103,101,70,105,108,101,72,101,108,112,101,114,0]) [CLSID_NDStorageFileHelper]);
+DEFINE_CLSID!(NDStorageFileHelper: "Windows.Media.Protection.PlayReady.NDStorageFileHelper");
 DEFINE_IID!(IID_INDStreamParser, 3770327448, 38806, 16841, 134, 149, 89, 67, 126, 103, 230, 106);
 RT_INTERFACE!{interface INDStreamParser(INDStreamParserVtbl): IInspectable(IInspectableVtbl) [IID_INDStreamParser] {
     fn ParseData(&self, dataBytesSize: u32, dataBytes: *mut u8) -> HRESULT,
@@ -21428,7 +21428,7 @@ impl INDStreamParserNotifier {
 }
 RT_CLASS!{class NDStreamParserNotifier: INDStreamParserNotifier}
 impl RtActivatable<IActivationFactory> for NDStreamParserNotifier {}
-DEFINE_CLSID!(NDStreamParserNotifier(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,83,116,114,101,97,109,80,97,114,115,101,114,78,111,116,105,102,105,101,114,0]) [CLSID_NDStreamParserNotifier]);
+DEFINE_CLSID!(NDStreamParserNotifier: "Windows.Media.Protection.PlayReady.NDStreamParserNotifier");
 RT_CLASS!{class NDTCPMessenger: INDMessenger}
 impl RtActivatable<INDTCPMessengerFactory> for NDTCPMessenger {}
 impl NDTCPMessenger {
@@ -21436,7 +21436,7 @@ impl NDTCPMessenger {
         <Self as RtActivatable<INDTCPMessengerFactory>>::get_activation_factory().create_instance(remoteHostName, remoteHostPort)
     }}
 }
-DEFINE_CLSID!(NDTCPMessenger(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,84,67,80,77,101,115,115,101,110,103,101,114,0]) [CLSID_NDTCPMessenger]);
+DEFINE_CLSID!(NDTCPMessenger: "Windows.Media.Protection.PlayReady.NDTCPMessenger");
 DEFINE_IID!(IID_INDTCPMessengerFactory, 2111331582, 7065, 20328, 143, 130, 129, 119, 247, 206, 223, 43);
 RT_INTERFACE!{static interface INDTCPMessengerFactory(INDTCPMessengerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INDTCPMessengerFactory] {
     fn CreateInstance(&self, remoteHostName: HSTRING, remoteHostPort: u32, out: *mut *mut NDTCPMessenger) -> HRESULT
@@ -21601,7 +21601,7 @@ impl PlayReadyContentHeader {
         <Self as RtActivatable<IPlayReadyContentHeaderFactory2>>::get_activation_factory().create_instance_from_components2(dwFlags, contentKeyIds, contentKeyIdStrings, contentEncryptionAlgorithm, licenseAcquisitionUrl, licenseAcquisitionUserInterfaceUrl, customAttributes, domainServiceId)
     }}
 }
-DEFINE_CLSID!(PlayReadyContentHeader(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,67,111,110,116,101,110,116,72,101,97,100,101,114,0]) [CLSID_PlayReadyContentHeader]);
+DEFINE_CLSID!(PlayReadyContentHeader: "Windows.Media.Protection.PlayReady.PlayReadyContentHeader");
 DEFINE_IID!(IID_IPlayReadyContentHeader2, 899447284, 8576, 18828, 150, 91, 231, 84, 216, 117, 234, 178);
 RT_INTERFACE!{interface IPlayReadyContentHeader2(IPlayReadyContentHeader2Vtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyContentHeader2] {
     fn get_KeyIds(&self, outSize: *mut u32, out: *mut *mut Guid) -> HRESULT,
@@ -21671,7 +21671,7 @@ impl PlayReadyContentResolver {
         <Self as RtActivatable<IPlayReadyContentResolver>>::get_activation_factory().service_request(contentHeader)
     }}
 }
-DEFINE_CLSID!(PlayReadyContentResolver(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,67,111,110,116,101,110,116,82,101,115,111,108,118,101,114,0]) [CLSID_PlayReadyContentResolver]);
+DEFINE_CLSID!(PlayReadyContentResolver: "Windows.Media.Protection.PlayReady.PlayReadyContentResolver");
 RT_ENUM! { enum PlayReadyDecryptorSetup: i32 {
     Uninitialized (PlayReadyDecryptorSetup_Uninitialized) = 0, OnDemand (PlayReadyDecryptorSetup_OnDemand) = 1,
 }}
@@ -21718,7 +21718,7 @@ impl PlayReadyDomainIterable {
         <Self as RtActivatable<IPlayReadyDomainIterableFactory>>::get_activation_factory().create_instance(domainAccountId)
     }}
 }
-DEFINE_CLSID!(PlayReadyDomainIterable(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,68,111,109,97,105,110,73,116,101,114,97,98,108,101,0]) [CLSID_PlayReadyDomainIterable]);
+DEFINE_CLSID!(PlayReadyDomainIterable: "Windows.Media.Protection.PlayReady.PlayReadyDomainIterable");
 DEFINE_IID!(IID_IPlayReadyDomainIterableFactory, 1307804910, 12577, 19955, 165, 232, 208, 194, 76, 5, 0, 252);
 RT_INTERFACE!{static interface IPlayReadyDomainIterableFactory(IPlayReadyDomainIterableFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyDomainIterableFactory] {
     fn CreateInstance(&self, domainAccountId: Guid, out: *mut *mut PlayReadyDomainIterable) -> HRESULT
@@ -21771,7 +21771,7 @@ impl IPlayReadyDomainJoinServiceRequest {
 }
 RT_CLASS!{class PlayReadyDomainJoinServiceRequest: IPlayReadyDomainJoinServiceRequest}
 impl RtActivatable<IActivationFactory> for PlayReadyDomainJoinServiceRequest {}
-DEFINE_CLSID!(PlayReadyDomainJoinServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,68,111,109,97,105,110,74,111,105,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyDomainJoinServiceRequest]);
+DEFINE_CLSID!(PlayReadyDomainJoinServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadyDomainJoinServiceRequest");
 DEFINE_IID!(IID_IPlayReadyDomainLeaveServiceRequest, 103635134, 38829, 18711, 170, 3, 70, 212, 194, 82, 212, 100);
 RT_INTERFACE!{interface IPlayReadyDomainLeaveServiceRequest(IPlayReadyDomainLeaveServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyDomainLeaveServiceRequest] {
     fn get_DomainAccountId(&self, out: *mut Guid) -> HRESULT,
@@ -21801,7 +21801,7 @@ impl IPlayReadyDomainLeaveServiceRequest {
 }
 RT_CLASS!{class PlayReadyDomainLeaveServiceRequest: IPlayReadyDomainLeaveServiceRequest}
 impl RtActivatable<IActivationFactory> for PlayReadyDomainLeaveServiceRequest {}
-DEFINE_CLSID!(PlayReadyDomainLeaveServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,68,111,109,97,105,110,76,101,97,118,101,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyDomainLeaveServiceRequest]);
+DEFINE_CLSID!(PlayReadyDomainLeaveServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadyDomainLeaveServiceRequest");
 RT_ENUM! { enum PlayReadyEncryptionAlgorithm: i32 {
     Unprotected (PlayReadyEncryptionAlgorithm_Unprotected) = 0, Aes128Ctr (PlayReadyEncryptionAlgorithm_Aes128Ctr) = 1, Cocktail (PlayReadyEncryptionAlgorithm_Cocktail) = 4, Aes128Cbc (PlayReadyEncryptionAlgorithm_Aes128Cbc) = 5, Unspecified (PlayReadyEncryptionAlgorithm_Unspecified) = 65535, Uninitialized (PlayReadyEncryptionAlgorithm_Uninitialized) = 2147483647,
 }}
@@ -21814,7 +21814,7 @@ RT_INTERFACE!{interface IPlayReadyIndividualizationServiceRequest(IPlayReadyIndi
 }}
 RT_CLASS!{class PlayReadyIndividualizationServiceRequest: IPlayReadyIndividualizationServiceRequest}
 impl RtActivatable<IActivationFactory> for PlayReadyIndividualizationServiceRequest {}
-DEFINE_CLSID!(PlayReadyIndividualizationServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,73,110,100,105,118,105,100,117,97,108,105,122,97,116,105,111,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyIndividualizationServiceRequest]);
+DEFINE_CLSID!(PlayReadyIndividualizationServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadyIndividualizationServiceRequest");
 RT_ENUM! { enum PlayReadyITADataFormat: i32 {
     SerializedProperties (PlayReadyITADataFormat_SerializedProperties) = 0, SerializedProperties_WithContentProtectionWrapper (PlayReadyITADataFormat_SerializedProperties_WithContentProtectionWrapper) = 1,
 }}
@@ -21831,7 +21831,7 @@ impl IPlayReadyITADataGenerator {
 }
 RT_CLASS!{class PlayReadyITADataGenerator: IPlayReadyITADataGenerator}
 impl RtActivatable<IActivationFactory> for PlayReadyITADataGenerator {}
-DEFINE_CLSID!(PlayReadyITADataGenerator(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,73,84,65,68,97,116,97,71,101,110,101,114,97,116,111,114,0]) [CLSID_PlayReadyITADataGenerator]);
+DEFINE_CLSID!(PlayReadyITADataGenerator: "Windows.Media.Protection.PlayReady.PlayReadyITADataGenerator");
 DEFINE_IID!(IID_IPlayReadyLicense, 3997649998, 64060, 16717, 169, 242, 63, 252, 30, 248, 50, 212);
 RT_INTERFACE!{interface IPlayReadyLicense(IPlayReadyLicenseVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicense] {
     fn get_FullyEvaluated(&self, out: *mut bool) -> HRESULT,
@@ -21938,7 +21938,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest {
 }
 RT_CLASS!{class PlayReadyLicenseAcquisitionServiceRequest: IPlayReadyLicenseAcquisitionServiceRequest}
 impl RtActivatable<IActivationFactory> for PlayReadyLicenseAcquisitionServiceRequest {}
-DEFINE_CLSID!(PlayReadyLicenseAcquisitionServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,76,105,99,101,110,115,101,65,99,113,117,105,115,105,116,105,111,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyLicenseAcquisitionServiceRequest]);
+DEFINE_CLSID!(PlayReadyLicenseAcquisitionServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadyLicenseAcquisitionServiceRequest");
 DEFINE_IID!(IID_IPlayReadyLicenseAcquisitionServiceRequest2, 3086638773, 65036, 45605, 188, 96, 90, 158, 221, 50, 206, 181);
 RT_INTERFACE!{interface IPlayReadyLicenseAcquisitionServiceRequest2(IPlayReadyLicenseAcquisitionServiceRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicenseAcquisitionServiceRequest2] {
     fn get_SessionId(&self, out: *mut Guid) -> HRESULT
@@ -21969,7 +21969,7 @@ impl PlayReadyLicenseIterable {
         <Self as RtActivatable<IPlayReadyLicenseIterableFactory>>::get_activation_factory().create_instance(contentHeader, fullyEvaluated)
     }}
 }
-DEFINE_CLSID!(PlayReadyLicenseIterable(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,76,105,99,101,110,115,101,73,116,101,114,97,98,108,101,0]) [CLSID_PlayReadyLicenseIterable]);
+DEFINE_CLSID!(PlayReadyLicenseIterable: "Windows.Media.Protection.PlayReady.PlayReadyLicenseIterable");
 DEFINE_IID!(IID_IPlayReadyLicenseIterableFactory, 3558317832, 2103, 18808, 142, 104, 190, 66, 147, 200, 215, 166);
 RT_INTERFACE!{static interface IPlayReadyLicenseIterableFactory(IPlayReadyLicenseIterableFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicenseIterableFactory] {
     fn CreateInstance(&self, contentHeader: *mut PlayReadyContentHeader, fullyEvaluated: bool, out: *mut *mut PlayReadyLicenseIterable) -> HRESULT
@@ -22000,7 +22000,7 @@ impl PlayReadyLicenseManagement {
         <Self as RtActivatable<IPlayReadyLicenseManagement>>::get_activation_factory().delete_licenses(contentHeader)
     }}
 }
-DEFINE_CLSID!(PlayReadyLicenseManagement(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,76,105,99,101,110,115,101,77,97,110,97,103,101,109,101,110,116,0]) [CLSID_PlayReadyLicenseManagement]);
+DEFINE_CLSID!(PlayReadyLicenseManagement: "Windows.Media.Protection.PlayReady.PlayReadyLicenseManagement");
 DEFINE_IID!(IID_IPlayReadyLicenseSession, 2708617785, 34810, 20445, 171, 187, 169, 114, 14, 132, 82, 89);
 RT_INTERFACE!{interface IPlayReadyLicenseSession(IPlayReadyLicenseSessionVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicenseSession] {
     fn CreateLAServiceRequest(&self, out: *mut *mut IPlayReadyLicenseAcquisitionServiceRequest) -> HRESULT,
@@ -22024,7 +22024,7 @@ impl PlayReadyLicenseSession {
         <Self as RtActivatable<IPlayReadyLicenseSessionFactory>>::get_activation_factory().create_instance(configuration)
     }}
 }
-DEFINE_CLSID!(PlayReadyLicenseSession(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,76,105,99,101,110,115,101,83,101,115,115,105,111,110,0]) [CLSID_PlayReadyLicenseSession]);
+DEFINE_CLSID!(PlayReadyLicenseSession: "Windows.Media.Protection.PlayReady.PlayReadyLicenseSession");
 DEFINE_IID!(IID_IPlayReadyLicenseSession2, 1225375290, 15085, 18006, 138, 215, 238, 15, 215, 121, 149, 16);
 RT_INTERFACE!{interface IPlayReadyLicenseSession2(IPlayReadyLicenseSession2Vtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicenseSession2] {
     fn CreateLicenseIterable(&self, contentHeader: *mut PlayReadyContentHeader, fullyEvaluated: bool, out: *mut *mut PlayReadyLicenseIterable) -> HRESULT
@@ -22065,14 +22065,14 @@ impl IPlayReadyMeteringReportServiceRequest {
 }
 RT_CLASS!{class PlayReadyMeteringReportServiceRequest: IPlayReadyMeteringReportServiceRequest}
 impl RtActivatable<IActivationFactory> for PlayReadyMeteringReportServiceRequest {}
-DEFINE_CLSID!(PlayReadyMeteringReportServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,77,101,116,101,114,105,110,103,82,101,112,111,114,116,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyMeteringReportServiceRequest]);
+DEFINE_CLSID!(PlayReadyMeteringReportServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadyMeteringReportServiceRequest");
 DEFINE_IID!(IID_IPlayReadyRevocationServiceRequest, 1413310124, 64240, 17760, 132, 165, 14, 74, 206, 201, 57, 228);
 RT_INTERFACE!{interface IPlayReadyRevocationServiceRequest(IPlayReadyRevocationServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyRevocationServiceRequest] {
     
 }}
 RT_CLASS!{class PlayReadyRevocationServiceRequest: IPlayReadyRevocationServiceRequest}
 impl RtActivatable<IActivationFactory> for PlayReadyRevocationServiceRequest {}
-DEFINE_CLSID!(PlayReadyRevocationServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,82,101,118,111,99,97,116,105,111,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyRevocationServiceRequest]);
+DEFINE_CLSID!(PlayReadyRevocationServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadyRevocationServiceRequest");
 RT_CLASS!{class PlayReadySecureStopIterable: ::rt::gen::windows::foundation::collections::IIterable<IPlayReadySecureStopServiceRequest>}
 impl RtActivatable<IPlayReadySecureStopIterableFactory> for PlayReadySecureStopIterable {}
 impl PlayReadySecureStopIterable {
@@ -22080,7 +22080,7 @@ impl PlayReadySecureStopIterable {
         <Self as RtActivatable<IPlayReadySecureStopIterableFactory>>::get_activation_factory().create_instance(publisherCertBytes)
     }}
 }
-DEFINE_CLSID!(PlayReadySecureStopIterable(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,83,101,99,117,114,101,83,116,111,112,73,116,101,114,97,98,108,101,0]) [CLSID_PlayReadySecureStopIterable]);
+DEFINE_CLSID!(PlayReadySecureStopIterable: "Windows.Media.Protection.PlayReady.PlayReadySecureStopIterable");
 DEFINE_IID!(IID_IPlayReadySecureStopIterableFactory, 1595867493, 16916, 19870, 129, 235, 232, 159, 157, 41, 74, 238);
 RT_INTERFACE!{static interface IPlayReadySecureStopIterableFactory(IPlayReadySecureStopIterableFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadySecureStopIterableFactory] {
     fn CreateInstance(&self, publisherCertBytesSize: u32, publisherCertBytes: *mut u8, out: *mut *mut PlayReadySecureStopIterable) -> HRESULT
@@ -22138,7 +22138,7 @@ impl PlayReadySecureStopServiceRequest {
         <Self as RtActivatable<IPlayReadySecureStopServiceRequestFactory>>::get_activation_factory().create_instance_from_session_id(sessionID, publisherCertBytes)
     }}
 }
-DEFINE_CLSID!(PlayReadySecureStopServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,83,101,99,117,114,101,83,116,111,112,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadySecureStopServiceRequest]);
+DEFINE_CLSID!(PlayReadySecureStopServiceRequest: "Windows.Media.Protection.PlayReady.PlayReadySecureStopServiceRequest");
 DEFINE_IID!(IID_IPlayReadySecureStopServiceRequestFactory, 239373001, 59006, 18766, 159, 73, 98, 133, 67, 140, 118, 207);
 RT_INTERFACE!{static interface IPlayReadySecureStopServiceRequestFactory(IPlayReadySecureStopServiceRequestFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadySecureStopServiceRequestFactory] {
     fn CreateInstance(&self, publisherCertBytesSize: u32, publisherCertBytes: *mut u8, out: *mut *mut PlayReadySecureStopServiceRequest) -> HRESULT,
@@ -22336,7 +22336,7 @@ impl PlayReadyStatics {
         <Self as RtActivatable<IPlayReadyStatics4>>::get_activation_factory().get_protection_system_id()
     }}
 }
-DEFINE_CLSID!(PlayReadyStatics(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,83,116,97,116,105,99,115,0]) [CLSID_PlayReadyStatics]);
+DEFINE_CLSID!(PlayReadyStatics: "Windows.Media.Protection.PlayReady.PlayReadyStatics");
 DEFINE_IID!(IID_IPlayReadyStatics2, 529361554, 24474, 16958, 148, 102, 179, 57, 105, 175, 122, 61);
 RT_INTERFACE!{static interface IPlayReadyStatics2(IPlayReadyStatics2Vtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyStatics2] {
     fn get_PlayReadyCertificateSecurityLevel(&self, out: *mut u32) -> HRESULT
@@ -22576,7 +22576,7 @@ impl SpeechRecognitionGrammarFileConstraint {
         <Self as RtActivatable<ISpeechRecognitionGrammarFileConstraintFactory>>::get_activation_factory().create_with_tag(file, tag)
     }}
 }
-DEFINE_CLSID!(SpeechRecognitionGrammarFileConstraint(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,71,114,97,109,109,97,114,70,105,108,101,67,111,110,115,116,114,97,105,110,116,0]) [CLSID_SpeechRecognitionGrammarFileConstraint]);
+DEFINE_CLSID!(SpeechRecognitionGrammarFileConstraint: "Windows.Media.SpeechRecognition.SpeechRecognitionGrammarFileConstraint");
 DEFINE_IID!(IID_ISpeechRecognitionGrammarFileConstraintFactory, 1034383595, 50297, 19495, 159, 25, 137, 151, 78, 243, 146, 209);
 RT_INTERFACE!{static interface ISpeechRecognitionGrammarFileConstraintFactory(ISpeechRecognitionGrammarFileConstraintFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionGrammarFileConstraintFactory] {
     #[cfg(feature="windows-storage")] fn Create(&self, file: *mut super::super::storage::StorageFile, out: *mut *mut SpeechRecognitionGrammarFileConstraint) -> HRESULT,
@@ -22639,7 +22639,7 @@ impl SpeechRecognitionListConstraint {
         <Self as RtActivatable<ISpeechRecognitionListConstraintFactory>>::get_activation_factory().create_with_tag(commands, tag)
     }}
 }
-DEFINE_CLSID!(SpeechRecognitionListConstraint(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,76,105,115,116,67,111,110,115,116,114,97,105,110,116,0]) [CLSID_SpeechRecognitionListConstraint]);
+DEFINE_CLSID!(SpeechRecognitionListConstraint: "Windows.Media.SpeechRecognition.SpeechRecognitionListConstraint");
 DEFINE_IID!(IID_ISpeechRecognitionListConstraintFactory, 1089719751, 22058, 17002, 159, 59, 59, 78, 40, 43, 225, 213);
 RT_INTERFACE!{static interface ISpeechRecognitionListConstraintFactory(ISpeechRecognitionListConstraintFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionListConstraintFactory] {
     fn Create(&self, commands: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut SpeechRecognitionListConstraint) -> HRESULT,
@@ -22785,7 +22785,7 @@ impl SpeechRecognitionTopicConstraint {
         <Self as RtActivatable<ISpeechRecognitionTopicConstraintFactory>>::get_activation_factory().create_with_tag(scenario, topicHint, tag)
     }}
 }
-DEFINE_CLSID!(SpeechRecognitionTopicConstraint(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,84,111,112,105,99,67,111,110,115,116,114,97,105,110,116,0]) [CLSID_SpeechRecognitionTopicConstraint]);
+DEFINE_CLSID!(SpeechRecognitionTopicConstraint: "Windows.Media.SpeechRecognition.SpeechRecognitionTopicConstraint");
 DEFINE_IID!(IID_ISpeechRecognitionTopicConstraintFactory, 1852335071, 60421, 18391, 165, 223, 86, 163, 67, 30, 88, 210);
 RT_INTERFACE!{static interface ISpeechRecognitionTopicConstraintFactory(ISpeechRecognitionTopicConstraintFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionTopicConstraintFactory] {
     fn Create(&self, scenario: SpeechRecognitionScenario, topicHint: HSTRING, out: *mut *mut SpeechRecognitionTopicConstraint) -> HRESULT,
@@ -22900,7 +22900,7 @@ impl SpeechRecognizer {
         <Self as RtActivatable<ISpeechRecognizerStatics2>>::get_activation_factory().try_set_system_speech_language_async(speechLanguage)
     }}
 }
-DEFINE_CLSID!(SpeechRecognizer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,112,101,101,99,104,82,101,99,111,103,110,105,116,105,111,110,46,83,112,101,101,99,104,82,101,99,111,103,110,105,122,101,114,0]) [CLSID_SpeechRecognizer]);
+DEFINE_CLSID!(SpeechRecognizer: "Windows.Media.SpeechRecognition.SpeechRecognizer");
 DEFINE_IID!(IID_ISpeechRecognizer2, 1674164977, 37347, 20132, 134, 161, 124, 56, 103, 208, 132, 166);
 RT_INTERFACE!{interface ISpeechRecognizer2(ISpeechRecognizer2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognizer2] {
     fn get_ContinuousRecognitionSession(&self, out: *mut *mut SpeechContinuousRecognitionSession) -> HRESULT,
@@ -23170,7 +23170,7 @@ impl SpeechSynthesizer {
         <Self as RtActivatable<IInstalledVoicesStatic2>>::get_activation_factory().try_set_default_voice_async(voice)
     }}
 }
-DEFINE_CLSID!(SpeechSynthesizer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,112,101,101,99,104,83,121,110,116,104,101,115,105,115,46,83,112,101,101,99,104,83,121,110,116,104,101,115,105,122,101,114,0]) [CLSID_SpeechSynthesizer]);
+DEFINE_CLSID!(SpeechSynthesizer: "Windows.Media.SpeechSynthesis.SpeechSynthesizer");
 DEFINE_IID!(IID_ISpeechSynthesizer2, 2814766258, 17209, 19818, 187, 248, 199, 164, 241, 84, 76, 46);
 RT_INTERFACE!{interface ISpeechSynthesizer2(ISpeechSynthesizer2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpeechSynthesizer2] {
     fn get_Options(&self, out: *mut *mut SpeechSynthesizerOptions) -> HRESULT
@@ -23378,7 +23378,7 @@ impl IMediaTranscoder {
 }
 RT_CLASS!{class MediaTranscoder: IMediaTranscoder}
 impl RtActivatable<IActivationFactory> for MediaTranscoder {}
-DEFINE_CLSID!(MediaTranscoder(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,84,114,97,110,115,99,111,100,105,110,103,46,77,101,100,105,97,84,114,97,110,115,99,111,100,101,114,0]) [CLSID_MediaTranscoder]);
+DEFINE_CLSID!(MediaTranscoder: "Windows.Media.Transcoding.MediaTranscoder");
 DEFINE_IID!(IID_IMediaTranscoder2, 1079188852, 13792, 20228, 133, 116, 202, 139, 196, 229, 160, 130);
 RT_INTERFACE!{interface IMediaTranscoder2(IMediaTranscoder2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaTranscoder2] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -23511,7 +23511,7 @@ impl AudioEncodingProperties {
         <Self as RtActivatable<IAudioEncodingPropertiesStatics2>>::get_activation_factory().create_flac(sampleRate, channelCount, bitsPerSample)
     }}
 }
-DEFINE_CLSID!(AudioEncodingProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,65,117,100,105,111,69,110,99,111,100,105,110,103,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_AudioEncodingProperties]);
+DEFINE_CLSID!(AudioEncodingProperties: "Windows.Media.MediaProperties.AudioEncodingProperties");
 DEFINE_IID!(IID_IAudioEncodingProperties2, 3294450906, 32957, 19491, 128, 213, 114, 212, 161, 129, 232, 148);
 RT_INTERFACE!{interface IAudioEncodingProperties2(IAudioEncodingProperties2Vtbl): IInspectable(IInspectableVtbl) [IID_IAudioEncodingProperties2] {
     fn get_IsSpatial(&self, out: *mut bool) -> HRESULT
@@ -23600,7 +23600,7 @@ RT_INTERFACE!{interface IContainerEncodingProperties(IContainerEncodingPropertie
 }}
 RT_CLASS!{class ContainerEncodingProperties: IContainerEncodingProperties}
 impl RtActivatable<IActivationFactory> for ContainerEncodingProperties {}
-DEFINE_CLSID!(ContainerEncodingProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,67,111,110,116,97,105,110,101,114,69,110,99,111,100,105,110,103,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_ContainerEncodingProperties]);
+DEFINE_CLSID!(ContainerEncodingProperties: "Windows.Media.MediaProperties.ContainerEncodingProperties");
 RT_CLASS!{static class H264ProfileIds}
 impl RtActivatable<IH264ProfileIdsStatics> for H264ProfileIds {}
 impl H264ProfileIds {
@@ -23635,7 +23635,7 @@ impl H264ProfileIds {
         <Self as RtActivatable<IH264ProfileIdsStatics>>::get_activation_factory().get_multiview_high()
     }}
 }
-DEFINE_CLSID!(H264ProfileIds(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,72,50,54,52,80,114,111,102,105,108,101,73,100,115,0]) [CLSID_H264ProfileIds]);
+DEFINE_CLSID!(H264ProfileIds: "Windows.Media.MediaProperties.H264ProfileIds");
 DEFINE_IID!(IID_IH264ProfileIdsStatics, 946162855, 33898, 20375, 162, 229, 195, 161, 91, 191, 112, 253);
 RT_INTERFACE!{static interface IH264ProfileIdsStatics(IH264ProfileIdsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IH264ProfileIdsStatics] {
     fn get_ConstrainedBaseline(&self, out: *mut i32) -> HRESULT,
@@ -23749,7 +23749,7 @@ impl ImageEncodingProperties {
         <Self as RtActivatable<IImageEncodingPropertiesStatics2>>::get_activation_factory().create_bmp()
     }}
 }
-DEFINE_CLSID!(ImageEncodingProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,73,109,97,103,101,69,110,99,111,100,105,110,103,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_ImageEncodingProperties]);
+DEFINE_CLSID!(ImageEncodingProperties: "Windows.Media.MediaProperties.ImageEncodingProperties");
 DEFINE_IID!(IID_IImageEncodingPropertiesStatics, 628910300, 35737, 17310, 170, 89, 145, 58, 54, 22, 18, 151);
 RT_INTERFACE!{static interface IImageEncodingPropertiesStatics(IImageEncodingPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IImageEncodingPropertiesStatics] {
     fn CreateJpeg(&self, out: *mut *mut ImageEncodingProperties) -> HRESULT,
@@ -23871,7 +23871,7 @@ impl MediaEncodingProfile {
         <Self as RtActivatable<IMediaEncodingProfileStatics3>>::get_activation_factory().create_hevc(quality)
     }}
 }
-DEFINE_CLSID!(MediaEncodingProfile(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,77,101,100,105,97,69,110,99,111,100,105,110,103,80,114,111,102,105,108,101,0]) [CLSID_MediaEncodingProfile]);
+DEFINE_CLSID!(MediaEncodingProfile: "Windows.Media.MediaProperties.MediaEncodingProfile");
 DEFINE_IID!(IID_IMediaEncodingProfile2, 882589194, 16437, 18574, 152, 119, 133, 99, 40, 101, 237, 16);
 RT_INTERFACE!{interface IMediaEncodingProfile2(IMediaEncodingProfile2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaEncodingProfile2] {
     fn SetAudioTracks(&self, value: *mut super::super::foundation::collections::IIterable<super::core::AudioStreamDescriptor>) -> HRESULT,
@@ -24158,7 +24158,7 @@ impl MediaEncodingSubtypes {
         <Self as RtActivatable<IMediaEncodingSubtypesStatics3>>::get_activation_factory().get_flac()
     }}
 }
-DEFINE_CLSID!(MediaEncodingSubtypes(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,77,101,100,105,97,69,110,99,111,100,105,110,103,83,117,98,116,121,112,101,115,0]) [CLSID_MediaEncodingSubtypes]);
+DEFINE_CLSID!(MediaEncodingSubtypes: "Windows.Media.MediaProperties.MediaEncodingSubtypes");
 DEFINE_IID!(IID_IMediaEncodingSubtypesStatics, 934696974, 41329, 17508, 186, 90, 83, 24, 158, 72, 193, 200);
 RT_INTERFACE!{static interface IMediaEncodingSubtypesStatics(IMediaEncodingSubtypesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaEncodingSubtypesStatics] {
     fn get_Aac(&self, out: *mut HSTRING) -> HRESULT,
@@ -24458,7 +24458,7 @@ RT_ENUM! { enum MediaPixelFormat: i32 {
 }}
 RT_CLASS!{class MediaPropertySet: super::super::foundation::collections::IMap<Guid, IInspectable>}
 impl RtActivatable<IActivationFactory> for MediaPropertySet {}
-DEFINE_CLSID!(MediaPropertySet(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,77,101,100,105,97,80,114,111,112,101,114,116,121,83,101,116,0]) [CLSID_MediaPropertySet]);
+DEFINE_CLSID!(MediaPropertySet: "Windows.Media.MediaProperties.MediaPropertySet");
 DEFINE_IID!(IID_IMediaRatio, 3536912101, 35113, 16413, 172, 120, 125, 53, 126, 55, 129, 99);
 RT_INTERFACE!{interface IMediaRatio(IMediaRatioVtbl): IInspectable(IInspectableVtbl) [IID_IMediaRatio] {
     fn put_Numerator(&self, value: u32) -> HRESULT,
@@ -24512,7 +24512,7 @@ impl Mpeg2ProfileIds {
         <Self as RtActivatable<IMpeg2ProfileIdsStatics>>::get_activation_factory().get_high()
     }}
 }
-DEFINE_CLSID!(Mpeg2ProfileIds(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,77,112,101,103,50,80,114,111,102,105,108,101,73,100,115,0]) [CLSID_Mpeg2ProfileIds]);
+DEFINE_CLSID!(Mpeg2ProfileIds: "Windows.Media.MediaProperties.Mpeg2ProfileIds");
 DEFINE_IID!(IID_IMpeg2ProfileIdsStatics, 2757885829, 58746, 16680, 155, 33, 213, 51, 27, 4, 35, 92);
 RT_INTERFACE!{static interface IMpeg2ProfileIdsStatics(IMpeg2ProfileIdsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMpeg2ProfileIdsStatics] {
     fn get_Simple(&self, out: *mut i32) -> HRESULT,
@@ -24622,7 +24622,7 @@ impl VideoEncodingProperties {
         <Self as RtActivatable<IVideoEncodingPropertiesStatics2>>::get_activation_factory().create_hevc()
     }}
 }
-DEFINE_CLSID!(VideoEncodingProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,86,105,100,101,111,69,110,99,111,100,105,110,103,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_VideoEncodingProperties]);
+DEFINE_CLSID!(VideoEncodingProperties: "Windows.Media.MediaProperties.VideoEncodingProperties");
 DEFINE_IID!(IID_IVideoEncodingProperties2, 4148404719, 54373, 17040, 169, 75, 239, 15, 21, 40, 248, 227);
 RT_INTERFACE!{interface IVideoEncodingProperties2(IVideoEncodingProperties2Vtbl): IInspectable(IInspectableVtbl) [IID_IVideoEncodingProperties2] {
     fn SetFormatUserData(&self, valueSize: u32, value: *mut u8) -> HRESULT,
@@ -24761,7 +24761,7 @@ impl ClosedCaptionProperties {
         <Self as RtActivatable<IClosedCaptionPropertiesStatics>>::get_activation_factory().get_region_opacity()
     }}
 }
-DEFINE_CLSID!(ClosedCaptionProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,108,111,115,101,100,67,97,112,116,105,111,110,105,110,103,46,67,108,111,115,101,100,67,97,112,116,105,111,110,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_ClosedCaptionProperties]);
+DEFINE_CLSID!(ClosedCaptionProperties: "Windows.Media.ClosedCaptioning.ClosedCaptionProperties");
 DEFINE_IID!(IID_IClosedCaptionPropertiesStatics, 279584644, 52272, 16705, 181, 3, 82, 114, 40, 158, 12, 32);
 RT_INTERFACE!{static interface IClosedCaptionPropertiesStatics(IClosedCaptionPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IClosedCaptionPropertiesStatics] {
     fn get_FontColor(&self, out: *mut ClosedCaptionColor) -> HRESULT,
@@ -25022,7 +25022,7 @@ impl AdaptiveMediaSource {
         <Self as RtActivatable<IAdaptiveMediaSourceStatics>>::get_activation_factory().create_from_stream_with_downloader_async(stream, uri, contentType, httpClient)
     }}
 }
-DEFINE_CLSID!(AdaptiveMediaSource(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,116,114,101,97,109,105,110,103,46,65,100,97,112,116,105,118,101,46,65,100,97,112,116,105,118,101,77,101,100,105,97,83,111,117,114,99,101,0]) [CLSID_AdaptiveMediaSource]);
+DEFINE_CLSID!(AdaptiveMediaSource: "Windows.Media.Streaming.Adaptive.AdaptiveMediaSource");
 DEFINE_IID!(IID_IAdaptiveMediaSource2, 394855234, 26464, 19385, 165, 138, 247, 170, 152, 176, 140, 14);
 RT_INTERFACE!{interface IAdaptiveMediaSource2(IAdaptiveMediaSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSource2] {
     fn get_AdvancedSettings(&self, out: *mut *mut AdaptiveMediaSourceAdvancedSettings) -> HRESULT
@@ -25781,7 +25781,7 @@ impl RatedContentDescription {
         <Self as RtActivatable<IRatedContentDescriptionFactory>>::get_activation_factory().create(id, title, category)
     }}
 }
-DEFINE_CLSID!(RatedContentDescription(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,110,116,101,110,116,82,101,115,116,114,105,99,116,105,111,110,115,46,82,97,116,101,100,67,111,110,116,101,110,116,68,101,115,99,114,105,112,116,105,111,110,0]) [CLSID_RatedContentDescription]);
+DEFINE_CLSID!(RatedContentDescription: "Windows.Media.ContentRestrictions.RatedContentDescription");
 DEFINE_IID!(IID_IRatedContentDescriptionFactory, 775479138, 39824, 20390, 137, 193, 75, 141, 47, 251, 53, 115);
 RT_INTERFACE!{static interface IRatedContentDescriptionFactory(IRatedContentDescriptionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRatedContentDescriptionFactory] {
     fn Create(&self, id: HSTRING, title: HSTRING, category: RatedContentCategory, out: *mut *mut RatedContentDescription) -> HRESULT
@@ -25835,7 +25835,7 @@ impl RatedContentRestrictions {
         <Self as RtActivatable<IRatedContentRestrictionsFactory>>::get_activation_factory().create_with_max_age_rating(maxAgeRating)
     }}
 }
-DEFINE_CLSID!(RatedContentRestrictions(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,110,116,101,110,116,82,101,115,116,114,105,99,116,105,111,110,115,46,82,97,116,101,100,67,111,110,116,101,110,116,82,101,115,116,114,105,99,116,105,111,110,115,0]) [CLSID_RatedContentRestrictions]);
+DEFINE_CLSID!(RatedContentRestrictions: "Windows.Media.ContentRestrictions.RatedContentRestrictions");
 DEFINE_IID!(IID_IRatedContentRestrictionsFactory, 4216007062, 50109, 18704, 150, 25, 151, 207, 208, 105, 77, 86);
 RT_INTERFACE!{static interface IRatedContentRestrictionsFactory(IRatedContentRestrictionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRatedContentRestrictionsFactory] {
     fn CreateWithMaxAgeRating(&self, maxAgeRating: u32, out: *mut *mut RatedContentRestrictions) -> HRESULT
@@ -25887,7 +25887,7 @@ impl Playlist {
         <Self as RtActivatable<IPlaylistStatics>>::get_activation_factory().load_async(file)
     }}
 }
-DEFINE_CLSID!(Playlist(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,108,105,115,116,115,46,80,108,97,121,108,105,115,116,0]) [CLSID_Playlist]);
+DEFINE_CLSID!(Playlist: "Windows.Media.Playlists.Playlist");
 RT_ENUM! { enum PlaylistFormat: i32 {
     WindowsMedia (PlaylistFormat_WindowsMedia) = 0, Zune (PlaylistFormat_Zune) = 1, M3u (PlaylistFormat_M3u) = 2,
 }}

--- a/src/rt/gen/windows/networking.rs
+++ b/src/rt/gen/windows/networking.rs
@@ -58,7 +58,7 @@ impl EndpointPair {
         <Self as RtActivatable<IEndpointPairFactory>>::get_activation_factory().create_endpoint_pair(localHostName, localServiceName, remoteHostName, remoteServiceName)
     }}
 }
-DEFINE_CLSID!(EndpointPair(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,69,110,100,112,111,105,110,116,80,97,105,114,0]) [CLSID_EndpointPair]);
+DEFINE_CLSID!(EndpointPair: "Windows.Networking.EndpointPair");
 DEFINE_IID!(IID_IEndpointPairFactory, 3054098801, 25824, 17451, 170, 111, 204, 140, 143, 24, 31, 120);
 RT_INTERFACE!{static interface IEndpointPairFactory(IEndpointPairFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEndpointPairFactory] {
     fn CreateEndpointPair(&self, localHostName: *mut HostName, localServiceName: HSTRING, remoteHostName: *mut HostName, remoteServiceName: HSTRING, out: *mut *mut EndpointPair) -> HRESULT
@@ -122,7 +122,7 @@ impl HostName {
         <Self as RtActivatable<IHostNameStatics>>::get_activation_factory().compare(value1, value2)
     }}
 }
-DEFINE_CLSID!(HostName(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,72,111,115,116,78,97,109,101,0]) [CLSID_HostName]);
+DEFINE_CLSID!(HostName: "Windows.Networking.HostName");
 DEFINE_IID!(IID_IHostNameFactory, 1166812141, 28975, 17782, 173, 241, 194, 11, 44, 100, 53, 88);
 RT_INTERFACE!{static interface IHostNameFactory(IHostNameFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHostNameFactory] {
     fn CreateHostName(&self, hostName: HSTRING, out: *mut *mut HostName) -> HRESULT
@@ -219,7 +219,7 @@ impl HotspotAuthenticationContext {
         <Self as RtActivatable<IHotspotAuthenticationContextStatics>>::get_activation_factory().try_get_authentication_context(evenToken)
     }}
 }
-DEFINE_CLSID!(HotspotAuthenticationContext(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,72,111,116,115,112,111,116,65,117,116,104,101,110,116,105,99,97,116,105,111,110,67,111,110,116,101,120,116,0]) [CLSID_HotspotAuthenticationContext]);
+DEFINE_CLSID!(HotspotAuthenticationContext: "Windows.Networking.NetworkOperators.HotspotAuthenticationContext");
 DEFINE_IID!(IID_IHotspotAuthenticationContext2, 3881224081, 4100, 19941, 131, 199, 222, 97, 216, 136, 49, 208);
 RT_INTERFACE!{interface IHotspotAuthenticationContext2(IHotspotAuthenticationContext2Vtbl): IInspectable(IInspectableVtbl) [IID_IHotspotAuthenticationContext2] {
     fn IssueCredentialsAsync(&self, userName: HSTRING, password: HSTRING, extraParameters: HSTRING, markAsManualConnectOnFailure: bool, out: *mut *mut super::super::foundation::IAsyncOperation<HotspotCredentialsAuthenticationResult>) -> HRESULT
@@ -300,7 +300,7 @@ impl KnownCSimFilePaths {
         <Self as RtActivatable<IKnownCSimFilePathsStatics>>::get_activation_factory().get_gid2()
     }}
 }
-DEFINE_CLSID!(KnownCSimFilePaths(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,75,110,111,119,110,67,83,105,109,70,105,108,101,80,97,116,104,115,0]) [CLSID_KnownCSimFilePaths]);
+DEFINE_CLSID!(KnownCSimFilePaths: "Windows.Networking.NetworkOperators.KnownCSimFilePaths");
 DEFINE_IID!(IID_IKnownCSimFilePathsStatics, 3025710829, 18929, 19490, 176, 115, 150, 213, 17, 191, 156, 53);
 RT_INTERFACE!{static interface IKnownCSimFilePathsStatics(IKnownCSimFilePathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownCSimFilePathsStatics] {
     fn get_EFSpn(&self, out: *mut *mut super::super::foundation::collections::IVectorView<u32>) -> HRESULT,
@@ -337,7 +337,7 @@ impl KnownRuimFilePaths {
         <Self as RtActivatable<IKnownRuimFilePathsStatics>>::get_activation_factory().get_gid2()
     }}
 }
-DEFINE_CLSID!(KnownRuimFilePaths(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,75,110,111,119,110,82,117,105,109,70,105,108,101,80,97,116,104,115,0]) [CLSID_KnownRuimFilePaths]);
+DEFINE_CLSID!(KnownRuimFilePaths: "Windows.Networking.NetworkOperators.KnownRuimFilePaths");
 DEFINE_IID!(IID_IKnownRuimFilePathsStatics, 948160697, 65316, 17777, 168, 103, 9, 249, 96, 66, 110, 20);
 RT_INTERFACE!{static interface IKnownRuimFilePathsStatics(IKnownRuimFilePathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownRuimFilePathsStatics] {
     fn get_EFSpn(&self, out: *mut *mut super::super::foundation::collections::IVectorView<u32>) -> HRESULT,
@@ -377,7 +377,7 @@ impl KnownSimFilePaths {
         <Self as RtActivatable<IKnownSimFilePathsStatics>>::get_activation_factory().get_gid2()
     }}
 }
-DEFINE_CLSID!(KnownSimFilePaths(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,75,110,111,119,110,83,105,109,70,105,108,101,80,97,116,104,115,0]) [CLSID_KnownSimFilePaths]);
+DEFINE_CLSID!(KnownSimFilePaths: "Windows.Networking.NetworkOperators.KnownSimFilePaths");
 DEFINE_IID!(IID_IKnownSimFilePathsStatics, 2160925283, 14245, 17363, 128, 163, 204, 210, 62, 143, 236, 238);
 RT_INTERFACE!{static interface IKnownSimFilePathsStatics(IKnownSimFilePathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownSimFilePathsStatics] {
     fn get_EFOns(&self, out: *mut *mut super::super::foundation::collections::IVectorView<u32>) -> HRESULT,
@@ -426,7 +426,7 @@ impl KnownUSimFilePaths {
         <Self as RtActivatable<IKnownUSimFilePathsStatics>>::get_activation_factory().get_gid2()
     }}
 }
-DEFINE_CLSID!(KnownUSimFilePaths(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,75,110,111,119,110,85,83,105,109,70,105,108,101,80,97,116,104,115,0]) [CLSID_KnownUSimFilePaths]);
+DEFINE_CLSID!(KnownUSimFilePaths: "Windows.Networking.NetworkOperators.KnownUSimFilePaths");
 DEFINE_IID!(IID_IKnownUSimFilePathsStatics, 2083841409, 7963, 17396, 149, 48, 139, 9, 45, 50, 215, 31);
 RT_INTERFACE!{static interface IKnownUSimFilePathsStatics(IKnownUSimFilePathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownUSimFilePathsStatics] {
     fn get_EFSpn(&self, out: *mut *mut super::super::foundation::collections::IVectorView<u32>) -> HRESULT,
@@ -507,7 +507,7 @@ impl MobileBroadbandAccount {
         <Self as RtActivatable<IMobileBroadbandAccountStatics>>::get_activation_factory().create_from_network_account_id(networkAccountId)
     }}
 }
-DEFINE_CLSID!(MobileBroadbandAccount(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,65,99,99,111,117,110,116,0]) [CLSID_MobileBroadbandAccount]);
+DEFINE_CLSID!(MobileBroadbandAccount: "Windows.Networking.NetworkOperators.MobileBroadbandAccount");
 DEFINE_IID!(IID_IMobileBroadbandAccount2, 955592476, 4406, 16983, 149, 159, 182, 88, 163, 82, 182, 212);
 RT_INTERFACE!{interface IMobileBroadbandAccount2(IMobileBroadbandAccount2Vtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandAccount2] {
     fn GetConnectionProfiles(&self, out: *mut *mut super::super::foundation::collections::IVectorView<super::connectivity::ConnectionProfile>) -> HRESULT
@@ -661,7 +661,7 @@ impl IMobileBroadbandAccountWatcher {
 }
 RT_CLASS!{class MobileBroadbandAccountWatcher: IMobileBroadbandAccountWatcher}
 impl RtActivatable<IActivationFactory> for MobileBroadbandAccountWatcher {}
-DEFINE_CLSID!(MobileBroadbandAccountWatcher(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,65,99,99,111,117,110,116,87,97,116,99,104,101,114,0]) [CLSID_MobileBroadbandAccountWatcher]);
+DEFINE_CLSID!(MobileBroadbandAccountWatcher: "Windows.Networking.NetworkOperators.MobileBroadbandAccountWatcher");
 RT_ENUM! { enum MobileBroadbandAccountWatcherStatus: i32 {
     Created (MobileBroadbandAccountWatcherStatus_Created) = 0, Started (MobileBroadbandAccountWatcherStatus_Started) = 1, EnumerationCompleted (MobileBroadbandAccountWatcherStatus_EnumerationCompleted) = 2, Stopped (MobileBroadbandAccountWatcherStatus_Stopped) = 3, Aborted (MobileBroadbandAccountWatcherStatus_Aborted) = 4,
 }}
@@ -1393,7 +1393,7 @@ impl MobileBroadbandModem {
         <Self as RtActivatable<IMobileBroadbandModemStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(MobileBroadbandModem(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,77,111,100,101,109,0]) [CLSID_MobileBroadbandModem]);
+DEFINE_CLSID!(MobileBroadbandModem: "Windows.Networking.NetworkOperators.MobileBroadbandModem");
 DEFINE_IID!(IID_IMobileBroadbandModem2, 310782760, 47595, 20194, 187, 227, 113, 31, 83, 238, 163, 115);
 RT_INTERFACE!{interface IMobileBroadbandModem2(IMobileBroadbandModem2Vtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandModem2] {
     fn GetIsPassthroughEnabledAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -2099,7 +2099,7 @@ impl INetworkOperatorTetheringAccessPointConfiguration {
 }
 RT_CLASS!{class NetworkOperatorTetheringAccessPointConfiguration: INetworkOperatorTetheringAccessPointConfiguration}
 impl RtActivatable<IActivationFactory> for NetworkOperatorTetheringAccessPointConfiguration {}
-DEFINE_CLSID!(NetworkOperatorTetheringAccessPointConfiguration(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,84,101,116,104,101,114,105,110,103,65,99,99,101,115,115,80,111,105,110,116,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_NetworkOperatorTetheringAccessPointConfiguration]);
+DEFINE_CLSID!(NetworkOperatorTetheringAccessPointConfiguration: "Windows.Networking.NetworkOperators.NetworkOperatorTetheringAccessPointConfiguration");
 DEFINE_IID!(IID_INetworkOperatorTetheringClient, 1889346892, 22879, 18503, 187, 48, 100, 105, 53, 84, 41, 24);
 RT_INTERFACE!{interface INetworkOperatorTetheringClient(INetworkOperatorTetheringClientVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorTetheringClient] {
     fn get_MacAddress(&self, out: *mut HSTRING) -> HRESULT,
@@ -2207,7 +2207,7 @@ impl NetworkOperatorTetheringManager {
         <Self as RtActivatable<INetworkOperatorTetheringManagerStatics3>>::get_activation_factory().create_from_connection_profile_with_target_adapter(profile, adapter)
     }}
 }
-DEFINE_CLSID!(NetworkOperatorTetheringManager(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,84,101,116,104,101,114,105,110,103,77,97,110,97,103,101,114,0]) [CLSID_NetworkOperatorTetheringManager]);
+DEFINE_CLSID!(NetworkOperatorTetheringManager: "Windows.Networking.NetworkOperators.NetworkOperatorTetheringManager");
 DEFINE_IID!(IID_INetworkOperatorTetheringManagerStatics, 1052555980, 63683, 16476, 153, 100, 112, 161, 238, 171, 225, 148);
 RT_INTERFACE!{static interface INetworkOperatorTetheringManagerStatics(INetworkOperatorTetheringManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorTetheringManagerStatics] {
     fn GetTetheringCapability(&self, networkAccountId: HSTRING, out: *mut TetheringCapability) -> HRESULT,
@@ -2339,7 +2339,7 @@ impl ProvisioningAgent {
         <Self as RtActivatable<IProvisioningAgentStaticMethods>>::get_activation_factory().create_from_network_account_id(networkAccountId)
     }}
 }
-DEFINE_CLSID!(ProvisioningAgent(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,80,114,111,118,105,115,105,111,110,105,110,103,65,103,101,110,116,0]) [CLSID_ProvisioningAgent]);
+DEFINE_CLSID!(ProvisioningAgent: "Windows.Networking.NetworkOperators.ProvisioningAgent");
 DEFINE_IID!(IID_IProvisioningAgentStaticMethods, 561447136, 33025, 4575, 173, 185, 244, 206, 70, 45, 145, 55);
 RT_INTERFACE!{static interface IProvisioningAgentStaticMethods(IProvisioningAgentStaticMethodsVtbl): IInspectable(IInspectableVtbl) [IID_IProvisioningAgentStaticMethods] {
     fn CreateFromNetworkAccountId(&self, networkAccountId: HSTRING, out: *mut *mut ProvisioningAgent) -> HRESULT
@@ -2414,7 +2414,7 @@ impl UssdMessage {
         <Self as RtActivatable<IUssdMessageFactory>>::get_activation_factory().create_message(messageText)
     }}
 }
-DEFINE_CLSID!(UssdMessage(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,85,115,115,100,77,101,115,115,97,103,101,0]) [CLSID_UssdMessage]);
+DEFINE_CLSID!(UssdMessage: "Windows.Networking.NetworkOperators.UssdMessage");
 DEFINE_IID!(IID_IUssdMessageFactory, 798674818, 4099, 19805, 191, 129, 42, 186, 27, 75, 228, 168);
 RT_INTERFACE!{static interface IUssdMessageFactory(IUssdMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IUssdMessageFactory] {
     fn CreateMessage(&self, messageText: HSTRING, out: *mut *mut UssdMessage) -> HRESULT
@@ -2473,7 +2473,7 @@ impl UssdSession {
         <Self as RtActivatable<IUssdSessionStatics>>::get_activation_factory().create_from_network_interface_id(networkInterfaceId)
     }}
 }
-DEFINE_CLSID!(UssdSession(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,85,115,115,100,83,101,115,115,105,111,110,0]) [CLSID_UssdSession]);
+DEFINE_CLSID!(UssdSession: "Windows.Networking.NetworkOperators.UssdSession");
 DEFINE_IID!(IID_IUssdSessionStatics, 798674818, 4097, 19805, 191, 129, 42, 186, 27, 75, 228, 168);
 RT_INTERFACE!{static interface IUssdSessionStatics(IUssdSessionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUssdSessionStatics] {
     fn CreateFromNetworkAccountId(&self, networkAccountId: HSTRING, out: *mut *mut UssdSession) -> HRESULT,
@@ -2606,7 +2606,7 @@ impl ICellularApnContext {
 }
 RT_CLASS!{class CellularApnContext: ICellularApnContext}
 impl RtActivatable<IActivationFactory> for CellularApnContext {}
-DEFINE_CLSID!(CellularApnContext(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,67,101,108,108,117,108,97,114,65,112,110,67,111,110,116,101,120,116,0]) [CLSID_CellularApnContext]);
+DEFINE_CLSID!(CellularApnContext: "Windows.Networking.Connectivity.CellularApnContext");
 DEFINE_IID!(IID_IConnectionCost, 3134707753, 13334, 19216, 162, 2, 186, 192, 176, 117, 189, 174);
 RT_INTERFACE!{interface IConnectionCost(IConnectionCostVtbl): IInspectable(IInspectableVtbl) [IID_IConnectionCost] {
     fn get_NetworkCostType(&self, out: *mut NetworkCostType) -> HRESULT,
@@ -2851,7 +2851,7 @@ impl IConnectionProfileFilter {
 }
 RT_CLASS!{class ConnectionProfileFilter: IConnectionProfileFilter}
 impl RtActivatable<IActivationFactory> for ConnectionProfileFilter {}
-DEFINE_CLSID!(ConnectionProfileFilter(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,67,111,110,110,101,99,116,105,111,110,80,114,111,102,105,108,101,70,105,108,116,101,114,0]) [CLSID_ConnectionProfileFilter]);
+DEFINE_CLSID!(ConnectionProfileFilter: "Windows.Networking.Connectivity.ConnectionProfileFilter");
 DEFINE_IID!(IID_IConnectionProfileFilter2, 3439759073, 50172, 20397, 157, 220, 89, 63, 170, 75, 120, 133);
 RT_INTERFACE!{interface IConnectionProfileFilter2(IConnectionProfileFilter2Vtbl): IInspectable(IInspectableVtbl) [IID_IConnectionProfileFilter2] {
     fn put_IsRoaming(&self, value: *mut super::super::foundation::IReference<bool>) -> HRESULT,
@@ -2939,7 +2939,7 @@ impl ConnectivityManager {
         <Self as RtActivatable<IConnectivityManagerStatics>>::get_activation_factory().remove_http_route_policy(routePolicy)
     }}
 }
-DEFINE_CLSID!(ConnectivityManager(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,67,111,110,110,101,99,116,105,118,105,116,121,77,97,110,97,103,101,114,0]) [CLSID_ConnectivityManager]);
+DEFINE_CLSID!(ConnectivityManager: "Windows.Networking.Connectivity.ConnectivityManager");
 DEFINE_IID!(IID_IConnectivityManagerStatics, 1361106097, 20401, 18608, 175, 201, 66, 224, 9, 42, 129, 100);
 RT_INTERFACE!{static interface IConnectivityManagerStatics(IConnectivityManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IConnectivityManagerStatics] {
     fn AcquireConnectionAsync(&self, cellularApnContext: *mut CellularApnContext, out: *mut *mut super::super::foundation::IAsyncOperation<ConnectionSession>) -> HRESULT,
@@ -3190,7 +3190,7 @@ impl NetworkInformation {
         <Self as RtActivatable<INetworkInformationStatics2>>::get_activation_factory().find_connection_profiles_async(pProfileFilter)
     }}
 }
-DEFINE_CLSID!(NetworkInformation(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,78,101,116,119,111,114,107,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_NetworkInformation]);
+DEFINE_CLSID!(NetworkInformation: "Windows.Networking.Connectivity.NetworkInformation");
 DEFINE_IID!(IID_INetworkInformationStatics, 1349843025, 38157, 16741, 156, 21, 54, 86, 25, 72, 30, 234);
 RT_INTERFACE!{static interface INetworkInformationStatics(INetworkInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_INetworkInformationStatics] {
     fn GetConnectionProfiles(&self, out: *mut *mut super::super::foundation::collections::IVectorView<ConnectionProfile>) -> HRESULT,
@@ -3465,7 +3465,7 @@ impl RoutePolicy {
         <Self as RtActivatable<IRoutePolicyFactory>>::get_activation_factory().create_route_policy(connectionProfile, hostName, type_)
     }}
 }
-DEFINE_CLSID!(RoutePolicy(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,82,111,117,116,101,80,111,108,105,99,121,0]) [CLSID_RoutePolicy]);
+DEFINE_CLSID!(RoutePolicy: "Windows.Networking.Connectivity.RoutePolicy");
 DEFINE_IID!(IID_IRoutePolicyFactory, 906131763, 41358, 19893, 166, 151, 245, 143, 167, 54, 78, 68);
 RT_INTERFACE!{static interface IRoutePolicyFactory(IRoutePolicyFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRoutePolicyFactory] {
     fn CreateRoutePolicy(&self, connectionProfile: *mut ConnectionProfile, hostName: *mut super::HostName, type_: super::DomainNameType, out: *mut *mut RoutePolicy) -> HRESULT
@@ -3577,7 +3577,7 @@ impl BackgroundDownloader {
         <Self as RtActivatable<IBackgroundDownloaderUserConsent>>::get_activation_factory().request_unconstrained_downloads_async(operations)
     }}
 }
-DEFINE_CLSID!(BackgroundDownloader(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,68,111,119,110,108,111,97,100,101,114,0]) [CLSID_BackgroundDownloader]);
+DEFINE_CLSID!(BackgroundDownloader: "Windows.Networking.BackgroundTransfer.BackgroundDownloader");
 DEFINE_IID!(IID_IBackgroundDownloader2, 2840221767, 13453, 18997, 137, 14, 138, 30, 243, 121, 132, 121);
 RT_INTERFACE!{interface IBackgroundDownloader2(IBackgroundDownloader2Vtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundDownloader2] {
     fn get_TransferGroup(&self, out: *mut *mut BackgroundTransferGroup) -> HRESULT,
@@ -3799,7 +3799,7 @@ impl IBackgroundTransferCompletionGroup {
 }
 RT_CLASS!{class BackgroundTransferCompletionGroup: IBackgroundTransferCompletionGroup}
 impl RtActivatable<IActivationFactory> for BackgroundTransferCompletionGroup {}
-DEFINE_CLSID!(BackgroundTransferCompletionGroup(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,67,111,109,112,108,101,116,105,111,110,71,114,111,117,112,0]) [CLSID_BackgroundTransferCompletionGroup]);
+DEFINE_CLSID!(BackgroundTransferCompletionGroup: "Windows.Networking.BackgroundTransfer.BackgroundTransferCompletionGroup");
 DEFINE_IID!(IID_IBackgroundTransferCompletionGroupTriggerDetails, 2070667910, 28231, 20790, 127, 203, 250, 67, 137, 244, 111, 91);
 RT_INTERFACE!{interface IBackgroundTransferCompletionGroupTriggerDetails(IBackgroundTransferCompletionGroupTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTransferCompletionGroupTriggerDetails] {
     fn get_Downloads(&self, out: *mut *mut super::super::foundation::collections::IVectorView<DownloadOperation>) -> HRESULT,
@@ -3849,7 +3849,7 @@ impl BackgroundTransferContentPart {
         <Self as RtActivatable<IBackgroundTransferContentPartFactory>>::get_activation_factory().create_with_name_and_file_name(name, fileName)
     }}
 }
-DEFINE_CLSID!(BackgroundTransferContentPart(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,67,111,110,116,101,110,116,80,97,114,116,0]) [CLSID_BackgroundTransferContentPart]);
+DEFINE_CLSID!(BackgroundTransferContentPart: "Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart");
 DEFINE_IID!(IID_IBackgroundTransferContentPartFactory, 2431621289, 31233, 18955, 159, 128, 160, 176, 187, 55, 15, 141);
 RT_INTERFACE!{static interface IBackgroundTransferContentPartFactory(IBackgroundTransferContentPartFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTransferContentPartFactory] {
     fn CreateWithName(&self, name: HSTRING, out: *mut *mut BackgroundTransferContentPart) -> HRESULT,
@@ -3877,7 +3877,7 @@ impl BackgroundTransferError {
         <Self as RtActivatable<IBackgroundTransferErrorStaticMethods>>::get_activation_factory().get_status(hresult)
     }}
 }
-DEFINE_CLSID!(BackgroundTransferError(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,69,114,114,111,114,0]) [CLSID_BackgroundTransferError]);
+DEFINE_CLSID!(BackgroundTransferError: "Windows.Networking.BackgroundTransfer.BackgroundTransferError");
 DEFINE_IID!(IID_IBackgroundTransferErrorStaticMethods, 2865969924, 4498, 19444, 139, 104, 57, 197, 173, 210, 68, 226);
 RT_INTERFACE!{static interface IBackgroundTransferErrorStaticMethods(IBackgroundTransferErrorStaticMethodsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTransferErrorStaticMethods] {
     #[cfg(feature="windows-web")] fn GetStatus(&self, hresult: i32, out: *mut super::super::web::WebErrorStatus) -> HRESULT
@@ -3921,7 +3921,7 @@ impl BackgroundTransferGroup {
         <Self as RtActivatable<IBackgroundTransferGroupStatics>>::get_activation_factory().create_group(name)
     }}
 }
-DEFINE_CLSID!(BackgroundTransferGroup(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,71,114,111,117,112,0]) [CLSID_BackgroundTransferGroup]);
+DEFINE_CLSID!(BackgroundTransferGroup: "Windows.Networking.BackgroundTransfer.BackgroundTransferGroup");
 DEFINE_IID!(IID_IBackgroundTransferGroupStatics, 49041586, 32024, 18779, 170, 34, 50, 169, 125, 69, 211, 226);
 RT_INTERFACE!{static interface IBackgroundTransferGroupStatics(IBackgroundTransferGroupStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTransferGroupStatics] {
     fn CreateGroup(&self, name: HSTRING, out: *mut *mut BackgroundTransferGroup) -> HRESULT
@@ -4092,7 +4092,7 @@ impl BackgroundUploader {
         <Self as RtActivatable<IBackgroundUploaderUserConsent>>::get_activation_factory().request_unconstrained_uploads_async(operations)
     }}
 }
-DEFINE_CLSID!(BackgroundUploader(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,85,112,108,111,97,100,101,114,0]) [CLSID_BackgroundUploader]);
+DEFINE_CLSID!(BackgroundUploader: "Windows.Networking.BackgroundTransfer.BackgroundUploader");
 DEFINE_IID!(IID_IBackgroundUploader2, 2382762702, 3124, 17507, 128, 127, 25, 138, 27, 139, 212, 173);
 RT_INTERFACE!{interface IBackgroundUploader2(IBackgroundUploader2Vtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundUploader2] {
     fn get_TransferGroup(&self, out: *mut *mut BackgroundTransferGroup) -> HRESULT,
@@ -4256,7 +4256,7 @@ impl ContentPrefetcher {
         <Self as RtActivatable<IContentPrefetcherTime>>::get_activation_factory().get_last_successful_prefetch_time()
     }}
 }
-DEFINE_CLSID!(ContentPrefetcher(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,67,111,110,116,101,110,116,80,114,101,102,101,116,99,104,101,114,0]) [CLSID_ContentPrefetcher]);
+DEFINE_CLSID!(ContentPrefetcher: "Windows.Networking.BackgroundTransfer.ContentPrefetcher");
 DEFINE_IID!(IID_IContentPrefetcherTime, 3814849800, 4906, 20446, 167, 204, 252, 176, 230, 101, 35, 175);
 RT_INTERFACE!{static interface IContentPrefetcherTime(IContentPrefetcherTimeVtbl): IInspectable(IInspectableVtbl) [IID_IContentPrefetcherTime] {
     fn get_LastSuccessfulPrefetchTime(&self, out: *mut *mut super::super::foundation::IReference<super::super::foundation::DateTime>) -> HRESULT
@@ -4596,7 +4596,7 @@ impl PeerFinder {
         <Self as RtActivatable<IPeerFinderStatics2>>::get_activation_factory().create_watcher()
     }}
 }
-DEFINE_CLSID!(PeerFinder(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,80,114,111,120,105,109,105,116,121,46,80,101,101,114,70,105,110,100,101,114,0]) [CLSID_PeerFinder]);
+DEFINE_CLSID!(PeerFinder: "Windows.Networking.Proximity.PeerFinder");
 DEFINE_IID!(IID_IPeerFinderStatics, 2437626721, 63201, 18372, 161, 76, 20, 138, 25, 3, 208, 198);
 RT_INTERFACE!{static interface IPeerFinderStatics(IPeerFinderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPeerFinderStatics] {
     fn get_AllowBluetooth(&self, out: *mut bool) -> HRESULT,
@@ -4983,7 +4983,7 @@ impl ProximityDevice {
         <Self as RtActivatable<IProximityDeviceStatics>>::get_activation_factory().from_id(deviceId)
     }}
 }
-DEFINE_CLSID!(ProximityDevice(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,80,114,111,120,105,109,105,116,121,46,80,114,111,120,105,109,105,116,121,68,101,118,105,99,101,0]) [CLSID_ProximityDevice]);
+DEFINE_CLSID!(ProximityDevice: "Windows.Networking.Proximity.ProximityDevice");
 DEFINE_IID!(IID_IProximityDeviceStatics, 2437652509, 63201, 18372, 161, 76, 20, 138, 25, 3, 208, 198);
 RT_INTERFACE!{static interface IProximityDeviceStatics(IProximityDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IProximityDeviceStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -5094,7 +5094,7 @@ impl IDnssdRegistrationResult {
 }
 RT_CLASS!{class DnssdRegistrationResult: IDnssdRegistrationResult}
 impl RtActivatable<IActivationFactory> for DnssdRegistrationResult {}
-DEFINE_CLSID!(DnssdRegistrationResult(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,101,114,118,105,99,101,68,105,115,99,111,118,101,114,121,46,68,110,115,115,100,46,68,110,115,115,100,82,101,103,105,115,116,114,97,116,105,111,110,82,101,115,117,108,116,0]) [CLSID_DnssdRegistrationResult]);
+DEFINE_CLSID!(DnssdRegistrationResult: "Windows.Networking.ServiceDiscovery.Dnssd.DnssdRegistrationResult");
 RT_ENUM! { enum DnssdRegistrationStatus: i32 {
     Success (DnssdRegistrationStatus_Success) = 0, InvalidServiceName (DnssdRegistrationStatus_InvalidServiceName) = 1, ServerError (DnssdRegistrationStatus_ServerError) = 2, SecurityError (DnssdRegistrationStatus_SecurityError) = 3,
 }}
@@ -5195,7 +5195,7 @@ impl DnssdServiceInstance {
         <Self as RtActivatable<IDnssdServiceInstanceFactory>>::get_activation_factory().create(dnssdServiceInstanceName, hostName, port)
     }}
 }
-DEFINE_CLSID!(DnssdServiceInstance(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,101,114,118,105,99,101,68,105,115,99,111,118,101,114,121,46,68,110,115,115,100,46,68,110,115,115,100,83,101,114,118,105,99,101,73,110,115,116,97,110,99,101,0]) [CLSID_DnssdServiceInstance]);
+DEFINE_CLSID!(DnssdServiceInstance: "Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceInstance");
 RT_CLASS!{class DnssdServiceInstanceCollection: ::rt::gen::windows::foundation::collections::IVectorView<DnssdServiceInstance>}
 DEFINE_IID!(IID_IDnssdServiceInstanceFactory, 1823498657, 50296, 17201, 150, 132, 74, 242, 24, 108, 10, 43);
 RT_INTERFACE!{static interface IDnssdServiceInstanceFactory(IDnssdServiceInstanceFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDnssdServiceInstanceFactory] {
@@ -5352,7 +5352,7 @@ impl ControlChannelTrigger {
         <Self as RtActivatable<IControlChannelTriggerFactory>>::get_activation_factory().create_control_channel_trigger_ex(channelId, serverKeepAliveIntervalInMinutes, resourceRequestType)
     }}
 }
-DEFINE_CLSID!(ControlChannelTrigger(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,67,111,110,116,114,111,108,67,104,97,110,110,101,108,84,114,105,103,103,101,114,0]) [CLSID_ControlChannelTrigger]);
+DEFINE_CLSID!(ControlChannelTrigger: "Windows.Networking.Sockets.ControlChannelTrigger");
 DEFINE_IID!(IID_IControlChannelTrigger2, 2936066615, 20926, 17684, 151, 37, 53, 86, 225, 135, 149, 128);
 RT_INTERFACE!{interface IControlChannelTrigger2(IControlChannelTrigger2Vtbl): IInspectable(IInspectableVtbl) [IID_IControlChannelTrigger2] {
     fn get_IsWakeFromLowPowerSupported(&self, out: *mut bool) -> HRESULT
@@ -5513,7 +5513,7 @@ impl DatagramSocket {
         <Self as RtActivatable<IDatagramSocketStatics>>::get_activation_factory().get_endpoint_pairs_with_sort_options_async(remoteHostName, remoteServiceName, sortOptions)
     }}
 }
-DEFINE_CLSID!(DatagramSocket(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,68,97,116,97,103,114,97,109,83,111,99,107,101,116,0]) [CLSID_DatagramSocket]);
+DEFINE_CLSID!(DatagramSocket: "Windows.Networking.Sockets.DatagramSocket");
 DEFINE_IID!(IID_IDatagramSocket2, 3627787092, 39581, 16773, 162, 10, 20, 36, 201, 194, 167, 205);
 RT_INTERFACE!{interface IDatagramSocket2(IDatagramSocket2Vtbl): IInspectable(IInspectableVtbl) [IID_IDatagramSocket2] {
     fn BindServiceNameAndAdapterAsync(&self, localServiceName: HSTRING, adapter: *mut super::connectivity::NetworkAdapter, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT
@@ -5745,7 +5745,7 @@ impl IMessageWebSocket {
 }
 RT_CLASS!{class MessageWebSocket: IMessageWebSocket}
 impl RtActivatable<IActivationFactory> for MessageWebSocket {}
-DEFINE_CLSID!(MessageWebSocket(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,77,101,115,115,97,103,101,87,101,98,83,111,99,107,101,116,0]) [CLSID_MessageWebSocket]);
+DEFINE_CLSID!(MessageWebSocket: "Windows.Networking.Sockets.MessageWebSocket");
 DEFINE_IID!(IID_IMessageWebSocket2, 3201355495, 63944, 17418, 154, 213, 115, 114, 129, 217, 116, 46);
 RT_INTERFACE!{interface IMessageWebSocket2(IMessageWebSocket2Vtbl): IInspectable(IInspectableVtbl) [IID_IMessageWebSocket2] {
     fn add_ServerCustomValidationRequested(&self, eventHandler: *mut super::super::foundation::TypedEventHandler<MessageWebSocket, WebSocketServerCustomValidationRequestedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -5897,7 +5897,7 @@ impl SocketActivityContext {
         <Self as RtActivatable<ISocketActivityContextFactory>>::get_activation_factory().create(data)
     }}
 }
-DEFINE_CLSID!(SocketActivityContext(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,111,99,107,101,116,65,99,116,105,118,105,116,121,67,111,110,116,101,120,116,0]) [CLSID_SocketActivityContext]);
+DEFINE_CLSID!(SocketActivityContext: "Windows.Networking.Sockets.SocketActivityContext");
 DEFINE_IID!(IID_ISocketActivityContextFactory, 3114255299, 2188, 17288, 131, 174, 37, 37, 19, 142, 4, 154);
 RT_INTERFACE!{static interface ISocketActivityContextFactory(ISocketActivityContextFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISocketActivityContextFactory] {
     #[cfg(feature="windows-storage")] fn Create(&self, data: *mut super::super::storage::streams::IBuffer, out: *mut *mut SocketActivityContext) -> HRESULT
@@ -5963,7 +5963,7 @@ impl SocketActivityInformation {
         <Self as RtActivatable<ISocketActivityInformationStatics>>::get_activation_factory().get_all_sockets()
     }}
 }
-DEFINE_CLSID!(SocketActivityInformation(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,111,99,107,101,116,65,99,116,105,118,105,116,121,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_SocketActivityInformation]);
+DEFINE_CLSID!(SocketActivityInformation: "Windows.Networking.Sockets.SocketActivityInformation");
 DEFINE_IID!(IID_ISocketActivityInformationStatics, 2238755962, 32381, 18230, 128, 65, 19, 39, 166, 84, 60, 86);
 RT_INTERFACE!{static interface ISocketActivityInformationStatics(ISocketActivityInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISocketActivityInformationStatics] {
     fn get_AllSockets(&self, out: *mut *mut super::super::foundation::collections::IMapView<HString, SocketActivityInformation>) -> HRESULT
@@ -6006,7 +6006,7 @@ impl SocketError {
         <Self as RtActivatable<ISocketErrorStatics>>::get_activation_factory().get_status(hresult)
     }}
 }
-DEFINE_CLSID!(SocketError(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,111,99,107,101,116,69,114,114,111,114,0]) [CLSID_SocketError]);
+DEFINE_CLSID!(SocketError: "Windows.Networking.Sockets.SocketError");
 DEFINE_IID!(IID_ISocketErrorStatics, 2189637620, 32086, 19854, 183, 180, 160, 125, 215, 193, 188, 169);
 RT_INTERFACE!{static interface ISocketErrorStatics(ISocketErrorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISocketErrorStatics] {
     fn GetStatus(&self, hresult: i32, out: *mut SocketErrorStatus) -> HRESULT
@@ -6105,7 +6105,7 @@ impl StreamSocket {
         <Self as RtActivatable<IStreamSocketStatics>>::get_activation_factory().get_endpoint_pairs_with_sort_options_async(remoteHostName, remoteServiceName, sortOptions)
     }}
 }
-DEFINE_CLSID!(StreamSocket(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,116,114,101,97,109,83,111,99,107,101,116,0]) [CLSID_StreamSocket]);
+DEFINE_CLSID!(StreamSocket: "Windows.Networking.Sockets.StreamSocket");
 DEFINE_IID!(IID_IStreamSocket2, 701556085, 62228, 19721, 173, 240, 15, 189, 150, 127, 189, 159);
 RT_INTERFACE!{interface IStreamSocket2(IStreamSocket2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocket2] {
     fn ConnectWithProtectionLevelAndAdapterAsync(&self, remoteHostName: *mut super::HostName, remoteServiceName: HSTRING, protectionLevel: SocketProtectionLevel, adapter: *mut super::connectivity::NetworkAdapter, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT
@@ -6405,7 +6405,7 @@ impl IStreamSocketListener {
 }
 RT_CLASS!{class StreamSocketListener: IStreamSocketListener}
 impl RtActivatable<IActivationFactory> for StreamSocketListener {}
-DEFINE_CLSID!(StreamSocketListener(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,116,114,101,97,109,83,111,99,107,101,116,76,105,115,116,101,110,101,114,0]) [CLSID_StreamSocketListener]);
+DEFINE_CLSID!(StreamSocketListener: "Windows.Networking.Sockets.StreamSocketListener");
 DEFINE_IID!(IID_IStreamSocketListener2, 1703788862, 47934, 17496, 178, 50, 237, 16, 136, 105, 75, 152);
 RT_INTERFACE!{interface IStreamSocketListener2(IStreamSocketListener2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocketListener2] {
     fn BindServiceNameWithProtectionLevelAsync(&self, localServiceName: HSTRING, protectionLevel: SocketProtectionLevel, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT,
@@ -6586,7 +6586,7 @@ impl IStreamWebSocket {
 }
 RT_CLASS!{class StreamWebSocket: IStreamWebSocket}
 impl RtActivatable<IActivationFactory> for StreamWebSocket {}
-DEFINE_CLSID!(StreamWebSocket(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,116,114,101,97,109,87,101,98,83,111,99,107,101,116,0]) [CLSID_StreamWebSocket]);
+DEFINE_CLSID!(StreamWebSocket: "Windows.Networking.Sockets.StreamWebSocket");
 DEFINE_IID!(IID_IStreamWebSocket2, 2857175243, 37877, 18040, 130, 54, 87, 204, 229, 65, 126, 213);
 RT_INTERFACE!{interface IStreamWebSocket2(IStreamWebSocket2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamWebSocket2] {
     fn add_ServerCustomValidationRequested(&self, eventHandler: *mut super::super::foundation::TypedEventHandler<StreamWebSocket, WebSocketServerCustomValidationRequestedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -6777,7 +6777,7 @@ impl WebSocketError {
         <Self as RtActivatable<IWebSocketErrorStatics>>::get_activation_factory().get_status(hresult)
     }}
 }
-DEFINE_CLSID!(WebSocketError(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,87,101,98,83,111,99,107,101,116,69,114,114,111,114,0]) [CLSID_WebSocketError]);
+DEFINE_CLSID!(WebSocketError: "Windows.Networking.Sockets.WebSocketError");
 DEFINE_IID!(IID_IWebSocketErrorStatics, 667808603, 8033, 18185, 142, 2, 97, 40, 58, 218, 78, 157);
 RT_INTERFACE!{static interface IWebSocketErrorStatics(IWebSocketErrorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebSocketErrorStatics] {
     #[cfg(feature="windows-web")] fn GetStatus(&self, hresult: i32, out: *mut super::super::web::WebErrorStatus) -> HRESULT
@@ -6844,7 +6844,7 @@ impl IWebSocketInformation2 {
 #[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebSocketKeepAlive: super::super::applicationmodel::background::IBackgroundTask}
 #[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebSocketKeepAlive: IInspectable}
 impl RtActivatable<IActivationFactory> for WebSocketKeepAlive {}
-DEFINE_CLSID!(WebSocketKeepAlive(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,87,101,98,83,111,99,107,101,116,75,101,101,112,65,108,105,118,101,0]) [CLSID_WebSocketKeepAlive]);
+DEFINE_CLSID!(WebSocketKeepAlive: "Windows.Networking.Sockets.WebSocketKeepAlive");
 DEFINE_IID!(IID_IWebSocketServerCustomValidationRequestedEventArgs, 4293918280, 554, 19127, 139, 54, 225, 10, 244, 100, 14, 107);
 RT_INTERFACE!{interface IWebSocketServerCustomValidationRequestedEventArgs(IWebSocketServerCustomValidationRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebSocketServerCustomValidationRequestedEventArgs] {
     #[cfg(not(feature="windows-security"))] fn __Dummy0(&self) -> (),
@@ -6926,7 +6926,7 @@ impl VpnAppId {
         <Self as RtActivatable<IVpnAppIdFactory>>::get_activation_factory().create(type_, value)
     }}
 }
-DEFINE_CLSID!(VpnAppId(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,65,112,112,73,100,0]) [CLSID_VpnAppId]);
+DEFINE_CLSID!(VpnAppId: "Windows.Networking.Vpn.VpnAppId");
 DEFINE_IID!(IID_IVpnAppIdFactory, 1185807658, 2731, 20443, 130, 29, 211, 221, 201, 25, 120, 139);
 RT_INTERFACE!{static interface IVpnAppIdFactory(IVpnAppIdFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVpnAppIdFactory] {
     fn Create(&self, type_: VpnAppIdType, value: HSTRING, out: *mut *mut VpnAppId) -> HRESULT
@@ -7044,7 +7044,7 @@ impl VpnChannel {
         <Self as RtActivatable<IVpnChannelStatics>>::get_activation_factory().process_event_async(thirdPartyPlugIn, event)
     }}
 }
-DEFINE_CLSID!(VpnChannel(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,104,97,110,110,101,108,0]) [CLSID_VpnChannel]);
+DEFINE_CLSID!(VpnChannel: "Windows.Networking.Vpn.VpnChannel");
 DEFINE_IID!(IID_IVpnChannel2, 576049509, 39227, 17961, 173, 96, 241, 195, 243, 83, 127, 80);
 RT_INTERFACE!{interface IVpnChannel2(IVpnChannel2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnChannel2] {
     fn StartWithMainTransport(&self, assignedClientIPv4list: *mut super::super::foundation::collections::IVectorView<super::HostName>, assignedClientIPv6list: *mut super::super::foundation::collections::IVectorView<super::HostName>, vpnInterfaceId: *mut VpnInterfaceId, assignedRoutes: *mut VpnRouteAssignment, assignedDomainName: *mut VpnDomainNameAssignment, mtuSize: u32, maxFrameSize: u32, reserved: bool, mainOuterTunnelTransport: *mut IInspectable) -> HRESULT,
@@ -7250,7 +7250,7 @@ impl IVpnCustomCheckBox {
 }
 RT_CLASS!{class VpnCustomCheckBox: IVpnCustomCheckBox}
 impl RtActivatable<IActivationFactory> for VpnCustomCheckBox {}
-DEFINE_CLSID!(VpnCustomCheckBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,67,104,101,99,107,66,111,120,0]) [CLSID_VpnCustomCheckBox]);
+DEFINE_CLSID!(VpnCustomCheckBox: "Windows.Networking.Vpn.VpnCustomCheckBox");
 DEFINE_IID!(IID_IVpnCustomComboBox, 2586056078, 56225, 19567, 130, 112, 220, 243, 201, 118, 28, 76);
 RT_INTERFACE!{interface IVpnCustomComboBox(IVpnCustomComboBoxVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomComboBox] {
     fn put_OptionsText(&self, value: *mut super::super::foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -7275,7 +7275,7 @@ impl IVpnCustomComboBox {
 }
 RT_CLASS!{class VpnCustomComboBox: IVpnCustomComboBox}
 impl RtActivatable<IActivationFactory> for VpnCustomComboBox {}
-DEFINE_CLSID!(VpnCustomComboBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,67,111,109,98,111,66,111,120,0]) [CLSID_VpnCustomComboBox]);
+DEFINE_CLSID!(VpnCustomComboBox: "Windows.Networking.Vpn.VpnCustomComboBox");
 DEFINE_IID!(IID_IVpnCustomEditBox, 805493152, 53183, 19467, 143, 60, 102, 245, 3, 194, 11, 57);
 RT_INTERFACE!{interface IVpnCustomEditBox(IVpnCustomEditBoxVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomEditBox] {
     fn put_DefaultText(&self, value: HSTRING) -> HRESULT,
@@ -7311,14 +7311,14 @@ impl IVpnCustomEditBox {
 }
 RT_CLASS!{class VpnCustomEditBox: IVpnCustomEditBox}
 impl RtActivatable<IActivationFactory> for VpnCustomEditBox {}
-DEFINE_CLSID!(VpnCustomEditBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,69,100,105,116,66,111,120,0]) [CLSID_VpnCustomEditBox]);
+DEFINE_CLSID!(VpnCustomEditBox: "Windows.Networking.Vpn.VpnCustomEditBox");
 DEFINE_IID!(IID_IVpnCustomErrorBox, 2663706546, 51522, 17071, 178, 35, 88, 139, 72, 50, 135, 33);
 RT_INTERFACE!{interface IVpnCustomErrorBox(IVpnCustomErrorBoxVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomErrorBox] {
     
 }}
 RT_CLASS!{class VpnCustomErrorBox: IVpnCustomErrorBox}
 impl RtActivatable<IActivationFactory> for VpnCustomErrorBox {}
-DEFINE_CLSID!(VpnCustomErrorBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,69,114,114,111,114,66,111,120,0]) [CLSID_VpnCustomErrorBox]);
+DEFINE_CLSID!(VpnCustomErrorBox: "Windows.Networking.Vpn.VpnCustomErrorBox");
 DEFINE_IID!(IID_IVpnCustomPrompt, 2603531899, 34773, 17212, 180, 246, 238, 230, 170, 104, 162, 68);
 RT_INTERFACE!{interface IVpnCustomPrompt(IVpnCustomPromptVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomPrompt] {
     fn put_Label(&self, value: HSTRING) -> HRESULT,
@@ -7381,7 +7381,7 @@ impl IVpnCustomPromptBooleanInput {
 }
 RT_CLASS!{class VpnCustomPromptBooleanInput: IVpnCustomPromptBooleanInput}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptBooleanInput {}
-DEFINE_CLSID!(VpnCustomPromptBooleanInput(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,66,111,111,108,101,97,110,73,110,112,117,116,0]) [CLSID_VpnCustomPromptBooleanInput]);
+DEFINE_CLSID!(VpnCustomPromptBooleanInput: "Windows.Networking.Vpn.VpnCustomPromptBooleanInput");
 DEFINE_IID!(IID_IVpnCustomPromptElement, 1941788216, 28420, 16461, 147, 221, 80, 164, 73, 36, 163, 139);
 RT_INTERFACE!{interface IVpnCustomPromptElement(IVpnCustomPromptElementVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomPromptElement] {
     fn put_DisplayName(&self, value: HSTRING) -> HRESULT,
@@ -7439,7 +7439,7 @@ impl IVpnCustomPromptOptionSelector {
 }
 RT_CLASS!{class VpnCustomPromptOptionSelector: IVpnCustomPromptOptionSelector}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptOptionSelector {}
-DEFINE_CLSID!(VpnCustomPromptOptionSelector(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,79,112,116,105,111,110,83,101,108,101,99,116,111,114,0]) [CLSID_VpnCustomPromptOptionSelector]);
+DEFINE_CLSID!(VpnCustomPromptOptionSelector: "Windows.Networking.Vpn.VpnCustomPromptOptionSelector");
 DEFINE_IID!(IID_IVpnCustomPromptText, 1003011566, 14914, 18851, 171, 221, 7, 178, 237, 234, 117, 45);
 RT_INTERFACE!{interface IVpnCustomPromptText(IVpnCustomPromptTextVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomPromptText] {
     fn put_Text(&self, value: HSTRING) -> HRESULT,
@@ -7458,7 +7458,7 @@ impl IVpnCustomPromptText {
 }
 RT_CLASS!{class VpnCustomPromptText: IVpnCustomPromptText}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptText {}
-DEFINE_CLSID!(VpnCustomPromptText(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,84,101,120,116,0]) [CLSID_VpnCustomPromptText]);
+DEFINE_CLSID!(VpnCustomPromptText: "Windows.Networking.Vpn.VpnCustomPromptText");
 DEFINE_IID!(IID_IVpnCustomPromptTextInput, 3386547317, 37180, 18389, 136, 186, 72, 252, 72, 147, 2, 53);
 RT_INTERFACE!{interface IVpnCustomPromptTextInput(IVpnCustomPromptTextInputVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomPromptTextInput] {
     fn put_PlaceholderText(&self, value: HSTRING) -> HRESULT,
@@ -7494,7 +7494,7 @@ impl IVpnCustomPromptTextInput {
 }
 RT_CLASS!{class VpnCustomPromptTextInput: IVpnCustomPromptTextInput}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptTextInput {}
-DEFINE_CLSID!(VpnCustomPromptTextInput(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,84,101,120,116,73,110,112,117,116,0]) [CLSID_VpnCustomPromptTextInput]);
+DEFINE_CLSID!(VpnCustomPromptTextInput: "Windows.Networking.Vpn.VpnCustomPromptTextInput");
 DEFINE_IID!(IID_IVpnCustomTextBox, 3668231114, 36643, 19766, 145, 241, 118, 217, 55, 130, 121, 66);
 RT_INTERFACE!{interface IVpnCustomTextBox(IVpnCustomTextBoxVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomTextBox] {
     fn put_DisplayText(&self, value: HSTRING) -> HRESULT,
@@ -7513,7 +7513,7 @@ impl IVpnCustomTextBox {
 }
 RT_CLASS!{class VpnCustomTextBox: IVpnCustomTextBox}
 impl RtActivatable<IActivationFactory> for VpnCustomTextBox {}
-DEFINE_CLSID!(VpnCustomTextBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,84,101,120,116,66,111,120,0]) [CLSID_VpnCustomTextBox]);
+DEFINE_CLSID!(VpnCustomTextBox: "Windows.Networking.Vpn.VpnCustomTextBox");
 RT_ENUM! { enum VpnDataPathType: i32 {
     Send (VpnDataPathType_Send) = 0, Receive (VpnDataPathType_Receive) = 1,
 }}
@@ -7541,7 +7541,7 @@ impl IVpnDomainNameAssignment {
 }
 RT_CLASS!{class VpnDomainNameAssignment: IVpnDomainNameAssignment}
 impl RtActivatable<IActivationFactory> for VpnDomainNameAssignment {}
-DEFINE_CLSID!(VpnDomainNameAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,68,111,109,97,105,110,78,97,109,101,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnDomainNameAssignment]);
+DEFINE_CLSID!(VpnDomainNameAssignment: "Windows.Networking.Vpn.VpnDomainNameAssignment");
 DEFINE_IID!(IID_IVpnDomainNameInfo, 2905520175, 60046, 20346, 132, 62, 26, 135, 227, 46, 27, 154);
 RT_INTERFACE!{interface IVpnDomainNameInfo(IVpnDomainNameInfoVtbl): IInspectable(IInspectableVtbl) [IID_IVpnDomainNameInfo] {
     fn put_DomainName(&self, value: *mut super::HostName) -> HRESULT,
@@ -7588,7 +7588,7 @@ impl VpnDomainNameInfo {
         <Self as RtActivatable<IVpnDomainNameInfoFactory>>::get_activation_factory().create_vpn_domain_name_info(name, nameType, dnsServerList, proxyServerList)
     }}
 }
-DEFINE_CLSID!(VpnDomainNameInfo(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,68,111,109,97,105,110,78,97,109,101,73,110,102,111,0]) [CLSID_VpnDomainNameInfo]);
+DEFINE_CLSID!(VpnDomainNameInfo: "Windows.Networking.Vpn.VpnDomainNameInfo");
 DEFINE_IID!(IID_IVpnDomainNameInfo2, 2877755729, 27731, 18472, 152, 131, 216, 134, 222, 16, 68, 7);
 RT_INTERFACE!{interface IVpnDomainNameInfo2(IVpnDomainNameInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnDomainNameInfo2] {
     fn get_WebProxyUris(&self, out: *mut *mut super::super::foundation::collections::IVector<super::super::foundation::Uri>) -> HRESULT
@@ -7632,7 +7632,7 @@ impl VpnInterfaceId {
         <Self as RtActivatable<IVpnInterfaceIdFactory>>::get_activation_factory().create_vpn_interface_id(address)
     }}
 }
-DEFINE_CLSID!(VpnInterfaceId(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,73,110,116,101,114,102,97,99,101,73,100,0]) [CLSID_VpnInterfaceId]);
+DEFINE_CLSID!(VpnInterfaceId: "Windows.Networking.Vpn.VpnInterfaceId");
 DEFINE_IID!(IID_IVpnInterfaceIdFactory, 2653805730, 5906, 19684, 177, 121, 140, 101, 44, 109, 16, 0);
 RT_INTERFACE!{static interface IVpnInterfaceIdFactory(IVpnInterfaceIdFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVpnInterfaceIdFactory] {
     fn CreateVpnInterfaceId(&self, addressSize: u32, address: *mut u8, out: *mut *mut VpnInterfaceId) -> HRESULT
@@ -7709,7 +7709,7 @@ impl IVpnManagementAgent {
 }
 RT_CLASS!{class VpnManagementAgent: IVpnManagementAgent}
 impl RtActivatable<IActivationFactory> for VpnManagementAgent {}
-DEFINE_CLSID!(VpnManagementAgent(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,77,97,110,97,103,101,109,101,110,116,65,103,101,110,116,0]) [CLSID_VpnManagementAgent]);
+DEFINE_CLSID!(VpnManagementAgent: "Windows.Networking.Vpn.VpnManagementAgent");
 RT_ENUM! { enum VpnManagementConnectionStatus: i32 {
     Disconnected (VpnManagementConnectionStatus_Disconnected) = 0, Disconnecting (VpnManagementConnectionStatus_Disconnecting) = 1, Connected (VpnManagementConnectionStatus_Connected) = 2, Connecting (VpnManagementConnectionStatus_Connecting) = 3,
 }}
@@ -7745,7 +7745,7 @@ impl IVpnNamespaceAssignment {
 }
 RT_CLASS!{class VpnNamespaceAssignment: IVpnNamespaceAssignment}
 impl RtActivatable<IActivationFactory> for VpnNamespaceAssignment {}
-DEFINE_CLSID!(VpnNamespaceAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,78,97,109,101,115,112,97,99,101,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnNamespaceAssignment]);
+DEFINE_CLSID!(VpnNamespaceAssignment: "Windows.Networking.Vpn.VpnNamespaceAssignment");
 DEFINE_IID!(IID_IVpnNamespaceInfo, 820902723, 17487, 17605, 129, 103, 163, 90, 145, 241, 175, 148);
 RT_INTERFACE!{interface IVpnNamespaceInfo(IVpnNamespaceInfoVtbl): IInspectable(IInspectableVtbl) [IID_IVpnNamespaceInfo] {
     fn put_Namespace(&self, value: HSTRING) -> HRESULT,
@@ -7791,7 +7791,7 @@ impl VpnNamespaceInfo {
         <Self as RtActivatable<IVpnNamespaceInfoFactory>>::get_activation_factory().create_vpn_namespace_info(name, dnsServerList, proxyServerList)
     }}
 }
-DEFINE_CLSID!(VpnNamespaceInfo(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,78,97,109,101,115,112,97,99,101,73,110,102,111,0]) [CLSID_VpnNamespaceInfo]);
+DEFINE_CLSID!(VpnNamespaceInfo: "Windows.Networking.Vpn.VpnNamespaceInfo");
 DEFINE_IID!(IID_IVpnNamespaceInfoFactory, 3409876250, 45262, 17451, 172, 187, 95, 153, 178, 2, 195, 28);
 RT_INTERFACE!{static interface IVpnNamespaceInfoFactory(IVpnNamespaceInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVpnNamespaceInfoFactory] {
     fn CreateVpnNamespaceInfo(&self, name: HSTRING, dnsServerList: *mut super::super::foundation::collections::IVector<super::HostName>, proxyServerList: *mut super::super::foundation::collections::IVector<super::HostName>, out: *mut *mut VpnNamespaceInfo) -> HRESULT
@@ -7871,7 +7871,7 @@ impl IVpnNativeProfile {
 }
 RT_CLASS!{class VpnNativeProfile: IVpnNativeProfile}
 impl RtActivatable<IActivationFactory> for VpnNativeProfile {}
-DEFINE_CLSID!(VpnNativeProfile(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,78,97,116,105,118,101,80,114,111,102,105,108,101,0]) [CLSID_VpnNativeProfile]);
+DEFINE_CLSID!(VpnNativeProfile: "Windows.Networking.Vpn.VpnNativeProfile");
 DEFINE_IID!(IID_IVpnNativeProfile2, 267134055, 52661, 19143, 181, 163, 10, 251, 94, 196, 118, 130);
 RT_INTERFACE!{interface IVpnNativeProfile2(IVpnNativeProfile2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnNativeProfile2] {
     fn get_RequireVpnClientAppUI(&self, out: *mut bool) -> HRESULT,
@@ -7938,7 +7938,7 @@ impl VpnPacketBuffer {
         <Self as RtActivatable<IVpnPacketBufferFactory>>::get_activation_factory().create_vpn_packet_buffer(parentBuffer, offset, length)
     }}
 }
-DEFINE_CLSID!(VpnPacketBuffer(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,80,97,99,107,101,116,66,117,102,102,101,114,0]) [CLSID_VpnPacketBuffer]);
+DEFINE_CLSID!(VpnPacketBuffer: "Windows.Networking.Vpn.VpnPacketBuffer");
 DEFINE_IID!(IID_IVpnPacketBuffer2, 1717473776, 34821, 19445, 166, 25, 46, 132, 136, 46, 107, 79);
 RT_INTERFACE!{interface IVpnPacketBuffer2(IVpnPacketBuffer2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnPacketBuffer2] {
     fn get_AppId(&self, out: *mut *mut VpnAppId) -> HRESULT
@@ -8131,7 +8131,7 @@ impl IVpnPlugInProfile {
 }
 RT_CLASS!{class VpnPlugInProfile: IVpnPlugInProfile}
 impl RtActivatable<IActivationFactory> for VpnPlugInProfile {}
-DEFINE_CLSID!(VpnPlugInProfile(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,80,108,117,103,73,110,80,114,111,102,105,108,101,0]) [CLSID_VpnPlugInProfile]);
+DEFINE_CLSID!(VpnPlugInProfile: "Windows.Networking.Vpn.VpnPlugInProfile");
 DEFINE_IID!(IID_IVpnPlugInProfile2, 1629243538, 53140, 19158, 186, 153, 0, 244, 255, 52, 86, 94);
 RT_INTERFACE!{interface IVpnPlugInProfile2(IVpnPlugInProfile2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnPlugInProfile2] {
     fn get_RequireVpnClientAppUI(&self, out: *mut bool) -> HRESULT,
@@ -8250,7 +8250,7 @@ impl VpnRoute {
         <Self as RtActivatable<IVpnRouteFactory>>::get_activation_factory().create_vpn_route(address, prefixSize)
     }}
 }
-DEFINE_CLSID!(VpnRoute(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,82,111,117,116,101,0]) [CLSID_VpnRoute]);
+DEFINE_CLSID!(VpnRoute: "Windows.Networking.Vpn.VpnRoute");
 DEFINE_IID!(IID_IVpnRouteAssignment, 3680820770, 52793, 19062, 149, 80, 246, 16, 57, 248, 14, 72);
 RT_INTERFACE!{interface IVpnRouteAssignment(IVpnRouteAssignmentVtbl): IInspectable(IInspectableVtbl) [IID_IVpnRouteAssignment] {
     fn put_Ipv4InclusionRoutes(&self, value: *mut super::super::foundation::collections::IVector<VpnRoute>) -> HRESULT,
@@ -8313,7 +8313,7 @@ impl IVpnRouteAssignment {
 }
 RT_CLASS!{class VpnRouteAssignment: IVpnRouteAssignment}
 impl RtActivatable<IActivationFactory> for VpnRouteAssignment {}
-DEFINE_CLSID!(VpnRouteAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,82,111,117,116,101,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnRouteAssignment]);
+DEFINE_CLSID!(VpnRouteAssignment: "Windows.Networking.Vpn.VpnRouteAssignment");
 DEFINE_IID!(IID_IVpnRouteFactory, 3186275839, 17871, 19353, 131, 251, 219, 59, 194, 103, 43, 2);
 RT_INTERFACE!{static interface IVpnRouteFactory(IVpnRouteFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVpnRouteFactory] {
     fn CreateVpnRoute(&self, address: *mut super::HostName, prefixSize: u8, out: *mut *mut VpnRoute) -> HRESULT
@@ -8415,7 +8415,7 @@ impl VpnTrafficFilter {
         <Self as RtActivatable<IVpnTrafficFilterFactory>>::get_activation_factory().create(appId)
     }}
 }
-DEFINE_CLSID!(VpnTrafficFilter(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,84,114,97,102,102,105,99,70,105,108,116,101,114,0]) [CLSID_VpnTrafficFilter]);
+DEFINE_CLSID!(VpnTrafficFilter: "Windows.Networking.Vpn.VpnTrafficFilter");
 DEFINE_IID!(IID_IVpnTrafficFilterAssignment, 1456264284, 58980, 18206, 137, 205, 96, 22, 3, 185, 224, 243);
 RT_INTERFACE!{interface IVpnTrafficFilterAssignment(IVpnTrafficFilterAssignmentVtbl): IInspectable(IInspectableVtbl) [IID_IVpnTrafficFilterAssignment] {
     fn get_TrafficFilterList(&self, out: *mut *mut super::super::foundation::collections::IVector<VpnTrafficFilter>) -> HRESULT,
@@ -8451,7 +8451,7 @@ impl IVpnTrafficFilterAssignment {
 }
 RT_CLASS!{class VpnTrafficFilterAssignment: IVpnTrafficFilterAssignment}
 impl RtActivatable<IActivationFactory> for VpnTrafficFilterAssignment {}
-DEFINE_CLSID!(VpnTrafficFilterAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,84,114,97,102,102,105,99,70,105,108,116,101,114,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnTrafficFilterAssignment]);
+DEFINE_CLSID!(VpnTrafficFilterAssignment: "Windows.Networking.Vpn.VpnTrafficFilterAssignment");
 DEFINE_IID!(IID_IVpnTrafficFilterFactory, 1208828373, 32665, 18252, 134, 238, 150, 223, 22, 131, 24, 241);
 RT_INTERFACE!{static interface IVpnTrafficFilterFactory(IVpnTrafficFilterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVpnTrafficFilterFactory] {
     fn Create(&self, appId: *mut VpnAppId, out: *mut *mut VpnTrafficFilter) -> HRESULT
@@ -8521,7 +8521,7 @@ impl PushNotificationChannelManager {
         <Self as RtActivatable<IPushNotificationChannelManagerStatics3>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(PushNotificationChannelManager(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,80,117,115,104,78,111,116,105,102,105,99,97,116,105,111,110,115,46,80,117,115,104,78,111,116,105,102,105,99,97,116,105,111,110,67,104,97,110,110,101,108,77,97,110,97,103,101,114,0]) [CLSID_PushNotificationChannelManager]);
+DEFINE_CLSID!(PushNotificationChannelManager: "Windows.Networking.PushNotifications.PushNotificationChannelManager");
 DEFINE_IID!(IID_IPushNotificationChannelManagerForUser, 2764330756, 4482, 17095, 136, 144, 245, 99, 196, 137, 13, 196);
 RT_INTERFACE!{interface IPushNotificationChannelManagerForUser(IPushNotificationChannelManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IPushNotificationChannelManagerForUser] {
     fn CreatePushNotificationChannelForApplicationAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<PushNotificationChannel>) -> HRESULT,
@@ -8777,7 +8777,7 @@ impl XboxLiveDeviceAddress {
         <Self as RtActivatable<IXboxLiveDeviceAddressStatics>>::get_activation_factory().get_max_snapshot_bytes_size()
     }}
 }
-DEFINE_CLSID!(XboxLiveDeviceAddress(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,88,98,111,120,76,105,118,101,46,88,98,111,120,76,105,118,101,68,101,118,105,99,101,65,100,100,114,101,115,115,0]) [CLSID_XboxLiveDeviceAddress]);
+DEFINE_CLSID!(XboxLiveDeviceAddress: "Windows.Networking.XboxLive.XboxLiveDeviceAddress");
 DEFINE_IID!(IID_IXboxLiveDeviceAddressStatics, 1498720281, 19065, 18737, 130, 124, 127, 80, 62, 150, 50, 99);
 RT_INTERFACE!{static interface IXboxLiveDeviceAddressStatics(IXboxLiveDeviceAddressStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IXboxLiveDeviceAddressStatics] {
     fn CreateFromSnapshotBase64(&self, base64: HSTRING, out: *mut *mut XboxLiveDeviceAddress) -> HRESULT,
@@ -8898,7 +8898,7 @@ impl XboxLiveEndpointPair {
         <Self as RtActivatable<IXboxLiveEndpointPairStatics>>::get_activation_factory().find_endpoint_pair_by_host_names_and_ports(localHostName, localPort, remoteHostName, remotePort)
     }}
 }
-DEFINE_CLSID!(XboxLiveEndpointPair(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,88,98,111,120,76,105,118,101,46,88,98,111,120,76,105,118,101,69,110,100,112,111,105,110,116,80,97,105,114,0]) [CLSID_XboxLiveEndpointPair]);
+DEFINE_CLSID!(XboxLiveEndpointPair: "Windows.Networking.XboxLive.XboxLiveEndpointPair");
 RT_ENUM! { enum XboxLiveEndpointPairCreationBehaviors: u32 {
     None (XboxLiveEndpointPairCreationBehaviors_None) = 0, ReevaluatePath (XboxLiveEndpointPairCreationBehaviors_ReevaluatePath) = 1,
 }}
@@ -9065,7 +9065,7 @@ impl XboxLiveEndpointPairTemplate {
         <Self as RtActivatable<IXboxLiveEndpointPairTemplateStatics>>::get_activation_factory().get_templates()
     }}
 }
-DEFINE_CLSID!(XboxLiveEndpointPairTemplate(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,88,98,111,120,76,105,118,101,46,88,98,111,120,76,105,118,101,69,110,100,112,111,105,110,116,80,97,105,114,84,101,109,112,108,97,116,101,0]) [CLSID_XboxLiveEndpointPairTemplate]);
+DEFINE_CLSID!(XboxLiveEndpointPairTemplate: "Windows.Networking.XboxLive.XboxLiveEndpointPairTemplate");
 DEFINE_IID!(IID_IXboxLiveEndpointPairTemplateStatics, 504566651, 29563, 18979, 188, 100, 8, 112, 247, 86, 85, 186);
 RT_INTERFACE!{static interface IXboxLiveEndpointPairTemplateStatics(IXboxLiveEndpointPairTemplateStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IXboxLiveEndpointPairTemplateStatics] {
     fn GetTemplateByName(&self, name: HSTRING, out: *mut *mut XboxLiveEndpointPairTemplate) -> HRESULT,
@@ -9234,7 +9234,7 @@ impl XboxLiveQualityOfServiceMeasurement {
         <Self as RtActivatable<IXboxLiveQualityOfServiceMeasurementStatics>>::get_activation_factory().get_max_private_payload_size()
     }}
 }
-DEFINE_CLSID!(XboxLiveQualityOfServiceMeasurement(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,88,98,111,120,76,105,118,101,46,88,98,111,120,76,105,118,101,81,117,97,108,105,116,121,79,102,83,101,114,118,105,99,101,77,101,97,115,117,114,101,109,101,110,116,0]) [CLSID_XboxLiveQualityOfServiceMeasurement]);
+DEFINE_CLSID!(XboxLiveQualityOfServiceMeasurement: "Windows.Networking.XboxLive.XboxLiveQualityOfServiceMeasurement");
 DEFINE_IID!(IID_IXboxLiveQualityOfServiceMeasurementStatics, 1848978890, 9167, 17418, 176, 119, 94, 48, 133, 122, 130, 52);
 RT_INTERFACE!{static interface IXboxLiveQualityOfServiceMeasurementStatics(IXboxLiveQualityOfServiceMeasurementStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IXboxLiveQualityOfServiceMeasurementStatics] {
     fn PublishPrivatePayloadBytes(&self, payloadSize: u32, payload: *mut u8) -> HRESULT,

--- a/src/rt/gen/windows/perception.rs
+++ b/src/rt/gen/windows/perception.rs
@@ -24,7 +24,7 @@ impl PerceptionTimestampHelper {
         <Self as RtActivatable<IPerceptionTimestampHelperStatics>>::get_activation_factory().from_historical_target_time(targetTime)
     }}
 }
-DEFINE_CLSID!(PerceptionTimestampHelper(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,80,101,114,99,101,112,116,105,111,110,84,105,109,101,115,116,97,109,112,72,101,108,112,101,114,0]) [CLSID_PerceptionTimestampHelper]);
+DEFINE_CLSID!(PerceptionTimestampHelper: "Windows.Perception.PerceptionTimestampHelper");
 DEFINE_IID!(IID_IPerceptionTimestampHelperStatics, 1202065876, 43487, 20188, 133, 93, 244, 211, 57, 217, 103, 172);
 RT_INTERFACE!{static interface IPerceptionTimestampHelperStatics(IPerceptionTimestampHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionTimestampHelperStatics] {
     fn FromHistoricalTargetTime(&self, targetTime: super::foundation::DateTime, out: *mut *mut PerceptionTimestamp) -> HRESULT
@@ -79,7 +79,7 @@ impl SpatialAnchor {
         <Self as RtActivatable<ISpatialAnchorStatics>>::get_activation_factory().try_create_with_position_and_orientation_relative_to(coordinateSystem, position, orientation)
     }}
 }
-DEFINE_CLSID!(SpatialAnchor(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,65,110,99,104,111,114,0]) [CLSID_SpatialAnchor]);
+DEFINE_CLSID!(SpatialAnchor: "Windows.Perception.Spatial.SpatialAnchor");
 DEFINE_IID!(IID_ISpatialAnchor2, 3977758984, 42645, 19702, 146, 253, 151, 38, 59, 167, 16, 71);
 RT_INTERFACE!{interface ISpatialAnchor2(ISpatialAnchor2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialAnchor2] {
     fn get_RemovedByUser(&self, out: *mut bool) -> HRESULT
@@ -98,7 +98,7 @@ impl SpatialAnchorManager {
         <Self as RtActivatable<ISpatialAnchorManagerStatics>>::get_activation_factory().request_store_async()
     }}
 }
-DEFINE_CLSID!(SpatialAnchorManager(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,65,110,99,104,111,114,77,97,110,97,103,101,114,0]) [CLSID_SpatialAnchorManager]);
+DEFINE_CLSID!(SpatialAnchorManager: "Windows.Perception.Spatial.SpatialAnchorManager");
 DEFINE_IID!(IID_ISpatialAnchorManagerStatics, 2296581803, 62391, 16907, 176, 134, 138, 128, 192, 125, 145, 13);
 RT_INTERFACE!{static interface ISpatialAnchorManagerStatics(ISpatialAnchorManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialAnchorManagerStatics] {
     fn RequestStoreAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<SpatialAnchorStore>) -> HRESULT
@@ -186,7 +186,7 @@ impl SpatialAnchorTransferManager {
         <Self as RtActivatable<ISpatialAnchorTransferManagerStatics>>::get_activation_factory().request_access_async()
     }}
 }
-DEFINE_CLSID!(SpatialAnchorTransferManager(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,65,110,99,104,111,114,84,114,97,110,115,102,101,114,77,97,110,97,103,101,114,0]) [CLSID_SpatialAnchorTransferManager]);
+DEFINE_CLSID!(SpatialAnchorTransferManager: "Windows.Perception.Spatial.SpatialAnchorTransferManager");
 DEFINE_IID!(IID_ISpatialAnchorTransferManagerStatics, 62650809, 4824, 19406, 136, 53, 197, 223, 58, 192, 173, 171);
 RT_INTERFACE!{static interface ISpatialAnchorTransferManagerStatics(ISpatialAnchorTransferManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialAnchorTransferManagerStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -244,7 +244,7 @@ impl SpatialBoundingVolume {
         <Self as RtActivatable<ISpatialBoundingVolumeStatics>>::get_activation_factory().from_frustum(coordinateSystem, frustum)
     }}
 }
-DEFINE_CLSID!(SpatialBoundingVolume(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,66,111,117,110,100,105,110,103,86,111,108,117,109,101,0]) [CLSID_SpatialBoundingVolume]);
+DEFINE_CLSID!(SpatialBoundingVolume: "Windows.Perception.Spatial.SpatialBoundingVolume");
 DEFINE_IID!(IID_ISpatialBoundingVolumeStatics, 92836119, 46049, 14040, 176, 23, 86, 97, 129, 165, 177, 150);
 RT_INTERFACE!{static interface ISpatialBoundingVolumeStatics(ISpatialBoundingVolumeStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialBoundingVolumeStatics] {
     fn FromBox(&self, coordinateSystem: *mut SpatialCoordinateSystem, box_: SpatialBoundingBox, out: *mut *mut SpatialBoundingVolume) -> HRESULT,
@@ -319,7 +319,7 @@ impl SpatialEntity {
         <Self as RtActivatable<ISpatialEntityFactory>>::get_activation_factory().create_with_spatial_anchor_and_properties(spatialAnchor, propertySet)
     }}
 }
-DEFINE_CLSID!(SpatialEntity(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,69,110,116,105,116,121,0]) [CLSID_SpatialEntity]);
+DEFINE_CLSID!(SpatialEntity: "Windows.Perception.Spatial.SpatialEntity");
 DEFINE_IID!(IID_ISpatialEntityAddedEventArgs, 2744644763, 5482, 18183, 172, 44, 211, 29, 87, 14, 211, 153);
 RT_INTERFACE!{interface ISpatialEntityAddedEventArgs(ISpatialEntityAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialEntityAddedEventArgs] {
     fn get_Entity(&self, out: *mut *mut SpatialEntity) -> HRESULT
@@ -394,7 +394,7 @@ impl SpatialEntityStore {
         <Self as RtActivatable<ISpatialEntityStoreStatics>>::get_activation_factory().try_get_for_remote_system_session(session)
     }}
 }
-DEFINE_CLSID!(SpatialEntityStore(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,69,110,116,105,116,121,83,116,111,114,101,0]) [CLSID_SpatialEntityStore]);
+DEFINE_CLSID!(SpatialEntityStore: "Windows.Perception.Spatial.SpatialEntityStore");
 DEFINE_IID!(IID_ISpatialEntityStoreStatics, 1800091806, 31824, 20114, 138, 98, 77, 29, 75, 124, 205, 62);
 RT_INTERFACE!{static interface ISpatialEntityStoreStatics(ISpatialEntityStoreStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialEntityStoreStatics] {
     fn get_IsSupported(&self, out: *mut bool) -> HRESULT,
@@ -632,7 +632,7 @@ impl SpatialLocator {
         <Self as RtActivatable<ISpatialLocatorStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(SpatialLocator(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,76,111,99,97,116,111,114,0]) [CLSID_SpatialLocator]);
+DEFINE_CLSID!(SpatialLocator: "Windows.Perception.Spatial.SpatialLocator");
 DEFINE_IID!(IID_ISpatialLocatorAttachedFrameOfReference, 3782692598, 8015, 18844, 150, 37, 239, 94, 110, 215, 160, 72);
 RT_INTERFACE!{interface ISpatialLocatorAttachedFrameOfReference(ISpatialLocatorAttachedFrameOfReferenceVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialLocatorAttachedFrameOfReference] {
     fn get_RelativePosition(&self, out: *mut super::super::foundation::numerics::Vector3) -> HRESULT,
@@ -766,7 +766,7 @@ impl SpatialStageFrameOfReference {
         <Self as RtActivatable<ISpatialStageFrameOfReferenceStatics>>::get_activation_factory().request_new_stage_async()
     }}
 }
-DEFINE_CLSID!(SpatialStageFrameOfReference(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,83,116,97,103,101,70,114,97,109,101,79,102,82,101,102,101,114,101,110,99,101,0]) [CLSID_SpatialStageFrameOfReference]);
+DEFINE_CLSID!(SpatialStageFrameOfReference: "Windows.Perception.Spatial.SpatialStageFrameOfReference");
 DEFINE_IID!(IID_ISpatialStageFrameOfReferenceStatics, 4153236557, 41124, 18844, 141, 145, 168, 201, 101, 212, 6, 84);
 RT_INTERFACE!{static interface ISpatialStageFrameOfReferenceStatics(ISpatialStageFrameOfReferenceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialStageFrameOfReferenceStatics] {
     fn get_Current(&self, out: *mut *mut SpatialStageFrameOfReference) -> HRESULT,
@@ -987,7 +987,7 @@ impl SpatialSurfaceMeshOptions {
         <Self as RtActivatable<ISpatialSurfaceMeshOptionsStatics>>::get_activation_factory().get_supported_vertex_normal_formats()
     }}
 }
-DEFINE_CLSID!(SpatialSurfaceMeshOptions(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,117,114,102,97,99,101,115,46,83,112,97,116,105,97,108,83,117,114,102,97,99,101,77,101,115,104,79,112,116,105,111,110,115,0]) [CLSID_SpatialSurfaceMeshOptions]);
+DEFINE_CLSID!(SpatialSurfaceMeshOptions: "Windows.Perception.Spatial.Surfaces.SpatialSurfaceMeshOptions");
 DEFINE_IID!(IID_ISpatialSurfaceMeshOptionsStatics, 2603879103, 38785, 17669, 137, 53, 1, 53, 117, 202, 174, 94);
 RT_INTERFACE!{static interface ISpatialSurfaceMeshOptionsStatics(ISpatialSurfaceMeshOptionsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMeshOptionsStatics] {
     #[cfg(feature="windows-graphics")] fn get_SupportedVertexPositionFormats(&self, out: *mut *mut ::rt::gen::windows::foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT,
@@ -1055,7 +1055,7 @@ impl SpatialSurfaceObserver {
         <Self as RtActivatable<ISpatialSurfaceObserverStatics2>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(SpatialSurfaceObserver(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,117,114,102,97,99,101,115,46,83,112,97,116,105,97,108,83,117,114,102,97,99,101,79,98,115,101,114,118,101,114,0]) [CLSID_SpatialSurfaceObserver]);
+DEFINE_CLSID!(SpatialSurfaceObserver: "Windows.Perception.Spatial.Surfaces.SpatialSurfaceObserver");
 DEFINE_IID!(IID_ISpatialSurfaceObserverStatics, 374952429, 8456, 16744, 145, 117, 135, 224, 39, 188, 146, 133);
 RT_INTERFACE!{static interface ISpatialSurfaceObserverStatics(ISpatialSurfaceObserverStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceObserverStatics] {
     fn RequestAccessAsync(&self, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<super::SpatialPerceptionAccessStatus>) -> HRESULT
@@ -1117,7 +1117,7 @@ impl CorePerceptionAutomation {
         <Self as RtActivatable<ICorePerceptionAutomationStatics>>::get_activation_factory().set_activation_factory_provider(provider)
     }}
 }
-DEFINE_CLSID!(CorePerceptionAutomation(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,65,117,116,111,109,97,116,105,111,110,46,67,111,114,101,46,67,111,114,101,80,101,114,99,101,112,116,105,111,110,65,117,116,111,109,97,116,105,111,110,0]) [CLSID_CorePerceptionAutomation]);
+DEFINE_CLSID!(CorePerceptionAutomation: "Windows.Perception.Automation.Core.CorePerceptionAutomation");
 DEFINE_IID!(IID_ICorePerceptionAutomationStatics, 196101441, 19682, 18723, 154, 118, 129, 135, 236, 197, 145, 18);
 RT_INTERFACE!{static interface ICorePerceptionAutomationStatics(ICorePerceptionAutomationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICorePerceptionAutomationStatics] {
     fn SetActivationFactoryProvider(&self, provider: *mut ::rt::gen::windows::foundation::IGetActivationFactory) -> HRESULT

--- a/src/rt/gen/windows/security.rs
+++ b/src/rt/gen/windows/security.rs
@@ -101,7 +101,7 @@ impl KeyCredentialManager {
         <Self as RtActivatable<IKeyCredentialManagerStatics>>::get_activation_factory().delete_async(name)
     }}
 }
-DEFINE_CLSID!(KeyCredentialManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,75,101,121,67,114,101,100,101,110,116,105,97,108,77,97,110,97,103,101,114,0]) [CLSID_KeyCredentialManager]);
+DEFINE_CLSID!(KeyCredentialManager: "Windows.Security.Credentials.KeyCredentialManager");
 DEFINE_IID!(IID_IKeyCredentialManagerStatics, 1789675147, 3825, 19680, 130, 144, 65, 6, 218, 106, 99, 181);
 RT_INTERFACE!{static interface IKeyCredentialManagerStatics(IKeyCredentialManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyCredentialManagerStatics] {
     fn IsSupportedAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -234,10 +234,10 @@ impl PasswordCredential {
         <Self as RtActivatable<ICredentialFactory>>::get_activation_factory().create_password_credential(resource, userName, password)
     }}
 }
-DEFINE_CLSID!(PasswordCredential(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,80,97,115,115,119,111,114,100,67,114,101,100,101,110,116,105,97,108,0]) [CLSID_PasswordCredential]);
+DEFINE_CLSID!(PasswordCredential: "Windows.Security.Credentials.PasswordCredential");
 RT_CLASS!{class PasswordCredentialPropertyStore: super::super::foundation::collections::IPropertySet}
 impl RtActivatable<IActivationFactory> for PasswordCredentialPropertyStore {}
-DEFINE_CLSID!(PasswordCredentialPropertyStore(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,80,97,115,115,119,111,114,100,67,114,101,100,101,110,116,105,97,108,80,114,111,112,101,114,116,121,83,116,111,114,101,0]) [CLSID_PasswordCredentialPropertyStore]);
+DEFINE_CLSID!(PasswordCredentialPropertyStore: "Windows.Security.Credentials.PasswordCredentialPropertyStore");
 DEFINE_IID!(IID_IPasswordVault, 1643981835, 51412, 18625, 165, 79, 188, 90, 100, 32, 90, 242);
 RT_INTERFACE!{interface IPasswordVault(IPasswordVaultVtbl): IInspectable(IInspectableVtbl) [IID_IPasswordVault] {
     fn Add(&self, credential: *mut PasswordCredential) -> HRESULT,
@@ -279,7 +279,7 @@ impl IPasswordVault {
 }
 RT_CLASS!{class PasswordVault: IPasswordVault}
 impl RtActivatable<IActivationFactory> for PasswordVault {}
-DEFINE_CLSID!(PasswordVault(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,80,97,115,115,119,111,114,100,86,97,117,108,116,0]) [CLSID_PasswordVault]);
+DEFINE_CLSID!(PasswordVault: "Windows.Security.Credentials.PasswordVault");
 DEFINE_IID!(IID_IWebAccount, 1766276786, 32817, 18878, 128, 187, 150, 203, 70, 217, 154, 186);
 RT_INTERFACE!{interface IWebAccount(IWebAccountVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccount] {
     fn get_WebAccountProvider(&self, out: *mut *mut WebAccountProvider) -> HRESULT,
@@ -310,7 +310,7 @@ impl WebAccount {
         <Self as RtActivatable<IWebAccountFactory>>::get_activation_factory().create_web_account(webAccountProvider, userName, state)
     }}
 }
-DEFINE_CLSID!(WebAccount(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,87,101,98,65,99,99,111,117,110,116,0]) [CLSID_WebAccount]);
+DEFINE_CLSID!(WebAccount: "Windows.Security.Credentials.WebAccount");
 DEFINE_IID!(IID_IWebAccount2, 2069288696, 39179, 20149, 148, 167, 86, 33, 243, 168, 184, 36);
 RT_INTERFACE!{interface IWebAccount2(IWebAccount2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebAccount2] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -391,7 +391,7 @@ impl WebAccountProvider {
         <Self as RtActivatable<IWebAccountProviderFactory>>::get_activation_factory().create_web_account_provider(id, displayName, iconUri)
     }}
 }
-DEFINE_CLSID!(WebAccountProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,87,101,98,65,99,99,111,117,110,116,80,114,111,118,105,100,101,114,0]) [CLSID_WebAccountProvider]);
+DEFINE_CLSID!(WebAccountProvider: "Windows.Security.Credentials.WebAccountProvider");
 DEFINE_IID!(IID_IWebAccountProvider2, 1241639685, 20034, 16852, 181, 24, 224, 8, 165, 22, 54, 20);
 RT_INTERFACE!{interface IWebAccountProvider2(IWebAccountProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProvider2] {
     fn get_DisplayPurpose(&self, out: *mut HSTRING) -> HRESULT,
@@ -452,7 +452,7 @@ impl CredentialPicker {
         <Self as RtActivatable<ICredentialPickerStatics>>::get_activation_factory().pick_with_caption_async(targetName, message, caption)
     }}
 }
-DEFINE_CLSID!(CredentialPicker(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,85,73,46,67,114,101,100,101,110,116,105,97,108,80,105,99,107,101,114,0]) [CLSID_CredentialPicker]);
+DEFINE_CLSID!(CredentialPicker: "Windows.Security.Credentials.UI.CredentialPicker");
 DEFINE_IID!(IID_ICredentialPickerOptions, 2522483532, 38394, 18047, 153, 43, 11, 34, 229, 133, 155, 246);
 RT_INTERFACE!{interface ICredentialPickerOptions(ICredentialPickerOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ICredentialPickerOptions] {
     fn put_Caption(&self, value: HSTRING) -> HRESULT,
@@ -572,7 +572,7 @@ impl ICredentialPickerOptions {
 }
 RT_CLASS!{class CredentialPickerOptions: ICredentialPickerOptions}
 impl RtActivatable<IActivationFactory> for CredentialPickerOptions {}
-DEFINE_CLSID!(CredentialPickerOptions(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,85,73,46,67,114,101,100,101,110,116,105,97,108,80,105,99,107,101,114,79,112,116,105,111,110,115,0]) [CLSID_CredentialPickerOptions]);
+DEFINE_CLSID!(CredentialPickerOptions: "Windows.Security.Credentials.UI.CredentialPickerOptions");
 DEFINE_IID!(IID_ICredentialPickerResults, 424212890, 52272, 16652, 156, 56, 204, 8, 132, 197, 179, 215);
 RT_INTERFACE!{interface ICredentialPickerResults(ICredentialPickerResultsVtbl): IInspectable(IInspectableVtbl) [IID_ICredentialPickerResults] {
     fn get_ErrorCode(&self, out: *mut u32) -> HRESULT,
@@ -661,7 +661,7 @@ impl UserConsentVerifier {
         <Self as RtActivatable<IUserConsentVerifierStatics>>::get_activation_factory().request_verification_async(message)
     }}
 }
-DEFINE_CLSID!(UserConsentVerifier(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,85,73,46,85,115,101,114,67,111,110,115,101,110,116,86,101,114,105,102,105,101,114,0]) [CLSID_UserConsentVerifier]);
+DEFINE_CLSID!(UserConsentVerifier: "Windows.Security.Credentials.UI.UserConsentVerifier");
 RT_ENUM! { enum UserConsentVerifierAvailability: i32 {
     Available (UserConsentVerifierAvailability_Available) = 0, DeviceNotPresent (UserConsentVerifierAvailability_DeviceNotPresent) = 1, NotConfiguredForUser (UserConsentVerifierAvailability_NotConfiguredForUser) = 2, DisabledByPolicy (UserConsentVerifierAvailability_DisabledByPolicy) = 3, DeviceBusy (UserConsentVerifierAvailability_DeviceBusy) = 4,
 }}
@@ -741,7 +741,7 @@ impl EnterpriseKeyCredentialRegistrationManager {
         <Self as RtActivatable<IEnterpriseKeyCredentialRegistrationManagerStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(EnterpriseKeyCredentialRegistrationManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,73,100,101,110,116,105,116,121,46,69,110,116,101,114,112,114,105,115,101,75,101,121,67,114,101,100,101,110,116,105,97,108,82,101,103,105,115,116,114,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_EnterpriseKeyCredentialRegistrationManager]);
+DEFINE_CLSID!(EnterpriseKeyCredentialRegistrationManager: "Windows.Security.Authentication.Identity.EnterpriseKeyCredentialRegistrationManager");
 DEFINE_IID!(IID_IEnterpriseKeyCredentialRegistrationManagerStatics, 2008571550, 44276, 19392, 186, 194, 64, 187, 70, 239, 187, 63);
 RT_INTERFACE!{static interface IEnterpriseKeyCredentialRegistrationManagerStatics(IEnterpriseKeyCredentialRegistrationManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IEnterpriseKeyCredentialRegistrationManagerStatics] {
     fn get_Current(&self, out: *mut *mut EnterpriseKeyCredentialRegistrationManager) -> HRESULT
@@ -820,7 +820,7 @@ impl SecondaryAuthenticationFactorAuthentication {
         <Self as RtActivatable<ISecondaryAuthenticationFactorAuthenticationStatics>>::get_activation_factory().get_authentication_stage_info_async()
     }}
 }
-DEFINE_CLSID!(SecondaryAuthenticationFactorAuthentication(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,73,100,101,110,116,105,116,121,46,80,114,111,118,105,100,101,114,46,83,101,99,111,110,100,97,114,121,65,117,116,104,101,110,116,105,99,97,116,105,111,110,70,97,99,116,111,114,65,117,116,104,101,110,116,105,99,97,116,105,111,110,0]) [CLSID_SecondaryAuthenticationFactorAuthentication]);
+DEFINE_CLSID!(SecondaryAuthenticationFactorAuthentication: "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthentication");
 RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationMessage: i32 {
     Invalid (SecondaryAuthenticationFactorAuthenticationMessage_Invalid) = 0, SwipeUpWelcome (SecondaryAuthenticationFactorAuthenticationMessage_SwipeUpWelcome) = 1, TapWelcome (SecondaryAuthenticationFactorAuthenticationMessage_TapWelcome) = 2, DeviceNeedsAttention (SecondaryAuthenticationFactorAuthenticationMessage_DeviceNeedsAttention) = 3, LookingForDevice (SecondaryAuthenticationFactorAuthenticationMessage_LookingForDevice) = 4, LookingForDevicePluggedin (SecondaryAuthenticationFactorAuthenticationMessage_LookingForDevicePluggedin) = 5, BluetoothIsDisabled (SecondaryAuthenticationFactorAuthenticationMessage_BluetoothIsDisabled) = 6, NfcIsDisabled (SecondaryAuthenticationFactorAuthenticationMessage_NfcIsDisabled) = 7, WiFiIsDisabled (SecondaryAuthenticationFactorAuthenticationMessage_WiFiIsDisabled) = 8, ExtraTapIsRequired (SecondaryAuthenticationFactorAuthenticationMessage_ExtraTapIsRequired) = 9, DisabledByPolicy (SecondaryAuthenticationFactorAuthenticationMessage_DisabledByPolicy) = 10, TapOnDeviceRequired (SecondaryAuthenticationFactorAuthenticationMessage_TapOnDeviceRequired) = 11, HoldFinger (SecondaryAuthenticationFactorAuthenticationMessage_HoldFinger) = 12, ScanFinger (SecondaryAuthenticationFactorAuthenticationMessage_ScanFinger) = 13, UnauthorizedUser (SecondaryAuthenticationFactorAuthenticationMessage_UnauthorizedUser) = 14, ReregisterRequired (SecondaryAuthenticationFactorAuthenticationMessage_ReregisterRequired) = 15, TryAgain (SecondaryAuthenticationFactorAuthenticationMessage_TryAgain) = 16, SayPassphrase (SecondaryAuthenticationFactorAuthenticationMessage_SayPassphrase) = 17, ReadyToSignIn (SecondaryAuthenticationFactorAuthenticationMessage_ReadyToSignIn) = 18, UseAnotherSignInOption (SecondaryAuthenticationFactorAuthenticationMessage_UseAnotherSignInOption) = 19,
 }}
@@ -1070,7 +1070,7 @@ impl SecondaryAuthenticationFactorRegistration {
         <Self as RtActivatable<ISecondaryAuthenticationFactorRegistrationStatics>>::get_activation_factory().update_device_configuration_data_async(deviceId, deviceConfigurationData)
     }}
 }
-DEFINE_CLSID!(SecondaryAuthenticationFactorRegistration(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,73,100,101,110,116,105,116,121,46,80,114,111,118,105,100,101,114,46,83,101,99,111,110,100,97,114,121,65,117,116,104,101,110,116,105,99,97,116,105,111,110,70,97,99,116,111,114,82,101,103,105,115,116,114,97,116,105,111,110,0]) [CLSID_SecondaryAuthenticationFactorRegistration]);
+DEFINE_CLSID!(SecondaryAuthenticationFactorRegistration: "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorRegistration");
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorRegistrationResult, 2768123376, 44515, 18817, 175, 107, 236, 25, 89, 33, 104, 42);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorRegistrationResult(ISecondaryAuthenticationFactorRegistrationResultVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorRegistrationResult] {
     fn get_Status(&self, out: *mut SecondaryAuthenticationFactorRegistrationStatus) -> HRESULT,
@@ -1196,7 +1196,7 @@ impl MicrosoftAccountMultiFactorAuthenticationManager {
         <Self as RtActivatable<IMicrosoftAccountMultiFactorAuthenticatorStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(MicrosoftAccountMultiFactorAuthenticationManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,73,100,101,110,116,105,116,121,46,67,111,114,101,46,77,105,99,114,111,115,111,102,116,65,99,99,111,117,110,116,77,117,108,116,105,70,97,99,116,111,114,65,117,116,104,101,110,116,105,99,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MicrosoftAccountMultiFactorAuthenticationManager]);
+DEFINE_CLSID!(MicrosoftAccountMultiFactorAuthenticationManager: "Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorAuthenticationManager");
 RT_ENUM! { enum MicrosoftAccountMultiFactorAuthenticationType: i32 {
     User (MicrosoftAccountMultiFactorAuthenticationType_User) = 0, Device (MicrosoftAccountMultiFactorAuthenticationType_Device) = 1,
 }}
@@ -1395,7 +1395,7 @@ impl IOnlineIdAuthenticator {
 }
 RT_CLASS!{class OnlineIdAuthenticator: IOnlineIdAuthenticator}
 impl RtActivatable<IActivationFactory> for OnlineIdAuthenticator {}
-DEFINE_CLSID!(OnlineIdAuthenticator(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,79,110,108,105,110,101,73,100,46,79,110,108,105,110,101,73,100,65,117,116,104,101,110,116,105,99,97,116,111,114,0]) [CLSID_OnlineIdAuthenticator]);
+DEFINE_CLSID!(OnlineIdAuthenticator: "Windows.Security.Authentication.OnlineId.OnlineIdAuthenticator");
 DEFINE_IID!(IID_IOnlineIdServiceTicket, 3378271359, 55169, 19092, 172, 184, 197, 152, 116, 35, 140, 38);
 RT_INTERFACE!{interface IOnlineIdServiceTicket(IOnlineIdServiceTicketVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdServiceTicket] {
     fn get_Value(&self, out: *mut HSTRING) -> HRESULT,
@@ -1447,7 +1447,7 @@ impl OnlineIdServiceTicketRequest {
         <Self as RtActivatable<IOnlineIdServiceTicketRequestFactory>>::get_activation_factory().create_online_id_service_ticket_request_advanced(service)
     }}
 }
-DEFINE_CLSID!(OnlineIdServiceTicketRequest(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,79,110,108,105,110,101,73,100,46,79,110,108,105,110,101,73,100,83,101,114,118,105,99,101,84,105,99,107,101,116,82,101,113,117,101,115,116,0]) [CLSID_OnlineIdServiceTicketRequest]);
+DEFINE_CLSID!(OnlineIdServiceTicketRequest: "Windows.Security.Authentication.OnlineId.OnlineIdServiceTicketRequest");
 DEFINE_IID!(IID_IOnlineIdServiceTicketRequestFactory, 3199928840, 40563, 16503, 150, 20, 8, 97, 76, 11, 194, 69);
 RT_INTERFACE!{static interface IOnlineIdServiceTicketRequestFactory(IOnlineIdServiceTicketRequestFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdServiceTicketRequestFactory] {
     fn CreateOnlineIdServiceTicketRequest(&self, service: HSTRING, policy: HSTRING, out: *mut *mut OnlineIdServiceTicketRequest) -> HRESULT,
@@ -1475,7 +1475,7 @@ impl OnlineIdSystemAuthenticator {
         <Self as RtActivatable<IOnlineIdSystemAuthenticatorStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(OnlineIdSystemAuthenticator(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,79,110,108,105,110,101,73,100,46,79,110,108,105,110,101,73,100,83,121,115,116,101,109,65,117,116,104,101,110,116,105,99,97,116,111,114,0]) [CLSID_OnlineIdSystemAuthenticator]);
+DEFINE_CLSID!(OnlineIdSystemAuthenticator: "Windows.Security.Authentication.OnlineId.OnlineIdSystemAuthenticator");
 DEFINE_IID!(IID_IOnlineIdSystemAuthenticatorForUser, 1469628155, 7652, 16774, 162, 230, 181, 99, 248, 106, 175, 68);
 RT_INTERFACE!{interface IOnlineIdSystemAuthenticatorForUser(IOnlineIdSystemAuthenticatorForUserVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdSystemAuthenticatorForUser] {
     fn GetTicketAsync(&self, request: *mut OnlineIdServiceTicketRequest, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<OnlineIdSystemTicketResult>) -> HRESULT,
@@ -1658,7 +1658,7 @@ impl WebAuthenticationBroker {
         <Self as RtActivatable<IWebAuthenticationBrokerStatics2>>::get_activation_factory().authenticate_silently_with_options_async(requestUri, options)
     }}
 }
-DEFINE_CLSID!(WebAuthenticationBroker(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,87,101,98,65,117,116,104,101,110,116,105,99,97,116,105,111,110,66,114,111,107,101,114,0]) [CLSID_WebAuthenticationBroker]);
+DEFINE_CLSID!(WebAuthenticationBroker: "Windows.Security.Authentication.Web.WebAuthenticationBroker");
 DEFINE_IID!(IID_IWebAuthenticationBrokerStatics, 789880602, 58995, 16565, 188, 34, 32, 26, 104, 100, 163, 123);
 RT_INTERFACE!{static interface IWebAuthenticationBrokerStatics(IWebAuthenticationBrokerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebAuthenticationBrokerStatics] {
     fn AuthenticateWithCallbackUriAsync(&self, options: WebAuthenticationOptions, requestUri: *mut ::rt::gen::windows::foundation::Uri, callbackUri: *mut ::rt::gen::windows::foundation::Uri, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<WebAuthenticationResult>) -> HRESULT,
@@ -1779,7 +1779,7 @@ impl WebAccountClientView {
         <Self as RtActivatable<IWebAccountClientViewFactory>>::get_activation_factory().create_with_pairwise_id(viewType, applicationCallbackUri, accountPairwiseId)
     }}
 }
-DEFINE_CLSID!(WebAccountClientView(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,80,114,111,118,105,100,101,114,46,87,101,98,65,99,99,111,117,110,116,67,108,105,101,110,116,86,105,101,119,0]) [CLSID_WebAccountClientView]);
+DEFINE_CLSID!(WebAccountClientView: "Windows.Security.Authentication.Web.Provider.WebAccountClientView");
 DEFINE_IID!(IID_IWebAccountClientViewFactory, 1634539172, 56866, 18517, 163, 38, 6, 206, 191, 42, 63, 35);
 RT_INTERFACE!{static interface IWebAccountClientViewFactory(IWebAccountClientViewFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountClientViewFactory] {
     fn Create(&self, viewType: WebAccountClientViewType, applicationCallbackUri: *mut ::rt::gen::windows::foundation::Uri, out: *mut *mut WebAccountClientView) -> HRESULT,
@@ -1881,7 +1881,7 @@ impl WebAccountManager {
         <Self as RtActivatable<IWebAccountScopeManagerStatics>>::get_activation_factory().get_scope(webAccount)
     }}
 }
-DEFINE_CLSID!(WebAccountManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,80,114,111,118,105,100,101,114,46,87,101,98,65,99,99,111,117,110,116,77,97,110,97,103,101,114,0]) [CLSID_WebAccountManager]);
+DEFINE_CLSID!(WebAccountManager: "Windows.Security.Authentication.Web.Provider.WebAccountManager");
 DEFINE_IID!(IID_IWebAccountManagerStatics, 3001606566, 54426, 16434, 132, 191, 26, 40, 71, 116, 123, 241);
 RT_INTERFACE!{static interface IWebAccountManagerStatics(IWebAccountManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountManagerStatics] {
     fn UpdateWebAccountPropertiesAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, webAccountUserName: HSTRING, additionalProperties: *mut ::rt::gen::windows::foundation::collections::IMapView<HString, HString>, out: *mut *mut ::rt::gen::windows::foundation::IAsyncAction) -> HRESULT,
@@ -2336,7 +2336,7 @@ impl WebProviderTokenResponse {
         <Self as RtActivatable<IWebProviderTokenResponseFactory>>::get_activation_factory().create(webTokenResponse)
     }}
 }
-DEFINE_CLSID!(WebProviderTokenResponse(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,80,114,111,118,105,100,101,114,46,87,101,98,80,114,111,118,105,100,101,114,84,111,107,101,110,82,101,115,112,111,110,115,101,0]) [CLSID_WebProviderTokenResponse]);
+DEFINE_CLSID!(WebProviderTokenResponse: "Windows.Security.Authentication.Web.Provider.WebProviderTokenResponse");
 DEFINE_IID!(IID_IWebProviderTokenResponseFactory, 4199143834, 9658, 16503, 156, 250, 157, 180, 222, 167, 183, 26);
 RT_INTERFACE!{static interface IWebProviderTokenResponseFactory(IWebProviderTokenResponseFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWebProviderTokenResponseFactory] {
     fn Create(&self, webTokenResponse: *mut super::core::WebTokenResponse, out: *mut *mut WebProviderTokenResponse) -> HRESULT
@@ -2435,7 +2435,7 @@ impl WebAuthenticationCoreManager {
         <Self as RtActivatable<IWebAuthenticationCoreManagerStatics3>>::get_activation_factory().create_web_account_monitor(webAccounts)
     }}
 }
-DEFINE_CLSID!(WebAuthenticationCoreManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,67,111,114,101,46,87,101,98,65,117,116,104,101,110,116,105,99,97,116,105,111,110,67,111,114,101,77,97,110,97,103,101,114,0]) [CLSID_WebAuthenticationCoreManager]);
+DEFINE_CLSID!(WebAuthenticationCoreManager: "Windows.Security.Authentication.Web.Core.WebAuthenticationCoreManager");
 DEFINE_IID!(IID_IWebAuthenticationCoreManagerStatics, 1791655058, 42369, 17529, 156, 16, 117, 46, 255, 68, 253, 52);
 RT_INTERFACE!{static interface IWebAuthenticationCoreManagerStatics(IWebAuthenticationCoreManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebAuthenticationCoreManagerStatics] {
     fn GetTokenSilentlyAsync(&self, request: *mut WebTokenRequest, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<WebTokenRequestResult>) -> HRESULT,
@@ -2535,7 +2535,7 @@ impl WebProviderError {
         <Self as RtActivatable<IWebProviderErrorFactory>>::get_activation_factory().create(errorCode, errorMessage)
     }}
 }
-DEFINE_CLSID!(WebProviderError(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,67,111,114,101,46,87,101,98,80,114,111,118,105,100,101,114,69,114,114,111,114,0]) [CLSID_WebProviderError]);
+DEFINE_CLSID!(WebProviderError: "Windows.Security.Authentication.Web.Core.WebProviderError");
 DEFINE_IID!(IID_IWebProviderErrorFactory, 3821275693, 35311, 20023, 132, 127, 168, 185, 213, 163, 41, 16);
 RT_INTERFACE!{static interface IWebProviderErrorFactory(IWebProviderErrorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWebProviderErrorFactory] {
     fn Create(&self, errorCode: u32, errorMessage: HSTRING, out: *mut *mut WebProviderError) -> HRESULT
@@ -2598,7 +2598,7 @@ impl WebTokenRequest {
         <Self as RtActivatable<IWebTokenRequestFactory>>::get_activation_factory().create_with_scope(provider, scope)
     }}
 }
-DEFINE_CLSID!(WebTokenRequest(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,67,111,114,101,46,87,101,98,84,111,107,101,110,82,101,113,117,101,115,116,0]) [CLSID_WebTokenRequest]);
+DEFINE_CLSID!(WebTokenRequest: "Windows.Security.Authentication.Web.Core.WebTokenRequest");
 DEFINE_IID!(IID_IWebTokenRequest2, 3607150713, 12488, 17303, 150, 84, 150, 28, 59, 232, 184, 85);
 RT_INTERFACE!{interface IWebTokenRequest2(IWebTokenRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebTokenRequest2] {
     fn get_AppProperties(&self, out: *mut *mut ::rt::gen::windows::foundation::collections::IMap<HString, HString>) -> HRESULT
@@ -2734,7 +2734,7 @@ impl WebTokenResponse {
         <Self as RtActivatable<IWebTokenResponseFactory>>::get_activation_factory().create_with_token_account_and_error(token, webAccount, error)
     }}
 }
-DEFINE_CLSID!(WebTokenResponse(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,87,101,98,46,67,111,114,101,46,87,101,98,84,111,107,101,110,82,101,115,112,111,110,115,101,0]) [CLSID_WebTokenResponse]);
+DEFINE_CLSID!(WebTokenResponse: "Windows.Security.Authentication.Web.Core.WebTokenResponse");
 DEFINE_IID!(IID_IWebTokenResponseFactory, 2875979768, 21584, 20214, 151, 247, 5, 43, 4, 49, 192, 240);
 RT_INTERFACE!{static interface IWebTokenResponseFactory(IWebTokenResponseFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWebTokenResponseFactory] {
     fn CreateWithToken(&self, token: HSTRING, out: *mut *mut WebTokenResponse) -> HRESULT,
@@ -2803,7 +2803,7 @@ impl CryptographicBuffer {
         <Self as RtActivatable<ICryptographicBufferStatics>>::get_activation_factory().convert_binary_to_string(encoding, buffer)
     }}
 }
-DEFINE_CLSID!(CryptographicBuffer(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,114,121,112,116,111,103,114,97,112,104,105,99,66,117,102,102,101,114,0]) [CLSID_CryptographicBuffer]);
+DEFINE_CLSID!(CryptographicBuffer: "Windows.Security.Cryptography.CryptographicBuffer");
 DEFINE_IID!(IID_ICryptographicBufferStatics, 839613986, 15536, 19679, 134, 99, 29, 40, 145, 0, 101, 235);
 RT_INTERFACE!{static interface ICryptographicBufferStatics(ICryptographicBufferStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICryptographicBufferStatics] {
     #[cfg(feature="windows-storage")] fn Compare(&self, object1: *mut super::super::storage::streams::IBuffer, object2: *mut super::super::storage::streams::IBuffer, out: *mut bool) -> HRESULT,
@@ -2979,7 +2979,7 @@ impl Certificate {
         <Self as RtActivatable<ICertificateFactory>>::get_activation_factory().create_certificate(certBlob)
     }}
 }
-DEFINE_CLSID!(Certificate(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,0]) [CLSID_Certificate]);
+DEFINE_CLSID!(Certificate: "Windows.Security.Cryptography.Certificates.Certificate");
 DEFINE_IID!(IID_ICertificate2, 397948748, 35365, 19862, 164, 146, 143, 194, 154, 196, 253, 166);
 RT_INTERFACE!{interface ICertificate2(ICertificate2Vtbl): IInspectable(IInspectableVtbl) [IID_ICertificate2] {
     fn get_IsSecurityDeviceBound(&self, out: *mut bool) -> HRESULT,
@@ -3095,7 +3095,7 @@ impl CertificateEnrollmentManager {
         <Self as RtActivatable<ICertificateEnrollmentManagerStatics3>>::get_activation_factory().import_pfx_data_to_ksp_with_parameters_async(pfxData, password, pfxImportParameters)
     }}
 }
-DEFINE_CLSID!(CertificateEnrollmentManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,69,110,114,111,108,108,109,101,110,116,77,97,110,97,103,101,114,0]) [CLSID_CertificateEnrollmentManager]);
+DEFINE_CLSID!(CertificateEnrollmentManager: "Windows.Security.Cryptography.Certificates.CertificateEnrollmentManager");
 DEFINE_IID!(IID_ICertificateEnrollmentManagerStatics, 2286350143, 43398, 18683, 159, 215, 154, 236, 6, 147, 91, 241);
 RT_INTERFACE!{static interface ICertificateEnrollmentManagerStatics(ICertificateEnrollmentManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICertificateEnrollmentManagerStatics] {
     fn CreateRequestAsync(&self, request: *mut CertificateRequestProperties, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -3192,7 +3192,7 @@ impl ICertificateExtension {
 }
 RT_CLASS!{class CertificateExtension: ICertificateExtension}
 impl RtActivatable<IActivationFactory> for CertificateExtension {}
-DEFINE_CLSID!(CertificateExtension(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,69,120,116,101,110,115,105,111,110,0]) [CLSID_CertificateExtension]);
+DEFINE_CLSID!(CertificateExtension: "Windows.Security.Cryptography.Certificates.CertificateExtension");
 DEFINE_IID!(IID_ICertificateFactory, 397681180, 19375, 17570, 150, 8, 4, 251, 98, 177, 105, 66);
 RT_INTERFACE!{static interface ICertificateFactory(ICertificateFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICertificateFactory] {
     #[cfg(feature="windows-storage")] fn CreateCertificate(&self, certBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut Certificate) -> HRESULT
@@ -3299,7 +3299,7 @@ impl ICertificateKeyUsages {
 }
 RT_CLASS!{class CertificateKeyUsages: ICertificateKeyUsages}
 impl RtActivatable<IActivationFactory> for CertificateKeyUsages {}
-DEFINE_CLSID!(CertificateKeyUsages(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,75,101,121,85,115,97,103,101,115,0]) [CLSID_CertificateKeyUsages]);
+DEFINE_CLSID!(CertificateKeyUsages: "Windows.Security.Cryptography.Certificates.CertificateKeyUsages");
 DEFINE_IID!(IID_ICertificateQuery, 1527261745, 42792, 18710, 181, 238, 255, 203, 138, 207, 36, 23);
 RT_INTERFACE!{interface ICertificateQuery(ICertificateQueryVtbl): IInspectable(IInspectableVtbl) [IID_ICertificateQuery] {
     fn get_EnhancedKeyUsages(&self, out: *mut *mut ::rt::gen::windows::foundation::collections::IVector<HString>) -> HRESULT,
@@ -3357,7 +3357,7 @@ impl ICertificateQuery {
 }
 RT_CLASS!{class CertificateQuery: ICertificateQuery}
 impl RtActivatable<IActivationFactory> for CertificateQuery {}
-DEFINE_CLSID!(CertificateQuery(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,81,117,101,114,121,0]) [CLSID_CertificateQuery]);
+DEFINE_CLSID!(CertificateQuery: "Windows.Security.Cryptography.Certificates.CertificateQuery");
 DEFINE_IID!(IID_ICertificateQuery2, 2472151799, 3033, 20341, 184, 194, 226, 122, 127, 116, 238, 205);
 RT_INTERFACE!{interface ICertificateQuery2(ICertificateQuery2Vtbl): IInspectable(IInspectableVtbl) [IID_ICertificateQuery2] {
     fn get_IncludeDuplicates(&self, out: *mut bool) -> HRESULT,
@@ -3502,7 +3502,7 @@ impl ICertificateRequestProperties {
 }
 RT_CLASS!{class CertificateRequestProperties: ICertificateRequestProperties}
 impl RtActivatable<IActivationFactory> for CertificateRequestProperties {}
-DEFINE_CLSID!(CertificateRequestProperties(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,82,101,113,117,101,115,116,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_CertificateRequestProperties]);
+DEFINE_CLSID!(CertificateRequestProperties: "Windows.Security.Cryptography.Certificates.CertificateRequestProperties");
 DEFINE_IID!(IID_ICertificateRequestProperties2, 1033947476, 55103, 20467, 160, 166, 6, 119, 192, 173, 160, 91);
 RT_INTERFACE!{interface ICertificateRequestProperties2(ICertificateRequestProperties2Vtbl): IInspectable(IInspectableVtbl) [IID_ICertificateRequestProperties2] {
     fn get_SmartcardReaderName(&self, out: *mut HSTRING) -> HRESULT,
@@ -3674,7 +3674,7 @@ impl CertificateStores {
         <Self as RtActivatable<ICertificateStoresStatics2>>::get_activation_factory().get_user_store_by_name(storeName)
     }}
 }
-DEFINE_CLSID!(CertificateStores(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,83,116,111,114,101,115,0]) [CLSID_CertificateStores]);
+DEFINE_CLSID!(CertificateStores: "Windows.Security.Cryptography.Certificates.CertificateStores");
 DEFINE_IID!(IID_ICertificateStoresStatics, 4226598713, 50942, 19943, 153, 207, 116, 195, 229, 150, 224, 50);
 RT_INTERFACE!{static interface ICertificateStoresStatics(ICertificateStoresStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICertificateStoresStatics] {
     fn FindAllAsync(&self, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<::rt::gen::windows::foundation::collections::IVectorView<Certificate>>) -> HRESULT,
@@ -3795,7 +3795,7 @@ impl IChainBuildingParameters {
 }
 RT_CLASS!{class ChainBuildingParameters: IChainBuildingParameters}
 impl RtActivatable<IActivationFactory> for ChainBuildingParameters {}
-DEFINE_CLSID!(ChainBuildingParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,104,97,105,110,66,117,105,108,100,105,110,103,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_ChainBuildingParameters]);
+DEFINE_CLSID!(ChainBuildingParameters: "Windows.Security.Cryptography.Certificates.ChainBuildingParameters");
 DEFINE_IID!(IID_IChainValidationParameters, 3295951690, 32432, 19286, 160, 64, 185, 200, 230, 85, 221, 243);
 RT_INTERFACE!{interface IChainValidationParameters(IChainValidationParametersVtbl): IInspectable(IInspectableVtbl) [IID_IChainValidationParameters] {
     fn get_CertificateChainPolicy(&self, out: *mut CertificateChainPolicy) -> HRESULT,
@@ -3825,7 +3825,7 @@ impl IChainValidationParameters {
 }
 RT_CLASS!{class ChainValidationParameters: IChainValidationParameters}
 impl RtActivatable<IActivationFactory> for ChainValidationParameters {}
-DEFINE_CLSID!(ChainValidationParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,104,97,105,110,86,97,108,105,100,97,116,105,111,110,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_ChainValidationParameters]);
+DEFINE_CLSID!(ChainValidationParameters: "Windows.Security.Cryptography.Certificates.ChainValidationParameters");
 RT_ENUM! { enum ChainValidationResult: i32 {
     Success (ChainValidationResult_Success) = 0, Untrusted (ChainValidationResult_Untrusted) = 1, Revoked (ChainValidationResult_Revoked) = 2, Expired (ChainValidationResult_Expired) = 3, IncompleteChain (ChainValidationResult_IncompleteChain) = 4, InvalidSignature (ChainValidationResult_InvalidSignature) = 5, WrongUsage (ChainValidationResult_WrongUsage) = 6, InvalidName (ChainValidationResult_InvalidName) = 7, InvalidCertificateAuthorityPolicy (ChainValidationResult_InvalidCertificateAuthorityPolicy) = 8, BasicConstraintsError (ChainValidationResult_BasicConstraintsError) = 9, UnknownCriticalExtension (ChainValidationResult_UnknownCriticalExtension) = 10, RevocationInformationMissing (ChainValidationResult_RevocationInformationMissing) = 11, RevocationFailure (ChainValidationResult_RevocationFailure) = 12, OtherErrors (ChainValidationResult_OtherErrors) = 13,
 }}
@@ -3869,7 +3869,7 @@ impl CmsAttachedSignature {
         <Self as RtActivatable<ICmsAttachedSignatureStatics>>::get_activation_factory().generate_signature_async(data, signers, certificates)
     }}
 }
-DEFINE_CLSID!(CmsAttachedSignature(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,109,115,65,116,116,97,99,104,101,100,83,105,103,110,97,116,117,114,101,0]) [CLSID_CmsAttachedSignature]);
+DEFINE_CLSID!(CmsAttachedSignature: "Windows.Security.Cryptography.Certificates.CmsAttachedSignature");
 DEFINE_IID!(IID_ICmsAttachedSignatureFactory, 3502832661, 63319, 19556, 163, 98, 82, 204, 28, 119, 207, 251);
 RT_INTERFACE!{static interface ICmsAttachedSignatureFactory(ICmsAttachedSignatureFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICmsAttachedSignatureFactory] {
     #[cfg(feature="windows-storage")] fn CreateCmsAttachedSignature(&self, inputBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CmsAttachedSignature) -> HRESULT
@@ -3926,7 +3926,7 @@ impl CmsDetachedSignature {
         <Self as RtActivatable<ICmsDetachedSignatureStatics>>::get_activation_factory().generate_signature_async(data, signers, certificates)
     }}
 }
-DEFINE_CLSID!(CmsDetachedSignature(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,109,115,68,101,116,97,99,104,101,100,83,105,103,110,97,116,117,114,101,0]) [CLSID_CmsDetachedSignature]);
+DEFINE_CLSID!(CmsDetachedSignature: "Windows.Security.Cryptography.Certificates.CmsDetachedSignature");
 DEFINE_IID!(IID_ICmsDetachedSignatureFactory, 3299554563, 44671, 17287, 173, 25, 0, 241, 80, 228, 142, 187);
 RT_INTERFACE!{static interface ICmsDetachedSignatureFactory(ICmsDetachedSignatureFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICmsDetachedSignatureFactory] {
     #[cfg(feature="windows-storage")] fn CreateCmsDetachedSignature(&self, inputBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CmsDetachedSignature) -> HRESULT
@@ -3984,7 +3984,7 @@ impl ICmsSignerInfo {
 }
 RT_CLASS!{class CmsSignerInfo: ICmsSignerInfo}
 impl RtActivatable<IActivationFactory> for CmsSignerInfo {}
-DEFINE_CLSID!(CmsSignerInfo(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,109,115,83,105,103,110,101,114,73,110,102,111,0]) [CLSID_CmsSignerInfo]);
+DEFINE_CLSID!(CmsSignerInfo: "Windows.Security.Cryptography.Certificates.CmsSignerInfo");
 DEFINE_IID!(IID_ICmsTimestampInfo, 794755314, 11288, 20360, 132, 53, 197, 52, 8, 96, 118, 245);
 RT_INTERFACE!{interface ICmsTimestampInfo(ICmsTimestampInfoVtbl): IInspectable(IInspectableVtbl) [IID_ICmsTimestampInfo] {
     fn get_SigningCertificate(&self, out: *mut *mut Certificate) -> HRESULT,
@@ -4053,7 +4053,7 @@ impl KeyAlgorithmNames {
         <Self as RtActivatable<IKeyAlgorithmNamesStatics2>>::get_activation_factory().get_ecdh()
     }}
 }
-DEFINE_CLSID!(KeyAlgorithmNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,75,101,121,65,108,103,111,114,105,116,104,109,78,97,109,101,115,0]) [CLSID_KeyAlgorithmNames]);
+DEFINE_CLSID!(KeyAlgorithmNames: "Windows.Security.Cryptography.Certificates.KeyAlgorithmNames");
 DEFINE_IID!(IID_IKeyAlgorithmNamesStatics, 1200645591, 31431, 17793, 140, 59, 208, 112, 39, 20, 4, 72);
 RT_INTERFACE!{static interface IKeyAlgorithmNamesStatics(IKeyAlgorithmNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyAlgorithmNamesStatics] {
     fn get_Rsa(&self, out: *mut HSTRING) -> HRESULT,
@@ -4138,7 +4138,7 @@ impl KeyAttestationHelper {
         <Self as RtActivatable<IKeyAttestationHelperStatics2>>::get_activation_factory().decrypt_tpm_attestation_credential_with_container_name_async(credential, containerName)
     }}
 }
-DEFINE_CLSID!(KeyAttestationHelper(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,75,101,121,65,116,116,101,115,116,97,116,105,111,110,72,101,108,112,101,114,0]) [CLSID_KeyAttestationHelper]);
+DEFINE_CLSID!(KeyAttestationHelper: "Windows.Security.Cryptography.Certificates.KeyAttestationHelper");
 DEFINE_IID!(IID_IKeyAttestationHelperStatics, 373875270, 63044, 17190, 136, 190, 58, 241, 2, 211, 14, 12);
 RT_INTERFACE!{static interface IKeyAttestationHelperStatics(IKeyAttestationHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyAttestationHelperStatics] {
     fn DecryptTpmAttestationCredentialAsync(&self, credential: HSTRING, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -4190,7 +4190,7 @@ impl KeyStorageProviderNames {
         <Self as RtActivatable<IKeyStorageProviderNamesStatics2>>::get_activation_factory().get_passport_key_storage_provider()
     }}
 }
-DEFINE_CLSID!(KeyStorageProviderNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,75,101,121,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,78,97,109,101,115,0]) [CLSID_KeyStorageProviderNames]);
+DEFINE_CLSID!(KeyStorageProviderNames: "Windows.Security.Cryptography.Certificates.KeyStorageProviderNames");
 DEFINE_IID!(IID_IKeyStorageProviderNamesStatics, 2937613024, 21801, 17922, 189, 148, 10, 171, 145, 149, 123, 92);
 RT_INTERFACE!{static interface IKeyStorageProviderNamesStatics(IKeyStorageProviderNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyStorageProviderNamesStatics] {
     fn get_SoftwareKeyStorageProvider(&self, out: *mut HSTRING) -> HRESULT,
@@ -4309,7 +4309,7 @@ impl IPfxImportParameters {
 }
 RT_CLASS!{class PfxImportParameters: IPfxImportParameters}
 impl RtActivatable<IActivationFactory> for PfxImportParameters {}
-DEFINE_CLSID!(PfxImportParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,80,102,120,73,109,112,111,114,116,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_PfxImportParameters]);
+DEFINE_CLSID!(PfxImportParameters: "Windows.Security.Cryptography.Certificates.PfxImportParameters");
 RT_ENUM! { enum SignatureValidationResult: i32 {
     Success (SignatureValidationResult_Success) = 0, InvalidParameter (SignatureValidationResult_InvalidParameter) = 1, BadMessage (SignatureValidationResult_BadMessage) = 2, InvalidSignature (SignatureValidationResult_InvalidSignature) = 3, OtherErrors (SignatureValidationResult_OtherErrors) = 4,
 }}
@@ -4326,7 +4326,7 @@ impl StandardCertificateStoreNames {
         <Self as RtActivatable<IStandardCertificateStoreNamesStatics>>::get_activation_factory().get_intermediate_certification_authorities()
     }}
 }
-DEFINE_CLSID!(StandardCertificateStoreNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,83,116,97,110,100,97,114,100,67,101,114,116,105,102,105,99,97,116,101,83,116,111,114,101,78,97,109,101,115,0]) [CLSID_StandardCertificateStoreNames]);
+DEFINE_CLSID!(StandardCertificateStoreNames: "Windows.Security.Cryptography.Certificates.StandardCertificateStoreNames");
 DEFINE_IID!(IID_IStandardCertificateStoreNamesStatics, 202722011, 42134, 16888, 143, 229, 158, 150, 243, 110, 251, 248);
 RT_INTERFACE!{static interface IStandardCertificateStoreNamesStatics(IStandardCertificateStoreNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStandardCertificateStoreNamesStatics] {
     fn get_Personal(&self, out: *mut HSTRING) -> HRESULT,
@@ -4393,7 +4393,7 @@ impl ISubjectAlternativeNameInfo {
 }
 RT_CLASS!{class SubjectAlternativeNameInfo: ISubjectAlternativeNameInfo}
 impl RtActivatable<IActivationFactory> for SubjectAlternativeNameInfo {}
-DEFINE_CLSID!(SubjectAlternativeNameInfo(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,83,117,98,106,101,99,116,65,108,116,101,114,110,97,116,105,118,101,78,97,109,101,73,110,102,111,0]) [CLSID_SubjectAlternativeNameInfo]);
+DEFINE_CLSID!(SubjectAlternativeNameInfo: "Windows.Security.Cryptography.Certificates.SubjectAlternativeNameInfo");
 DEFINE_IID!(IID_ISubjectAlternativeNameInfo2, 1132099782, 7249, 16874, 179, 74, 61, 101, 67, 152, 163, 112);
 RT_INTERFACE!{interface ISubjectAlternativeNameInfo2(ISubjectAlternativeNameInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_ISubjectAlternativeNameInfo2] {
     fn get_EmailNames(&self, out: *mut *mut ::rt::gen::windows::foundation::collections::IVector<HString>) -> HRESULT,
@@ -4577,7 +4577,7 @@ impl AsymmetricAlgorithmNames {
         <Self as RtActivatable<IAsymmetricAlgorithmNamesStatics2>>::get_activation_factory().get_ecdsa_sha512()
     }}
 }
-DEFINE_CLSID!(AsymmetricAlgorithmNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,65,115,121,109,109,101,116,114,105,99,65,108,103,111,114,105,116,104,109,78,97,109,101,115,0]) [CLSID_AsymmetricAlgorithmNames]);
+DEFINE_CLSID!(AsymmetricAlgorithmNames: "Windows.Security.Cryptography.Core.AsymmetricAlgorithmNames");
 DEFINE_IID!(IID_IAsymmetricAlgorithmNamesStatics, 3405184228, 26560, 18090, 132, 249, 117, 46, 119, 68, 159, 155);
 RT_INTERFACE!{static interface IAsymmetricAlgorithmNamesStatics(IAsymmetricAlgorithmNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAsymmetricAlgorithmNamesStatics] {
     fn get_RsaPkcs1(&self, out: *mut HSTRING) -> HRESULT,
@@ -4762,7 +4762,7 @@ impl AsymmetricKeyAlgorithmProvider {
         <Self as RtActivatable<IAsymmetricKeyAlgorithmProviderStatics>>::get_activation_factory().open_algorithm(algorithm)
     }}
 }
-DEFINE_CLSID!(AsymmetricKeyAlgorithmProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,65,115,121,109,109,101,116,114,105,99,75,101,121,65,108,103,111,114,105,116,104,109,80,114,111,118,105,100,101,114,0]) [CLSID_AsymmetricKeyAlgorithmProvider]);
+DEFINE_CLSID!(AsymmetricKeyAlgorithmProvider: "Windows.Security.Cryptography.Core.AsymmetricKeyAlgorithmProvider");
 DEFINE_IID!(IID_IAsymmetricKeyAlgorithmProvider2, 1311910526, 31821, 18839, 172, 79, 27, 132, 139, 54, 48, 110);
 RT_INTERFACE!{interface IAsymmetricKeyAlgorithmProvider2(IAsymmetricKeyAlgorithmProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IAsymmetricKeyAlgorithmProvider2] {
     fn CreateKeyPairWithCurveName(&self, curveName: HSTRING, out: *mut *mut CryptographicKey) -> HRESULT,
@@ -4835,7 +4835,7 @@ impl CryptographicEngine {
         <Self as RtActivatable<ICryptographicEngineStatics2>>::get_activation_factory().sign_hashed_data_async(key, data)
     }}
 }
-DEFINE_CLSID!(CryptographicEngine(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,67,114,121,112,116,111,103,114,97,112,104,105,99,69,110,103,105,110,101,0]) [CLSID_CryptographicEngine]);
+DEFINE_CLSID!(CryptographicEngine: "Windows.Security.Cryptography.Core.CryptographicEngine");
 DEFINE_IID!(IID_ICryptographicEngineStatics, 2682914361, 28663, 19589, 160, 149, 149, 235, 49, 113, 94, 185);
 RT_INTERFACE!{static interface ICryptographicEngineStatics(ICryptographicEngineStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICryptographicEngineStatics] {
     #[cfg(feature="windows-storage")] fn Encrypt(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, iv: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
@@ -5106,7 +5106,7 @@ impl EccCurveNames {
         <Self as RtActivatable<IEccCurveNamesStatics>>::get_activation_factory().get_all_ecc_curve_names()
     }}
 }
-DEFINE_CLSID!(EccCurveNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,69,99,99,67,117,114,118,101,78,97,109,101,115,0]) [CLSID_EccCurveNames]);
+DEFINE_CLSID!(EccCurveNames: "Windows.Security.Cryptography.Core.EccCurveNames");
 DEFINE_IID!(IID_IEccCurveNamesStatics, 3019870988, 44779, 16542, 183, 212, 155, 149, 41, 90, 174, 207);
 RT_INTERFACE!{static interface IEccCurveNamesStatics(IEccCurveNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IEccCurveNamesStatics] {
     fn get_BrainpoolP160r1(&self, out: *mut HSTRING) -> HRESULT,
@@ -5425,7 +5425,7 @@ impl HashAlgorithmNames {
         <Self as RtActivatable<IHashAlgorithmNamesStatics>>::get_activation_factory().get_sha512()
     }}
 }
-DEFINE_CLSID!(HashAlgorithmNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,72,97,115,104,65,108,103,111,114,105,116,104,109,78,97,109,101,115,0]) [CLSID_HashAlgorithmNames]);
+DEFINE_CLSID!(HashAlgorithmNames: "Windows.Security.Cryptography.Core.HashAlgorithmNames");
 DEFINE_IID!(IID_IHashAlgorithmNamesStatics, 1801323798, 56982, 20234, 141, 87, 220, 201, 218, 227, 108, 118);
 RT_INTERFACE!{static interface IHashAlgorithmNamesStatics(IHashAlgorithmNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHashAlgorithmNamesStatics] {
     fn get_Md5(&self, out: *mut HSTRING) -> HRESULT,
@@ -5498,7 +5498,7 @@ impl HashAlgorithmProvider {
         <Self as RtActivatable<IHashAlgorithmProviderStatics>>::get_activation_factory().open_algorithm(algorithm)
     }}
 }
-DEFINE_CLSID!(HashAlgorithmProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,72,97,115,104,65,108,103,111,114,105,116,104,109,80,114,111,118,105,100,101,114,0]) [CLSID_HashAlgorithmProvider]);
+DEFINE_CLSID!(HashAlgorithmProvider: "Windows.Security.Cryptography.Core.HashAlgorithmProvider");
 DEFINE_IID!(IID_IHashAlgorithmProviderStatics, 2678888257, 23748, 17206, 174, 56, 98, 18, 183, 90, 145, 90);
 RT_INTERFACE!{static interface IHashAlgorithmProviderStatics(IHashAlgorithmProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHashAlgorithmProviderStatics] {
     fn OpenAlgorithm(&self, algorithm: HSTRING, out: *mut *mut HashAlgorithmProvider) -> HRESULT
@@ -5591,7 +5591,7 @@ impl KeyDerivationAlgorithmNames {
         <Self as RtActivatable<IKeyDerivationAlgorithmNamesStatics2>>::get_activation_factory().get_capi_kdf_sha512()
     }}
 }
-DEFINE_CLSID!(KeyDerivationAlgorithmNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,75,101,121,68,101,114,105,118,97,116,105,111,110,65,108,103,111,114,105,116,104,109,78,97,109,101,115,0]) [CLSID_KeyDerivationAlgorithmNames]);
+DEFINE_CLSID!(KeyDerivationAlgorithmNames: "Windows.Security.Cryptography.Core.KeyDerivationAlgorithmNames");
 DEFINE_IID!(IID_IKeyDerivationAlgorithmNamesStatics, 2070820414, 38098, 18233, 165, 123, 2, 46, 12, 58, 64, 42);
 RT_INTERFACE!{static interface IKeyDerivationAlgorithmNamesStatics(IKeyDerivationAlgorithmNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyDerivationAlgorithmNamesStatics] {
     fn get_Pbkdf2Md5(&self, out: *mut HSTRING) -> HRESULT,
@@ -5746,7 +5746,7 @@ impl KeyDerivationAlgorithmProvider {
         <Self as RtActivatable<IKeyDerivationAlgorithmProviderStatics>>::get_activation_factory().open_algorithm(algorithm)
     }}
 }
-DEFINE_CLSID!(KeyDerivationAlgorithmProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,75,101,121,68,101,114,105,118,97,116,105,111,110,65,108,103,111,114,105,116,104,109,80,114,111,118,105,100,101,114,0]) [CLSID_KeyDerivationAlgorithmProvider]);
+DEFINE_CLSID!(KeyDerivationAlgorithmProvider: "Windows.Security.Cryptography.Core.KeyDerivationAlgorithmProvider");
 DEFINE_IID!(IID_IKeyDerivationAlgorithmProviderStatics, 170002810, 2588, 17467, 148, 24, 185, 73, 138, 235, 22, 3);
 RT_INTERFACE!{static interface IKeyDerivationAlgorithmProviderStatics(IKeyDerivationAlgorithmProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyDerivationAlgorithmProviderStatics] {
     fn OpenAlgorithm(&self, algorithm: HSTRING, out: *mut *mut KeyDerivationAlgorithmProvider) -> HRESULT
@@ -5799,7 +5799,7 @@ impl KeyDerivationParameters {
         <Self as RtActivatable<IKeyDerivationParametersStatics2>>::get_activation_factory().build_for_capi1_kdf(capi1KdfTargetAlgorithm)
     }}
 }
-DEFINE_CLSID!(KeyDerivationParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,75,101,121,68,101,114,105,118,97,116,105,111,110,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_KeyDerivationParameters]);
+DEFINE_CLSID!(KeyDerivationParameters: "Windows.Security.Cryptography.Core.KeyDerivationParameters");
 DEFINE_IID!(IID_IKeyDerivationParameters2, 3443615441, 16766, 20300, 182, 102, 192, 216, 121, 243, 248, 224);
 RT_INTERFACE!{interface IKeyDerivationParameters2(IKeyDerivationParameters2Vtbl): IInspectable(IInspectableVtbl) [IID_IKeyDerivationParameters2] {
     fn get_Capi1KdfTargetAlgorithm(&self, out: *mut Capi1KdfTargetAlgorithm) -> HRESULT,
@@ -5872,7 +5872,7 @@ impl MacAlgorithmNames {
         <Self as RtActivatable<IMacAlgorithmNamesStatics>>::get_activation_factory().get_aes_cmac()
     }}
 }
-DEFINE_CLSID!(MacAlgorithmNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,77,97,99,65,108,103,111,114,105,116,104,109,78,97,109,101,115,0]) [CLSID_MacAlgorithmNames]);
+DEFINE_CLSID!(MacAlgorithmNames: "Windows.Security.Cryptography.Core.MacAlgorithmNames");
 DEFINE_IID!(IID_IMacAlgorithmNamesStatics, 1094788728, 64286, 17316, 137, 94, 169, 2, 110, 67, 144, 163);
 RT_INTERFACE!{static interface IMacAlgorithmNamesStatics(IMacAlgorithmNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMacAlgorithmNamesStatics] {
     fn get_HmacMd5(&self, out: *mut HSTRING) -> HRESULT,
@@ -5944,7 +5944,7 @@ impl MacAlgorithmProvider {
         <Self as RtActivatable<IMacAlgorithmProviderStatics>>::get_activation_factory().open_algorithm(algorithm)
     }}
 }
-DEFINE_CLSID!(MacAlgorithmProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,77,97,99,65,108,103,111,114,105,116,104,109,80,114,111,118,105,100,101,114,0]) [CLSID_MacAlgorithmProvider]);
+DEFINE_CLSID!(MacAlgorithmProvider: "Windows.Security.Cryptography.Core.MacAlgorithmProvider");
 DEFINE_IID!(IID_IMacAlgorithmProvider2, 1839409685, 55601, 17133, 142, 126, 195, 1, 202, 238, 17, 156);
 RT_INTERFACE!{interface IMacAlgorithmProvider2(IMacAlgorithmProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IMacAlgorithmProvider2] {
     #[cfg(feature="windows-storage")] fn CreateHash(&self, keyMaterial: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicHash) -> HRESULT
@@ -5977,7 +5977,7 @@ impl PersistedKeyProvider {
         <Self as RtActivatable<IPersistedKeyProviderStatics>>::get_activation_factory().open_public_key_from_certificate(certificate, hashAlgorithmName, padding)
     }}
 }
-DEFINE_CLSID!(PersistedKeyProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,80,101,114,115,105,115,116,101,100,75,101,121,80,114,111,118,105,100,101,114,0]) [CLSID_PersistedKeyProvider]);
+DEFINE_CLSID!(PersistedKeyProvider: "Windows.Security.Cryptography.Core.PersistedKeyProvider");
 DEFINE_IID!(IID_IPersistedKeyProviderStatics, 1999063060, 55764, 19701, 182, 104, 224, 69, 125, 243, 8, 148);
 RT_INTERFACE!{static interface IPersistedKeyProviderStatics(IPersistedKeyProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPersistedKeyProviderStatics] {
     fn OpenKeyPairFromCertificateAsync(&self, certificate: *mut super::certificates::Certificate, hashAlgorithmName: HSTRING, padding: CryptographicPadding, out: *mut *mut ::rt::gen::windows::foundation::IAsyncOperation<CryptographicKey>) -> HRESULT,
@@ -6056,7 +6056,7 @@ impl SymmetricAlgorithmNames {
         <Self as RtActivatable<ISymmetricAlgorithmNamesStatics>>::get_activation_factory().get_rc4()
     }}
 }
-DEFINE_CLSID!(SymmetricAlgorithmNames(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,83,121,109,109,101,116,114,105,99,65,108,103,111,114,105,116,104,109,78,97,109,101,115,0]) [CLSID_SymmetricAlgorithmNames]);
+DEFINE_CLSID!(SymmetricAlgorithmNames: "Windows.Security.Cryptography.Core.SymmetricAlgorithmNames");
 DEFINE_IID!(IID_ISymmetricAlgorithmNamesStatics, 1752199803, 51606, 20142, 132, 215, 121, 178, 174, 183, 59, 156);
 RT_INTERFACE!{static interface ISymmetricAlgorithmNamesStatics(ISymmetricAlgorithmNamesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISymmetricAlgorithmNamesStatics] {
     fn get_DesCbc(&self, out: *mut HSTRING) -> HRESULT,
@@ -6206,7 +6206,7 @@ impl SymmetricKeyAlgorithmProvider {
         <Self as RtActivatable<ISymmetricKeyAlgorithmProviderStatics>>::get_activation_factory().open_algorithm(algorithm)
     }}
 }
-DEFINE_CLSID!(SymmetricKeyAlgorithmProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,83,121,109,109,101,116,114,105,99,75,101,121,65,108,103,111,114,105,116,104,109,80,114,111,118,105,100,101,114,0]) [CLSID_SymmetricKeyAlgorithmProvider]);
+DEFINE_CLSID!(SymmetricKeyAlgorithmProvider: "Windows.Security.Cryptography.Core.SymmetricKeyAlgorithmProvider");
 DEFINE_IID!(IID_ISymmetricKeyAlgorithmProviderStatics, 2369463078, 7991, 18719, 182, 14, 245, 67, 27, 38, 180, 131);
 RT_INTERFACE!{static interface ISymmetricKeyAlgorithmProviderStatics(ISymmetricKeyAlgorithmProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISymmetricKeyAlgorithmProviderStatics] {
     fn OpenAlgorithm(&self, algorithm: HSTRING, out: *mut *mut SymmetricKeyAlgorithmProvider) -> HRESULT
@@ -6258,7 +6258,7 @@ impl DataProtectionProvider {
         <Self as RtActivatable<IDataProtectionProviderFactory>>::get_activation_factory().create_overload_explicit(protectionDescriptor)
     }}
 }
-DEFINE_CLSID!(DataProtectionProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,68,97,116,97,80,114,111,116,101,99,116,105,111,110,46,68,97,116,97,80,114,111,116,101,99,116,105,111,110,80,114,111,118,105,100,101,114,0]) [CLSID_DataProtectionProvider]);
+DEFINE_CLSID!(DataProtectionProvider: "Windows.Security.Cryptography.DataProtection.DataProtectionProvider");
 DEFINE_IID!(IID_IDataProtectionProviderFactory, 2918399404, 18738, 19679, 172, 65, 114, 20, 51, 53, 20, 202);
 RT_INTERFACE!{static interface IDataProtectionProviderFactory(IDataProtectionProviderFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDataProtectionProviderFactory] {
     fn CreateOverloadExplicit(&self, protectionDescriptor: HSTRING, out: *mut *mut DataProtectionProvider) -> HRESULT
@@ -6333,7 +6333,7 @@ impl DataProtectionManager {
         <Self as RtActivatable<IDataProtectionManagerStatics>>::get_activation_factory().get_stream_protection_info_async(protectedStream)
     }}
 }
-DEFINE_CLSID!(DataProtectionManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,110,116,101,114,112,114,105,115,101,68,97,116,97,46,68,97,116,97,80,114,111,116,101,99,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_DataProtectionManager]);
+DEFINE_CLSID!(DataProtectionManager: "Windows.Security.EnterpriseData.DataProtectionManager");
 DEFINE_IID!(IID_IDataProtectionManagerStatics, 3054803828, 37188, 20196, 138, 138, 48, 181, 243, 97, 67, 14);
 RT_INTERFACE!{static interface IDataProtectionManagerStatics(IDataProtectionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDataProtectionManagerStatics] {
     #[cfg(feature="windows-storage")] fn ProtectAsync(&self, data: *mut super::super::storage::streams::IBuffer, identity: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<BufferProtectUnprotectResult>) -> HRESULT,
@@ -6458,7 +6458,7 @@ impl FileProtectionManager {
         <Self as RtActivatable<IFileProtectionManagerStatics3>>::get_activation_factory().unprotect_with_options_async(target, options)
     }}
 }
-DEFINE_CLSID!(FileProtectionManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,110,116,101,114,112,114,105,115,101,68,97,116,97,46,70,105,108,101,80,114,111,116,101,99,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_FileProtectionManager]);
+DEFINE_CLSID!(FileProtectionManager: "Windows.Security.EnterpriseData.FileProtectionManager");
 DEFINE_IID!(IID_IFileProtectionManagerStatics, 1481047195, 58899, 17003, 187, 56, 136, 203, 161, 220, 154, 219);
 RT_INTERFACE!{static interface IFileProtectionManagerStatics(IFileProtectionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFileProtectionManagerStatics] {
     #[cfg(feature="windows-storage")] fn ProtectAsync(&self, target: *mut super::super::storage::IStorageItem, identity: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<FileProtectionInfo>) -> HRESULT,
@@ -6565,7 +6565,7 @@ impl FileRevocationManager {
         <Self as RtActivatable<IFileRevocationManagerStatics>>::get_activation_factory().get_status_async(storageItem)
     }}
 }
-DEFINE_CLSID!(FileRevocationManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,110,116,101,114,112,114,105,115,101,68,97,116,97,46,70,105,108,101,82,101,118,111,99,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_FileRevocationManager]);
+DEFINE_CLSID!(FileRevocationManager: "Windows.Security.EnterpriseData.FileRevocationManager");
 DEFINE_IID!(IID_IFileRevocationManagerStatics, 627817533, 7261, 16992, 140, 117, 145, 68, 207, 183, 139, 169);
 RT_INTERFACE!{static interface IFileRevocationManagerStatics(IFileRevocationManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFileRevocationManagerStatics] {
     #[cfg(feature="windows-storage")] fn ProtectAsync(&self, storageItem: *mut super::super::storage::IStorageItem, enterpriseIdentity: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<FileProtectionStatus>) -> HRESULT,
@@ -6617,7 +6617,7 @@ impl FileUnprotectOptions {
         <Self as RtActivatable<IFileUnprotectOptionsFactory>>::get_activation_factory().create(audit)
     }}
 }
-DEFINE_CLSID!(FileUnprotectOptions(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,110,116,101,114,112,114,105,115,101,68,97,116,97,46,70,105,108,101,85,110,112,114,111,116,101,99,116,79,112,116,105,111,110,115,0]) [CLSID_FileUnprotectOptions]);
+DEFINE_CLSID!(FileUnprotectOptions: "Windows.Security.EnterpriseData.FileUnprotectOptions");
 DEFINE_IID!(IID_IFileUnprotectOptionsFactory, 1370403740, 55948, 19519, 155, 251, 203, 115, 167, 204, 224, 221);
 RT_INTERFACE!{static interface IFileUnprotectOptionsFactory(IFileUnprotectOptionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IFileUnprotectOptionsFactory] {
     fn Create(&self, audit: bool, out: *mut *mut FileUnprotectOptions) -> HRESULT
@@ -6804,7 +6804,7 @@ impl ProtectionPolicyAuditInfo {
         <Self as RtActivatable<IProtectionPolicyAuditInfoFactory>>::get_activation_factory().create_with_action_and_data_description(action, dataDescription)
     }}
 }
-DEFINE_CLSID!(ProtectionPolicyAuditInfo(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,110,116,101,114,112,114,105,115,101,68,97,116,97,46,80,114,111,116,101,99,116,105,111,110,80,111,108,105,99,121,65,117,100,105,116,73,110,102,111,0]) [CLSID_ProtectionPolicyAuditInfo]);
+DEFINE_CLSID!(ProtectionPolicyAuditInfo: "Windows.Security.EnterpriseData.ProtectionPolicyAuditInfo");
 DEFINE_IID!(IID_IProtectionPolicyAuditInfoFactory, 2127829003, 37608, 17109, 131, 212, 37, 68, 11, 66, 53, 73);
 RT_INTERFACE!{static interface IProtectionPolicyAuditInfoFactory(IProtectionPolicyAuditInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IProtectionPolicyAuditInfoFactory] {
     fn Create(&self, action: ProtectionPolicyAuditAction, dataDescription: HSTRING, sourceDescription: HSTRING, targetDescription: HSTRING, out: *mut *mut ProtectionPolicyAuditInfo) -> HRESULT,
@@ -6968,7 +6968,7 @@ impl ProtectionPolicyManager {
         <Self as RtActivatable<IProtectionPolicyManagerStatics4>>::get_activation_factory().get_primary_managed_identity_for_identity(identity)
     }}
 }
-DEFINE_CLSID!(ProtectionPolicyManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,110,116,101,114,112,114,105,115,101,68,97,116,97,46,80,114,111,116,101,99,116,105,111,110,80,111,108,105,99,121,77,97,110,97,103,101,114,0]) [CLSID_ProtectionPolicyManager]);
+DEFINE_CLSID!(ProtectionPolicyManager: "Windows.Security.EnterpriseData.ProtectionPolicyManager");
 DEFINE_IID!(IID_IProtectionPolicyManager2, 2885112442, 33845, 16767, 153, 182, 81, 190, 175, 54, 88, 136);
 RT_INTERFACE!{interface IProtectionPolicyManager2(IProtectionPolicyManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IProtectionPolicyManager2] {
     fn put_ShowEnterpriseIndicator(&self, value: bool) -> HRESULT,
@@ -7299,7 +7299,7 @@ impl IEasClientDeviceInformation {
 }
 RT_CLASS!{class EasClientDeviceInformation: IEasClientDeviceInformation}
 impl RtActivatable<IActivationFactory> for EasClientDeviceInformation {}
-DEFINE_CLSID!(EasClientDeviceInformation(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,120,99,104,97,110,103,101,65,99,116,105,118,101,83,121,110,99,80,114,111,118,105,115,105,111,110,105,110,103,46,69,97,115,67,108,105,101,110,116,68,101,118,105,99,101,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_EasClientDeviceInformation]);
+DEFINE_CLSID!(EasClientDeviceInformation: "Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation");
 DEFINE_IID!(IID_IEasClientDeviceInformation2, 4289943843, 47910, 19818, 129, 188, 22, 90, 238, 10, 215, 84);
 RT_INTERFACE!{interface IEasClientDeviceInformation2(IEasClientDeviceInformation2Vtbl): IInspectable(IInspectableVtbl) [IID_IEasClientDeviceInformation2] {
     fn get_SystemHardwareVersion(&self, out: *mut HSTRING) -> HRESULT,
@@ -7424,7 +7424,7 @@ impl IEasClientSecurityPolicy {
 }
 RT_CLASS!{class EasClientSecurityPolicy: IEasClientSecurityPolicy}
 impl RtActivatable<IActivationFactory> for EasClientSecurityPolicy {}
-DEFINE_CLSID!(EasClientSecurityPolicy(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,120,99,104,97,110,103,101,65,99,116,105,118,101,83,121,110,99,80,114,111,118,105,115,105,111,110,105,110,103,46,69,97,115,67,108,105,101,110,116,83,101,99,117,114,105,116,121,80,111,108,105,99,121,0]) [CLSID_EasClientSecurityPolicy]);
+DEFINE_CLSID!(EasClientSecurityPolicy: "Windows.Security.ExchangeActiveSyncProvisioning.EasClientSecurityPolicy");
 DEFINE_IID!(IID_IEasComplianceResults, 1178347932, 32537, 19558, 180, 3, 203, 69, 221, 87, 162, 179);
 RT_INTERFACE!{interface IEasComplianceResults(IEasComplianceResultsVtbl): IInspectable(IInspectableVtbl) [IID_IEasComplianceResults] {
     fn get_Compliant(&self, out: *mut bool) -> HRESULT,

--- a/src/rt/gen/windows/services.rs
+++ b/src/rt/gen/windows/services.rs
@@ -42,7 +42,7 @@ impl CortanaPermissionsManager {
         <Self as RtActivatable<ICortanaPermissionsManagerStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(CortanaPermissionsManager(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,67,111,114,116,97,110,97,46,67,111,114,116,97,110,97,80,101,114,109,105,115,115,105,111,110,115,77,97,110,97,103,101,114,0]) [CLSID_CortanaPermissionsManager]);
+DEFINE_CLSID!(CortanaPermissionsManager: "Windows.Services.Cortana.CortanaPermissionsManager");
 DEFINE_IID!(IID_ICortanaPermissionsManagerStatics, 1991370362, 45125, 17428, 157, 109, 42, 211, 165, 254, 58, 126);
 RT_INTERFACE!{static interface ICortanaPermissionsManagerStatics(ICortanaPermissionsManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICortanaPermissionsManagerStatics] {
     fn GetDefault(&self, out: *mut *mut CortanaPermissionsManager) -> HRESULT
@@ -86,7 +86,7 @@ impl CortanaSettings {
         <Self as RtActivatable<ICortanaSettingsStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(CortanaSettings(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,67,111,114,116,97,110,97,46,67,111,114,116,97,110,97,83,101,116,116,105,110,103,115,0]) [CLSID_CortanaSettings]);
+DEFINE_CLSID!(CortanaSettings: "Windows.Services.Cortana.CortanaSettings");
 DEFINE_IID!(IID_ICortanaSettingsStatics, 2334969214, 11968, 17517, 146, 133, 51, 240, 124, 232, 172, 4);
 RT_INTERFACE!{static interface ICortanaSettingsStatics(ICortanaSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICortanaSettingsStatics] {
     fn IsSupported(&self, out: *mut bool) -> HRESULT,
@@ -132,7 +132,7 @@ impl EnhancedWaypoint {
         <Self as RtActivatable<IEnhancedWaypointFactory>>::get_activation_factory().create(point, kind)
     }}
 }
-DEFINE_CLSID!(EnhancedWaypoint(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,69,110,104,97,110,99,101,100,87,97,121,112,111,105,110,116,0]) [CLSID_EnhancedWaypoint]);
+DEFINE_CLSID!(EnhancedWaypoint: "Windows.Services.Maps.EnhancedWaypoint");
 DEFINE_IID!(IID_IEnhancedWaypointFactory, 2944828535, 41642, 18141, 182, 69, 35, 179, 27, 138, 166, 199);
 RT_INTERFACE!{static interface IEnhancedWaypointFactory(IEnhancedWaypointFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IEnhancedWaypointFactory] {
     #[cfg(feature="windows-devices")] fn Create(&self, point: *mut super::super::devices::geolocation::Geopoint, kind: WaypointKind, out: *mut *mut EnhancedWaypoint) -> HRESULT
@@ -326,7 +326,7 @@ impl MapLocationFinder {
         <Self as RtActivatable<IMapLocationFinderStatics2>>::get_activation_factory().find_locations_at_with_accuracy_async(queryPoint, accuracy)
     }}
 }
-DEFINE_CLSID!(MapLocationFinder(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,76,111,99,97,116,105,111,110,70,105,110,100,101,114,0]) [CLSID_MapLocationFinder]);
+DEFINE_CLSID!(MapLocationFinder: "Windows.Services.Maps.MapLocationFinder");
 DEFINE_IID!(IID_IMapLocationFinderResult, 1139929465, 59596, 17910, 190, 210, 84, 204, 191, 150, 93, 154);
 RT_INTERFACE!{interface IMapLocationFinderResult(IMapLocationFinderResultVtbl): IInspectable(IInspectableVtbl) [IID_IMapLocationFinderResult] {
     fn get_Locations(&self, out: *mut *mut super::super::foundation::collections::IVectorView<MapLocation>) -> HRESULT,
@@ -392,7 +392,7 @@ impl MapManager {
         <Self as RtActivatable<IMapManagerStatics>>::get_activation_factory().show_maps_update_ui()
     }}
 }
-DEFINE_CLSID!(MapManager(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,77,97,110,97,103,101,114,0]) [CLSID_MapManager]);
+DEFINE_CLSID!(MapManager: "Windows.Services.Maps.MapManager");
 DEFINE_IID!(IID_IMapManagerStatics, 937682197, 33460, 19796, 143, 217, 175, 38, 36, 179, 1, 28);
 RT_INTERFACE!{static interface IMapManagerStatics(IMapManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMapManagerStatics] {
     fn ShowDownloadedMapsUI(&self) -> HRESULT,
@@ -551,7 +551,7 @@ impl IMapRouteDrivingOptions {
 }
 RT_CLASS!{class MapRouteDrivingOptions: IMapRouteDrivingOptions}
 impl RtActivatable<IActivationFactory> for MapRouteDrivingOptions {}
-DEFINE_CLSID!(MapRouteDrivingOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,82,111,117,116,101,68,114,105,118,105,110,103,79,112,116,105,111,110,115,0]) [CLSID_MapRouteDrivingOptions]);
+DEFINE_CLSID!(MapRouteDrivingOptions: "Windows.Services.Maps.MapRouteDrivingOptions");
 RT_CLASS!{static class MapRouteFinder}
 impl RtActivatable<IMapRouteFinderStatics> for MapRouteFinder {}
 impl RtActivatable<IMapRouteFinderStatics2> for MapRouteFinder {}
@@ -597,7 +597,7 @@ impl MapRouteFinder {
         <Self as RtActivatable<IMapRouteFinderStatics3>>::get_activation_factory().get_driving_route_from_enhanced_waypoints_with_options_async(waypoints, options)
     }}
 }
-DEFINE_CLSID!(MapRouteFinder(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,82,111,117,116,101,70,105,110,100,101,114,0]) [CLSID_MapRouteFinder]);
+DEFINE_CLSID!(MapRouteFinder: "Windows.Services.Maps.MapRouteFinder");
 DEFINE_IID!(IID_IMapRouteFinderResult, 2825429786, 37922, 18092, 140, 161, 177, 97, 77, 75, 251, 226);
 RT_INTERFACE!{interface IMapRouteFinderResult(IMapRouteFinderResultVtbl): IInspectable(IInspectableVtbl) [IID_IMapRouteFinderResult] {
     fn get_Route(&self, out: *mut *mut MapRoute) -> HRESULT,
@@ -889,7 +889,7 @@ impl MapService {
         <Self as RtActivatable<IMapServiceStatics4>>::get_activation_factory().get_data_usage_preference()
     }}
 }
-DEFINE_CLSID!(MapService(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,83,101,114,118,105,99,101,0]) [CLSID_MapService]);
+DEFINE_CLSID!(MapService: "Windows.Services.Maps.MapService");
 RT_ENUM! { enum MapServiceDataUsagePreference: i32 {
     Default (MapServiceDataUsagePreference_Default) = 0, OfflineMapDataOnly (MapServiceDataUsagePreference_OfflineMapDataOnly) = 1,
 }}
@@ -1009,7 +1009,7 @@ impl PlaceInfo {
         <Self as RtActivatable<IPlaceInfoStatics>>::get_activation_factory().get_is_show_supported()
     }}
 }
-DEFINE_CLSID!(PlaceInfo(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,80,108,97,99,101,73,110,102,111,0]) [CLSID_PlaceInfo]);
+DEFINE_CLSID!(PlaceInfo: "Windows.Services.Maps.PlaceInfo");
 DEFINE_IID!(IID_IPlaceInfoCreateOptions, 3442721061, 26609, 19379, 153, 7, 236, 206, 147, 155, 3, 153);
 RT_INTERFACE!{interface IPlaceInfoCreateOptions(IPlaceInfoCreateOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IPlaceInfoCreateOptions] {
     fn put_DisplayName(&self, value: HSTRING) -> HRESULT,
@@ -1039,7 +1039,7 @@ impl IPlaceInfoCreateOptions {
 }
 RT_CLASS!{class PlaceInfoCreateOptions: IPlaceInfoCreateOptions}
 impl RtActivatable<IActivationFactory> for PlaceInfoCreateOptions {}
-DEFINE_CLSID!(PlaceInfoCreateOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,80,108,97,99,101,73,110,102,111,67,114,101,97,116,101,79,112,116,105,111,110,115,0]) [CLSID_PlaceInfoCreateOptions]);
+DEFINE_CLSID!(PlaceInfoCreateOptions: "Windows.Services.Maps.PlaceInfoCreateOptions");
 DEFINE_IID!(IID_IPlaceInfoStatics, 2193227633, 27856, 18596, 175, 217, 94, 216, 32, 151, 147, 107);
 RT_INTERFACE!{static interface IPlaceInfoStatics(IPlaceInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlaceInfoStatics] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -1151,7 +1151,7 @@ impl OfflineMapPackage {
         <Self as RtActivatable<IOfflineMapPackageStatics>>::get_activation_factory().find_packages_in_geocircle_async(queryCircle)
     }}
 }
-DEFINE_CLSID!(OfflineMapPackage(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,79,102,102,108,105,110,101,77,97,112,115,46,79,102,102,108,105,110,101,77,97,112,80,97,99,107,97,103,101,0]) [CLSID_OfflineMapPackage]);
+DEFINE_CLSID!(OfflineMapPackage: "Windows.Services.Maps.OfflineMaps.OfflineMapPackage");
 DEFINE_IID!(IID_IOfflineMapPackageQueryResult, 1431852049, 14817, 20033, 164, 225, 95, 72, 114, 190, 225, 153);
 RT_INTERFACE!{interface IOfflineMapPackageQueryResult(IOfflineMapPackageQueryResultVtbl): IInspectable(IInspectableVtbl) [IID_IOfflineMapPackageQueryResult] {
     fn get_Status(&self, out: *mut OfflineMapPackageQueryStatus) -> HRESULT,
@@ -1245,7 +1245,7 @@ impl LocalCategories {
         <Self as RtActivatable<ILocalCategoriesStatics>>::get_activation_factory().get_shop()
     }}
 }
-DEFINE_CLSID!(LocalCategories(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,76,111,99,97,108,83,101,97,114,99,104,46,76,111,99,97,108,67,97,116,101,103,111,114,105,101,115,0]) [CLSID_LocalCategories]);
+DEFINE_CLSID!(LocalCategories: "Windows.Services.Maps.LocalSearch.LocalCategories");
 DEFINE_IID!(IID_ILocalCategoriesStatics, 4103313909, 33377, 17185, 153, 116, 239, 146, 212, 154, 141, 202);
 RT_INTERFACE!{static interface ILocalCategoriesStatics(ILocalCategoriesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILocalCategoriesStatics] {
     fn get_BankAndCreditUnions(&self, out: *mut HSTRING) -> HRESULT,
@@ -1378,7 +1378,7 @@ impl LocalLocationFinder {
         <Self as RtActivatable<ILocalLocationFinderStatics>>::get_activation_factory().find_local_locations_async(searchTerm, searchArea, localCategory, maxResults)
     }}
 }
-DEFINE_CLSID!(LocalLocationFinder(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,76,111,99,97,108,83,101,97,114,99,104,46,76,111,99,97,108,76,111,99,97,116,105,111,110,70,105,110,100,101,114,0]) [CLSID_LocalLocationFinder]);
+DEFINE_CLSID!(LocalLocationFinder: "Windows.Services.Maps.LocalSearch.LocalLocationFinder");
 DEFINE_IID!(IID_ILocalLocationFinderResult, 3499846854, 62264, 16785, 159, 216, 84, 64, 185, 166, 143, 82);
 RT_INTERFACE!{interface ILocalLocationFinderResult(ILocalLocationFinderResultVtbl): IInspectable(IInspectableVtbl) [IID_ILocalLocationFinderResult] {
     fn get_LocalLocations(&self, out: *mut *mut ::rt::gen::windows::foundation::collections::IVectorView<LocalLocation>) -> HRESULT,
@@ -1467,7 +1467,7 @@ impl PlaceInfoHelper {
         <Self as RtActivatable<IPlaceInfoHelperStatics>>::get_activation_factory().create_from_local_location(location)
     }}
 }
-DEFINE_CLSID!(PlaceInfoHelper(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,76,111,99,97,108,83,101,97,114,99,104,46,80,108,97,99,101,73,110,102,111,72,101,108,112,101,114,0]) [CLSID_PlaceInfoHelper]);
+DEFINE_CLSID!(PlaceInfoHelper: "Windows.Services.Maps.LocalSearch.PlaceInfoHelper");
 DEFINE_IID!(IID_IPlaceInfoHelperStatics, 3709643175, 43462, 18715, 188, 9, 232, 15, 206, 164, 142, 230);
 RT_INTERFACE!{static interface IPlaceInfoHelperStatics(IPlaceInfoHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlaceInfoHelperStatics] {
     fn CreateFromLocalLocation(&self, location: *mut LocalLocation, out: *mut *mut super::PlaceInfo) -> HRESULT
@@ -1823,7 +1823,7 @@ impl GuidanceNavigator {
         <Self as RtActivatable<IGuidanceNavigatorStatics2>>::get_activation_factory().get_use_app_provided_voice()
     }}
 }
-DEFINE_CLSID!(GuidanceNavigator(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,71,117,105,100,97,110,99,101,46,71,117,105,100,97,110,99,101,78,97,118,105,103,97,116,111,114,0]) [CLSID_GuidanceNavigator]);
+DEFINE_CLSID!(GuidanceNavigator: "Windows.Services.Maps.Guidance.GuidanceNavigator");
 DEFINE_IID!(IID_IGuidanceNavigator2, 1826377937, 1052, 19443, 182, 51, 161, 1, 252, 47, 107, 87);
 RT_INTERFACE!{interface IGuidanceNavigator2(IGuidanceNavigator2Vtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceNavigator2] {
     fn add_AudioNotificationRequested(&self, value: *mut ::rt::gen::windows::foundation::TypedEventHandler<GuidanceNavigator, GuidanceAudioNotificationRequestedEventArgs>, out: *mut ::rt::gen::windows::foundation::EventRegistrationToken) -> HRESULT,
@@ -2054,7 +2054,7 @@ impl GuidanceRoute {
         <Self as RtActivatable<IGuidanceRouteStatics>>::get_activation_factory().try_create_from_map_route(mapRoute)
     }}
 }
-DEFINE_CLSID!(GuidanceRoute(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,71,117,105,100,97,110,99,101,46,71,117,105,100,97,110,99,101,82,111,117,116,101,0]) [CLSID_GuidanceRoute]);
+DEFINE_CLSID!(GuidanceRoute: "Windows.Services.Maps.Guidance.GuidanceRoute");
 DEFINE_IID!(IID_IGuidanceRouteStatics, 4117598826, 21997, 18881, 176, 156, 75, 130, 35, 181, 13, 179);
 RT_INTERFACE!{static interface IGuidanceRouteStatics(IGuidanceRouteStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceRouteStatics] {
     fn CanCreateFromMapRoute(&self, mapRoute: *mut super::MapRoute, out: *mut bool) -> HRESULT,
@@ -2122,7 +2122,7 @@ impl GuidanceTelemetryCollector {
         <Self as RtActivatable<IGuidanceTelemetryCollectorStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(GuidanceTelemetryCollector(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,71,117,105,100,97,110,99,101,46,71,117,105,100,97,110,99,101,84,101,108,101,109,101,116,114,121,67,111,108,108,101,99,116,111,114,0]) [CLSID_GuidanceTelemetryCollector]);
+DEFINE_CLSID!(GuidanceTelemetryCollector: "Windows.Services.Maps.Guidance.GuidanceTelemetryCollector");
 DEFINE_IID!(IID_IGuidanceTelemetryCollectorStatics, 911417415, 61792, 17659, 181, 120, 148, 87, 124, 160, 89, 144);
 RT_INTERFACE!{static interface IGuidanceTelemetryCollectorStatics(IGuidanceTelemetryCollectorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceTelemetryCollectorStatics] {
     fn GetCurrent(&self, out: *mut *mut GuidanceTelemetryCollector) -> HRESULT
@@ -2577,7 +2577,7 @@ impl StoreContext {
         <Self as RtActivatable<IStoreContextStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(StoreContext(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,83,116,111,114,101,46,83,116,111,114,101,67,111,110,116,101,120,116,0]) [CLSID_StoreContext]);
+DEFINE_CLSID!(StoreContext: "Windows.Services.Store.StoreContext");
 DEFINE_IID!(IID_IStoreContext2, 414995674, 31705, 17708, 145, 22, 59, 189, 6, 255, 198, 58);
 RT_INTERFACE!{interface IStoreContext2(IStoreContext2Vtbl): IInspectable(IInspectableVtbl) [IID_IStoreContext2] {
     #[cfg(feature="windows-applicationmodel")] fn FindStoreProductForPackageAsync(&self, productKinds: *mut super::super::foundation::collections::IIterable<HString>, package: *mut super::super::applicationmodel::Package, out: *mut *mut super::super::foundation::IAsyncOperation<StoreProductResult>) -> HRESULT
@@ -3016,7 +3016,7 @@ impl StorePurchaseProperties {
         <Self as RtActivatable<IStorePurchasePropertiesFactory>>::get_activation_factory().create(name)
     }}
 }
-DEFINE_CLSID!(StorePurchaseProperties(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,83,116,111,114,101,46,83,116,111,114,101,80,117,114,99,104,97,115,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_StorePurchaseProperties]);
+DEFINE_CLSID!(StorePurchaseProperties: "Windows.Services.Store.StorePurchaseProperties");
 DEFINE_IID!(IID_IStorePurchasePropertiesFactory, 2808673694, 65277, 18591, 154, 23, 34, 165, 147, 230, 139, 157);
 RT_INTERFACE!{static interface IStorePurchasePropertiesFactory(IStorePurchasePropertiesFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IStorePurchasePropertiesFactory] {
     fn Create(&self, name: HSTRING, out: *mut *mut StorePurchaseProperties) -> HRESULT
@@ -3056,7 +3056,7 @@ impl StoreRequestHelper {
         <Self as RtActivatable<IStoreRequestHelperStatics>>::get_activation_factory().send_request_async(context, requestKind, parametersAsJson)
     }}
 }
-DEFINE_CLSID!(StoreRequestHelper(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,83,116,111,114,101,46,83,116,111,114,101,82,101,113,117,101,115,116,72,101,108,112,101,114,0]) [CLSID_StoreRequestHelper]);
+DEFINE_CLSID!(StoreRequestHelper: "Windows.Services.Store.StoreRequestHelper");
 DEFINE_IID!(IID_IStoreRequestHelperStatics, 1827005945, 41161, 19244, 150, 166, 161, 113, 198, 48, 3, 141);
 RT_INTERFACE!{static interface IStoreRequestHelperStatics(IStoreRequestHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStoreRequestHelperStatics] {
     fn SendRequestAsync(&self, context: *mut StoreContext, requestKind: u32, parametersAsJson: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<StoreSendRequestResult>) -> HRESULT
@@ -3434,7 +3434,7 @@ impl TargetedContentContainer {
         <Self as RtActivatable<ITargetedContentContainerStatics>>::get_activation_factory().get_async(contentId)
     }}
 }
-DEFINE_CLSID!(TargetedContentContainer(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,84,97,114,103,101,116,101,100,67,111,110,116,101,110,116,46,84,97,114,103,101,116,101,100,67,111,110,116,101,110,116,67,111,110,116,97,105,110,101,114,0]) [CLSID_TargetedContentContainer]);
+DEFINE_CLSID!(TargetedContentContainer: "Windows.Services.TargetedContent.TargetedContentContainer");
 DEFINE_IID!(IID_ITargetedContentContainerStatics, 1531439099, 8512, 19487, 167, 54, 197, 149, 131, 242, 39, 216);
 RT_INTERFACE!{static interface ITargetedContentContainerStatics(ITargetedContentContainerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentContainerStatics] {
     fn GetAsync(&self, contentId: HSTRING, out: *mut *mut super::super::foundation::IAsyncOperation<TargetedContentContainer>) -> HRESULT
@@ -3632,7 +3632,7 @@ impl TargetedContentSubscription {
         <Self as RtActivatable<ITargetedContentSubscriptionStatics>>::get_activation_factory().get_options(subscriptionId)
     }}
 }
-DEFINE_CLSID!(TargetedContentSubscription(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,84,97,114,103,101,116,101,100,67,111,110,116,101,110,116,46,84,97,114,103,101,116,101,100,67,111,110,116,101,110,116,83,117,98,115,99,114,105,112,116,105,111,110,0]) [CLSID_TargetedContentSubscription]);
+DEFINE_CLSID!(TargetedContentSubscription: "Windows.Services.TargetedContent.TargetedContentSubscription");
 DEFINE_IID!(IID_ITargetedContentSubscriptionOptions, 1643014864, 11395, 16923, 132, 103, 65, 62, 175, 26, 235, 151);
 RT_INTERFACE!{interface ITargetedContentSubscriptionOptions(ITargetedContentSubscriptionOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentSubscriptionOptions] {
     fn get_SubscriptionId(&self, out: *mut HSTRING) -> HRESULT,

--- a/src/rt/gen/windows/storage.rs
+++ b/src/rt/gen/windows/storage.rs
@@ -68,7 +68,7 @@ impl AppDataPaths {
         <Self as RtActivatable<IAppDataPathsStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(AppDataPaths(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,65,112,112,68,97,116,97,80,97,116,104,115,0]) [CLSID_AppDataPaths]);
+DEFINE_CLSID!(AppDataPaths: "Windows.Storage.AppDataPaths");
 DEFINE_IID!(IID_IAppDataPathsStatics, 3639290622, 43481, 19220, 185, 153, 227, 146, 19, 121, 217, 3);
 RT_INTERFACE!{static interface IAppDataPathsStatics(IAppDataPathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppDataPathsStatics] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -179,7 +179,7 @@ impl ApplicationData {
         <Self as RtActivatable<IApplicationDataStatics2>>::get_activation_factory().get_for_user_async(user)
     }}
 }
-DEFINE_CLSID!(ApplicationData(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,65,112,112,108,105,99,97,116,105,111,110,68,97,116,97,0]) [CLSID_ApplicationData]);
+DEFINE_CLSID!(ApplicationData: "Windows.Storage.ApplicationData");
 DEFINE_IID!(IID_IApplicationData2, 2657471849, 2979, 20018, 190, 41, 176, 45, 230, 96, 118, 56);
 RT_INTERFACE!{interface IApplicationData2(IApplicationData2Vtbl): IInspectable(IInspectableVtbl) [IID_IApplicationData2] {
     fn get_LocalCacheFolder(&self, out: *mut *mut StorageFolder) -> HRESULT
@@ -216,7 +216,7 @@ impl IApplicationData3 {
 }
 RT_CLASS!{class ApplicationDataCompositeValue: super::foundation::collections::IPropertySet}
 impl RtActivatable<IActivationFactory> for ApplicationDataCompositeValue {}
-DEFINE_CLSID!(ApplicationDataCompositeValue(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,65,112,112,108,105,99,97,116,105,111,110,68,97,116,97,67,111,109,112,111,115,105,116,101,86,97,108,117,101,0]) [CLSID_ApplicationDataCompositeValue]);
+DEFINE_CLSID!(ApplicationDataCompositeValue: "Windows.Storage.ApplicationDataCompositeValue");
 DEFINE_IID!(IID_IApplicationDataContainer, 3316579614, 62567, 16570, 133, 102, 171, 100, 10, 68, 30, 29);
 RT_INTERFACE!{interface IApplicationDataContainer(IApplicationDataContainerVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationDataContainer] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -307,7 +307,7 @@ impl CachedFileManager {
         <Self as RtActivatable<ICachedFileManagerStatics>>::get_activation_factory().complete_updates_async(file)
     }}
 }
-DEFINE_CLSID!(CachedFileManager(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,67,97,99,104,101,100,70,105,108,101,77,97,110,97,103,101,114,0]) [CLSID_CachedFileManager]);
+DEFINE_CLSID!(CachedFileManager: "Windows.Storage.CachedFileManager");
 DEFINE_IID!(IID_ICachedFileManagerStatics, 2415665738, 59266, 18781, 182, 20, 101, 76, 79, 11, 35, 112);
 RT_INTERFACE!{static interface ICachedFileManagerStatics(ICachedFileManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileManagerStatics] {
     fn DeferUpdates(&self, file: *mut IStorageFile) -> HRESULT,
@@ -356,7 +356,7 @@ impl DownloadsFolder {
         <Self as RtActivatable<IDownloadsFolderStatics2>>::get_activation_factory().create_folder_for_user_with_collision_option_async(user, desiredName, option)
     }}
 }
-DEFINE_CLSID!(DownloadsFolder(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,68,111,119,110,108,111,97,100,115,70,111,108,100,101,114,0]) [CLSID_DownloadsFolder]);
+DEFINE_CLSID!(DownloadsFolder: "Windows.Storage.DownloadsFolder");
 DEFINE_IID!(IID_IDownloadsFolderStatics, 663105232, 16462, 18399, 161, 226, 227, 115, 8, 190, 123, 55);
 RT_INTERFACE!{static interface IDownloadsFolderStatics(IDownloadsFolderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDownloadsFolderStatics] {
     fn CreateFileAsync(&self, desiredName: HSTRING, out: *mut *mut super::foundation::IAsyncOperation<StorageFile>) -> HRESULT,
@@ -470,7 +470,7 @@ impl FileIO {
         <Self as RtActivatable<IFileIOStatics>>::get_activation_factory().write_bytes_async(file, buffer)
     }}
 }
-DEFINE_CLSID!(FileIO(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,70,105,108,101,73,79,0]) [CLSID_FileIO]);
+DEFINE_CLSID!(FileIO: "Windows.Storage.FileIO");
 DEFINE_IID!(IID_IFileIOStatics, 2289308139, 32596, 18226, 165, 240, 94, 67, 227, 184, 194, 245);
 RT_INTERFACE!{static interface IFileIOStatics(IFileIOStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFileIOStatics] {
     fn ReadTextAsync(&self, file: *mut IStorageFile, out: *mut *mut super::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -620,7 +620,7 @@ impl KnownFolders {
         <Self as RtActivatable<IKnownFoldersStatics3>>::get_activation_factory().get_folder_for_user_async(user, folderId)
     }}
 }
-DEFINE_CLSID!(KnownFolders(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,75,110,111,119,110,70,111,108,100,101,114,115,0]) [CLSID_KnownFolders]);
+DEFINE_CLSID!(KnownFolders: "Windows.Storage.KnownFolders");
 DEFINE_IID!(IID_IKnownFoldersCameraRollStatics, 1561419366, 10216, 18735, 184, 229, 47, 144, 137, 108, 212, 205);
 RT_INTERFACE!{static interface IKnownFoldersCameraRollStatics(IKnownFoldersCameraRollStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownFoldersCameraRollStatics] {
     fn get_CameraRoll(&self, out: *mut *mut StorageFolder) -> HRESULT
@@ -790,7 +790,7 @@ impl PathIO {
         <Self as RtActivatable<IPathIOStatics>>::get_activation_factory().write_bytes_async(absolutePath, buffer)
     }}
 }
-DEFINE_CLSID!(PathIO(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,97,116,104,73,79,0]) [CLSID_PathIO]);
+DEFINE_CLSID!(PathIO: "Windows.Storage.PathIO");
 DEFINE_IID!(IID_IPathIOStatics, 254752600, 36551, 17281, 146, 43, 143, 108, 7, 210, 136, 243);
 RT_INTERFACE!{static interface IPathIOStatics(IPathIOStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPathIOStatics] {
     fn ReadTextAsync(&self, absolutePath: HSTRING, out: *mut *mut super::foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -1023,7 +1023,7 @@ impl StorageFile {
         <Self as RtActivatable<IStorageFileStatics>>::get_activation_factory().replace_with_streamed_file_from_uri_async(fileToReplace, uri, thumbnail)
     }}
 }
-DEFINE_CLSID!(StorageFile(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,111,114,97,103,101,70,105,108,101,0]) [CLSID_StorageFile]);
+DEFINE_CLSID!(StorageFile: "Windows.Storage.StorageFile");
 DEFINE_IID!(IID_IStorageFile2, 2504936399, 2679, 17147, 183, 119, 194, 237, 88, 165, 46, 68);
 RT_INTERFACE!{interface IStorageFile2(IStorageFile2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorageFile2] {
     fn OpenWithOptionsAsync(&self, accessMode: FileAccessMode, options: StorageOpenOptions, out: *mut *mut super::foundation::IAsyncOperation<streams::IRandomAccessStream>) -> HRESULT,
@@ -1165,7 +1165,7 @@ impl StorageFolder {
         <Self as RtActivatable<IStorageFolderStatics>>::get_activation_factory().get_folder_from_path_async(path)
     }}
 }
-DEFINE_CLSID!(StorageFolder(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,111,114,97,103,101,70,111,108,100,101,114,0]) [CLSID_StorageFolder]);
+DEFINE_CLSID!(StorageFolder: "Windows.Storage.StorageFolder");
 DEFINE_IID!(IID_IStorageFolder2, 3894929593, 2265, 19086, 160, 172, 254, 94, 211, 203, 187, 211);
 RT_INTERFACE!{interface IStorageFolder2(IStorageFolder2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorageFolder2] {
     fn TryGetItemAsync(&self, name: HSTRING, out: *mut *mut super::foundation::IAsyncOperation<IStorageItem>) -> HRESULT
@@ -1405,7 +1405,7 @@ impl StorageLibrary {
         <Self as RtActivatable<IStorageLibraryStatics2>>::get_activation_factory().get_library_for_user_async(user, libraryId)
     }}
 }
-DEFINE_CLSID!(StorageLibrary(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,111,114,97,103,101,76,105,98,114,97,114,121,0]) [CLSID_StorageLibrary]);
+DEFINE_CLSID!(StorageLibrary: "Windows.Storage.StorageLibrary");
 DEFINE_IID!(IID_IStorageLibrary2, 1527571272, 64691, 16433, 175, 176, 166, 141, 123, 212, 69, 52);
 RT_INTERFACE!{interface IStorageLibrary2(IStorageLibrary2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibrary2] {
     fn get_ChangeTracker(&self, out: *mut *mut StorageLibraryChangeTracker) -> HRESULT
@@ -1723,7 +1723,7 @@ impl SystemDataPaths {
         <Self as RtActivatable<ISystemDataPathsStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(SystemDataPaths(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,121,115,116,101,109,68,97,116,97,80,97,116,104,115,0]) [CLSID_SystemDataPaths]);
+DEFINE_CLSID!(SystemDataPaths: "Windows.Storage.SystemDataPaths");
 DEFINE_IID!(IID_ISystemDataPathsStatics, 3774443472, 39200, 19402, 179, 121, 249, 111, 223, 124, 170, 216);
 RT_INTERFACE!{static interface ISystemDataPathsStatics(ISystemDataPathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemDataPathsStatics] {
     fn GetDefault(&self, out: *mut *mut SystemDataPaths) -> HRESULT
@@ -2029,7 +2029,7 @@ impl SystemProperties {
         <Self as RtActivatable<ISystemProperties>>::get_activation_factory().get_image()
     }}
 }
-DEFINE_CLSID!(SystemProperties(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,121,115,116,101,109,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_SystemProperties]);
+DEFINE_CLSID!(SystemProperties: "Windows.Storage.SystemProperties");
 DEFINE_IID!(IID_ISystemVideoProperties, 541128469, 26616, 17186, 155, 128, 79, 169, 254, 251, 131, 232);
 RT_INTERFACE!{interface ISystemVideoProperties(ISystemVideoPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISystemVideoProperties] {
     fn get_Director(&self, out: *mut HSTRING) -> HRESULT,
@@ -2195,7 +2195,7 @@ impl UserDataPaths {
         <Self as RtActivatable<IUserDataPathsStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(UserDataPaths(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,85,115,101,114,68,97,116,97,80,97,116,104,115,0]) [CLSID_UserDataPaths]);
+DEFINE_CLSID!(UserDataPaths: "Windows.Storage.UserDataPaths");
 DEFINE_IID!(IID_IUserDataPathsStatics, 28483055, 57442, 18593, 139, 12, 242, 199, 169, 202, 86, 192);
 RT_INTERFACE!{static interface IUserDataPathsStatics(IUserDataPathsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataPathsStatics] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -2252,7 +2252,7 @@ impl Buffer {
         <Self as RtActivatable<IBufferStatics>>::get_activation_factory().create_memory_buffer_over_ibuffer(input)
     }}
 }
-DEFINE_CLSID!(Buffer(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,66,117,102,102,101,114,0]) [CLSID_Buffer]);
+DEFINE_CLSID!(Buffer: "Windows.Storage.Streams.Buffer");
 DEFINE_IID!(IID_IBufferFactory, 1907331405, 49423, 18507, 188, 80, 20, 188, 98, 59, 58, 39);
 RT_INTERFACE!{static interface IBufferFactory(IBufferFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBufferFactory] {
     fn Create(&self, capacity: u32, out: *mut *mut Buffer) -> HRESULT
@@ -2463,7 +2463,7 @@ impl DataReader {
         <Self as RtActivatable<IDataReaderStatics>>::get_activation_factory().from_buffer(buffer)
     }}
 }
-DEFINE_CLSID!(DataReader(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,68,97,116,97,82,101,97,100,101,114,0]) [CLSID_DataReader]);
+DEFINE_CLSID!(DataReader: "Windows.Storage.Streams.DataReader");
 DEFINE_IID!(IID_IDataReaderFactory, 3612506183, 22490, 19989, 145, 76, 6, 128, 102, 153, 160, 152);
 RT_INTERFACE!{static interface IDataReaderFactory(IDataReaderFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDataReaderFactory] {
     fn CreateDataReader(&self, inputStream: *mut IInputStream, out: *mut *mut DataReader) -> HRESULT
@@ -2644,7 +2644,7 @@ impl DataWriter {
         <Self as RtActivatable<IDataWriterFactory>>::get_activation_factory().create_data_writer(outputStream)
     }}
 }
-DEFINE_CLSID!(DataWriter(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,68,97,116,97,87,114,105,116,101,114,0]) [CLSID_DataWriter]);
+DEFINE_CLSID!(DataWriter: "Windows.Storage.Streams.DataWriter");
 DEFINE_IID!(IID_IDataWriterFactory, 864839618, 35716, 19499, 156, 80, 123, 135, 103, 132, 122, 31);
 RT_INTERFACE!{static interface IDataWriterFactory(IDataWriterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDataWriterFactory] {
     fn CreateDataWriter(&self, outputStream: *mut IOutputStream, out: *mut *mut DataWriter) -> HRESULT
@@ -2690,7 +2690,7 @@ impl FileRandomAccessStream {
         <Self as RtActivatable<IFileRandomAccessStreamStatics>>::get_activation_factory().open_transacted_write_for_user_with_options_async(user, filePath, openOptions, openDisposition)
     }}
 }
-DEFINE_CLSID!(FileRandomAccessStream(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,70,105,108,101,82,97,110,100,111,109,65,99,99,101,115,115,83,116,114,101,97,109,0]) [CLSID_FileRandomAccessStream]);
+DEFINE_CLSID!(FileRandomAccessStream: "Windows.Storage.Streams.FileRandomAccessStream");
 DEFINE_IID!(IID_IFileRandomAccessStreamStatics, 1934950663, 15191, 19293, 131, 69, 85, 77, 47, 198, 33, 240);
 RT_INTERFACE!{static interface IFileRandomAccessStreamStatics(IFileRandomAccessStreamStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFileRandomAccessStreamStatics] {
     fn OpenAsync(&self, filePath: HSTRING, accessMode: super::FileAccessMode, out: *mut *mut super::super::foundation::IAsyncOperation<IRandomAccessStream>) -> HRESULT,
@@ -2746,7 +2746,7 @@ impl IFileRandomAccessStreamStatics {
 }
 RT_CLASS!{class InMemoryRandomAccessStream: IRandomAccessStream}
 impl RtActivatable<IActivationFactory> for InMemoryRandomAccessStream {}
-DEFINE_CLSID!(InMemoryRandomAccessStream(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,73,110,77,101,109,111,114,121,82,97,110,100,111,109,65,99,99,101,115,115,83,116,114,101,97,109,0]) [CLSID_InMemoryRandomAccessStream]);
+DEFINE_CLSID!(InMemoryRandomAccessStream: "Windows.Storage.Streams.InMemoryRandomAccessStream");
 DEFINE_IID!(IID_IInputStream, 2421821410, 48211, 4575, 140, 73, 0, 30, 79, 198, 134, 218);
 RT_INTERFACE!{interface IInputStream(IInputStreamVtbl): IInspectable(IInspectableVtbl) [IID_IInputStream] {
     fn ReadAsync(&self, buffer: *mut IBuffer, count: u32, options: InputStreamOptions, out: *mut *mut super::super::foundation::IAsyncOperationWithProgress<IBuffer, u32>) -> HRESULT
@@ -2861,7 +2861,7 @@ impl RandomAccessStream {
         <Self as RtActivatable<IRandomAccessStreamStatics>>::get_activation_factory().copy_and_close_async(source, destination)
     }}
 }
-DEFINE_CLSID!(RandomAccessStream(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,82,97,110,100,111,109,65,99,99,101,115,115,83,116,114,101,97,109,0]) [CLSID_RandomAccessStream]);
+DEFINE_CLSID!(RandomAccessStream: "Windows.Storage.Streams.RandomAccessStream");
 RT_CLASS!{class RandomAccessStreamOverStream: IRandomAccessStream}
 DEFINE_IID!(IID_IRandomAccessStreamReference, 871248180, 7638, 20026, 128, 103, 209, 193, 98, 232, 100, 43);
 RT_INTERFACE!{interface IRandomAccessStreamReference(IRandomAccessStreamReferenceVtbl): IInspectable(IInspectableVtbl) [IID_IRandomAccessStreamReference] {
@@ -2887,7 +2887,7 @@ impl RandomAccessStreamReference {
         <Self as RtActivatable<IRandomAccessStreamReferenceStatics>>::get_activation_factory().create_from_stream(stream)
     }}
 }
-DEFINE_CLSID!(RandomAccessStreamReference(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,82,97,110,100,111,109,65,99,99,101,115,115,83,116,114,101,97,109,82,101,102,101,114,101,110,99,101,0]) [CLSID_RandomAccessStreamReference]);
+DEFINE_CLSID!(RandomAccessStreamReference: "Windows.Storage.Streams.RandomAccessStreamReference");
 DEFINE_IID!(IID_IRandomAccessStreamReferenceStatics, 2238908892, 16319, 20093, 152, 111, 239, 59, 26, 7, 169, 100);
 RT_INTERFACE!{static interface IRandomAccessStreamReferenceStatics(IRandomAccessStreamReferenceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRandomAccessStreamReferenceStatics] {
     fn CreateFromFile(&self, file: *mut super::IStorageFile, out: *mut *mut RandomAccessStreamReference) -> HRESULT,
@@ -2974,7 +2974,7 @@ impl Compressor {
         <Self as RtActivatable<ICompressorFactory>>::get_activation_factory().create_compressor_ex(underlyingStream, algorithm, blockSize)
     }}
 }
-DEFINE_CLSID!(Compressor(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,67,111,109,112,114,101,115,115,105,111,110,46,67,111,109,112,114,101,115,115,111,114,0]) [CLSID_Compressor]);
+DEFINE_CLSID!(Compressor: "Windows.Storage.Compression.Compressor");
 DEFINE_IID!(IID_ICompressorFactory, 1597871780, 11515, 17452, 168, 186, 215, 209, 27, 3, 157, 160);
 RT_INTERFACE!{static interface ICompressorFactory(ICompressorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompressorFactory] {
     fn CreateCompressor(&self, underlyingStream: *mut super::streams::IOutputStream, out: *mut *mut Compressor) -> HRESULT,
@@ -3010,7 +3010,7 @@ impl Decompressor {
         <Self as RtActivatable<IDecompressorFactory>>::get_activation_factory().create_decompressor(underlyingStream)
     }}
 }
-DEFINE_CLSID!(Decompressor(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,67,111,109,112,114,101,115,115,105,111,110,46,68,101,99,111,109,112,114,101,115,115,111,114,0]) [CLSID_Decompressor]);
+DEFINE_CLSID!(Decompressor: "Windows.Storage.Compression.Decompressor");
 DEFINE_IID!(IID_IDecompressorFactory, 1396171346, 7586, 17121, 136, 52, 3, 121, 210, 141, 116, 47);
 RT_INTERFACE!{static interface IDecompressorFactory(IDecompressorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDecompressorFactory] {
     fn CreateDecompressor(&self, underlyingStream: *mut super::streams::IInputStream, out: *mut *mut Decompressor) -> HRESULT
@@ -3088,7 +3088,7 @@ impl ContentIndexer {
         <Self as RtActivatable<IContentIndexerStatics>>::get_activation_factory().get_indexer()
     }}
 }
-DEFINE_CLSID!(ContentIndexer(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,67,111,110,116,101,110,116,73,110,100,101,120,101,114,0]) [CLSID_ContentIndexer]);
+DEFINE_CLSID!(ContentIndexer: "Windows.Storage.Search.ContentIndexer");
 DEFINE_IID!(IID_IContentIndexerQuery, 1893970168, 19452, 17034, 136, 137, 204, 81, 218, 154, 123, 157);
 RT_INTERFACE!{interface IContentIndexerQuery(IContentIndexerQueryVtbl): IInspectable(IInspectableVtbl) [IID_IContentIndexerQuery] {
     fn GetCountAsync(&self, out: *mut *mut super::super::foundation::IAsyncOperation<u32>) -> HRESULT,
@@ -3223,7 +3223,7 @@ impl IIndexableContent {
 }
 RT_CLASS!{class IndexableContent: IIndexableContent}
 impl RtActivatable<IActivationFactory> for IndexableContent {}
-DEFINE_CLSID!(IndexableContent(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,73,110,100,101,120,97,98,108,101,67,111,110,116,101,110,116,0]) [CLSID_IndexableContent]);
+DEFINE_CLSID!(IndexableContent: "Windows.Storage.Search.IndexableContent");
 RT_ENUM! { enum IndexedState: i32 {
     Unknown (IndexedState_Unknown) = 0, NotIndexed (IndexedState_NotIndexed) = 1, PartiallyIndexed (IndexedState_PartiallyIndexed) = 2, FullyIndexed (IndexedState_FullyIndexed) = 3,
 }}
@@ -3346,7 +3346,7 @@ impl QueryOptions {
         <Self as RtActivatable<IQueryOptionsFactory>>::get_activation_factory().create_common_folder_query(query)
     }}
 }
-DEFINE_CLSID!(QueryOptions(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_QueryOptions]);
+DEFINE_CLSID!(QueryOptions: "Windows.Storage.Search.QueryOptions");
 DEFINE_IID!(IID_IQueryOptionsFactory, 53354380, 43457, 20081, 128, 17, 13, 238, 157, 72, 17, 163);
 RT_INTERFACE!{static interface IQueryOptionsFactory(IQueryOptionsFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IQueryOptionsFactory] {
     fn CreateCommonFileQuery(&self, query: CommonFileQuery, fileTypeFilter: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut QueryOptions) -> HRESULT,
@@ -3654,7 +3654,7 @@ impl IValueAndLanguage {
 }
 RT_CLASS!{class ValueAndLanguage: IValueAndLanguage}
 impl RtActivatable<IActivationFactory> for ValueAndLanguage {}
-DEFINE_CLSID!(ValueAndLanguage(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,86,97,108,117,101,65,110,100,76,97,110,103,117,97,103,101,0]) [CLSID_ValueAndLanguage]);
+DEFINE_CLSID!(ValueAndLanguage: "Windows.Storage.Search.ValueAndLanguage");
 } // Windows.Storage.Search
 pub mod pickers { // Windows.Storage.Pickers
 use ::prelude::*;
@@ -3734,7 +3734,7 @@ impl FileOpenPicker {
         <Self as RtActivatable<IFileOpenPickerStatics>>::get_activation_factory().resume_pick_single_file_async()
     }}
 }
-DEFINE_CLSID!(FileOpenPicker(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,105,99,107,101,114,115,46,70,105,108,101,79,112,101,110,80,105,99,107,101,114,0]) [CLSID_FileOpenPicker]);
+DEFINE_CLSID!(FileOpenPicker: "Windows.Storage.Pickers.FileOpenPicker");
 DEFINE_IID!(IID_IFileOpenPicker2, 2364239058, 46150, 18167, 178, 101, 144, 248, 229, 90, 214, 80);
 RT_INTERFACE!{interface IFileOpenPicker2(IFileOpenPicker2Vtbl): IInspectable(IInspectableVtbl) [IID_IFileOpenPicker2] {
     fn get_ContinuationData(&self, out: *mut *mut super::super::foundation::collections::ValueSet) -> HRESULT,
@@ -3865,7 +3865,7 @@ impl IFileSavePicker {
 }
 RT_CLASS!{class FileSavePicker: IFileSavePicker}
 impl RtActivatable<IActivationFactory> for FileSavePicker {}
-DEFINE_CLSID!(FileSavePicker(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,105,99,107,101,114,115,46,70,105,108,101,83,97,118,101,80,105,99,107,101,114,0]) [CLSID_FileSavePicker]);
+DEFINE_CLSID!(FileSavePicker: "Windows.Storage.Pickers.FileSavePicker");
 DEFINE_IID!(IID_IFileSavePicker2, 247665570, 53835, 17562, 129, 151, 232, 145, 4, 253, 66, 204);
 RT_INTERFACE!{interface IFileSavePicker2(IFileSavePicker2Vtbl): IInspectable(IInspectableVtbl) [IID_IFileSavePicker2] {
     fn get_ContinuationData(&self, out: *mut *mut super::super::foundation::collections::ValueSet) -> HRESULT,
@@ -3961,7 +3961,7 @@ impl IFolderPicker {
 }
 RT_CLASS!{class FolderPicker: IFolderPicker}
 impl RtActivatable<IActivationFactory> for FolderPicker {}
-DEFINE_CLSID!(FolderPicker(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,105,99,107,101,114,115,46,70,111,108,100,101,114,80,105,99,107,101,114,0]) [CLSID_FolderPicker]);
+DEFINE_CLSID!(FolderPicker: "Windows.Storage.Pickers.FolderPicker");
 DEFINE_IID!(IID_IFolderPicker2, 2394143383, 56453, 17942, 190, 148, 150, 96, 136, 31, 47, 93);
 RT_INTERFACE!{interface IFolderPicker2(IFolderPicker2Vtbl): IInspectable(IInspectableVtbl) [IID_IFolderPicker2] {
     fn get_ContinuationData(&self, out: *mut *mut super::super::foundation::collections::ValueSet) -> HRESULT,
@@ -4260,7 +4260,7 @@ impl CachedFileUpdater {
         <Self as RtActivatable<ICachedFileUpdaterStatics>>::get_activation_factory().set_update_information(file, contentId, readMode, writeMode, options)
     }}
 }
-DEFINE_CLSID!(CachedFileUpdater(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,67,97,99,104,101,100,70,105,108,101,85,112,100,97,116,101,114,0]) [CLSID_CachedFileUpdater]);
+DEFINE_CLSID!(CachedFileUpdater: "Windows.Storage.Provider.CachedFileUpdater");
 DEFINE_IID!(IID_ICachedFileUpdaterStatics, 2680752416, 31695, 18568, 168, 30, 16, 45, 112, 52, 215, 206);
 RT_INTERFACE!{static interface ICachedFileUpdaterStatics(ICachedFileUpdaterStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileUpdaterStatics] {
     fn SetUpdateInformation(&self, file: *mut super::IStorageFile, contentId: HSTRING, readMode: ReadActivationMode, writeMode: WriteActivationMode, options: CachedFileOptions) -> HRESULT
@@ -4443,7 +4443,7 @@ impl StorageProviderItemProperties {
         <Self as RtActivatable<IStorageProviderItemPropertiesStatics>>::get_activation_factory().set_async(item, itemProperties)
     }}
 }
-DEFINE_CLSID!(StorageProviderItemProperties(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,73,116,101,109,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_StorageProviderItemProperties]);
+DEFINE_CLSID!(StorageProviderItemProperties: "Windows.Storage.Provider.StorageProviderItemProperties");
 DEFINE_IID!(IID_IStorageProviderItemPropertiesStatics, 757865623, 9988, 18217, 143, 169, 126, 107, 142, 21, 140, 47);
 RT_INTERFACE!{static interface IStorageProviderItemPropertiesStatics(IStorageProviderItemPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageProviderItemPropertiesStatics] {
     fn SetAsync(&self, item: *mut super::IStorageItem, itemProperties: *mut super::super::foundation::collections::IIterable<StorageProviderItemProperty>, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT
@@ -4495,7 +4495,7 @@ impl IStorageProviderItemProperty {
 }
 RT_CLASS!{class StorageProviderItemProperty: IStorageProviderItemProperty}
 impl RtActivatable<IActivationFactory> for StorageProviderItemProperty {}
-DEFINE_CLSID!(StorageProviderItemProperty(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,73,116,101,109,80,114,111,112,101,114,116,121,0]) [CLSID_StorageProviderItemProperty]);
+DEFINE_CLSID!(StorageProviderItemProperty: "Windows.Storage.Provider.StorageProviderItemProperty");
 DEFINE_IID!(IID_IStorageProviderItemPropertyDefinition, 3316876219, 65311, 17048, 131, 30, 255, 28, 8, 8, 150, 144);
 RT_INTERFACE!{interface IStorageProviderItemPropertyDefinition(IStorageProviderItemPropertyDefinitionVtbl): IInspectable(IInspectableVtbl) [IID_IStorageProviderItemPropertyDefinition] {
     fn get_Id(&self, out: *mut i32) -> HRESULT,
@@ -4525,7 +4525,7 @@ impl IStorageProviderItemPropertyDefinition {
 }
 RT_CLASS!{class StorageProviderItemPropertyDefinition: IStorageProviderItemPropertyDefinition}
 impl RtActivatable<IActivationFactory> for StorageProviderItemPropertyDefinition {}
-DEFINE_CLSID!(StorageProviderItemPropertyDefinition(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,73,116,101,109,80,114,111,112,101,114,116,121,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_StorageProviderItemPropertyDefinition]);
+DEFINE_CLSID!(StorageProviderItemPropertyDefinition: "Windows.Storage.Provider.StorageProviderItemPropertyDefinition");
 DEFINE_IID!(IID_IStorageProviderItemPropertySource, 2406456382, 63026, 19099, 141, 153, 210, 215, 161, 29, 245, 106);
 RT_INTERFACE!{interface IStorageProviderItemPropertySource(IStorageProviderItemPropertySourceVtbl): IInspectable(IInspectableVtbl) [IID_IStorageProviderItemPropertySource] {
     fn GetItemProperties(&self, itemPath: HSTRING, out: *mut *mut super::super::foundation::collections::IIterable<StorageProviderItemProperty>) -> HRESULT
@@ -4732,7 +4732,7 @@ impl IStorageProviderSyncRootInfo {
 }
 RT_CLASS!{class StorageProviderSyncRootInfo: IStorageProviderSyncRootInfo}
 impl RtActivatable<IActivationFactory> for StorageProviderSyncRootInfo {}
-DEFINE_CLSID!(StorageProviderSyncRootInfo(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,83,121,110,99,82,111,111,116,73,110,102,111,0]) [CLSID_StorageProviderSyncRootInfo]);
+DEFINE_CLSID!(StorageProviderSyncRootInfo: "Windows.Storage.Provider.StorageProviderSyncRootInfo");
 RT_CLASS!{static class StorageProviderSyncRootManager}
 impl RtActivatable<IStorageProviderSyncRootManagerStatics> for StorageProviderSyncRootManager {}
 impl StorageProviderSyncRootManager {
@@ -4752,7 +4752,7 @@ impl StorageProviderSyncRootManager {
         <Self as RtActivatable<IStorageProviderSyncRootManagerStatics>>::get_activation_factory().get_current_sync_roots()
     }}
 }
-DEFINE_CLSID!(StorageProviderSyncRootManager(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,83,121,110,99,82,111,111,116,77,97,110,97,103,101,114,0]) [CLSID_StorageProviderSyncRootManager]);
+DEFINE_CLSID!(StorageProviderSyncRootManager: "Windows.Storage.Provider.StorageProviderSyncRootManager");
 DEFINE_IID!(IID_IStorageProviderSyncRootManagerStatics, 1050278847, 36835, 19264, 171, 199, 246, 252, 61, 116, 201, 142);
 RT_INTERFACE!{static interface IStorageProviderSyncRootManagerStatics(IStorageProviderSyncRootManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageProviderSyncRootManagerStatics] {
     fn Register(&self, syncRootInformation: *mut StorageProviderSyncRootInfo) -> HRESULT,
@@ -4872,7 +4872,7 @@ impl GeotagHelper {
         <Self as RtActivatable<IGeotagHelperStatics>>::get_activation_factory().set_geotag_async(file, geopoint)
     }}
 }
-DEFINE_CLSID!(GeotagHelper(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,70,105,108,101,80,114,111,112,101,114,116,105,101,115,46,71,101,111,116,97,103,72,101,108,112,101,114,0]) [CLSID_GeotagHelper]);
+DEFINE_CLSID!(GeotagHelper: "Windows.Storage.FileProperties.GeotagHelper");
 DEFINE_IID!(IID_IGeotagHelperStatics, 1095316036, 9508, 18005, 134, 166, 237, 22, 245, 252, 113, 107);
 RT_INTERFACE!{static interface IGeotagHelperStatics(IGeotagHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGeotagHelperStatics] {
     #[cfg(feature="windows-devices")] fn GetGeotagAsync(&self, file: *mut super::IStorageFile, out: *mut *mut super::super::foundation::IAsyncOperation<super::super::devices::geolocation::Geopoint>) -> HRESULT,
@@ -5409,7 +5409,7 @@ impl StorageApplicationPermissions {
         <Self as RtActivatable<IStorageApplicationPermissionsStatics>>::get_activation_factory().get_most_recently_used_list()
     }}
 }
-DEFINE_CLSID!(StorageApplicationPermissions(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,65,99,99,101,115,115,67,97,99,104,101,46,83,116,111,114,97,103,101,65,112,112,108,105,99,97,116,105,111,110,80,101,114,109,105,115,115,105,111,110,115,0]) [CLSID_StorageApplicationPermissions]);
+DEFINE_CLSID!(StorageApplicationPermissions: "Windows.Storage.AccessCache.StorageApplicationPermissions");
 DEFINE_IID!(IID_IStorageApplicationPermissionsStatics, 1133633450, 53299, 18681, 128, 96, 62, 200, 71, 210, 227, 241);
 RT_INTERFACE!{static interface IStorageApplicationPermissionsStatics(IStorageApplicationPermissionsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageApplicationPermissionsStatics] {
     fn get_FutureAccessList(&self, out: *mut *mut StorageItemAccessList) -> HRESULT,
@@ -5637,7 +5637,7 @@ impl FileInformationFactory {
         <Self as RtActivatable<IFileInformationFactoryFactory>>::get_activation_factory().create_with_mode_and_size_and_options_and_flags(queryResult, mode, requestedThumbnailSize, thumbnailOptions, delayLoad)
     }}
 }
-DEFINE_CLSID!(FileInformationFactory(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,66,117,108,107,65,99,99,101,115,115,46,70,105,108,101,73,110,102,111,114,109,97,116,105,111,110,70,97,99,116,111,114,121,0]) [CLSID_FileInformationFactory]);
+DEFINE_CLSID!(FileInformationFactory: "Windows.Storage.BulkAccess.FileInformationFactory");
 DEFINE_IID!(IID_IFileInformationFactoryFactory, 2229931645, 58530, 20224, 138, 250, 175, 94, 15, 130, 107, 213);
 RT_INTERFACE!{static interface IFileInformationFactoryFactory(IFileInformationFactoryFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IFileInformationFactoryFactory] {
     fn CreateWithMode(&self, queryResult: *mut super::search::IStorageQueryResultBase, mode: super::fileproperties::ThumbnailMode, out: *mut *mut FileInformationFactory) -> HRESULT,

--- a/src/rt/gen/windows/system.rs
+++ b/src/rt/gen/windows/system.rs
@@ -33,7 +33,7 @@ impl AppDiagnosticInfo {
         <Self as RtActivatable<IAppDiagnosticInfoStatics2>>::get_activation_factory().request_info_for_app_user_model_id(appUserModelId)
     }}
 }
-DEFINE_CLSID!(AppDiagnosticInfo(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,65,112,112,68,105,97,103,110,111,115,116,105,99,73,110,102,111,0]) [CLSID_AppDiagnosticInfo]);
+DEFINE_CLSID!(AppDiagnosticInfo: "Windows.System.AppDiagnosticInfo");
 DEFINE_IID!(IID_IAppDiagnosticInfo2, 3745971159, 6426, 17516, 148, 115, 143, 188, 35, 116, 163, 84);
 RT_INTERFACE!{interface IAppDiagnosticInfo2(IAppDiagnosticInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppDiagnosticInfo2] {
     fn GetResourceGroups(&self, out: *mut *mut super::foundation::collections::IVector<AppResourceGroupInfo>) -> HRESULT,
@@ -489,7 +489,7 @@ impl DateTimeSettings {
         <Self as RtActivatable<IDateTimeSettingsStatics>>::get_activation_factory().set_system_date_time(utcDateTime)
     }}
 }
-DEFINE_CLSID!(DateTimeSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,97,116,101,84,105,109,101,83,101,116,116,105,110,103,115,0]) [CLSID_DateTimeSettings]);
+DEFINE_CLSID!(DateTimeSettings: "Windows.System.DateTimeSettings");
 DEFINE_IID!(IID_IDateTimeSettingsStatics, 1562464465, 18414, 18603, 165, 43, 159, 25, 84, 39, 141, 130);
 RT_INTERFACE!{static interface IDateTimeSettingsStatics(IDateTimeSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDateTimeSettingsStatics] {
     fn SetSystemDateTime(&self, utcDateTime: super::foundation::DateTime) -> HRESULT
@@ -555,7 +555,7 @@ impl DispatcherQueue {
         <Self as RtActivatable<IDispatcherQueueStatics>>::get_activation_factory().get_for_current_thread()
     }}
 }
-DEFINE_CLSID!(DispatcherQueue(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,115,112,97,116,99,104,101,114,81,117,101,117,101,0]) [CLSID_DispatcherQueue]);
+DEFINE_CLSID!(DispatcherQueue: "Windows.System.DispatcherQueue");
 DEFINE_IID!(IID_IDispatcherQueueController, 586370662, 20699, 20022, 169, 141, 97, 192, 27, 56, 77, 32);
 RT_INTERFACE!{interface IDispatcherQueueController(IDispatcherQueueControllerVtbl): IInspectable(IInspectableVtbl) [IID_IDispatcherQueueController] {
     fn get_DispatcherQueue(&self, out: *mut *mut DispatcherQueue) -> HRESULT,
@@ -580,7 +580,7 @@ impl DispatcherQueueController {
         <Self as RtActivatable<IDispatcherQueueControllerStatics>>::get_activation_factory().create_on_dedicated_thread()
     }}
 }
-DEFINE_CLSID!(DispatcherQueueController(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,115,112,97,116,99,104,101,114,81,117,101,117,101,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_DispatcherQueueController]);
+DEFINE_CLSID!(DispatcherQueueController: "Windows.System.DispatcherQueueController");
 DEFINE_IID!(IID_IDispatcherQueueControllerStatics, 174889184, 20888, 18850, 163, 19, 63, 112, 209, 241, 60, 39);
 RT_INTERFACE!{static interface IDispatcherQueueControllerStatics(IDispatcherQueueControllerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDispatcherQueueControllerStatics] {
     fn CreateOnDedicatedThread(&self, out: *mut *mut DispatcherQueueController) -> HRESULT
@@ -696,7 +696,7 @@ impl IFolderLauncherOptions {
 }
 RT_CLASS!{class FolderLauncherOptions: IFolderLauncherOptions}
 impl RtActivatable<IActivationFactory> for FolderLauncherOptions {}
-DEFINE_CLSID!(FolderLauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,70,111,108,100,101,114,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_FolderLauncherOptions]);
+DEFINE_CLSID!(FolderLauncherOptions: "Windows.System.FolderLauncherOptions");
 RT_CLASS!{static class KnownUserProperties}
 impl RtActivatable<IKnownUserPropertiesStatics> for KnownUserProperties {}
 impl KnownUserProperties {
@@ -728,7 +728,7 @@ impl KnownUserProperties {
         <Self as RtActivatable<IKnownUserPropertiesStatics>>::get_activation_factory().get_session_initiation_protocol_uri()
     }}
 }
-DEFINE_CLSID!(KnownUserProperties(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,75,110,111,119,110,85,115,101,114,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownUserProperties]);
+DEFINE_CLSID!(KnownUserProperties: "Windows.System.KnownUserProperties");
 DEFINE_IID!(IID_IKnownUserPropertiesStatics, 2002096410, 28869, 18661, 182, 55, 91, 163, 68, 30, 78, 228);
 RT_INTERFACE!{static interface IKnownUserPropertiesStatics(IKnownUserPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownUserPropertiesStatics] {
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -867,7 +867,7 @@ impl Launcher {
         <Self as RtActivatable<ILauncherStatics4>>::get_activation_factory().launch_uri_for_results_with_data_for_user_async(user, uri, options, inputData)
     }}
 }
-DEFINE_CLSID!(Launcher(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,76,97,117,110,99,104,101,114,0]) [CLSID_Launcher]);
+DEFINE_CLSID!(Launcher: "Windows.System.Launcher");
 DEFINE_IID!(IID_ILauncherOptions, 3136954840, 45169, 19672, 133, 62, 52, 18, 3, 229, 87, 211);
 RT_INTERFACE!{interface ILauncherOptions(ILauncherOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ILauncherOptions] {
     fn get_TreatAsUntrusted(&self, out: *mut bool) -> HRESULT,
@@ -947,7 +947,7 @@ impl ILauncherOptions {
 }
 RT_CLASS!{class LauncherOptions: ILauncherOptions}
 impl RtActivatable<IActivationFactory> for LauncherOptions {}
-DEFINE_CLSID!(LauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_LauncherOptions]);
+DEFINE_CLSID!(LauncherOptions: "Windows.System.LauncherOptions");
 DEFINE_IID!(IID_ILauncherOptions2, 1000378036, 28224, 19918, 161, 163, 47, 83, 149, 10, 251, 73);
 RT_INTERFACE!{interface ILauncherOptions2(ILauncherOptions2Vtbl): IInspectable(IInspectableVtbl) [IID_ILauncherOptions2] {
     fn get_TargetApplicationPackageFamilyName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1307,7 +1307,7 @@ impl MemoryManager {
         <Self as RtActivatable<IMemoryManagerStatics4>>::get_activation_factory().get_expected_app_memory_usage_limit()
     }}
 }
-DEFINE_CLSID!(MemoryManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,77,101,109,111,114,121,77,97,110,97,103,101,114,0]) [CLSID_MemoryManager]);
+DEFINE_CLSID!(MemoryManager: "Windows.System.MemoryManager");
 DEFINE_IID!(IID_IMemoryManagerStatics, 1550591900, 55242, 18297, 145, 136, 64, 87, 33, 156, 230, 76);
 RT_INTERFACE!{static interface IMemoryManagerStatics(IMemoryManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMemoryManagerStatics] {
     fn get_AppMemoryUsage(&self, out: *mut u64) -> HRESULT,
@@ -1416,7 +1416,7 @@ impl ProcessLauncher {
         <Self as RtActivatable<IProcessLauncherStatics>>::get_activation_factory().run_to_completion_async_with_options(fileName, args, options)
     }}
 }
-DEFINE_CLSID!(ProcessLauncher(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,99,101,115,115,76,97,117,110,99,104,101,114,0]) [CLSID_ProcessLauncher]);
+DEFINE_CLSID!(ProcessLauncher: "Windows.System.ProcessLauncher");
 DEFINE_IID!(IID_IProcessLauncherOptions, 813742543, 62532, 19075, 190, 175, 165, 73, 160, 243, 34, 156);
 RT_INTERFACE!{interface IProcessLauncherOptions(IProcessLauncherOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IProcessLauncherOptions] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -1474,7 +1474,7 @@ impl IProcessLauncherOptions {
 }
 RT_CLASS!{class ProcessLauncherOptions: IProcessLauncherOptions}
 impl RtActivatable<IActivationFactory> for ProcessLauncherOptions {}
-DEFINE_CLSID!(ProcessLauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,99,101,115,115,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_ProcessLauncherOptions]);
+DEFINE_CLSID!(ProcessLauncherOptions: "Windows.System.ProcessLauncherOptions");
 DEFINE_IID!(IID_IProcessLauncherResult, 1414302004, 34520, 18833, 142, 117, 236, 232, 164, 59, 107, 109);
 RT_INTERFACE!{interface IProcessLauncherResult(IProcessLauncherResultVtbl): IInspectable(IInspectableVtbl) [IID_IProcessLauncherResult] {
     fn get_ExitCode(&self, out: *mut u32) -> HRESULT
@@ -1549,7 +1549,7 @@ impl RemoteLauncher {
         <Self as RtActivatable<IRemoteLauncherStatics>>::get_activation_factory().launch_uri_with_data_async(remoteSystemConnectionRequest, uri, options, inputData)
     }}
 }
-DEFINE_CLSID!(RemoteLauncher(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,76,97,117,110,99,104,101,114,0]) [CLSID_RemoteLauncher]);
+DEFINE_CLSID!(RemoteLauncher: "Windows.System.RemoteLauncher");
 DEFINE_IID!(IID_IRemoteLauncherOptions, 2654611336, 10385, 19679, 162, 214, 157, 255, 125, 2, 230, 147);
 RT_INTERFACE!{interface IRemoteLauncherOptions(IRemoteLauncherOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteLauncherOptions] {
     fn get_FallbackUri(&self, out: *mut *mut super::foundation::Uri) -> HRESULT,
@@ -1574,7 +1574,7 @@ impl IRemoteLauncherOptions {
 }
 RT_CLASS!{class RemoteLauncherOptions: IRemoteLauncherOptions}
 impl RtActivatable<IActivationFactory> for RemoteLauncherOptions {}
-DEFINE_CLSID!(RemoteLauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_RemoteLauncherOptions]);
+DEFINE_CLSID!(RemoteLauncherOptions: "Windows.System.RemoteLauncherOptions");
 DEFINE_IID!(IID_IRemoteLauncherStatics, 3621485203, 41740, 18615, 159, 33, 5, 16, 38, 164, 229, 23);
 RT_INTERFACE!{static interface IRemoteLauncherStatics(IRemoteLauncherStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteLauncherStatics] {
     fn LaunchUriAsync(&self, remoteSystemConnectionRequest: *mut remotesystems::RemoteSystemConnectionRequest, uri: *mut super::foundation::Uri, out: *mut *mut super::foundation::IAsyncOperation<RemoteLaunchUriStatus>) -> HRESULT,
@@ -1624,7 +1624,7 @@ impl ShutdownManager {
         <Self as RtActivatable<IShutdownManagerStatics2>>::get_activation_factory().enter_power_state_with_time_span(powerState, wakeUpAfter)
     }}
 }
-DEFINE_CLSID!(ShutdownManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,83,104,117,116,100,111,119,110,77,97,110,97,103,101,114,0]) [CLSID_ShutdownManager]);
+DEFINE_CLSID!(ShutdownManager: "Windows.System.ShutdownManager");
 DEFINE_IID!(IID_IShutdownManagerStatics, 1927432173, 56667, 19820, 177, 208, 197, 122, 123, 187, 95, 148);
 RT_INTERFACE!{static interface IShutdownManagerStatics(IShutdownManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IShutdownManagerStatics] {
     fn BeginShutdown(&self, shutdownKind: ShutdownKind, timeout: super::foundation::TimeSpan) -> HRESULT,
@@ -1677,7 +1677,7 @@ impl TimeZoneSettings {
         <Self as RtActivatable<ITimeZoneSettingsStatics>>::get_activation_factory().change_time_zone_by_display_name(timeZoneDisplayName)
     }}
 }
-DEFINE_CLSID!(TimeZoneSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,84,105,109,101,90,111,110,101,83,101,116,116,105,110,103,115,0]) [CLSID_TimeZoneSettings]);
+DEFINE_CLSID!(TimeZoneSettings: "Windows.System.TimeZoneSettings");
 DEFINE_IID!(IID_ITimeZoneSettingsStatics, 2604346346, 41217, 16814, 159, 189, 2, 135, 40, 186, 183, 61);
 RT_INTERFACE!{static interface ITimeZoneSettingsStatics(ITimeZoneSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITimeZoneSettingsStatics] {
     fn get_CurrentTimeZoneDisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1766,7 +1766,7 @@ impl User {
         <Self as RtActivatable<IUserStatics>>::get_activation_factory().get_from_id(nonRoamableId)
     }}
 }
-DEFINE_CLSID!(User(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,0]) [CLSID_User]);
+DEFINE_CLSID!(User: "Windows.System.User");
 RT_ENUM! { enum UserAuthenticationStatus: i32 {
     Unauthenticated (UserAuthenticationStatus_Unauthenticated) = 0, LocallyAuthenticated (UserAuthenticationStatus_LocallyAuthenticated) = 1, RemotelyAuthenticated (UserAuthenticationStatus_RemotelyAuthenticated) = 2,
 }}
@@ -1836,7 +1836,7 @@ impl UserDeviceAssociation {
         <Self as RtActivatable<IUserDeviceAssociationStatics>>::get_activation_factory().remove_user_device_association_changed(token)
     }}
 }
-DEFINE_CLSID!(UserDeviceAssociation(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,68,101,118,105,99,101,65,115,115,111,99,105,97,116,105,111,110,0]) [CLSID_UserDeviceAssociation]);
+DEFINE_CLSID!(UserDeviceAssociation: "Windows.System.UserDeviceAssociation");
 DEFINE_IID!(IID_IUserDeviceAssociationChangedEventArgs, 3172953964, 47965, 19835, 165, 240, 200, 205, 17, 163, 141, 66);
 RT_INTERFACE!{interface IUserDeviceAssociationChangedEventArgs(IUserDeviceAssociationChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDeviceAssociationChangedEventArgs] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -1924,7 +1924,7 @@ impl UserPicker {
         <Self as RtActivatable<IUserPickerStatics>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(UserPicker(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,105,99,107,101,114,0]) [CLSID_UserPicker]);
+DEFINE_CLSID!(UserPicker: "Windows.System.UserPicker");
 DEFINE_IID!(IID_IUserPickerStatics, 3727855836, 32371, 19958, 161, 174, 77, 126, 202, 130, 180, 13);
 RT_INTERFACE!{static interface IUserPickerStatics(IUserPickerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserPickerStatics] {
     fn IsSupported(&self, out: *mut bool) -> HRESULT
@@ -2101,7 +2101,7 @@ impl AdvertisingManager {
         <Self as RtActivatable<IAdvertisingManagerStatics2>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(AdvertisingManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,65,100,118,101,114,116,105,115,105,110,103,77,97,110,97,103,101,114,0]) [CLSID_AdvertisingManager]);
+DEFINE_CLSID!(AdvertisingManager: "Windows.System.UserProfile.AdvertisingManager");
 DEFINE_IID!(IID_IAdvertisingManagerForUser, 2458645456, 53116, 19120, 167, 220, 109, 197, 188, 212, 66, 82);
 RT_INTERFACE!{interface IAdvertisingManagerForUser(IAdvertisingManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IAdvertisingManagerForUser] {
     fn get_AdvertisingId(&self, out: *mut HSTRING) -> HRESULT,
@@ -2169,7 +2169,7 @@ impl DiagnosticsSettings {
         <Self as RtActivatable<IDiagnosticsSettingsStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(DiagnosticsSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,68,105,97,103,110,111,115,116,105,99,115,83,101,116,116,105,110,103,115,0]) [CLSID_DiagnosticsSettings]);
+DEFINE_CLSID!(DiagnosticsSettings: "Windows.System.UserProfile.DiagnosticsSettings");
 DEFINE_IID!(IID_IDiagnosticsSettingsStatics, 1926424591, 21392, 18323, 153, 11, 60, 204, 125, 106, 201, 200);
 RT_INTERFACE!{static interface IDiagnosticsSettingsStatics(IDiagnosticsSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDiagnosticsSettingsStatics] {
     fn GetDefault(&self, out: *mut *mut DiagnosticsSettings) -> HRESULT,
@@ -2198,7 +2198,7 @@ impl FirstSignInSettings {
         <Self as RtActivatable<IFirstSignInSettingsStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(FirstSignInSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,70,105,114,115,116,83,105,103,110,73,110,83,101,116,116,105,110,103,115,0]) [CLSID_FirstSignInSettings]);
+DEFINE_CLSID!(FirstSignInSettings: "Windows.System.UserProfile.FirstSignInSettings");
 DEFINE_IID!(IID_IFirstSignInSettingsStatics, 484544271, 7233, 20128, 183, 162, 111, 12, 28, 126, 132, 56);
 RT_INTERFACE!{static interface IFirstSignInSettingsStatics(IFirstSignInSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFirstSignInSettingsStatics] {
     fn GetDefault(&self, out: *mut *mut FirstSignInSettings) -> HRESULT
@@ -2239,7 +2239,7 @@ impl GlobalizationPreferences {
         <Self as RtActivatable<IGlobalizationPreferencesStatics2>>::get_activation_factory().try_set_languages(languageTags)
     }}
 }
-DEFINE_CLSID!(GlobalizationPreferences(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,71,108,111,98,97,108,105,122,97,116,105,111,110,80,114,101,102,101,114,101,110,99,101,115,0]) [CLSID_GlobalizationPreferences]);
+DEFINE_CLSID!(GlobalizationPreferences: "Windows.System.UserProfile.GlobalizationPreferences");
 DEFINE_IID!(IID_IGlobalizationPreferencesStatics, 29311782, 60727, 20118, 176, 233, 193, 52, 13, 30, 161, 88);
 RT_INTERFACE!{static interface IGlobalizationPreferencesStatics(IGlobalizationPreferencesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGlobalizationPreferencesStatics] {
     fn get_Calendars(&self, out: *mut *mut super::super::foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -2321,7 +2321,7 @@ impl LockScreen {
         <Self as RtActivatable<ILockScreenStatics>>::get_activation_factory().set_image_stream_async(value)
     }}
 }
-DEFINE_CLSID!(LockScreen(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,76,111,99,107,83,99,114,101,101,110,0]) [CLSID_LockScreen]);
+DEFINE_CLSID!(LockScreen: "Windows.System.UserProfile.LockScreen");
 DEFINE_IID!(IID_ILockScreenImageFeedStatics, 739079158, 937, 16806, 155, 1, 73, 82, 81, 255, 81, 213);
 RT_INTERFACE!{static interface ILockScreenImageFeedStatics(ILockScreenImageFeedStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenImageFeedStatics] {
     fn RequestSetImageFeedAsync(&self, syndicationFeedUri: *mut super::super::foundation::Uri, out: *mut *mut super::super::foundation::IAsyncOperation<SetImageFeedResult>) -> HRESULT,
@@ -2423,7 +2423,7 @@ impl UserInformation {
         <Self as RtActivatable<IUserInformationStatics>>::get_activation_factory().get_domain_name_async()
     }}
 }
-DEFINE_CLSID!(UserInformation(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,85,115,101,114,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_UserInformation]);
+DEFINE_CLSID!(UserInformation: "Windows.System.UserProfile.UserInformation");
 DEFINE_IID!(IID_IUserInformationStatics, 2012457232, 18682, 18588, 147, 78, 42, 232, 91, 168, 247, 114);
 RT_INTERFACE!{static interface IUserInformationStatics(IUserInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserInformationStatics] {
     fn get_AccountPictureChangeEnabled(&self, out: *mut bool) -> HRESULT,
@@ -2550,7 +2550,7 @@ impl UserProfilePersonalizationSettings {
         <Self as RtActivatable<IUserProfilePersonalizationSettingsStatics>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(UserProfilePersonalizationSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,80,114,111,102,105,108,101,46,85,115,101,114,80,114,111,102,105,108,101,80,101,114,115,111,110,97,108,105,122,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_UserProfilePersonalizationSettings]);
+DEFINE_CLSID!(UserProfilePersonalizationSettings: "Windows.System.UserProfile.UserProfilePersonalizationSettings");
 DEFINE_IID!(IID_IUserProfilePersonalizationSettingsStatics, 2444015681, 20535, 17739, 152, 131, 187, 119, 45, 8, 221, 22);
 RT_INTERFACE!{static interface IUserProfilePersonalizationSettingsStatics(IUserProfilePersonalizationSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserProfilePersonalizationSettingsStatics] {
     fn get_Current(&self, out: *mut *mut UserProfilePersonalizationSettings) -> HRESULT,
@@ -2581,7 +2581,7 @@ impl AnalyticsInfo {
         <Self as RtActivatable<IAnalyticsInfoStatics>>::get_activation_factory().get_device_form()
     }}
 }
-DEFINE_CLSID!(AnalyticsInfo(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,65,110,97,108,121,116,105,99,115,73,110,102,111,0]) [CLSID_AnalyticsInfo]);
+DEFINE_CLSID!(AnalyticsInfo: "Windows.System.Profile.AnalyticsInfo");
 DEFINE_IID!(IID_IAnalyticsInfoStatics, 492757094, 6285, 23465, 67, 135, 172, 174, 176, 231, 227, 5);
 RT_INTERFACE!{static interface IAnalyticsInfoStatics(IAnalyticsInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAnalyticsInfoStatics] {
     fn get_VersionInfo(&self, out: *mut *mut AnalyticsVersionInfo) -> HRESULT,
@@ -2624,7 +2624,7 @@ impl EducationSettings {
         <Self as RtActivatable<IEducationSettingsStatics>>::get_activation_factory().get_is_education_environment()
     }}
 }
-DEFINE_CLSID!(EducationSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,69,100,117,99,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_EducationSettings]);
+DEFINE_CLSID!(EducationSettings: "Windows.System.Profile.EducationSettings");
 DEFINE_IID!(IID_IEducationSettingsStatics, 4233359599, 19774, 19987, 155, 35, 80, 95, 77, 9, 30, 146);
 RT_INTERFACE!{static interface IEducationSettingsStatics(IEducationSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IEducationSettingsStatics] {
     fn get_IsEducationEnvironment(&self, out: *mut bool) -> HRESULT
@@ -2643,7 +2643,7 @@ impl HardwareIdentification {
         <Self as RtActivatable<IHardwareIdentificationStatics>>::get_activation_factory().get_package_specific_token(nonce)
     }}
 }
-DEFINE_CLSID!(HardwareIdentification(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,72,97,114,100,119,97,114,101,73,100,101,110,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_HardwareIdentification]);
+DEFINE_CLSID!(HardwareIdentification: "Windows.System.Profile.HardwareIdentification");
 DEFINE_IID!(IID_IHardwareIdentificationStatics, 2534564064, 61808, 19010, 189, 85, 169, 0, 178, 18, 218, 226);
 RT_INTERFACE!{static interface IHardwareIdentificationStatics(IHardwareIdentificationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHardwareIdentificationStatics] {
     #[cfg(feature="windows-storage")] fn GetPackageSpecificToken(&self, nonce: *mut super::super::storage::streams::IBuffer, out: *mut *mut HardwareToken) -> HRESULT
@@ -2749,7 +2749,7 @@ impl KnownRetailInfoProperties {
         <Self as RtActivatable<IKnownRetailInfoPropertiesStatics>>::get_activation_factory().get_windows_edition()
     }}
 }
-DEFINE_CLSID!(KnownRetailInfoProperties(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,75,110,111,119,110,82,101,116,97,105,108,73,110,102,111,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_KnownRetailInfoProperties]);
+DEFINE_CLSID!(KnownRetailInfoProperties: "Windows.System.Profile.KnownRetailInfoProperties");
 DEFINE_IID!(IID_IKnownRetailInfoPropertiesStatics, 2572620152, 20495, 18558, 142, 117, 41, 229, 81, 114, 135, 18);
 RT_INTERFACE!{static interface IKnownRetailInfoPropertiesStatics(IKnownRetailInfoPropertiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownRetailInfoPropertiesStatics] {
     fn get_RetailAccessCode(&self, out: *mut HSTRING) -> HRESULT,
@@ -2906,7 +2906,7 @@ impl PlatformDiagnosticsAndUsageDataSettings {
         <Self as RtActivatable<IPlatformDiagnosticsAndUsageDataSettingsStatics>>::get_activation_factory().can_collect_diagnostics(level)
     }}
 }
-DEFINE_CLSID!(PlatformDiagnosticsAndUsageDataSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,80,108,97,116,102,111,114,109,68,105,97,103,110,111,115,116,105,99,115,65,110,100,85,115,97,103,101,68,97,116,97,83,101,116,116,105,110,103,115,0]) [CLSID_PlatformDiagnosticsAndUsageDataSettings]);
+DEFINE_CLSID!(PlatformDiagnosticsAndUsageDataSettings: "Windows.System.Profile.PlatformDiagnosticsAndUsageDataSettings");
 DEFINE_IID!(IID_IPlatformDiagnosticsAndUsageDataSettingsStatics, 3068283931, 31516, 19250, 140, 98, 166, 101, 151, 206, 114, 58);
 RT_INTERFACE!{static interface IPlatformDiagnosticsAndUsageDataSettingsStatics(IPlatformDiagnosticsAndUsageDataSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlatformDiagnosticsAndUsageDataSettingsStatics] {
     fn get_CollectionLevel(&self, out: *mut PlatformDataCollectionLevel) -> HRESULT,
@@ -2945,7 +2945,7 @@ impl RetailInfo {
         <Self as RtActivatable<IRetailInfoStatics>>::get_activation_factory().get_properties()
     }}
 }
-DEFINE_CLSID!(RetailInfo(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,82,101,116,97,105,108,73,110,102,111,0]) [CLSID_RetailInfo]);
+DEFINE_CLSID!(RetailInfo: "Windows.System.Profile.RetailInfo");
 DEFINE_IID!(IID_IRetailInfoStatics, 118671032, 35730, 20266, 132, 153, 3, 31, 23, 152, 214, 239);
 RT_INTERFACE!{static interface IRetailInfoStatics(IRetailInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRetailInfoStatics] {
     fn get_IsDemoModeEnabled(&self, out: *mut bool) -> HRESULT,
@@ -2974,7 +2974,7 @@ impl SharedModeSettings {
         <Self as RtActivatable<ISharedModeSettingsStatics2>>::get_activation_factory().get_should_avoid_local_storage()
     }}
 }
-DEFINE_CLSID!(SharedModeSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,83,104,97,114,101,100,77,111,100,101,83,101,116,116,105,110,103,115,0]) [CLSID_SharedModeSettings]);
+DEFINE_CLSID!(SharedModeSettings: "Windows.System.Profile.SharedModeSettings");
 DEFINE_IID!(IID_ISharedModeSettingsStatics, 2302538766, 51926, 19792, 140, 73, 111, 207, 192, 62, 219, 41);
 RT_INTERFACE!{static interface ISharedModeSettingsStatics(ISharedModeSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISharedModeSettingsStatics] {
     fn get_IsEnabled(&self, out: *mut bool) -> HRESULT
@@ -3007,7 +3007,7 @@ impl SystemIdentification {
         <Self as RtActivatable<ISystemIdentificationStatics>>::get_activation_factory().get_system_id_for_user(user)
     }}
 }
-DEFINE_CLSID!(SystemIdentification(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,83,121,115,116,101,109,73,100,101,110,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_SystemIdentification]);
+DEFINE_CLSID!(SystemIdentification: "Windows.System.Profile.SystemIdentification");
 DEFINE_IID!(IID_ISystemIdentificationInfo, 207986301, 50114, 19763, 162, 223, 33, 188, 65, 145, 110, 179);
 RT_INTERFACE!{interface ISystemIdentificationInfo(ISystemIdentificationInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISystemIdentificationInfo] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -3080,7 +3080,7 @@ impl SmbiosInformation {
         <Self as RtActivatable<ISmbiosInformationStatics>>::get_activation_factory().get_serial_number()
     }}
 }
-DEFINE_CLSID!(SmbiosInformation(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,83,121,115,116,101,109,77,97,110,117,102,97,99,116,117,114,101,114,115,46,83,109,98,105,111,115,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_SmbiosInformation]);
+DEFINE_CLSID!(SmbiosInformation: "Windows.System.Profile.SystemManufacturers.SmbiosInformation");
 DEFINE_IID!(IID_ISmbiosInformationStatics, 135055996, 25468, 18628, 183, 40, 249, 39, 56, 18, 219, 142);
 RT_INTERFACE!{static interface ISmbiosInformationStatics(ISmbiosInformationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISmbiosInformationStatics] {
     fn get_SerialNumber(&self, out: *mut HSTRING) -> HRESULT
@@ -3102,7 +3102,7 @@ impl SystemSupportInfo {
         <Self as RtActivatable<ISystemSupportInfoStatics>>::get_activation_factory().get_oem_support_info()
     }}
 }
-DEFINE_CLSID!(SystemSupportInfo(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,102,105,108,101,46,83,121,115,116,101,109,77,97,110,117,102,97,99,116,117,114,101,114,115,46,83,121,115,116,101,109,83,117,112,112,111,114,116,73,110,102,111,0]) [CLSID_SystemSupportInfo]);
+DEFINE_CLSID!(SystemSupportInfo: "Windows.System.Profile.SystemManufacturers.SystemSupportInfo");
 DEFINE_IID!(IID_ISystemSupportInfoStatics, 4017424756, 50210, 17879, 164, 77, 92, 28, 0, 67, 162, 179);
 RT_INTERFACE!{static interface ISystemSupportInfoStatics(ISystemSupportInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemSupportInfoStatics] {
     fn get_LocalSystemEdition(&self, out: *mut HSTRING) -> HRESULT,
@@ -3131,7 +3131,7 @@ impl InteractiveSession {
         <Self as RtActivatable<IInteractiveSessionStatics>>::get_activation_factory().get_is_remote()
     }}
 }
-DEFINE_CLSID!(InteractiveSession(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,68,101,115,107,116,111,112,46,73,110,116,101,114,97,99,116,105,118,101,83,101,115,115,105,111,110,0]) [CLSID_InteractiveSession]);
+DEFINE_CLSID!(InteractiveSession: "Windows.System.RemoteDesktop.InteractiveSession");
 DEFINE_IID!(IID_IInteractiveSessionStatics, 1619543601, 56634, 17782, 156, 141, 232, 2, 118, 24, 189, 206);
 RT_INTERFACE!{static interface IInteractiveSessionStatics(IInteractiveSessionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractiveSessionStatics] {
     fn get_IsRemote(&self, out: *mut bool) -> HRESULT
@@ -3186,7 +3186,7 @@ impl BackgroundEnergyManager {
         <Self as RtActivatable<IBackgroundEnergyManagerStatics>>::get_activation_factory().remove_recent_energy_usage_returned_to_low(token)
     }}
 }
-DEFINE_CLSID!(BackgroundEnergyManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,111,119,101,114,46,66,97,99,107,103,114,111,117,110,100,69,110,101,114,103,121,77,97,110,97,103,101,114,0]) [CLSID_BackgroundEnergyManager]);
+DEFINE_CLSID!(BackgroundEnergyManager: "Windows.System.Power.BackgroundEnergyManager");
 DEFINE_IID!(IID_IBackgroundEnergyManagerStatics, 3004571029, 4480, 17270, 150, 225, 64, 149, 86, 129, 71, 206);
 RT_INTERFACE!{static interface IBackgroundEnergyManagerStatics(IBackgroundEnergyManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundEnergyManagerStatics] {
     fn get_LowUsageLevel(&self, out: *mut u32) -> HRESULT,
@@ -3302,7 +3302,7 @@ impl ForegroundEnergyManager {
         <Self as RtActivatable<IForegroundEnergyManagerStatics>>::get_activation_factory().remove_recent_energy_usage_returned_to_low(token)
     }}
 }
-DEFINE_CLSID!(ForegroundEnergyManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,111,119,101,114,46,70,111,114,101,103,114,111,117,110,100,69,110,101,114,103,121,77,97,110,97,103,101,114,0]) [CLSID_ForegroundEnergyManager]);
+DEFINE_CLSID!(ForegroundEnergyManager: "Windows.System.Power.ForegroundEnergyManager");
 DEFINE_IID!(IID_IForegroundEnergyManagerStatics, 2683857010, 58999, 18452, 154, 32, 83, 55, 202, 115, 43, 152);
 RT_INTERFACE!{static interface IForegroundEnergyManagerStatics(IForegroundEnergyManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IForegroundEnergyManagerStatics] {
     fn get_LowUsageLevel(&self, out: *mut u32) -> HRESULT,
@@ -3415,7 +3415,7 @@ impl PowerManager {
         <Self as RtActivatable<IPowerManagerStatics>>::get_activation_factory().remove_remaining_discharge_time_changed(token)
     }}
 }
-DEFINE_CLSID!(PowerManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,111,119,101,114,46,80,111,119,101,114,77,97,110,97,103,101,114,0]) [CLSID_PowerManager]);
+DEFINE_CLSID!(PowerManager: "Windows.System.Power.PowerManager");
 DEFINE_IID!(IID_IPowerManagerStatics, 328499805, 25294, 17252, 152, 213, 170, 40, 199, 251, 209, 91);
 RT_INTERFACE!{static interface IPowerManagerStatics(IPowerManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPowerManagerStatics] {
     fn get_EnergySaverStatus(&self, out: *mut EnergySaverStatus) -> HRESULT,
@@ -3524,7 +3524,7 @@ impl BackgroundEnergyDiagnostics {
         <Self as RtActivatable<IBackgroundEnergyDiagnosticsStatics>>::get_activation_factory().reset_total_energy_usage()
     }}
 }
-DEFINE_CLSID!(BackgroundEnergyDiagnostics(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,111,119,101,114,46,68,105,97,103,110,111,115,116,105,99,115,46,66,97,99,107,103,114,111,117,110,100,69,110,101,114,103,121,68,105,97,103,110,111,115,116,105,99,115,0]) [CLSID_BackgroundEnergyDiagnostics]);
+DEFINE_CLSID!(BackgroundEnergyDiagnostics: "Windows.System.Power.Diagnostics.BackgroundEnergyDiagnostics");
 DEFINE_IID!(IID_IBackgroundEnergyDiagnosticsStatics, 3613800194, 54182, 18144, 143, 155, 80, 185, 91, 180, 249, 197);
 RT_INTERFACE!{static interface IBackgroundEnergyDiagnosticsStatics(IBackgroundEnergyDiagnosticsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundEnergyDiagnosticsStatics] {
     fn get_DeviceSpecificConversionFactor(&self, out: *mut f64) -> HRESULT,
@@ -3560,7 +3560,7 @@ impl ForegroundEnergyDiagnostics {
         <Self as RtActivatable<IForegroundEnergyDiagnosticsStatics>>::get_activation_factory().reset_total_energy_usage()
     }}
 }
-DEFINE_CLSID!(ForegroundEnergyDiagnostics(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,111,119,101,114,46,68,105,97,103,110,111,115,116,105,99,115,46,70,111,114,101,103,114,111,117,110,100,69,110,101,114,103,121,68,105,97,103,110,111,115,116,105,99,115,0]) [CLSID_ForegroundEnergyDiagnostics]);
+DEFINE_CLSID!(ForegroundEnergyDiagnostics: "Windows.System.Power.Diagnostics.ForegroundEnergyDiagnostics");
 DEFINE_IID!(IID_IForegroundEnergyDiagnosticsStatics, 600443159, 52487, 17929, 190, 21, 143, 232, 148, 197, 228, 30);
 RT_INTERFACE!{static interface IForegroundEnergyDiagnosticsStatics(IForegroundEnergyDiagnosticsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IForegroundEnergyDiagnosticsStatics] {
     fn get_DeviceSpecificConversionFactor(&self, out: *mut f64) -> HRESULT,
@@ -3632,7 +3632,7 @@ impl DiagnosticInvoker {
         <Self as RtActivatable<IDiagnosticInvokerStatics>>::get_activation_factory().get_is_supported()
     }}
 }
-DEFINE_CLSID!(DiagnosticInvoker(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,68,105,97,103,110,111,115,116,105,99,73,110,118,111,107,101,114,0]) [CLSID_DiagnosticInvoker]);
+DEFINE_CLSID!(DiagnosticInvoker: "Windows.System.Diagnostics.DiagnosticInvoker");
 DEFINE_IID!(IID_IDiagnosticInvokerStatics, 1559943390, 61788, 17748, 168, 19, 193, 19, 195, 136, 27, 9);
 RT_INTERFACE!{static interface IDiagnosticInvokerStatics(IDiagnosticInvokerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDiagnosticInvokerStatics] {
     fn GetDefault(&self, out: *mut *mut DiagnosticInvoker) -> HRESULT,
@@ -3747,7 +3747,7 @@ impl ProcessDiagnosticInfo {
         <Self as RtActivatable<IProcessDiagnosticInfoStatics2>>::get_activation_factory().try_get_for_process_id(processId)
     }}
 }
-DEFINE_CLSID!(ProcessDiagnosticInfo(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,80,114,111,99,101,115,115,68,105,97,103,110,111,115,116,105,99,73,110,102,111,0]) [CLSID_ProcessDiagnosticInfo]);
+DEFINE_CLSID!(ProcessDiagnosticInfo: "Windows.System.Diagnostics.ProcessDiagnosticInfo");
 DEFINE_IID!(IID_IProcessDiagnosticInfo2, 2505624346, 15627, 18924, 171, 112, 79, 122, 17, 40, 5, 222);
 RT_INTERFACE!{interface IProcessDiagnosticInfo2(IProcessDiagnosticInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IProcessDiagnosticInfo2] {
     fn GetAppDiagnosticInfos(&self, out: *mut *mut super::super::foundation::collections::IVector<super::AppDiagnosticInfo>) -> HRESULT,
@@ -3997,7 +3997,7 @@ impl SystemDiagnosticInfo {
         <Self as RtActivatable<ISystemDiagnosticInfoStatics>>::get_activation_factory().get_for_current_system()
     }}
 }
-DEFINE_CLSID!(SystemDiagnosticInfo(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,83,121,115,116,101,109,68,105,97,103,110,111,115,116,105,99,73,110,102,111,0]) [CLSID_SystemDiagnosticInfo]);
+DEFINE_CLSID!(SystemDiagnosticInfo: "Windows.System.Diagnostics.SystemDiagnosticInfo");
 DEFINE_IID!(IID_ISystemDiagnosticInfoStatics, 3557076001, 64637, 17904, 154, 63, 57, 32, 58, 237, 159, 126);
 RT_INTERFACE!{static interface ISystemDiagnosticInfoStatics(ISystemDiagnosticInfoStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemDiagnosticInfoStatics] {
     fn GetForCurrentSystem(&self, out: *mut *mut SystemDiagnosticInfo) -> HRESULT
@@ -4075,7 +4075,7 @@ impl PlatformDiagnosticActions {
         <Self as RtActivatable<IPlatformDiagnosticActionsStatics>>::get_activation_factory().get_known_trace_list(slotType)
     }}
 }
-DEFINE_CLSID!(PlatformDiagnosticActions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,84,114,97,99,101,82,101,112,111,114,116,105,110,103,46,80,108,97,116,102,111,114,109,68,105,97,103,110,111,115,116,105,99,65,99,116,105,111,110,115,0]) [CLSID_PlatformDiagnosticActions]);
+DEFINE_CLSID!(PlatformDiagnosticActions: "Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticActions");
 DEFINE_IID!(IID_IPlatformDiagnosticActionsStatics, 3239337210, 37522, 16999, 137, 10, 158, 163, 237, 7, 35, 18);
 RT_INTERFACE!{static interface IPlatformDiagnosticActionsStatics(IPlatformDiagnosticActionsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlatformDiagnosticActionsStatics] {
     fn IsScenarioEnabled(&self, scenarioId: Guid, out: *mut bool) -> HRESULT,
@@ -4220,7 +4220,7 @@ impl PlatformTelemetryClient {
         <Self as RtActivatable<IPlatformTelemetryClientStatics>>::get_activation_factory().register_with_settings(id, settings)
     }}
 }
-DEFINE_CLSID!(PlatformTelemetryClient(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,84,101,108,101,109,101,116,114,121,46,80,108,97,116,102,111,114,109,84,101,108,101,109,101,116,114,121,67,108,105,101,110,116,0]) [CLSID_PlatformTelemetryClient]);
+DEFINE_CLSID!(PlatformTelemetryClient: "Windows.System.Diagnostics.Telemetry.PlatformTelemetryClient");
 DEFINE_IID!(IID_IPlatformTelemetryClientStatics, 2616455773, 54723, 20202, 141, 190, 156, 141, 187, 13, 157, 143);
 RT_INTERFACE!{static interface IPlatformTelemetryClientStatics(IPlatformTelemetryClientStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlatformTelemetryClientStatics] {
     fn Register(&self, id: HSTRING, out: *mut *mut PlatformTelemetryRegistrationResult) -> HRESULT,
@@ -4279,7 +4279,7 @@ impl IPlatformTelemetryRegistrationSettings {
 }
 RT_CLASS!{class PlatformTelemetryRegistrationSettings: IPlatformTelemetryRegistrationSettings}
 impl RtActivatable<IActivationFactory> for PlatformTelemetryRegistrationSettings {}
-DEFINE_CLSID!(PlatformTelemetryRegistrationSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,84,101,108,101,109,101,116,114,121,46,80,108,97,116,102,111,114,109,84,101,108,101,109,101,116,114,121,82,101,103,105,115,116,114,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_PlatformTelemetryRegistrationSettings]);
+DEFINE_CLSID!(PlatformTelemetryRegistrationSettings: "Windows.System.Diagnostics.Telemetry.PlatformTelemetryRegistrationSettings");
 RT_ENUM! { enum PlatformTelemetryRegistrationStatus: i32 {
     Success (PlatformTelemetryRegistrationStatus_Success) = 0, SettingsOutOfRange (PlatformTelemetryRegistrationStatus_SettingsOutOfRange) = 1, UnknownFailure (PlatformTelemetryRegistrationStatus_UnknownFailure) = 2,
 }}
@@ -4320,7 +4320,7 @@ impl DevicePortalConnection {
         <Self as RtActivatable<IDevicePortalConnectionStatics>>::get_activation_factory().get_for_app_service_connection(appServiceConnection)
     }}
 }
-DEFINE_CLSID!(DevicePortalConnection(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,68,101,118,105,99,101,80,111,114,116,97,108,46,68,101,118,105,99,101,80,111,114,116,97,108,67,111,110,110,101,99,116,105,111,110,0]) [CLSID_DevicePortalConnection]);
+DEFINE_CLSID!(DevicePortalConnection: "Windows.System.Diagnostics.DevicePortal.DevicePortalConnection");
 DEFINE_IID!(IID_IDevicePortalConnectionClosedEventArgs, 4244049464, 28722, 17036, 159, 80, 148, 92, 21, 169, 240, 203);
 RT_INTERFACE!{interface IDevicePortalConnectionClosedEventArgs(IDevicePortalConnectionClosedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePortalConnectionClosedEventArgs] {
     fn get_Reason(&self, out: *mut DevicePortalConnectionClosedReason) -> HRESULT
@@ -4385,7 +4385,7 @@ impl KnownRemoteSystemCapabilities {
         <Self as RtActivatable<IKnownRemoteSystemCapabilitiesStatics>>::get_activation_factory().get_spatial_entity()
     }}
 }
-DEFINE_CLSID!(KnownRemoteSystemCapabilities(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,75,110,111,119,110,82,101,109,111,116,101,83,121,115,116,101,109,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_KnownRemoteSystemCapabilities]);
+DEFINE_CLSID!(KnownRemoteSystemCapabilities: "Windows.System.RemoteSystems.KnownRemoteSystemCapabilities");
 DEFINE_IID!(IID_IKnownRemoteSystemCapabilitiesStatics, 2164843392, 32650, 17636, 146, 205, 3, 182, 70, 155, 148, 163);
 RT_INTERFACE!{static interface IKnownRemoteSystemCapabilitiesStatics(IKnownRemoteSystemCapabilitiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownRemoteSystemCapabilitiesStatics] {
     fn get_AppService(&self, out: *mut HSTRING) -> HRESULT,
@@ -4470,7 +4470,7 @@ impl RemoteSystem {
         <Self as RtActivatable<IRemoteSystemStatics2>>::get_activation_factory().is_authorization_kind_enabled(kind)
     }}
 }
-DEFINE_CLSID!(RemoteSystem(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,0]) [CLSID_RemoteSystem]);
+DEFINE_CLSID!(RemoteSystem: "Windows.System.RemoteSystems.RemoteSystem");
 DEFINE_IID!(IID_IRemoteSystem2, 165668076, 64395, 18952, 167, 88, 104, 118, 67, 93, 118, 158);
 RT_INTERFACE!{interface IRemoteSystem2(IRemoteSystem2Vtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystem2] {
     fn get_IsAvailableBySpatialProximity(&self, out: *mut bool) -> HRESULT,
@@ -4541,7 +4541,7 @@ impl RemoteSystemAuthorizationKindFilter {
         <Self as RtActivatable<IRemoteSystemAuthorizationKindFilterFactory>>::get_activation_factory().create(remoteSystemAuthorizationKind)
     }}
 }
-DEFINE_CLSID!(RemoteSystemAuthorizationKindFilter(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,65,117,116,104,111,114,105,122,97,116,105,111,110,75,105,110,100,70,105,108,116,101,114,0]) [CLSID_RemoteSystemAuthorizationKindFilter]);
+DEFINE_CLSID!(RemoteSystemAuthorizationKindFilter: "Windows.System.RemoteSystems.RemoteSystemAuthorizationKindFilter");
 DEFINE_IID!(IID_IRemoteSystemAuthorizationKindFilterFactory, 2909134669, 46698, 17828, 129, 119, 140, 174, 215, 93, 158, 90);
 RT_INTERFACE!{static interface IRemoteSystemAuthorizationKindFilterFactory(IRemoteSystemAuthorizationKindFilterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemAuthorizationKindFilterFactory] {
     fn Create(&self, remoteSystemAuthorizationKind: RemoteSystemAuthorizationKind, out: *mut *mut RemoteSystemAuthorizationKindFilter) -> HRESULT
@@ -4571,7 +4571,7 @@ impl RemoteSystemConnectionRequest {
         <Self as RtActivatable<IRemoteSystemConnectionRequestFactory>>::get_activation_factory().create(remoteSystem)
     }}
 }
-DEFINE_CLSID!(RemoteSystemConnectionRequest(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,67,111,110,110,101,99,116,105,111,110,82,101,113,117,101,115,116,0]) [CLSID_RemoteSystemConnectionRequest]);
+DEFINE_CLSID!(RemoteSystemConnectionRequest: "Windows.System.RemoteSystems.RemoteSystemConnectionRequest");
 DEFINE_IID!(IID_IRemoteSystemConnectionRequestFactory, 2852784672, 47851, 17781, 181, 48, 129, 11, 185, 120, 99, 52);
 RT_INTERFACE!{static interface IRemoteSystemConnectionRequestFactory(IRemoteSystemConnectionRequestFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemConnectionRequestFactory] {
     fn Create(&self, remoteSystem: *mut RemoteSystem, out: *mut *mut RemoteSystemConnectionRequest) -> HRESULT
@@ -4604,7 +4604,7 @@ impl RemoteSystemDiscoveryTypeFilter {
         <Self as RtActivatable<IRemoteSystemDiscoveryTypeFilterFactory>>::get_activation_factory().create(discoveryType)
     }}
 }
-DEFINE_CLSID!(RemoteSystemDiscoveryTypeFilter(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,68,105,115,99,111,118,101,114,121,84,121,112,101,70,105,108,116,101,114,0]) [CLSID_RemoteSystemDiscoveryTypeFilter]);
+DEFINE_CLSID!(RemoteSystemDiscoveryTypeFilter: "Windows.System.RemoteSystems.RemoteSystemDiscoveryTypeFilter");
 DEFINE_IID!(IID_IRemoteSystemDiscoveryTypeFilterFactory, 2677979539, 49760, 16737, 146, 242, 156, 2, 31, 35, 254, 93);
 RT_INTERFACE!{static interface IRemoteSystemDiscoveryTypeFilterFactory(IRemoteSystemDiscoveryTypeFilterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemDiscoveryTypeFilterFactory] {
     fn Create(&self, discoveryType: RemoteSystemDiscoveryType, out: *mut *mut RemoteSystemDiscoveryTypeFilter) -> HRESULT
@@ -4638,7 +4638,7 @@ impl RemoteSystemKindFilter {
         <Self as RtActivatable<IRemoteSystemKindFilterFactory>>::get_activation_factory().create(remoteSystemKinds)
     }}
 }
-DEFINE_CLSID!(RemoteSystemKindFilter(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,75,105,110,100,70,105,108,116,101,114,0]) [CLSID_RemoteSystemKindFilter]);
+DEFINE_CLSID!(RemoteSystemKindFilter: "Windows.System.RemoteSystems.RemoteSystemKindFilter");
 DEFINE_IID!(IID_IRemoteSystemKindFilterFactory, 2717587694, 39402, 16572, 154, 57, 198, 112, 170, 128, 74, 40);
 RT_INTERFACE!{static interface IRemoteSystemKindFilterFactory(IRemoteSystemKindFilterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemKindFilterFactory] {
     fn Create(&self, remoteSystemKinds: *mut super::super::foundation::collections::IIterable<HString>, out: *mut *mut RemoteSystemKindFilter) -> HRESULT
@@ -4679,7 +4679,7 @@ impl RemoteSystemKinds {
         <Self as RtActivatable<IRemoteSystemKindStatics2>>::get_activation_factory().get_laptop()
     }}
 }
-DEFINE_CLSID!(RemoteSystemKinds(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,75,105,110,100,115,0]) [CLSID_RemoteSystemKinds]);
+DEFINE_CLSID!(RemoteSystemKinds: "Windows.System.RemoteSystems.RemoteSystemKinds");
 DEFINE_IID!(IID_IRemoteSystemKindStatics, 4130436659, 43796, 16848, 149, 83, 121, 106, 173, 184, 130, 219);
 RT_INTERFACE!{static interface IRemoteSystemKindStatics(IRemoteSystemKindStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemKindStatics] {
     fn get_Phone(&self, out: *mut HSTRING) -> HRESULT,
@@ -4803,7 +4803,7 @@ impl RemoteSystemSession {
         <Self as RtActivatable<IRemoteSystemSessionStatics>>::get_activation_factory().create_watcher()
     }}
 }
-DEFINE_CLSID!(RemoteSystemSession(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,0]) [CLSID_RemoteSystemSession]);
+DEFINE_CLSID!(RemoteSystemSession: "Windows.System.RemoteSystems.RemoteSystemSession");
 DEFINE_IID!(IID_IRemoteSystemSessionAddedEventArgs, 3582318420, 48279, 19513, 153, 180, 190, 202, 118, 224, 76, 63);
 RT_INTERFACE!{interface IRemoteSystemSessionAddedEventArgs(IRemoteSystemSessionAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionAddedEventArgs] {
     fn get_SessionInfo(&self, out: *mut *mut RemoteSystemSessionInfo) -> HRESULT
@@ -4854,7 +4854,7 @@ impl RemoteSystemSessionController {
         <Self as RtActivatable<IRemoteSystemSessionControllerFactory>>::get_activation_factory().create_controller_with_session_options(displayName, options)
     }}
 }
-DEFINE_CLSID!(RemoteSystemSessionController(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_RemoteSystemSessionController]);
+DEFINE_CLSID!(RemoteSystemSessionController: "Windows.System.RemoteSystems.RemoteSystemSessionController");
 DEFINE_IID!(IID_IRemoteSystemSessionControllerFactory, 3217829739, 44093, 16793, 130, 205, 102, 112, 167, 115, 239, 46);
 RT_INTERFACE!{static interface IRemoteSystemSessionControllerFactory(IRemoteSystemSessionControllerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionControllerFactory] {
     fn CreateController(&self, displayName: HSTRING, out: *mut *mut RemoteSystemSessionController) -> HRESULT,
@@ -4968,7 +4968,7 @@ impl IRemoteSystemSessionInvitationListener {
 }
 RT_CLASS!{class RemoteSystemSessionInvitationListener: IRemoteSystemSessionInvitationListener}
 impl RtActivatable<IActivationFactory> for RemoteSystemSessionInvitationListener {}
-DEFINE_CLSID!(RemoteSystemSessionInvitationListener(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,73,110,118,105,116,97,116,105,111,110,76,105,115,116,101,110,101,114,0]) [CLSID_RemoteSystemSessionInvitationListener]);
+DEFINE_CLSID!(RemoteSystemSessionInvitationListener: "Windows.System.RemoteSystems.RemoteSystemSessionInvitationListener");
 DEFINE_IID!(IID_IRemoteSystemSessionInvitationReceivedEventArgs, 1586907693, 41229, 20187, 141, 234, 84, 210, 10, 193, 149, 67);
 RT_INTERFACE!{interface IRemoteSystemSessionInvitationReceivedEventArgs(IRemoteSystemSessionInvitationReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionInvitationReceivedEventArgs] {
     fn get_Invitation(&self, out: *mut *mut RemoteSystemSessionInvitation) -> HRESULT
@@ -5087,7 +5087,7 @@ impl RemoteSystemSessionMessageChannel {
         <Self as RtActivatable<IRemoteSystemSessionMessageChannelFactory>>::get_activation_factory().create_with_reliability(session, channelName, reliability)
     }}
 }
-DEFINE_CLSID!(RemoteSystemSessionMessageChannel(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,77,101,115,115,97,103,101,67,104,97,110,110,101,108,0]) [CLSID_RemoteSystemSessionMessageChannel]);
+DEFINE_CLSID!(RemoteSystemSessionMessageChannel: "Windows.System.RemoteSystems.RemoteSystemSessionMessageChannel");
 DEFINE_IID!(IID_IRemoteSystemSessionMessageChannelFactory, 694033482, 48406, 17048, 183, 206, 65, 84, 130, 176, 225, 29);
 RT_INTERFACE!{static interface IRemoteSystemSessionMessageChannelFactory(IRemoteSystemSessionMessageChannelFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionMessageChannelFactory] {
     fn Create(&self, session: *mut RemoteSystemSession, channelName: HSTRING, out: *mut *mut RemoteSystemSessionMessageChannel) -> HRESULT,
@@ -5126,7 +5126,7 @@ impl IRemoteSystemSessionOptions {
 }
 RT_CLASS!{class RemoteSystemSessionOptions: IRemoteSystemSessionOptions}
 impl RtActivatable<IActivationFactory> for RemoteSystemSessionOptions {}
-DEFINE_CLSID!(RemoteSystemSessionOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,79,112,116,105,111,110,115,0]) [CLSID_RemoteSystemSessionOptions]);
+DEFINE_CLSID!(RemoteSystemSessionOptions: "Windows.System.RemoteSystems.RemoteSystemSessionOptions");
 DEFINE_IID!(IID_IRemoteSystemSessionParticipant, 2123367820, 44281, 18217, 138, 23, 68, 231, 186, 237, 93, 204);
 RT_INTERFACE!{interface IRemoteSystemSessionParticipant(IRemoteSystemSessionParticipantVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionParticipant] {
     fn get_RemoteSystem(&self, out: *mut *mut RemoteSystem) -> HRESULT,
@@ -5403,7 +5403,7 @@ impl RemoteSystemStatusTypeFilter {
         <Self as RtActivatable<IRemoteSystemStatusTypeFilterFactory>>::get_activation_factory().create(remoteSystemStatusType)
     }}
 }
-DEFINE_CLSID!(RemoteSystemStatusTypeFilter(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,116,97,116,117,115,84,121,112,101,70,105,108,116,101,114,0]) [CLSID_RemoteSystemStatusTypeFilter]);
+DEFINE_CLSID!(RemoteSystemStatusTypeFilter: "Windows.System.RemoteSystems.RemoteSystemStatusTypeFilter");
 DEFINE_IID!(IID_IRemoteSystemStatusTypeFilterFactory, 869234938, 55076, 16677, 172, 122, 141, 40, 30, 68, 201, 73);
 RT_INTERFACE!{static interface IRemoteSystemStatusTypeFilterFactory(IRemoteSystemStatusTypeFilterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemStatusTypeFilterFactory] {
     fn Create(&self, remoteSystemStatusType: RemoteSystemStatusType, out: *mut *mut RemoteSystemStatusTypeFilter) -> HRESULT
@@ -5492,7 +5492,7 @@ impl ThreadPool {
         <Self as RtActivatable<IThreadPoolStatics>>::get_activation_factory().run_with_priority_and_options_async(handler, priority, options)
     }}
 }
-DEFINE_CLSID!(ThreadPool(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,84,104,114,101,97,100,105,110,103,46,84,104,114,101,97,100,80,111,111,108,0]) [CLSID_ThreadPool]);
+DEFINE_CLSID!(ThreadPool: "Windows.System.Threading.ThreadPool");
 DEFINE_IID!(IID_IThreadPoolStatics, 3065997277, 33981, 17656, 172, 28, 147, 235, 203, 157, 186, 145);
 RT_INTERFACE!{static interface IThreadPoolStatics(IThreadPoolStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IThreadPoolStatics] {
     fn RunAsync(&self, handler: *mut WorkItemHandler, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT,
@@ -5554,7 +5554,7 @@ impl ThreadPoolTimer {
         <Self as RtActivatable<IThreadPoolTimerStatics>>::get_activation_factory().create_timer_with_completion(handler, delay, destroyed)
     }}
 }
-DEFINE_CLSID!(ThreadPoolTimer(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,84,104,114,101,97,100,105,110,103,46,84,104,114,101,97,100,80,111,111,108,84,105,109,101,114,0]) [CLSID_ThreadPoolTimer]);
+DEFINE_CLSID!(ThreadPoolTimer: "Windows.System.Threading.ThreadPoolTimer");
 DEFINE_IID!(IID_IThreadPoolTimerStatics, 445291778, 58498, 17947, 184, 199, 142, 250, 209, 204, 229, 144);
 RT_INTERFACE!{static interface IThreadPoolTimerStatics(IThreadPoolTimerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IThreadPoolTimerStatics] {
     fn CreatePeriodicTimer(&self, handler: *mut TimerElapsedHandler, period: super::super::foundation::TimeSpan, out: *mut *mut ThreadPoolTimer) -> HRESULT,
@@ -5646,7 +5646,7 @@ impl PreallocatedWorkItem {
         <Self as RtActivatable<IPreallocatedWorkItemFactory>>::get_activation_factory().create_work_item_with_priority_and_options(handler, priority, options)
     }}
 }
-DEFINE_CLSID!(PreallocatedWorkItem(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,84,104,114,101,97,100,105,110,103,46,67,111,114,101,46,80,114,101,97,108,108,111,99,97,116,101,100,87,111,114,107,73,116,101,109,0]) [CLSID_PreallocatedWorkItem]);
+DEFINE_CLSID!(PreallocatedWorkItem: "Windows.System.Threading.Core.PreallocatedWorkItem");
 DEFINE_IID!(IID_IPreallocatedWorkItemFactory, 3822267205, 57322, 18075, 130, 197, 246, 227, 206, 253, 234, 251);
 RT_INTERFACE!{static interface IPreallocatedWorkItemFactory(IPreallocatedWorkItemFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPreallocatedWorkItemFactory] {
     fn CreateWorkItem(&self, handler: *mut super::WorkItemHandler, out: *mut *mut PreallocatedWorkItem) -> HRESULT,
@@ -5711,7 +5711,7 @@ impl SignalNotifier {
         <Self as RtActivatable<ISignalNotifierStatics>>::get_activation_factory().attach_to_semaphore_with_timeout(name, handler, timeout)
     }}
 }
-DEFINE_CLSID!(SignalNotifier(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,84,104,114,101,97,100,105,110,103,46,67,111,114,101,46,83,105,103,110,97,108,78,111,116,105,102,105,101,114,0]) [CLSID_SignalNotifier]);
+DEFINE_CLSID!(SignalNotifier: "Windows.System.Threading.Core.SignalNotifier");
 DEFINE_IID!(IID_ISignalNotifierStatics, 474891622, 33792, 18131, 161, 21, 125, 12, 13, 252, 159, 98);
 RT_INTERFACE!{static interface ISignalNotifierStatics(ISignalNotifierStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISignalNotifierStatics] {
     fn AttachToEvent(&self, name: HSTRING, handler: *mut SignalHandler, out: *mut *mut SignalNotifier) -> HRESULT,
@@ -5762,5 +5762,5 @@ impl IDisplayRequest {
 }
 RT_CLASS!{class DisplayRequest: IDisplayRequest}
 impl RtActivatable<IActivationFactory> for DisplayRequest {}
-DEFINE_CLSID!(DisplayRequest(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,115,112,108,97,121,46,68,105,115,112,108,97,121,82,101,113,117,101,115,116,0]) [CLSID_DisplayRequest]);
+DEFINE_CLSID!(DisplayRequest: "Windows.System.Display.DisplayRequest");
 } // Windows.System.Display

--- a/src/rt/gen/windows/ui/mod.rs
+++ b/src/rt/gen/windows/ui/mod.rs
@@ -17,7 +17,7 @@ impl ColorHelper {
         <Self as RtActivatable<IColorHelperStatics2>>::get_activation_factory().to_display_name(color)
     }}
 }
-DEFINE_CLSID!(ColorHelper(&[87,105,110,100,111,119,115,46,85,73,46,67,111,108,111,114,72,101,108,112,101,114,0]) [CLSID_ColorHelper]);
+DEFINE_CLSID!(ColorHelper: "Windows.UI.ColorHelper");
 DEFINE_IID!(IID_IColorHelperStatics, 2231688170, 64362, 16708, 166, 194, 51, 73, 156, 146, 132, 245);
 RT_INTERFACE!{static interface IColorHelperStatics(IColorHelperStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IColorHelperStatics] {
     fn FromArgb(&self, a: u8, r: u8, g: u8, b: u8, out: *mut Color) -> HRESULT
@@ -471,7 +471,7 @@ impl Colors {
         <Self as RtActivatable<IColorsStatics>>::get_activation_factory().get_yellow_green()
     }}
 }
-DEFINE_CLSID!(Colors(&[87,105,110,100,111,119,115,46,85,73,46,67,111,108,111,114,115,0]) [CLSID_Colors]);
+DEFINE_CLSID!(Colors: "Windows.UI.Colors");
 DEFINE_IID!(IID_IColorsStatics, 3488951812, 52390, 17940, 161, 126, 117, 73, 16, 200, 74, 153);
 RT_INTERFACE!{static interface IColorsStatics(IColorsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IColorsStatics] {
     fn get_AliceBlue(&self, out: *mut Color) -> HRESULT,
@@ -1539,7 +1539,7 @@ impl CoreCursor {
         <Self as RtActivatable<ICoreCursorFactory>>::get_activation_factory().create_cursor(type_, id)
     }}
 }
-DEFINE_CLSID!(CoreCursor(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,67,111,114,101,67,117,114,115,111,114,0]) [CLSID_CoreCursor]);
+DEFINE_CLSID!(CoreCursor: "Windows.UI.Core.CoreCursor");
 DEFINE_IID!(IID_ICoreCursorFactory, 4130706977, 42909, 20179, 140, 50, 169, 239, 157, 107, 118, 164);
 RT_INTERFACE!{static interface ICoreCursorFactory(ICoreCursorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICoreCursorFactory] {
     fn CreateCursor(&self, type_: CoreCursorType, id: u32, out: *mut *mut CoreCursor) -> HRESULT
@@ -2215,7 +2215,7 @@ impl CoreWindow {
         <Self as RtActivatable<ICoreWindowStatic>>::get_activation_factory().get_for_current_thread()
     }}
 }
-DEFINE_CLSID!(CoreWindow(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,67,111,114,101,87,105,110,100,111,119,0]) [CLSID_CoreWindow]);
+DEFINE_CLSID!(CoreWindow: "Windows.UI.Core.CoreWindow");
 DEFINE_IID!(IID_ICoreWindow2, 2083199877, 26903, 17249, 156, 2, 13, 158, 58, 66, 11, 149);
 RT_INTERFACE!{interface ICoreWindow2(ICoreWindow2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreWindow2] {
     fn put_PointerPosition(&self, value: super::super::foundation::Point) -> HRESULT
@@ -2402,7 +2402,7 @@ impl CoreWindowDialog {
         <Self as RtActivatable<ICoreWindowDialogFactory>>::get_activation_factory().create_with_title(title)
     }}
 }
-DEFINE_CLSID!(CoreWindowDialog(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,67,111,114,101,87,105,110,100,111,119,68,105,97,108,111,103,0]) [CLSID_CoreWindowDialog]);
+DEFINE_CLSID!(CoreWindowDialog: "Windows.UI.Core.CoreWindowDialog");
 DEFINE_IID!(IID_ICoreWindowDialogFactory, 3484592213, 7257, 19219, 177, 229, 22, 226, 152, 5, 247, 196);
 RT_INTERFACE!{static interface ICoreWindowDialogFactory(ICoreWindowDialogFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICoreWindowDialogFactory] {
     fn CreateWithTitle(&self, title: HSTRING, out: *mut *mut CoreWindowDialog) -> HRESULT
@@ -2528,7 +2528,7 @@ impl CoreWindowFlyout {
         <Self as RtActivatable<ICoreWindowFlyoutFactory>>::get_activation_factory().create_with_title(position, title)
     }}
 }
-DEFINE_CLSID!(CoreWindowFlyout(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,67,111,114,101,87,105,110,100,111,119,70,108,121,111,117,116,0]) [CLSID_CoreWindowFlyout]);
+DEFINE_CLSID!(CoreWindowFlyout: "Windows.UI.Core.CoreWindowFlyout");
 DEFINE_IID!(IID_ICoreWindowFlyoutFactory, 3737437892, 37864, 20348, 190, 39, 206, 250, 161, 175, 104, 167);
 RT_INTERFACE!{static interface ICoreWindowFlyoutFactory(ICoreWindowFlyoutFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICoreWindowFlyoutFactory] {
     fn Create(&self, position: super::super::foundation::Point, out: *mut *mut CoreWindowFlyout) -> HRESULT,
@@ -2574,7 +2574,7 @@ impl CoreWindowResizeManager {
         <Self as RtActivatable<ICoreWindowResizeManagerStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(CoreWindowResizeManager(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,67,111,114,101,87,105,110,100,111,119,82,101,115,105,122,101,77,97,110,97,103,101,114,0]) [CLSID_CoreWindowResizeManager]);
+DEFINE_CLSID!(CoreWindowResizeManager: "Windows.UI.Core.CoreWindowResizeManager");
 DEFINE_IID!(IID_ICoreWindowResizeManagerLayoutCapability, 3145003643, 42308, 17153, 128, 230, 10, 224, 51, 239, 69, 54);
 RT_INTERFACE!{interface ICoreWindowResizeManagerLayoutCapability(ICoreWindowResizeManagerLayoutCapabilityVtbl): IInspectable(IInspectableVtbl) [IID_ICoreWindowResizeManagerLayoutCapability] {
     fn put_ShouldWaitForLayoutCompletion(&self, value: bool) -> HRESULT,
@@ -2745,7 +2745,7 @@ impl SystemNavigationManager {
         <Self as RtActivatable<ISystemNavigationManagerStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(SystemNavigationManager(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,83,121,115,116,101,109,78,97,118,105,103,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_SystemNavigationManager]);
+DEFINE_CLSID!(SystemNavigationManager: "Windows.UI.Core.SystemNavigationManager");
 DEFINE_IID!(IID_ISystemNavigationManager2, 2354119681, 26558, 18862, 149, 9, 103, 28, 30, 84, 163, 137);
 RT_INTERFACE!{interface ISystemNavigationManager2(ISystemNavigationManager2Vtbl): IInspectable(IInspectableVtbl) [IID_ISystemNavigationManager2] {
     fn get_AppViewBackButtonVisibility(&self, out: *mut AppViewBackButtonVisibility) -> HRESULT,
@@ -2898,7 +2898,7 @@ impl SystemNavigationManagerPreview {
         <Self as RtActivatable<ISystemNavigationManagerPreviewStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(SystemNavigationManagerPreview(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,80,114,101,118,105,101,119,46,83,121,115,116,101,109,78,97,118,105,103,97,116,105,111,110,77,97,110,97,103,101,114,80,114,101,118,105,101,119,0]) [CLSID_SystemNavigationManagerPreview]);
+DEFINE_CLSID!(SystemNavigationManagerPreview: "Windows.UI.Core.Preview.SystemNavigationManagerPreview");
 DEFINE_IID!(IID_ISystemNavigationManagerPreviewStatics, 244781920, 57204, 19406, 132, 203, 189, 17, 129, 172, 10, 113);
 RT_INTERFACE!{static interface ISystemNavigationManagerPreviewStatics(ISystemNavigationManagerPreviewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemNavigationManagerPreviewStatics] {
     fn GetForCurrentView(&self, out: *mut *mut SystemNavigationManagerPreview) -> HRESULT
@@ -2955,7 +2955,7 @@ impl AnimationDescription {
         <Self as RtActivatable<IAnimationDescriptionFactory>>::get_activation_factory().create_instance(effect, target)
     }}
 }
-DEFINE_CLSID!(AnimationDescription(&[87,105,110,100,111,119,115,46,85,73,46,67,111,114,101,46,65,110,105,109,97,116,105,111,110,77,101,116,114,105,99,115,46,65,110,105,109,97,116,105,111,110,68,101,115,99,114,105,112,116,105,111,110,0]) [CLSID_AnimationDescription]);
+DEFINE_CLSID!(AnimationDescription: "Windows.UI.Core.AnimationMetrics.AnimationDescription");
 DEFINE_IID!(IID_IAnimationDescriptionFactory, 3336731326, 49659, 18613, 146, 113, 236, 199, 10, 200, 110, 240);
 RT_INTERFACE!{static interface IAnimationDescriptionFactory(IAnimationDescriptionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAnimationDescriptionFactory] {
     fn CreateInstance(&self, effect: AnimationEffect, target: AnimationEffectTarget, out: *mut *mut AnimationDescription) -> HRESULT
@@ -3175,7 +3175,7 @@ impl EdgeGesture {
         <Self as RtActivatable<IEdgeGestureStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(EdgeGesture(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,69,100,103,101,71,101,115,116,117,114,101,0]) [CLSID_EdgeGesture]);
+DEFINE_CLSID!(EdgeGesture: "Windows.UI.Input.EdgeGesture");
 DEFINE_IID!(IID_IEdgeGestureEventArgs, 1157253668, 11529, 17121, 139, 94, 54, 130, 8, 121, 106, 76);
 RT_INTERFACE!{interface IEdgeGestureEventArgs(IEdgeGestureEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEdgeGestureEventArgs] {
     fn get_Kind(&self, out: *mut EdgeGestureKind) -> HRESULT
@@ -3527,7 +3527,7 @@ impl IGestureRecognizer {
 }
 RT_CLASS!{class GestureRecognizer: IGestureRecognizer}
 impl RtActivatable<IActivationFactory> for GestureRecognizer {}
-DEFINE_CLSID!(GestureRecognizer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,71,101,115,116,117,114,101,82,101,99,111,103,110,105,122,101,114,0]) [CLSID_GestureRecognizer]);
+DEFINE_CLSID!(GestureRecognizer: "Windows.UI.Input.GestureRecognizer");
 RT_ENUM! { enum GestureSettings: u32 {
     None (GestureSettings_None) = 0, Tap (GestureSettings_Tap) = 1, DoubleTap (GestureSettings_DoubleTap) = 2, Hold (GestureSettings_Hold) = 4, HoldWithMouse (GestureSettings_HoldWithMouse) = 8, RightTap (GestureSettings_RightTap) = 16, Drag (GestureSettings_Drag) = 32, ManipulationTranslateX (GestureSettings_ManipulationTranslateX) = 64, ManipulationTranslateY (GestureSettings_ManipulationTranslateY) = 128, ManipulationTranslateRailsX (GestureSettings_ManipulationTranslateRailsX) = 256, ManipulationTranslateRailsY (GestureSettings_ManipulationTranslateRailsY) = 512, ManipulationRotate (GestureSettings_ManipulationRotate) = 1024, ManipulationScale (GestureSettings_ManipulationScale) = 2048, ManipulationTranslateInertia (GestureSettings_ManipulationTranslateInertia) = 4096, ManipulationRotateInertia (GestureSettings_ManipulationRotateInertia) = 8192, ManipulationScaleInertia (GestureSettings_ManipulationScaleInertia) = 16384, CrossSlide (GestureSettings_CrossSlide) = 32768, ManipulationMultipleFingerPanning (GestureSettings_ManipulationMultipleFingerPanning) = 65536,
 }}
@@ -3604,7 +3604,7 @@ impl KeyboardDeliveryInterceptor {
         <Self as RtActivatable<IKeyboardDeliveryInterceptorStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(KeyboardDeliveryInterceptor(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,75,101,121,98,111,97,114,100,68,101,108,105,118,101,114,121,73,110,116,101,114,99,101,112,116,111,114,0]) [CLSID_KeyboardDeliveryInterceptor]);
+DEFINE_CLSID!(KeyboardDeliveryInterceptor: "Windows.UI.Input.KeyboardDeliveryInterceptor");
 DEFINE_IID!(IID_IKeyboardDeliveryInterceptorStatics, 4193663906, 52922, 18261, 138, 126, 20, 192, 255, 236, 210, 57);
 RT_INTERFACE!{static interface IKeyboardDeliveryInterceptorStatics(IKeyboardDeliveryInterceptorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyboardDeliveryInterceptorStatics] {
     fn GetForCurrentView(&self, out: *mut *mut KeyboardDeliveryInterceptor) -> HRESULT
@@ -3872,7 +3872,7 @@ impl PointerPoint {
         <Self as RtActivatable<IPointerPointStatics>>::get_activation_factory().get_intermediate_points_transformed(pointerId, transform)
     }}
 }
-DEFINE_CLSID!(PointerPoint(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,111,105,110,116,101,114,80,111,105,110,116,0]) [CLSID_PointerPoint]);
+DEFINE_CLSID!(PointerPoint: "Windows.UI.Input.PointerPoint");
 DEFINE_IID!(IID_IPointerPointProperties, 3348990539, 49507, 20199, 128, 63, 103, 206, 121, 249, 151, 45);
 RT_INTERFACE!{interface IPointerPointProperties(IPointerPointPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IPointerPointProperties] {
     fn get_Pressure(&self, out: *mut f32) -> HRESULT,
@@ -4123,7 +4123,7 @@ impl PointerVisualizationSettings {
         <Self as RtActivatable<IPointerVisualizationSettingsStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(PointerVisualizationSettings(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,111,105,110,116,101,114,86,105,115,117,97,108,105,122,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_PointerVisualizationSettings]);
+DEFINE_CLSID!(PointerVisualizationSettings: "Windows.UI.Input.PointerVisualizationSettings");
 DEFINE_IID!(IID_IPointerVisualizationSettingsStatics, 1753681627, 5723, 16916, 180, 243, 88, 78, 202, 140, 138, 105);
 RT_INTERFACE!{static interface IPointerVisualizationSettingsStatics(IPointerVisualizationSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPointerVisualizationSettingsStatics] {
     fn GetForCurrentView(&self, out: *mut *mut PointerVisualizationSettings) -> HRESULT
@@ -4255,7 +4255,7 @@ impl RadialController {
         <Self as RtActivatable<IRadialControllerStatics>>::get_activation_factory().create_for_current_view()
     }}
 }
-DEFINE_CLSID!(RadialController(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,82,97,100,105,97,108,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_RadialController]);
+DEFINE_CLSID!(RadialController: "Windows.UI.Input.RadialController");
 DEFINE_IID!(IID_IRadialController2, 1029144319, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialController2(IRadialController2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialController2] {
     fn add_ButtonPressed(&self, handler: *mut super::super::foundation::TypedEventHandler<RadialController, RadialControllerButtonPressedEventArgs>, out: *mut super::super::foundation::EventRegistrationToken) -> HRESULT,
@@ -4412,7 +4412,7 @@ impl RadialControllerConfiguration {
         <Self as RtActivatable<IRadialControllerConfigurationStatics2>>::get_activation_factory().get_is_app_controller_enabled()
     }}
 }
-DEFINE_CLSID!(RadialControllerConfiguration(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,82,97,100,105,97,108,67,111,110,116,114,111,108,108,101,114,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_RadialControllerConfiguration]);
+DEFINE_CLSID!(RadialControllerConfiguration: "Windows.UI.Input.RadialControllerConfiguration");
 DEFINE_IID!(IID_IRadialControllerConfiguration2, 1029144311, 15598, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerConfiguration2(IRadialControllerConfiguration2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerConfiguration2] {
     fn put_ActiveControllerWhenMenuIsSuppressed(&self, value: *mut RadialController) -> HRESULT,
@@ -4597,7 +4597,7 @@ impl RadialControllerMenuItem {
         <Self as RtActivatable<IRadialControllerMenuItemStatics2>>::get_activation_factory().create_from_font_glyph_with_uri(displayText, glyph, fontFamily, fontUri)
     }}
 }
-DEFINE_CLSID!(RadialControllerMenuItem(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,82,97,100,105,97,108,67,111,110,116,114,111,108,108,101,114,77,101,110,117,73,116,101,109,0]) [CLSID_RadialControllerMenuItem]);
+DEFINE_CLSID!(RadialControllerMenuItem: "Windows.UI.Input.RadialControllerMenuItem");
 DEFINE_IID!(IID_IRadialControllerMenuItemStatics, 614336647, 55362, 17700, 157, 248, 224, 214, 71, 237, 200, 135);
 RT_INTERFACE!{static interface IRadialControllerMenuItemStatics(IRadialControllerMenuItemStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerMenuItemStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -4927,7 +4927,7 @@ impl InjectedInputGamepadInfo {
         <Self as RtActivatable<IInjectedInputGamepadInfoFactory>>::get_activation_factory().create_instance_from_gamepad_reading(reading)
     }}
 }
-DEFINE_CLSID!(InjectedInputGamepadInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,71,97,109,101,112,97,100,73,110,102,111,0]) [CLSID_InjectedInputGamepadInfo]);
+DEFINE_CLSID!(InjectedInputGamepadInfo: "Windows.UI.Input.Preview.Injection.InjectedInputGamepadInfo");
 DEFINE_IID!(IID_IInjectedInputGamepadInfoFactory, 1499031670, 27705, 20164, 139, 42, 41, 239, 125, 225, 138, 202);
 RT_INTERFACE!{static interface IInjectedInputGamepadInfoFactory(IInjectedInputGamepadInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IInjectedInputGamepadInfoFactory] {
     #[cfg(feature="windows-gaming")] fn CreateInstanceFromGamepadReading(&self, reading: ::rt::gen::windows::gaming::input::GamepadReading, out: *mut *mut InjectedInputGamepadInfo) -> HRESULT
@@ -4979,7 +4979,7 @@ impl IInjectedInputKeyboardInfo {
 }
 RT_CLASS!{class InjectedInputKeyboardInfo: IInjectedInputKeyboardInfo}
 impl RtActivatable<IActivationFactory> for InjectedInputKeyboardInfo {}
-DEFINE_CLSID!(InjectedInputKeyboardInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,75,101,121,98,111,97,114,100,73,110,102,111,0]) [CLSID_InjectedInputKeyboardInfo]);
+DEFINE_CLSID!(InjectedInputKeyboardInfo: "Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo");
 RT_ENUM! { enum InjectedInputKeyOptions: u32 {
     None (InjectedInputKeyOptions_None) = 0, ExtendedKey (InjectedInputKeyOptions_ExtendedKey) = 1, KeyUp (InjectedInputKeyOptions_KeyUp) = 2, ScanCode (InjectedInputKeyOptions_ScanCode) = 8, Unicode (InjectedInputKeyOptions_Unicode) = 4,
 }}
@@ -5045,7 +5045,7 @@ impl IInjectedInputMouseInfo {
 }
 RT_CLASS!{class InjectedInputMouseInfo: IInjectedInputMouseInfo}
 impl RtActivatable<IActivationFactory> for InjectedInputMouseInfo {}
-DEFINE_CLSID!(InjectedInputMouseInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,77,111,117,115,101,73,110,102,111,0]) [CLSID_InjectedInputMouseInfo]);
+DEFINE_CLSID!(InjectedInputMouseInfo: "Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo");
 RT_ENUM! { enum InjectedInputMouseOptions: u32 {
     None (InjectedInputMouseOptions_None) = 0, Move (InjectedInputMouseOptions_Move) = 1, LeftDown (InjectedInputMouseOptions_LeftDown) = 2, LeftUp (InjectedInputMouseOptions_LeftUp) = 4, RightDown (InjectedInputMouseOptions_RightDown) = 8, RightUp (InjectedInputMouseOptions_RightUp) = 16, MiddleDown (InjectedInputMouseOptions_MiddleDown) = 32, MiddleUp (InjectedInputMouseOptions_MiddleUp) = 64, XDown (InjectedInputMouseOptions_XDown) = 128, XUp (InjectedInputMouseOptions_XUp) = 256, Wheel (InjectedInputMouseOptions_Wheel) = 2048, HWheel (InjectedInputMouseOptions_HWheel) = 4096, MoveNoCoalesce (InjectedInputMouseOptions_MoveNoCoalesce) = 8192, VirtualDesk (InjectedInputMouseOptions_VirtualDesk) = 16384, Absolute (InjectedInputMouseOptions_Absolute) = 32768,
 }}
@@ -5136,7 +5136,7 @@ impl IInjectedInputPenInfo {
 }
 RT_CLASS!{class InjectedInputPenInfo: IInjectedInputPenInfo}
 impl RtActivatable<IActivationFactory> for InjectedInputPenInfo {}
-DEFINE_CLSID!(InjectedInputPenInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,80,101,110,73,110,102,111,0]) [CLSID_InjectedInputPenInfo]);
+DEFINE_CLSID!(InjectedInputPenInfo: "Windows.UI.Input.Preview.Injection.InjectedInputPenInfo");
 RT_ENUM! { enum InjectedInputPenParameters: u32 {
     None (InjectedInputPenParameters_None) = 0, Pressure (InjectedInputPenParameters_Pressure) = 1, Rotation (InjectedInputPenParameters_Rotation) = 2, TiltX (InjectedInputPenParameters_TiltX) = 4, TiltY (InjectedInputPenParameters_TiltY) = 8,
 }}
@@ -5217,7 +5217,7 @@ impl IInjectedInputTouchInfo {
 }
 RT_CLASS!{class InjectedInputTouchInfo: IInjectedInputTouchInfo}
 impl RtActivatable<IActivationFactory> for InjectedInputTouchInfo {}
-DEFINE_CLSID!(InjectedInputTouchInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,84,111,117,99,104,73,110,102,111,0]) [CLSID_InjectedInputTouchInfo]);
+DEFINE_CLSID!(InjectedInputTouchInfo: "Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo");
 RT_ENUM! { enum InjectedInputTouchParameters: u32 {
     None (InjectedInputTouchParameters_None) = 0, Contact (InjectedInputTouchParameters_Contact) = 1, Orientation (InjectedInputTouchParameters_Orientation) = 2, Pressure (InjectedInputTouchParameters_Pressure) = 4,
 }}
@@ -5285,7 +5285,7 @@ impl InputInjector {
         <Self as RtActivatable<IInputInjectorStatics2>>::get_activation_factory().try_create_for_app_broadcast_only()
     }}
 }
-DEFINE_CLSID!(InputInjector(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,112,117,116,73,110,106,101,99,116,111,114,0]) [CLSID_InputInjector]);
+DEFINE_CLSID!(InputInjector: "Windows.UI.Input.Preview.Injection.InputInjector");
 DEFINE_IID!(IID_IInputInjector2, 2390397021, 5203, 17319, 155, 203, 6, 214, 215, 179, 5, 247);
 RT_INTERFACE!{interface IInputInjector2(IInputInjector2Vtbl): IInspectable(IInspectableVtbl) [IID_IInputInjector2] {
     fn InitializeGamepadInjection(&self) -> HRESULT,
@@ -5520,7 +5520,7 @@ impl SpatialGestureRecognizer {
         <Self as RtActivatable<ISpatialGestureRecognizerFactory>>::get_activation_factory().create(settings)
     }}
 }
-DEFINE_CLSID!(SpatialGestureRecognizer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,71,101,115,116,117,114,101,82,101,99,111,103,110,105,122,101,114,0]) [CLSID_SpatialGestureRecognizer]);
+DEFINE_CLSID!(SpatialGestureRecognizer: "Windows.UI.Input.Spatial.SpatialGestureRecognizer");
 DEFINE_IID!(IID_ISpatialGestureRecognizerFactory, 1998668166, 22457, 12624, 131, 130, 105, 139, 36, 226, 100, 208);
 RT_INTERFACE!{static interface ISpatialGestureRecognizerFactory(ISpatialGestureRecognizerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialGestureRecognizerFactory] {
     fn Create(&self, settings: SpatialGestureSettings, out: *mut *mut SpatialGestureRecognizer) -> HRESULT
@@ -5811,7 +5811,7 @@ impl SpatialInteractionManager {
         <Self as RtActivatable<ISpatialInteractionManagerStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(SpatialInteractionManager(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,73,110,116,101,114,97,99,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_SpatialInteractionManager]);
+DEFINE_CLSID!(SpatialInteractionManager: "Windows.UI.Input.Spatial.SpatialInteractionManager");
 DEFINE_IID!(IID_ISpatialInteractionManagerStatics, 14884774, 36002, 12479, 145, 254, 217, 203, 74, 0, 137, 144);
 RT_INTERFACE!{static interface ISpatialInteractionManagerStatics(ISpatialInteractionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionManagerStatics] {
     fn GetForCurrentView(&self, out: *mut *mut SpatialInteractionManager) -> HRESULT
@@ -6297,7 +6297,7 @@ impl SpatialPointerPose {
         <Self as RtActivatable<ISpatialPointerPoseStatics>>::get_activation_factory().try_get_at_timestamp(coordinateSystem, timestamp)
     }}
 }
-DEFINE_CLSID!(SpatialPointerPose(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,83,112,97,116,105,97,108,46,83,112,97,116,105,97,108,80,111,105,110,116,101,114,80,111,115,101,0]) [CLSID_SpatialPointerPose]);
+DEFINE_CLSID!(SpatialPointerPose: "Windows.UI.Input.Spatial.SpatialPointerPose");
 DEFINE_IID!(IID_ISpatialPointerPose2, 2636131095, 38222, 19980, 150, 209, 182, 121, 11, 111, 194, 253);
 RT_INTERFACE!{interface ISpatialPointerPose2(ISpatialPointerPose2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialPointerPose2] {
     fn TryGetInteractionSourcePose(&self, source: *mut SpatialInteractionSource, out: *mut *mut SpatialPointerInteractionSourcePose) -> HRESULT
@@ -6409,7 +6409,7 @@ impl RadialControllerIndependentInputSource {
         <Self as RtActivatable<IRadialControllerIndependentInputSourceStatics>>::get_activation_factory().create_for_view(view)
     }}
 }
-DEFINE_CLSID!(RadialControllerIndependentInputSource(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,67,111,114,101,46,82,97,100,105,97,108,67,111,110,116,114,111,108,108,101,114,73,110,100,101,112,101,110,100,101,110,116,73,110,112,117,116,83,111,117,114,99,101,0]) [CLSID_RadialControllerIndependentInputSource]);
+DEFINE_CLSID!(RadialControllerIndependentInputSource: "Windows.UI.Input.Core.RadialControllerIndependentInputSource");
 DEFINE_IID!(IID_IRadialControllerIndependentInputSourceStatics, 1029144309, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{static interface IRadialControllerIndependentInputSourceStatics(IRadialControllerIndependentInputSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerIndependentInputSourceStatics] {
     #[cfg(feature="windows-applicationmodel")] fn CreateForView(&self, view: *mut ::rt::gen::windows::applicationmodel::core::CoreApplicationView, out: *mut *mut RadialControllerIndependentInputSource) -> HRESULT
@@ -6492,7 +6492,7 @@ impl InkDrawingAttributes {
         <Self as RtActivatable<IInkDrawingAttributesStatics>>::get_activation_factory().create_for_pencil()
     }}
 }
-DEFINE_CLSID!(InkDrawingAttributes(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,68,114,97,119,105,110,103,65,116,116,114,105,98,117,116,101,115,0]) [CLSID_InkDrawingAttributes]);
+DEFINE_CLSID!(InkDrawingAttributes: "Windows.UI.Input.Inking.InkDrawingAttributes");
 DEFINE_IID!(IID_IInkDrawingAttributes2, 2091607304, 36548, 17149, 165, 165, 228, 183, 209, 213, 49, 109);
 RT_INTERFACE!{interface IInkDrawingAttributes2(IInkDrawingAttributes2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkDrawingAttributes2] {
     fn get_PenTipTransform(&self, out: *mut ::rt::gen::windows::foundation::numerics::Matrix3x2) -> HRESULT,
@@ -6667,7 +6667,7 @@ impl IInkManager {
 }
 RT_CLASS!{class InkManager: IInkManager}
 impl RtActivatable<IActivationFactory> for InkManager {}
-DEFINE_CLSID!(InkManager(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,77,97,110,97,103,101,114,0]) [CLSID_InkManager]);
+DEFINE_CLSID!(InkManager: "Windows.UI.Input.Inking.InkManager");
 RT_ENUM! { enum InkManipulationMode: i32 {
     Inking (InkManipulationMode_Inking) = 0, Erasing (InkManipulationMode_Erasing) = 1, Selecting (InkManipulationMode_Selecting) = 2,
 }}
@@ -6702,7 +6702,7 @@ impl InkPoint {
         <Self as RtActivatable<IInkPointFactory2>>::get_activation_factory().create_ink_point_with_tilt_and_timestamp(position, pressure, tiltX, tiltY, timestamp)
     }}
 }
-DEFINE_CLSID!(InkPoint(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,80,111,105,110,116,0]) [CLSID_InkPoint]);
+DEFINE_CLSID!(InkPoint: "Windows.UI.Input.Inking.InkPoint");
 DEFINE_IID!(IID_IInkPoint2, 4222206967, 44630, 19804, 189, 47, 10, 196, 95, 94, 74, 249);
 RT_INTERFACE!{interface IInkPoint2(IInkPoint2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkPoint2] {
     fn get_TiltX(&self, out: *mut f32) -> HRESULT,
@@ -6957,7 +6957,7 @@ impl InkPresenterProtractor {
         <Self as RtActivatable<IInkPresenterProtractorFactory>>::get_activation_factory().create(inkPresenter)
     }}
 }
-DEFINE_CLSID!(InkPresenterProtractor(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,80,114,101,115,101,110,116,101,114,80,114,111,116,114,97,99,116,111,114,0]) [CLSID_InkPresenterProtractor]);
+DEFINE_CLSID!(InkPresenterProtractor: "Windows.UI.Input.Inking.InkPresenterProtractor");
 DEFINE_IID!(IID_IInkPresenterProtractorFactory, 838927305, 26874, 18409, 129, 39, 131, 112, 113, 31, 196, 108);
 RT_INTERFACE!{static interface IInkPresenterProtractorFactory(IInkPresenterProtractorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IInkPresenterProtractorFactory] {
     fn Create(&self, inkPresenter: *mut InkPresenter, out: *mut *mut InkPresenterProtractor) -> HRESULT
@@ -7003,7 +7003,7 @@ impl InkPresenterRuler {
         <Self as RtActivatable<IInkPresenterRulerFactory>>::get_activation_factory().create(inkPresenter)
     }}
 }
-DEFINE_CLSID!(InkPresenterRuler(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,80,114,101,115,101,110,116,101,114,82,117,108,101,114,0]) [CLSID_InkPresenterRuler]);
+DEFINE_CLSID!(InkPresenterRuler: "Windows.UI.Input.Inking.InkPresenterRuler");
 DEFINE_IID!(IID_IInkPresenterRuler2, 1158876609, 48225, 17620, 164, 35, 84, 113, 42, 230, 113, 196);
 RT_INTERFACE!{interface IInkPresenterRuler2(IInkPresenterRuler2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkPresenterRuler2] {
     fn get_AreTickMarksVisible(&self, out: *mut bool) -> HRESULT,
@@ -7163,7 +7163,7 @@ impl IInkRecognizerContainer {
 }
 RT_CLASS!{class InkRecognizerContainer: IInkRecognizerContainer}
 impl RtActivatable<IActivationFactory> for InkRecognizerContainer {}
-DEFINE_CLSID!(InkRecognizerContainer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,82,101,99,111,103,110,105,122,101,114,67,111,110,116,97,105,110,101,114,0]) [CLSID_InkRecognizerContainer]);
+DEFINE_CLSID!(InkRecognizerContainer: "Windows.UI.Input.Inking.InkRecognizerContainer");
 DEFINE_IID!(IID_IInkStroke, 353652064, 52451, 20431, 157, 82, 17, 81, 138, 182, 175, 212);
 RT_INTERFACE!{interface IInkStroke(IInkStrokeVtbl): IInspectable(IInspectableVtbl) [IID_IInkStroke] {
     fn get_DrawingAttributes(&self, out: *mut *mut InkDrawingAttributes) -> HRESULT,
@@ -7306,7 +7306,7 @@ impl IInkStrokeBuilder {
 }
 RT_CLASS!{class InkStrokeBuilder: IInkStrokeBuilder}
 impl RtActivatable<IActivationFactory> for InkStrokeBuilder {}
-DEFINE_CLSID!(InkStrokeBuilder(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,83,116,114,111,107,101,66,117,105,108,100,101,114,0]) [CLSID_InkStrokeBuilder]);
+DEFINE_CLSID!(InkStrokeBuilder: "Windows.UI.Input.Inking.InkStrokeBuilder");
 DEFINE_IID!(IID_IInkStrokeBuilder2, 3179461671, 29471, 19644, 187, 191, 109, 70, 128, 68, 241, 229);
 RT_INTERFACE!{interface IInkStrokeBuilder2(IInkStrokeBuilder2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkStrokeBuilder2] {
     fn CreateStrokeFromInkPoints(&self, inkPoints: *mut ::rt::gen::windows::foundation::collections::IIterable<InkPoint>, transform: ::rt::gen::windows::foundation::numerics::Matrix3x2, out: *mut *mut InkStroke) -> HRESULT
@@ -7419,7 +7419,7 @@ impl IInkStrokeContainer {
 }
 RT_CLASS!{class InkStrokeContainer: IInkStrokeContainer}
 impl RtActivatable<IActivationFactory> for InkStrokeContainer {}
-DEFINE_CLSID!(InkStrokeContainer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,83,116,114,111,107,101,67,111,110,116,97,105,110,101,114,0]) [CLSID_InkStrokeContainer]);
+DEFINE_CLSID!(InkStrokeContainer: "Windows.UI.Input.Inking.InkStrokeContainer");
 DEFINE_IID!(IID_IInkStrokeContainer2, 2298598244, 55862, 19407, 158, 92, 209, 149, 130, 89, 149, 180);
 RT_INTERFACE!{interface IInkStrokeContainer2(IInkStrokeContainer2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkStrokeContainer2] {
     fn AddStrokes(&self, strokes: *mut ::rt::gen::windows::foundation::collections::IIterable<InkStroke>) -> HRESULT,
@@ -7950,7 +7950,7 @@ impl IInkAnalyzer {
 }
 RT_CLASS!{class InkAnalyzer: IInkAnalyzer}
 impl RtActivatable<IActivationFactory> for InkAnalyzer {}
-DEFINE_CLSID!(InkAnalyzer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,65,110,97,108,121,115,105,115,46,73,110,107,65,110,97,108,121,122,101,114,0]) [CLSID_InkAnalyzer]);
+DEFINE_CLSID!(InkAnalyzer: "Windows.UI.Input.Inking.Analysis.InkAnalyzer");
 DEFINE_IID!(IID_IInkAnalyzerFactory, 689145478, 6499, 18904, 149, 137, 225, 67, 132, 199, 105, 227);
 RT_INTERFACE!{interface IInkAnalyzerFactory(IInkAnalyzerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalyzerFactory] {
     fn CreateAnalyzer(&self, out: *mut *mut InkAnalyzer) -> HRESULT
@@ -8007,7 +8007,7 @@ impl CoreIncrementalInkStroke {
         <Self as RtActivatable<ICoreIncrementalInkStrokeFactory>>::get_activation_factory().create(drawingAttributes, pointTransform)
     }}
 }
-DEFINE_CLSID!(CoreIncrementalInkStroke(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,67,111,114,101,46,67,111,114,101,73,110,99,114,101,109,101,110,116,97,108,73,110,107,83,116,114,111,107,101,0]) [CLSID_CoreIncrementalInkStroke]);
+DEFINE_CLSID!(CoreIncrementalInkStroke: "Windows.UI.Input.Inking.Core.CoreIncrementalInkStroke");
 DEFINE_IID!(IID_ICoreIncrementalInkStrokeFactory, 3620052806, 36264, 20336, 151, 81, 229, 59, 182, 223, 69, 150);
 RT_INTERFACE!{static interface ICoreIncrementalInkStrokeFactory(ICoreIncrementalInkStrokeFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICoreIncrementalInkStrokeFactory] {
     fn Create(&self, drawingAttributes: *mut super::InkDrawingAttributes, pointTransform: ::rt::gen::windows::foundation::numerics::Matrix3x2, out: *mut *mut CoreIncrementalInkStroke) -> HRESULT
@@ -8114,7 +8114,7 @@ impl CoreInkIndependentInputSource {
         <Self as RtActivatable<ICoreInkIndependentInputSourceStatics>>::get_activation_factory().create(inkPresenter)
     }}
 }
-DEFINE_CLSID!(CoreInkIndependentInputSource(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,67,111,114,101,46,67,111,114,101,73,110,107,73,110,100,101,112,101,110,100,101,110,116,73,110,112,117,116,83,111,117,114,99,101,0]) [CLSID_CoreInkIndependentInputSource]);
+DEFINE_CLSID!(CoreInkIndependentInputSource: "Windows.UI.Input.Inking.Core.CoreInkIndependentInputSource");
 DEFINE_IID!(IID_ICoreInkIndependentInputSourceStatics, 1944453403, 32960, 19963, 155, 102, 16, 186, 127, 63, 156, 132);
 RT_INTERFACE!{static interface ICoreInkIndependentInputSourceStatics(ICoreInkIndependentInputSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreInkIndependentInputSourceStatics] {
     fn Create(&self, inkPresenter: *mut super::InkPresenter, out: *mut *mut CoreInkIndependentInputSource) -> HRESULT
@@ -8150,7 +8150,7 @@ impl ICoreInkPresenterHost {
 }
 RT_CLASS!{class CoreInkPresenterHost: ICoreInkPresenterHost}
 impl RtActivatable<IActivationFactory> for CoreInkPresenterHost {}
-DEFINE_CLSID!(CoreInkPresenterHost(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,67,111,114,101,46,67,111,114,101,73,110,107,80,114,101,115,101,110,116,101,114,72,111,115,116,0]) [CLSID_CoreInkPresenterHost]);
+DEFINE_CLSID!(CoreInkPresenterHost: "Windows.UI.Input.Inking.Core.CoreInkPresenterHost");
 RT_ENUM! { enum CoreWetStrokeDisposition: i32 {
     Inking (CoreWetStrokeDisposition_Inking) = 0, Completed (CoreWetStrokeDisposition_Completed) = 1, Canceled (CoreWetStrokeDisposition_Canceled) = 2,
 }}
@@ -8256,7 +8256,7 @@ impl CoreWetStrokeUpdateSource {
         <Self as RtActivatable<ICoreWetStrokeUpdateSourceStatics>>::get_activation_factory().create(inkPresenter)
     }}
 }
-DEFINE_CLSID!(CoreWetStrokeUpdateSource(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,67,111,114,101,46,67,111,114,101,87,101,116,83,116,114,111,107,101,85,112,100,97,116,101,83,111,117,114,99,101,0]) [CLSID_CoreWetStrokeUpdateSource]);
+DEFINE_CLSID!(CoreWetStrokeUpdateSource: "Windows.UI.Input.Inking.Core.CoreWetStrokeUpdateSource");
 DEFINE_IID!(IID_ICoreWetStrokeUpdateSourceStatics, 1034788026, 7485, 18094, 171, 157, 134, 71, 72, 108, 111, 144);
 RT_INTERFACE!{static interface ICoreWetStrokeUpdateSourceStatics(ICoreWetStrokeUpdateSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreWetStrokeUpdateSourceStatics] {
     fn Create(&self, inkPresenter: *mut super::InkPresenter, out: *mut *mut CoreWetStrokeUpdateSource) -> HRESULT
@@ -8329,7 +8329,7 @@ impl FontWeights {
         <Self as RtActivatable<IFontWeightsStatics>>::get_activation_factory().get_thin()
     }}
 }
-DEFINE_CLSID!(FontWeights(&[87,105,110,100,111,119,115,46,85,73,46,84,101,120,116,46,70,111,110,116,87,101,105,103,104,116,115,0]) [CLSID_FontWeights]);
+DEFINE_CLSID!(FontWeights: "Windows.UI.Text.FontWeights");
 DEFINE_IID!(IID_IFontWeightsStatics, 3015014869, 7081, 18667, 157, 173, 192, 149, 232, 194, 59, 163);
 RT_INTERFACE!{static interface IFontWeightsStatics(IFontWeightsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IFontWeightsStatics] {
     fn get_Black(&self, out: *mut FontWeight) -> HRESULT,
@@ -8759,7 +8759,7 @@ impl TextConstants {
         <Self as RtActivatable<ITextConstantsStatics>>::get_activation_factory().get_undefined_font_style()
     }}
 }
-DEFINE_CLSID!(TextConstants(&[87,105,110,100,111,119,115,46,85,73,46,84,101,120,116,46,84,101,120,116,67,111,110,115,116,97,110,116,115,0]) [CLSID_TextConstants]);
+DEFINE_CLSID!(TextConstants: "Windows.UI.Text.TextConstants");
 DEFINE_IID!(IID_ITextConstantsStatics, 2006875187, 6301, 19450, 151, 200, 16, 219, 19, 93, 151, 110);
 RT_INTERFACE!{static interface ITextConstantsStatics(ITextConstantsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITextConstantsStatics] {
     fn get_AutoColor(&self, out: *mut super::Color) -> HRESULT,
@@ -10136,7 +10136,7 @@ impl CoreTextServicesConstants {
         <Self as RtActivatable<ICoreTextServicesStatics>>::get_activation_factory().get_hidden_character()
     }}
 }
-DEFINE_CLSID!(CoreTextServicesConstants(&[87,105,110,100,111,119,115,46,85,73,46,84,101,120,116,46,67,111,114,101,46,67,111,114,101,84,101,120,116,83,101,114,118,105,99,101,115,67,111,110,115,116,97,110,116,115,0]) [CLSID_CoreTextServicesConstants]);
+DEFINE_CLSID!(CoreTextServicesConstants: "Windows.UI.Text.Core.CoreTextServicesConstants");
 DEFINE_IID!(IID_ICoreTextServicesManager, 3260054915, 28170, 19082, 189, 248, 25, 72, 135, 72, 84, 186);
 RT_INTERFACE!{interface ICoreTextServicesManager(ICoreTextServicesManagerVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextServicesManager] {
     #[cfg(not(feature="windows-globalization"))] fn __Dummy0(&self) -> (),
@@ -10173,7 +10173,7 @@ impl CoreTextServicesManager {
         <Self as RtActivatable<ICoreTextServicesManagerStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(CoreTextServicesManager(&[87,105,110,100,111,119,115,46,85,73,46,84,101,120,116,46,67,111,114,101,46,67,111,114,101,84,101,120,116,83,101,114,118,105,99,101,115,77,97,110,97,103,101,114,0]) [CLSID_CoreTextServicesManager]);
+DEFINE_CLSID!(CoreTextServicesManager: "Windows.UI.Text.Core.CoreTextServicesManager");
 DEFINE_IID!(IID_ICoreTextServicesManagerStatics, 354460552, 58063, 19813, 174, 185, 179, 45, 134, 254, 57, 185);
 RT_INTERFACE!{static interface ICoreTextServicesManagerStatics(ICoreTextServicesManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextServicesManagerStatics] {
     fn GetForCurrentView(&self, out: *mut *mut CoreTextServicesManager) -> HRESULT
@@ -10334,7 +10334,7 @@ impl IAccessibilitySettings {
 }
 RT_CLASS!{class AccessibilitySettings: IAccessibilitySettings}
 impl RtActivatable<IActivationFactory> for AccessibilitySettings {}
-DEFINE_CLSID!(AccessibilitySettings(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,65,99,99,101,115,115,105,98,105,108,105,116,121,83,101,116,116,105,110,103,115,0]) [CLSID_AccessibilitySettings]);
+DEFINE_CLSID!(AccessibilitySettings: "Windows.UI.ViewManagement.AccessibilitySettings");
 DEFINE_IID!(IID_IActivationViewSwitcher, 3701939126, 29520, 18731, 170, 199, 200, 161, 61, 114, 36, 173);
 RT_INTERFACE!{interface IActivationViewSwitcher(IActivationViewSwitcherVtbl): IInspectable(IInspectableVtbl) [IID_IActivationViewSwitcher] {
     fn ShowAsStandaloneAsync(&self, viewId: i32, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT,
@@ -10474,7 +10474,7 @@ impl ApplicationView {
         <Self as RtActivatable<IApplicationViewStatics3>>::get_activation_factory().set_preferred_launch_view_size(value)
     }}
 }
-DEFINE_CLSID!(ApplicationView(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,65,112,112,108,105,99,97,116,105,111,110,86,105,101,119,0]) [CLSID_ApplicationView]);
+DEFINE_CLSID!(ApplicationView: "Windows.UI.ViewManagement.ApplicationView");
 DEFINE_IID!(IID_IApplicationView2, 3900092822, 42309, 16604, 181, 148, 69, 12, 186, 104, 204, 0);
 RT_INTERFACE!{interface IApplicationView2(IApplicationView2Vtbl): IInspectable(IInspectableVtbl) [IID_IApplicationView2] {
     fn get_SuppressSystemOverlays(&self, out: *mut bool) -> HRESULT,
@@ -10678,7 +10678,7 @@ impl ApplicationViewScaling {
         <Self as RtActivatable<IApplicationViewScalingStatics>>::get_activation_factory().try_set_disable_layout_scaling(disableLayoutScaling)
     }}
 }
-DEFINE_CLSID!(ApplicationViewScaling(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,65,112,112,108,105,99,97,116,105,111,110,86,105,101,119,83,99,97,108,105,110,103,0]) [CLSID_ApplicationViewScaling]);
+DEFINE_CLSID!(ApplicationViewScaling: "Windows.UI.ViewManagement.ApplicationViewScaling");
 DEFINE_IID!(IID_IApplicationViewScalingStatics, 2962222320, 47430, 17864, 165, 227, 113, 245, 170, 120, 248, 97);
 RT_INTERFACE!{static interface IApplicationViewScalingStatics(IApplicationViewScalingStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationViewScalingStatics] {
     fn get_DisableLayoutScaling(&self, out: *mut bool) -> HRESULT,
@@ -10804,7 +10804,7 @@ impl ApplicationViewSwitcher {
         <Self as RtActivatable<IApplicationViewSwitcherStatics3>>::get_activation_factory().try_show_as_view_mode_with_preferences_async(viewId, viewMode, viewModePreferences)
     }}
 }
-DEFINE_CLSID!(ApplicationViewSwitcher(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,65,112,112,108,105,99,97,116,105,111,110,86,105,101,119,83,119,105,116,99,104,101,114,0]) [CLSID_ApplicationViewSwitcher]);
+DEFINE_CLSID!(ApplicationViewSwitcher: "Windows.UI.ViewManagement.ApplicationViewSwitcher");
 DEFINE_IID!(IID_IApplicationViewSwitcherStatics, 2539597598, 58966, 19550, 160, 161, 113, 124, 111, 250, 125, 100);
 RT_INTERFACE!{static interface IApplicationViewSwitcherStatics(IApplicationViewSwitcherStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationViewSwitcherStatics] {
     fn DisableShowingMainViewOnActivation(&self) -> HRESULT,
@@ -11049,7 +11049,7 @@ impl ApplicationViewTransferContext {
         <Self as RtActivatable<IApplicationViewTransferContextStatics>>::get_activation_factory().get_data_package_format_id()
     }}
 }
-DEFINE_CLSID!(ApplicationViewTransferContext(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,65,112,112,108,105,99,97,116,105,111,110,86,105,101,119,84,114,97,110,115,102,101,114,67,111,110,116,101,120,116,0]) [CLSID_ApplicationViewTransferContext]);
+DEFINE_CLSID!(ApplicationViewTransferContext: "Windows.UI.ViewManagement.ApplicationViewTransferContext");
 DEFINE_IID!(IID_IApplicationViewTransferContextStatics, 363371922, 56697, 19211, 188, 71, 213, 241, 149, 241, 70, 97);
 RT_INTERFACE!{static interface IApplicationViewTransferContextStatics(IApplicationViewTransferContextStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationViewTransferContextStatics] {
     fn get_DataPackageFormatId(&self, out: *mut HSTRING) -> HRESULT
@@ -11110,7 +11110,7 @@ impl InputPane {
         <Self as RtActivatable<IInputPaneStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(InputPane(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,73,110,112,117,116,80,97,110,101,0]) [CLSID_InputPane]);
+DEFINE_CLSID!(InputPane: "Windows.UI.ViewManagement.InputPane");
 DEFINE_IID!(IID_IInputPane2, 2322284326, 28816, 18323, 148, 76, 195, 242, 205, 226, 98, 118);
 RT_INTERFACE!{interface IInputPane2(IInputPane2Vtbl): IInspectable(IInspectableVtbl) [IID_IInputPane2] {
     fn TryShow(&self, out: *mut bool) -> HRESULT,
@@ -11213,7 +11213,7 @@ impl ProjectionManager {
         <Self as RtActivatable<IProjectionManagerStatics2>>::get_activation_factory().get_device_selector()
     }}
 }
-DEFINE_CLSID!(ProjectionManager(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,80,114,111,106,101,99,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_ProjectionManager]);
+DEFINE_CLSID!(ProjectionManager: "Windows.UI.ViewManagement.ProjectionManager");
 DEFINE_IID!(IID_IProjectionManagerStatics, 3059716413, 58096, 20477, 186, 149, 52, 36, 22, 71, 228, 92);
 RT_INTERFACE!{static interface IProjectionManagerStatics(IProjectionManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IProjectionManagerStatics] {
     fn StartProjectingAsync(&self, projectionViewId: i32, anchorViewId: i32, out: *mut *mut super::super::foundation::IAsyncAction) -> HRESULT,
@@ -11375,7 +11375,7 @@ impl IUISettings {
 }
 RT_CLASS!{class UISettings: IUISettings}
 impl RtActivatable<IActivationFactory> for UISettings {}
-DEFINE_CLSID!(UISettings(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,85,73,83,101,116,116,105,110,103,115,0]) [CLSID_UISettings]);
+DEFINE_CLSID!(UISettings: "Windows.UI.ViewManagement.UISettings");
 DEFINE_IID!(IID_IUISettings2, 3134727169, 10017, 17657, 187, 145, 43, 178, 40, 190, 68, 47);
 RT_INTERFACE!{interface IUISettings2(IUISettings2Vtbl): IInspectable(IInspectableVtbl) [IID_IUISettings2] {
     fn get_TextScaleFactor(&self, out: *mut f64) -> HRESULT,
@@ -11460,7 +11460,7 @@ impl UIViewSettings {
         <Self as RtActivatable<IUIViewSettingsStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(UIViewSettings(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,85,73,86,105,101,119,83,101,116,116,105,110,103,115,0]) [CLSID_UIViewSettings]);
+DEFINE_CLSID!(UIViewSettings: "Windows.UI.ViewManagement.UIViewSettings");
 DEFINE_IID!(IID_IUIViewSettingsStatics, 1499240357, 63734, 16847, 176, 251, 170, 205, 184, 31, 213, 246);
 RT_INTERFACE!{static interface IUIViewSettingsStatics(IUIViewSettingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUIViewSettingsStatics] {
     fn GetForCurrentView(&self, out: *mut *mut UIViewSettings) -> HRESULT
@@ -11509,7 +11509,7 @@ impl ViewModePreferences {
         <Self as RtActivatable<IViewModePreferencesStatics>>::get_activation_factory().create_default(mode)
     }}
 }
-DEFINE_CLSID!(ViewModePreferences(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,86,105,101,119,77,111,100,101,80,114,101,102,101,114,101,110,99,101,115,0]) [CLSID_ViewModePreferences]);
+DEFINE_CLSID!(ViewModePreferences: "Windows.UI.ViewManagement.ViewModePreferences");
 DEFINE_IID!(IID_IViewModePreferencesStatics, 1773537893, 24037, 16600, 131, 6, 56, 51, 223, 122, 34, 116);
 RT_INTERFACE!{static interface IViewModePreferencesStatics(IViewModePreferencesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IViewModePreferencesStatics] {
     fn CreateDefault(&self, mode: ApplicationViewMode, out: *mut *mut ViewModePreferences) -> HRESULT
@@ -11567,7 +11567,7 @@ impl CoreInputView {
         <Self as RtActivatable<ICoreInputViewStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(CoreInputView(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,67,111,114,101,46,67,111,114,101,73,110,112,117,116,86,105,101,119,0]) [CLSID_CoreInputView]);
+DEFINE_CLSID!(CoreInputView: "Windows.UI.ViewManagement.Core.CoreInputView");
 DEFINE_IID!(IID_ICoreInputViewOcclusion, 3426143750, 14437, 16759, 181, 245, 139, 101, 224, 185, 206, 132);
 RT_INTERFACE!{interface ICoreInputViewOcclusion(ICoreInputViewOcclusionVtbl): IInspectable(IInspectableVtbl) [IID_ICoreInputViewOcclusion] {
     fn get_OccludingRect(&self, out: *mut ::rt::gen::windows::foundation::Rect) -> HRESULT,
@@ -11660,7 +11660,7 @@ impl AccountsSettingsPane {
         <Self as RtActivatable<IAccountsSettingsPaneStatics2>>::get_activation_factory().show_add_account_async()
     }}
 }
-DEFINE_CLSID!(AccountsSettingsPane(&[87,105,110,100,111,119,115,46,85,73,46,65,112,112,108,105,99,97,116,105,111,110,83,101,116,116,105,110,103,115,46,65,99,99,111,117,110,116,115,83,101,116,116,105,110,103,115,80,97,110,101,0]) [CLSID_AccountsSettingsPane]);
+DEFINE_CLSID!(AccountsSettingsPane: "Windows.UI.ApplicationSettings.AccountsSettingsPane");
 DEFINE_IID!(IID_IAccountsSettingsPaneCommandsRequestedEventArgs, 996720793, 56089, 17872, 154, 191, 149, 211, 119, 60, 147, 48);
 RT_INTERFACE!{interface IAccountsSettingsPaneCommandsRequestedEventArgs(IAccountsSettingsPaneCommandsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAccountsSettingsPaneCommandsRequestedEventArgs] {
     fn get_WebAccountProviderCommands(&self, out: *mut *mut super::super::foundation::collections::IVector<WebAccountProviderCommand>) -> HRESULT,
@@ -11780,7 +11780,7 @@ impl CredentialCommand {
         <Self as RtActivatable<ICredentialCommandFactory>>::get_activation_factory().create_credential_command_with_handler(passwordCredential, deleted)
     }}
 }
-DEFINE_CLSID!(CredentialCommand(&[87,105,110,100,111,119,115,46,85,73,46,65,112,112,108,105,99,97,116,105,111,110,83,101,116,116,105,110,103,115,46,67,114,101,100,101,110,116,105,97,108,67,111,109,109,97,110,100,0]) [CLSID_CredentialCommand]);
+DEFINE_CLSID!(CredentialCommand: "Windows.UI.ApplicationSettings.CredentialCommand");
 DEFINE_IID!(IID_CredentialCommandCredentialDeletedHandler, 1640030597, 2423, 18040, 180, 226, 152, 114, 122, 251, 238, 217);
 RT_DELEGATE!{delegate CredentialCommandCredentialDeletedHandler(CredentialCommandCredentialDeletedHandlerVtbl, CredentialCommandCredentialDeletedHandlerImpl) [IID_CredentialCommandCredentialDeletedHandler] {
     fn Invoke(&self, command: *mut CredentialCommand) -> HRESULT
@@ -11819,7 +11819,7 @@ impl SettingsCommand {
         <Self as RtActivatable<ISettingsCommandStatics>>::get_activation_factory().get_accounts_command()
     }}
 }
-DEFINE_CLSID!(SettingsCommand(&[87,105,110,100,111,119,115,46,85,73,46,65,112,112,108,105,99,97,116,105,111,110,83,101,116,116,105,110,103,115,46,83,101,116,116,105,110,103,115,67,111,109,109,97,110,100,0]) [CLSID_SettingsCommand]);
+DEFINE_CLSID!(SettingsCommand: "Windows.UI.ApplicationSettings.SettingsCommand");
 DEFINE_IID!(IID_ISettingsCommandFactory, 1759599411, 7299, 17210, 170, 90, 206, 238, 165, 189, 71, 100);
 RT_INTERFACE!{static interface ISettingsCommandFactory(ISettingsCommandFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISettingsCommandFactory] {
     fn CreateSettingsCommand(&self, settingsCommandId: *mut IInspectable, label: HSTRING, handler: *mut super::popups::UICommandInvokedHandler, out: *mut *mut SettingsCommand) -> HRESULT
@@ -11874,7 +11874,7 @@ impl SettingsPane {
         <Self as RtActivatable<ISettingsPaneStatics>>::get_activation_factory().get_edge()
     }}
 }
-DEFINE_CLSID!(SettingsPane(&[87,105,110,100,111,119,115,46,85,73,46,65,112,112,108,105,99,97,116,105,111,110,83,101,116,116,105,110,103,115,46,83,101,116,116,105,110,103,115,80,97,110,101,0]) [CLSID_SettingsPane]);
+DEFINE_CLSID!(SettingsPane: "Windows.UI.ApplicationSettings.SettingsPane");
 DEFINE_IID!(IID_ISettingsPaneCommandsRequest, 1155474350, 23918, 16488, 161, 104, 244, 118, 67, 24, 33, 20);
 RT_INTERFACE!{interface ISettingsPaneCommandsRequest(ISettingsPaneCommandsRequestVtbl): IInspectable(IInspectableVtbl) [IID_ISettingsPaneCommandsRequest] {
     fn get_ApplicationCommands(&self, out: *mut *mut super::super::foundation::collections::IVector<SettingsCommand>) -> HRESULT
@@ -11958,7 +11958,7 @@ impl WebAccountCommand {
         <Self as RtActivatable<IWebAccountCommandFactory>>::get_activation_factory().create_web_account_command(webAccount, invoked, actions)
     }}
 }
-DEFINE_CLSID!(WebAccountCommand(&[87,105,110,100,111,119,115,46,85,73,46,65,112,112,108,105,99,97,116,105,111,110,83,101,116,116,105,110,103,115,46,87,101,98,65,99,99,111,117,110,116,67,111,109,109,97,110,100,0]) [CLSID_WebAccountCommand]);
+DEFINE_CLSID!(WebAccountCommand: "Windows.UI.ApplicationSettings.WebAccountCommand");
 DEFINE_IID!(IID_IWebAccountCommandFactory, 3215379967, 12077, 17141, 129, 222, 29, 86, 186, 252, 73, 109);
 RT_INTERFACE!{static interface IWebAccountCommandFactory(IWebAccountCommandFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountCommandFactory] {
     #[cfg(feature="windows-security")] fn CreateWebAccountCommand(&self, webAccount: *mut super::super::security::credentials::WebAccount, invoked: *mut WebAccountCommandInvokedHandler, actions: SupportedWebAccountActions, out: *mut *mut WebAccountCommand) -> HRESULT
@@ -12017,7 +12017,7 @@ impl WebAccountProviderCommand {
         <Self as RtActivatable<IWebAccountProviderCommandFactory>>::get_activation_factory().create_web_account_provider_command(webAccountProvider, invoked)
     }}
 }
-DEFINE_CLSID!(WebAccountProviderCommand(&[87,105,110,100,111,119,115,46,85,73,46,65,112,112,108,105,99,97,116,105,111,110,83,101,116,116,105,110,103,115,46,87,101,98,65,99,99,111,117,110,116,80,114,111,118,105,100,101,114,67,111,109,109,97,110,100,0]) [CLSID_WebAccountProviderCommand]);
+DEFINE_CLSID!(WebAccountProviderCommand: "Windows.UI.ApplicationSettings.WebAccountProviderCommand");
 DEFINE_IID!(IID_IWebAccountProviderCommandFactory, 3580201499, 45430, 18294, 132, 105, 169, 211, 255, 11, 63, 89);
 RT_INTERFACE!{static interface IWebAccountProviderCommandFactory(IWebAccountProviderCommandFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderCommandFactory] {
     #[cfg(feature="windows-security")] fn CreateWebAccountProviderCommand(&self, webAccountProvider: *mut super::super::security::credentials::WebAccountProvider, invoked: *mut WebAccountProviderCommandInvokedHandler, out: *mut *mut WebAccountProviderCommand) -> HRESULT
@@ -12405,7 +12405,7 @@ impl WebUIApplication {
         <Self as RtActivatable<IWebUIActivationStatics3>>::get_activation_factory().request_restart_for_user_async(user, launchArguments)
     }}
 }
-DEFINE_CLSID!(WebUIApplication(&[87,105,110,100,111,119,115,46,85,73,46,87,101,98,85,73,46,87,101,98,85,73,65,112,112,108,105,99,97,116,105,111,110,0]) [CLSID_WebUIApplication]);
+DEFINE_CLSID!(WebUIApplication: "Windows.UI.WebUI.WebUIApplication");
 #[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderAddAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderAddAppointmentActivatedEventArgs}
 #[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderAddAppointmentActivatedEventArgs: IInspectable}
 #[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderRemoveAppointmentActivatedEventArgs}
@@ -12439,7 +12439,7 @@ impl WebUIBackgroundTaskInstance {
         <Self as RtActivatable<IWebUIBackgroundTaskInstanceStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(WebUIBackgroundTaskInstance(&[87,105,110,100,111,119,115,46,85,73,46,87,101,98,85,73,46,87,101,98,85,73,66,97,99,107,103,114,111,117,110,100,84,97,115,107,73,110,115,116,97,110,99,101,0]) [CLSID_WebUIBackgroundTaskInstance]);
+DEFINE_CLSID!(WebUIBackgroundTaskInstance: "Windows.UI.WebUI.WebUIBackgroundTaskInstance");
 RT_CLASS!{class WebUIBackgroundTaskInstanceRuntimeClass: IWebUIBackgroundTaskInstance}
 DEFINE_IID!(IID_IWebUIBackgroundTaskInstanceStatics, 2625262225, 6574, 19619, 185, 75, 254, 78, 199, 68, 167, 64);
 RT_INTERFACE!{static interface IWebUIBackgroundTaskInstanceStatics(IWebUIBackgroundTaskInstanceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebUIBackgroundTaskInstanceStatics] {
@@ -12584,7 +12584,7 @@ impl AdaptiveCardBuilder {
         <Self as RtActivatable<IAdaptiveCardBuilderStatics>>::get_activation_factory().create_adaptive_card_from_json(value)
     }}
 }
-DEFINE_CLSID!(AdaptiveCardBuilder(&[87,105,110,100,111,119,115,46,85,73,46,83,104,101,108,108,46,65,100,97,112,116,105,118,101,67,97,114,100,66,117,105,108,100,101,114,0]) [CLSID_AdaptiveCardBuilder]);
+DEFINE_CLSID!(AdaptiveCardBuilder: "Windows.UI.Shell.AdaptiveCardBuilder");
 DEFINE_IID!(IID_IAdaptiveCardBuilderStatics, 1986891528, 54270, 17223, 160, 188, 185, 234, 154, 109, 194, 142);
 RT_INTERFACE!{static interface IAdaptiveCardBuilderStatics(IAdaptiveCardBuilderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveCardBuilderStatics] {
     fn CreateAdaptiveCardFromJson(&self, value: HSTRING, out: *mut *mut IAdaptiveCard) -> HRESULT
@@ -12644,7 +12644,7 @@ impl TaskbarManager {
         <Self as RtActivatable<ITaskbarManagerStatics>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(TaskbarManager(&[87,105,110,100,111,119,115,46,85,73,46,83,104,101,108,108,46,84,97,115,107,98,97,114,77,97,110,97,103,101,114,0]) [CLSID_TaskbarManager]);
+DEFINE_CLSID!(TaskbarManager: "Windows.UI.Shell.TaskbarManager");
 DEFINE_IID!(IID_ITaskbarManagerStatics, 3677530996, 56914, 20454, 183, 182, 149, 255, 159, 131, 149, 223);
 RT_INTERFACE!{static interface ITaskbarManagerStatics(ITaskbarManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITaskbarManagerStatics] {
     fn GetDefault(&self, out: *mut *mut TaskbarManager) -> HRESULT
@@ -12700,7 +12700,7 @@ impl JumpList {
         <Self as RtActivatable<IJumpListStatics>>::get_activation_factory().is_supported()
     }}
 }
-DEFINE_CLSID!(JumpList(&[87,105,110,100,111,119,115,46,85,73,46,83,116,97,114,116,83,99,114,101,101,110,46,74,117,109,112,76,105,115,116,0]) [CLSID_JumpList]);
+DEFINE_CLSID!(JumpList: "Windows.UI.StartScreen.JumpList");
 DEFINE_IID!(IID_IJumpListItem, 2061199127, 35677, 18464, 153, 91, 155, 65, 141, 190, 72, 176);
 RT_INTERFACE!{interface IJumpListItem(IJumpListItemVtbl): IInspectable(IInspectableVtbl) [IID_IJumpListItem] {
     fn get_Kind(&self, out: *mut JumpListItemKind) -> HRESULT,
@@ -12778,7 +12778,7 @@ impl JumpListItem {
         <Self as RtActivatable<IJumpListItemStatics>>::get_activation_factory().create_separator()
     }}
 }
-DEFINE_CLSID!(JumpListItem(&[87,105,110,100,111,119,115,46,85,73,46,83,116,97,114,116,83,99,114,101,101,110,46,74,117,109,112,76,105,115,116,73,116,101,109,0]) [CLSID_JumpListItem]);
+DEFINE_CLSID!(JumpListItem: "Windows.UI.StartScreen.JumpListItem");
 RT_ENUM! { enum JumpListItemKind: i32 {
     Arguments (JumpListItemKind_Arguments) = 0, Separator (JumpListItemKind_Separator) = 1,
 }}
@@ -13041,7 +13041,7 @@ impl SecondaryTile {
         <Self as RtActivatable<ISecondaryTileStatics>>::get_activation_factory().find_all_for_package_async()
     }}
 }
-DEFINE_CLSID!(SecondaryTile(&[87,105,110,100,111,119,115,46,85,73,46,83,116,97,114,116,83,99,114,101,101,110,46,83,101,99,111,110,100,97,114,121,84,105,108,101,0]) [CLSID_SecondaryTile]);
+DEFINE_CLSID!(SecondaryTile: "Windows.UI.StartScreen.SecondaryTile");
 DEFINE_IID!(IID_ISecondaryTile2, 3002518581, 12880, 18832, 146, 60, 41, 74, 180, 182, 148, 221);
 RT_INTERFACE!{interface ISecondaryTile2(ISecondaryTile2Vtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryTile2] {
     fn put_PhoneticName(&self, value: HSTRING) -> HRESULT,
@@ -13348,7 +13348,7 @@ impl StartScreenManager {
         <Self as RtActivatable<IStartScreenManagerStatics>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(StartScreenManager(&[87,105,110,100,111,119,115,46,85,73,46,83,116,97,114,116,83,99,114,101,101,110,46,83,116,97,114,116,83,99,114,101,101,110,77,97,110,97,103,101,114,0]) [CLSID_StartScreenManager]);
+DEFINE_CLSID!(StartScreenManager: "Windows.UI.StartScreen.StartScreenManager");
 DEFINE_IID!(IID_IStartScreenManagerStatics, 2019946255, 46469, 17998, 137, 147, 52, 232, 248, 115, 141, 72);
 RT_INTERFACE!{static interface IStartScreenManagerStatics(IStartScreenManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStartScreenManagerStatics] {
     fn GetDefault(&self, out: *mut *mut StartScreenManager) -> HRESULT,
@@ -13538,7 +13538,7 @@ impl MessageDialog {
         <Self as RtActivatable<IMessageDialogFactory>>::get_activation_factory().create_with_title(content, title)
     }}
 }
-DEFINE_CLSID!(MessageDialog(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,77,101,115,115,97,103,101,68,105,97,108,111,103,0]) [CLSID_MessageDialog]);
+DEFINE_CLSID!(MessageDialog: "Windows.UI.Popups.MessageDialog");
 DEFINE_IID!(IID_IMessageDialogFactory, 756422519, 42607, 20133, 187, 135, 121, 63, 250, 73, 65, 242);
 RT_INTERFACE!{static interface IMessageDialogFactory(IMessageDialogFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMessageDialogFactory] {
     fn Create(&self, content: HSTRING, out: *mut *mut MessageDialog) -> HRESULT,
@@ -13593,7 +13593,7 @@ impl IPopupMenu {
 }
 RT_CLASS!{class PopupMenu: IPopupMenu}
 impl RtActivatable<IActivationFactory> for PopupMenu {}
-DEFINE_CLSID!(PopupMenu(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,80,111,112,117,112,77,101,110,117,0]) [CLSID_PopupMenu]);
+DEFINE_CLSID!(PopupMenu: "Windows.UI.Popups.PopupMenu");
 DEFINE_IID!(IID_IUICommand, 1341733493, 16709, 18431, 172, 127, 223, 241, 193, 250, 91, 15);
 RT_INTERFACE!{interface IUICommand(IUICommandVtbl): IInspectable(IInspectableVtbl) [IID_IUICommand] {
     fn get_Label(&self, out: *mut HSTRING) -> HRESULT,
@@ -13646,7 +13646,7 @@ impl UICommand {
         <Self as RtActivatable<IUICommandFactory>>::get_activation_factory().create_with_handler_and_id(label, action, commandId)
     }}
 }
-DEFINE_CLSID!(UICommand(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,85,73,67,111,109,109,97,110,100,0]) [CLSID_UICommand]);
+DEFINE_CLSID!(UICommand: "Windows.UI.Popups.UICommand");
 DEFINE_IID!(IID_IUICommandFactory, 2719646089, 9904, 18038, 174, 148, 84, 4, 27, 193, 37, 232);
 RT_INTERFACE!{static interface IUICommandFactory(IUICommandFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IUICommandFactory] {
     fn Create(&self, label: HSTRING, out: *mut *mut UICommand) -> HRESULT,
@@ -13682,7 +13682,7 @@ impl UICommandInvokedHandler {
 }
 RT_CLASS!{class UICommandSeparator: IUICommand}
 impl RtActivatable<IActivationFactory> for UICommandSeparator {}
-DEFINE_CLSID!(UICommandSeparator(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,85,73,67,111,109,109,97,110,100,83,101,112,97,114,97,116,111,114,0]) [CLSID_UICommandSeparator]);
+DEFINE_CLSID!(UICommandSeparator: "Windows.UI.Popups.UICommandSeparator");
 } // Windows.UI.Popups
 pub mod notifications { // Windows.UI.Notifications
 use ::prelude::*;
@@ -13735,7 +13735,7 @@ impl IAdaptiveNotificationText {
 }
 RT_CLASS!{class AdaptiveNotificationText: IAdaptiveNotificationText}
 impl RtActivatable<IActivationFactory> for AdaptiveNotificationText {}
-DEFINE_CLSID!(AdaptiveNotificationText(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,65,100,97,112,116,105,118,101,78,111,116,105,102,105,99,97,116,105,111,110,84,101,120,116,0]) [CLSID_AdaptiveNotificationText]);
+DEFINE_CLSID!(AdaptiveNotificationText: "Windows.UI.Notifications.AdaptiveNotificationText");
 DEFINE_IID!(IID_IBadgeNotification, 123516106, 53386, 20015, 146, 51, 126, 40, 156, 31, 119, 34);
 RT_INTERFACE!{interface IBadgeNotification(IBadgeNotificationVtbl): IInspectable(IInspectableVtbl) [IID_IBadgeNotification] {
     #[cfg(not(feature="windows-data"))] fn __Dummy0(&self) -> (),
@@ -13766,7 +13766,7 @@ impl BadgeNotification {
         <Self as RtActivatable<IBadgeNotificationFactory>>::get_activation_factory().create_badge_notification(content)
     }}
 }
-DEFINE_CLSID!(BadgeNotification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,66,97,100,103,101,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_BadgeNotification]);
+DEFINE_CLSID!(BadgeNotification: "Windows.UI.Notifications.BadgeNotification");
 DEFINE_IID!(IID_IBadgeNotificationFactory, 3992081870, 1560, 19801, 148, 138, 90, 97, 4, 12, 82, 249);
 RT_INTERFACE!{static interface IBadgeNotificationFactory(IBadgeNotificationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBadgeNotificationFactory] {
     #[cfg(feature="windows-data")] fn CreateBadgeNotification(&self, content: *mut super::super::data::xml::dom::XmlDocument, out: *mut *mut BadgeNotification) -> HRESULT
@@ -13801,7 +13801,7 @@ impl BadgeUpdateManager {
         <Self as RtActivatable<IBadgeUpdateManagerStatics2>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(BadgeUpdateManager(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,66,97,100,103,101,85,112,100,97,116,101,77,97,110,97,103,101,114,0]) [CLSID_BadgeUpdateManager]);
+DEFINE_CLSID!(BadgeUpdateManager: "Windows.UI.Notifications.BadgeUpdateManager");
 DEFINE_IID!(IID_IBadgeUpdateManagerForUser, 2573935036, 902, 17637, 186, 141, 12, 16, 119, 166, 46, 146);
 RT_INTERFACE!{interface IBadgeUpdateManagerForUser(IBadgeUpdateManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IBadgeUpdateManagerForUser] {
     fn CreateBadgeUpdaterForApplication(&self, out: *mut *mut BadgeUpdater) -> HRESULT,
@@ -13925,7 +13925,7 @@ impl KnownAdaptiveNotificationHints {
         <Self as RtActivatable<IKnownAdaptiveNotificationHintsStatics>>::get_activation_factory().get_align()
     }}
 }
-DEFINE_CLSID!(KnownAdaptiveNotificationHints(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,75,110,111,119,110,65,100,97,112,116,105,118,101,78,111,116,105,102,105,99,97,116,105,111,110,72,105,110,116,115,0]) [CLSID_KnownAdaptiveNotificationHints]);
+DEFINE_CLSID!(KnownAdaptiveNotificationHints: "Windows.UI.Notifications.KnownAdaptiveNotificationHints");
 DEFINE_IID!(IID_IKnownAdaptiveNotificationHintsStatics, 102786456, 54422, 18813, 134, 146, 79, 125, 124, 39, 112, 223);
 RT_INTERFACE!{static interface IKnownAdaptiveNotificationHintsStatics(IKnownAdaptiveNotificationHintsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownAdaptiveNotificationHintsStatics] {
     fn get_Style(&self, out: *mut HSTRING) -> HRESULT,
@@ -14028,7 +14028,7 @@ impl KnownAdaptiveNotificationTextStyles {
         <Self as RtActivatable<IKnownAdaptiveNotificationTextStylesStatics>>::get_activation_factory().get_header_numeral_subtle()
     }}
 }
-DEFINE_CLSID!(KnownAdaptiveNotificationTextStyles(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,75,110,111,119,110,65,100,97,112,116,105,118,101,78,111,116,105,102,105,99,97,116,105,111,110,84,101,120,116,83,116,121,108,101,115,0]) [CLSID_KnownAdaptiveNotificationTextStyles]);
+DEFINE_CLSID!(KnownAdaptiveNotificationTextStyles: "Windows.UI.Notifications.KnownAdaptiveNotificationTextStyles");
 DEFINE_IID!(IID_IKnownAdaptiveNotificationTextStylesStatics, 539071191, 35222, 17834, 139, 161, 212, 97, 215, 44, 42, 27);
 RT_INTERFACE!{static interface IKnownAdaptiveNotificationTextStylesStatics(IKnownAdaptiveNotificationTextStylesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownAdaptiveNotificationTextStylesStatics] {
     fn get_Caption(&self, out: *mut HSTRING) -> HRESULT,
@@ -14155,7 +14155,7 @@ impl KnownNotificationBindings {
         <Self as RtActivatable<IKnownNotificationBindingsStatics>>::get_activation_factory().get_toast_generic()
     }}
 }
-DEFINE_CLSID!(KnownNotificationBindings(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,75,110,111,119,110,78,111,116,105,102,105,99,97,116,105,111,110,66,105,110,100,105,110,103,115,0]) [CLSID_KnownNotificationBindings]);
+DEFINE_CLSID!(KnownNotificationBindings: "Windows.UI.Notifications.KnownNotificationBindings");
 DEFINE_IID!(IID_IKnownNotificationBindingsStatics, 2034400174, 43191, 19800, 137, 234, 118, 167, 183, 188, 205, 237);
 RT_INTERFACE!{static interface IKnownNotificationBindingsStatics(IKnownNotificationBindingsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownNotificationBindingsStatics] {
     fn get_ToastGeneric(&self, out: *mut HSTRING) -> HRESULT
@@ -14196,7 +14196,7 @@ impl INotification {
 }
 RT_CLASS!{class Notification: INotification}
 impl RtActivatable<IActivationFactory> for Notification {}
-DEFINE_CLSID!(Notification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_Notification]);
+DEFINE_CLSID!(Notification: "Windows.UI.Notifications.Notification");
 DEFINE_IID!(IID_INotificationBinding, 4070460293, 880, 19155, 180, 234, 218, 158, 53, 231, 234, 191);
 RT_INTERFACE!{interface INotificationBinding(INotificationBindingVtbl): IInspectable(IInspectableVtbl) [IID_INotificationBinding] {
     fn get_Template(&self, out: *mut HSTRING) -> HRESULT,
@@ -14270,7 +14270,7 @@ impl NotificationData {
         <Self as RtActivatable<INotificationDataFactory>>::get_activation_factory().create_notification_data_with_values(initialValues)
     }}
 }
-DEFINE_CLSID!(NotificationData(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,78,111,116,105,102,105,99,97,116,105,111,110,68,97,116,97,0]) [CLSID_NotificationData]);
+DEFINE_CLSID!(NotificationData: "Windows.UI.Notifications.NotificationData");
 DEFINE_IID!(IID_INotificationDataFactory, 599909178, 7184, 18171, 128, 64, 222, 195, 132, 98, 28, 248);
 RT_INTERFACE!{static interface INotificationDataFactory(INotificationDataFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INotificationDataFactory] {
     fn CreateNotificationDataWithValuesAndSequenceNumber(&self, initialValues: *mut super::super::foundation::collections::IIterable<super::super::foundation::collections::IKeyValuePair<HString, HString>>, sequenceNumber: u32, out: *mut *mut NotificationData) -> HRESULT,
@@ -14390,7 +14390,7 @@ impl ScheduledTileNotification {
         <Self as RtActivatable<IScheduledTileNotificationFactory>>::get_activation_factory().create_scheduled_tile_notification(content, deliveryTime)
     }}
 }
-DEFINE_CLSID!(ScheduledTileNotification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,83,99,104,101,100,117,108,101,100,84,105,108,101,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_ScheduledTileNotification]);
+DEFINE_CLSID!(ScheduledTileNotification: "Windows.UI.Notifications.ScheduledTileNotification");
 DEFINE_IID!(IID_IScheduledTileNotificationFactory, 864228234, 39104, 19515, 187, 214, 74, 99, 60, 124, 252, 41);
 RT_INTERFACE!{static interface IScheduledTileNotificationFactory(IScheduledTileNotificationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IScheduledTileNotificationFactory] {
     #[cfg(feature="windows-data")] fn CreateScheduledTileNotification(&self, content: *mut super::super::data::xml::dom::XmlDocument, deliveryTime: super::super::foundation::DateTime, out: *mut *mut ScheduledTileNotification) -> HRESULT
@@ -14453,7 +14453,7 @@ impl ScheduledToastNotification {
         <Self as RtActivatable<IScheduledToastNotificationFactory>>::get_activation_factory().create_scheduled_toast_notification_recurring(content, deliveryTime, snoozeInterval, maximumSnoozeCount)
     }}
 }
-DEFINE_CLSID!(ScheduledToastNotification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,83,99,104,101,100,117,108,101,100,84,111,97,115,116,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_ScheduledToastNotification]);
+DEFINE_CLSID!(ScheduledToastNotification: "Windows.UI.Notifications.ScheduledToastNotification");
 DEFINE_IID!(IID_IScheduledToastNotification2, 2792267932, 12724, 17328, 181, 221, 122, 64, 232, 83, 99, 177);
 RT_INTERFACE!{interface IScheduledToastNotification2(IScheduledToastNotification2Vtbl): IInspectable(IInspectableVtbl) [IID_IScheduledToastNotification2] {
     fn put_Tag(&self, value: HSTRING) -> HRESULT,
@@ -14578,7 +14578,7 @@ impl TileFlyoutNotification {
         <Self as RtActivatable<ITileFlyoutNotificationFactory>>::get_activation_factory().create_tile_flyout_notification(content)
     }}
 }
-DEFINE_CLSID!(TileFlyoutNotification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,105,108,101,70,108,121,111,117,116,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_TileFlyoutNotification]);
+DEFINE_CLSID!(TileFlyoutNotification: "Windows.UI.Notifications.TileFlyoutNotification");
 DEFINE_IID!(IID_ITileFlyoutNotificationFactory, 4015353845, 21030, 20267, 178, 120, 136, 163, 93, 254, 86, 159);
 RT_INTERFACE!{static interface ITileFlyoutNotificationFactory(ITileFlyoutNotificationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ITileFlyoutNotificationFactory] {
     #[cfg(feature="windows-data")] fn CreateTileFlyoutNotification(&self, content: *mut super::super::data::xml::dom::XmlDocument, out: *mut *mut TileFlyoutNotification) -> HRESULT
@@ -14609,7 +14609,7 @@ impl TileFlyoutUpdateManager {
         <Self as RtActivatable<ITileFlyoutUpdateManagerStatics>>::get_activation_factory().get_template_content(type_)
     }}
 }
-DEFINE_CLSID!(TileFlyoutUpdateManager(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,105,108,101,70,108,121,111,117,116,85,112,100,97,116,101,77,97,110,97,103,101,114,0]) [CLSID_TileFlyoutUpdateManager]);
+DEFINE_CLSID!(TileFlyoutUpdateManager: "Windows.UI.Notifications.TileFlyoutUpdateManager");
 DEFINE_IID!(IID_ITileFlyoutUpdateManagerStatics, 70662923, 6848, 19353, 136, 231, 173, 168, 62, 149, 61, 72);
 RT_INTERFACE!{static interface ITileFlyoutUpdateManagerStatics(ITileFlyoutUpdateManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITileFlyoutUpdateManagerStatics] {
     fn CreateTileFlyoutUpdaterForApplication(&self, out: *mut *mut TileFlyoutUpdater) -> HRESULT,
@@ -14717,7 +14717,7 @@ impl TileNotification {
         <Self as RtActivatable<ITileNotificationFactory>>::get_activation_factory().create_tile_notification(content)
     }}
 }
-DEFINE_CLSID!(TileNotification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,105,108,101,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_TileNotification]);
+DEFINE_CLSID!(TileNotification: "Windows.UI.Notifications.TileNotification");
 DEFINE_IID!(IID_ITileNotificationFactory, 3333152110, 18728, 18120, 189, 191, 129, 160, 71, 222, 160, 212);
 RT_INTERFACE!{static interface ITileNotificationFactory(ITileNotificationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ITileNotificationFactory] {
     #[cfg(feature="windows-data")] fn CreateTileNotification(&self, content: *mut super::super::data::xml::dom::XmlDocument, out: *mut *mut TileNotification) -> HRESULT
@@ -14752,7 +14752,7 @@ impl TileUpdateManager {
         <Self as RtActivatable<ITileUpdateManagerStatics2>>::get_activation_factory().get_for_user(user)
     }}
 }
-DEFINE_CLSID!(TileUpdateManager(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,105,108,101,85,112,100,97,116,101,77,97,110,97,103,101,114,0]) [CLSID_TileUpdateManager]);
+DEFINE_CLSID!(TileUpdateManager: "Windows.UI.Notifications.TileUpdateManager");
 DEFINE_IID!(IID_ITileUpdateManagerForUser, 1427379016, 12002, 20013, 156, 193, 33, 106, 32, 222, 204, 159);
 RT_INTERFACE!{interface ITileUpdateManagerForUser(ITileUpdateManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_ITileUpdateManagerForUser] {
     fn CreateTileUpdaterForApplication(&self, out: *mut *mut TileUpdater) -> HRESULT,
@@ -14974,7 +14974,7 @@ impl ToastCollection {
         <Self as RtActivatable<IToastCollectionFactory>>::get_activation_factory().create_instance(collectionId, displayName, launchArgs, iconUri)
     }}
 }
-DEFINE_CLSID!(ToastCollection(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,111,97,115,116,67,111,108,108,101,99,116,105,111,110,0]) [CLSID_ToastCollection]);
+DEFINE_CLSID!(ToastCollection: "Windows.UI.Notifications.ToastCollection");
 DEFINE_IID!(IID_IToastCollectionFactory, 374199255, 29636, 17655, 180, 255, 251, 109, 75, 241, 244, 198);
 RT_INTERFACE!{static interface IToastCollectionFactory(IToastCollectionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IToastCollectionFactory] {
     fn CreateInstance(&self, collectionId: HSTRING, displayName: HSTRING, launchArgs: HSTRING, iconUri: *mut super::super::foundation::Uri, out: *mut *mut ToastCollection) -> HRESULT
@@ -15128,7 +15128,7 @@ impl ToastNotification {
         <Self as RtActivatable<IToastNotificationFactory>>::get_activation_factory().create_toast_notification(content)
     }}
 }
-DEFINE_CLSID!(ToastNotification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,111,97,115,116,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_ToastNotification]);
+DEFINE_CLSID!(ToastNotification: "Windows.UI.Notifications.ToastNotification");
 DEFINE_IID!(IID_IToastNotification2, 2650513361, 5178, 18702, 144, 191, 185, 251, 167, 19, 45, 231);
 RT_INTERFACE!{interface IToastNotification2(IToastNotification2Vtbl): IInspectable(IInspectableVtbl) [IID_IToastNotification2] {
     fn put_Tag(&self, value: HSTRING) -> HRESULT,
@@ -15359,7 +15359,7 @@ impl ToastNotificationManager {
         <Self as RtActivatable<IToastNotificationManagerStatics5>>::get_activation_factory().get_default()
     }}
 }
-DEFINE_CLSID!(ToastNotificationManager(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,84,111,97,115,116,78,111,116,105,102,105,99,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_ToastNotificationManager]);
+DEFINE_CLSID!(ToastNotificationManager: "Windows.UI.Notifications.ToastNotificationManager");
 DEFINE_IID!(IID_IToastNotificationManagerForUser, 2041272310, 17406, 18555, 138, 127, 153, 86, 114, 0, 174, 148);
 RT_INTERFACE!{interface IToastNotificationManagerForUser(IToastNotificationManagerForUserVtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationManagerForUser] {
     fn CreateToastNotifier(&self, out: *mut *mut ToastNotifier) -> HRESULT,
@@ -15653,7 +15653,7 @@ impl UserNotificationListener {
         <Self as RtActivatable<IUserNotificationListenerStatics>>::get_activation_factory().get_current()
     }}
 }
-DEFINE_CLSID!(UserNotificationListener(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,77,97,110,97,103,101,109,101,110,116,46,85,115,101,114,78,111,116,105,102,105,99,97,116,105,111,110,76,105,115,116,101,110,101,114,0]) [CLSID_UserNotificationListener]);
+DEFINE_CLSID!(UserNotificationListener: "Windows.UI.Notifications.Management.UserNotificationListener");
 RT_ENUM! { enum UserNotificationListenerAccessStatus: i32 {
     Unspecified (UserNotificationListenerAccessStatus_Unspecified) = 0, Allowed (UserNotificationListenerAccessStatus_Allowed) = 1, Denied (UserNotificationListenerAccessStatus_Denied) = 2,
 }}
@@ -15938,7 +15938,7 @@ impl CompositionCapabilities {
         <Self as RtActivatable<ICompositionCapabilitiesStatics>>::get_activation_factory().get_for_current_view()
     }}
 }
-DEFINE_CLSID!(CompositionCapabilities(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,67,111,109,112,111,115,105,116,105,111,110,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_CompositionCapabilities]);
+DEFINE_CLSID!(CompositionCapabilities: "Windows.UI.Composition.CompositionCapabilities");
 DEFINE_IID!(IID_ICompositionCapabilitiesStatics, 4156008558, 25622, 18917, 141, 223, 175, 233, 73, 226, 5, 98);
 RT_INTERFACE!{static interface ICompositionCapabilitiesStatics(ICompositionCapabilitiesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionCapabilitiesStatics] {
     fn GetForCurrentView(&self, out: *mut *mut CompositionCapabilities) -> HRESULT
@@ -16266,7 +16266,7 @@ impl CompositionEffectSourceParameter {
         <Self as RtActivatable<ICompositionEffectSourceParameterFactory>>::get_activation_factory().create(name)
     }}
 }
-DEFINE_CLSID!(CompositionEffectSourceParameter(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,67,111,109,112,111,115,105,116,105,111,110,69,102,102,101,99,116,83,111,117,114,99,101,80,97,114,97,109,101,116,101,114,0]) [CLSID_CompositionEffectSourceParameter]);
+DEFINE_CLSID!(CompositionEffectSourceParameter: "Windows.UI.Composition.CompositionEffectSourceParameter");
 DEFINE_IID!(IID_ICompositionEffectSourceParameterFactory, 3017405046, 43939, 18212, 172, 243, 208, 57, 116, 100, 219, 28);
 RT_INTERFACE!{static interface ICompositionEffectSourceParameterFactory(ICompositionEffectSourceParameterFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionEffectSourceParameterFactory] {
     fn Create(&self, name: HSTRING, out: *mut *mut CompositionEffectSourceParameter) -> HRESULT
@@ -17247,7 +17247,7 @@ impl ICompositor {
 }
 RT_CLASS!{class Compositor: ICompositor}
 impl RtActivatable<IActivationFactory> for Compositor {}
-DEFINE_CLSID!(Compositor(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,67,111,109,112,111,115,105,116,111,114,0]) [CLSID_Compositor]);
+DEFINE_CLSID!(Compositor: "Windows.UI.Composition.Compositor");
 DEFINE_IID!(IID_ICompositor2, 1934655964, 24100, 17882, 163, 143, 227, 44, 195, 73, 169, 160);
 RT_INTERFACE!{interface ICompositor2(ICompositor2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositor2] {
     fn CreateAmbientLight(&self, out: *mut *mut AmbientLight) -> HRESULT,
@@ -18833,7 +18833,7 @@ impl ISceneLightingEffect {
 }
 RT_CLASS!{class SceneLightingEffect: ISceneLightingEffect}
 impl RtActivatable<IActivationFactory> for SceneLightingEffect {}
-DEFINE_CLSID!(SceneLightingEffect(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,69,102,102,101,99,116,115,46,83,99,101,110,101,76,105,103,104,116,105,110,103,69,102,102,101,99,116,0]) [CLSID_SceneLightingEffect]);
+DEFINE_CLSID!(SceneLightingEffect: "Windows.UI.Composition.Effects.SceneLightingEffect");
 DEFINE_IID!(IID_ISceneLightingEffect2, 2653359745, 29424, 19548, 149, 248, 138, 110, 0, 36, 244, 9);
 RT_INTERFACE!{interface ISceneLightingEffect2(ISceneLightingEffect2Vtbl): IInspectable(IInspectableVtbl) [IID_ISceneLightingEffect2] {
     fn get_ReflectanceModel(&self, out: *mut SceneLightingEffectReflectanceModel) -> HRESULT,
@@ -18890,7 +18890,7 @@ impl CompositionConditionalValue {
         <Self as RtActivatable<ICompositionConditionalValueStatics>>::get_activation_factory().create(compositor)
     }}
 }
-DEFINE_CLSID!(CompositionConditionalValue(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,67,111,109,112,111,115,105,116,105,111,110,67,111,110,100,105,116,105,111,110,97,108,86,97,108,117,101,0]) [CLSID_CompositionConditionalValue]);
+DEFINE_CLSID!(CompositionConditionalValue: "Windows.UI.Composition.Interactions.CompositionConditionalValue");
 DEFINE_IID!(IID_ICompositionConditionalValueStatics, 151800690, 33895, 19722, 144, 101, 172, 70, 184, 10, 85, 34);
 RT_INTERFACE!{static interface ICompositionConditionalValueStatics(ICompositionConditionalValueStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionConditionalValueStatics] {
     fn Create(&self, compositor: *mut super::Compositor, out: *mut *mut CompositionConditionalValue) -> HRESULT
@@ -19141,7 +19141,7 @@ impl InteractionTracker {
         <Self as RtActivatable<IInteractionTrackerStatics>>::get_activation_factory().create_with_owner(compositor, owner)
     }}
 }
-DEFINE_CLSID!(InteractionTracker(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,73,110,116,101,114,97,99,116,105,111,110,84,114,97,99,107,101,114,0]) [CLSID_InteractionTracker]);
+DEFINE_CLSID!(InteractionTracker: "Windows.UI.Composition.Interactions.InteractionTracker");
 DEFINE_IID!(IID_IInteractionTracker2, 628529726, 52845, 17548, 131, 134, 146, 98, 13, 36, 7, 86);
 RT_INTERFACE!{interface IInteractionTracker2(IInteractionTracker2Vtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTracker2] {
     fn ConfigureCenterPointXInertiaModifiers(&self, conditionalValues: *mut ::rt::gen::windows::foundation::collections::IIterable<CompositionConditionalValue>) -> HRESULT,
@@ -19234,7 +19234,7 @@ impl InteractionTrackerInertiaMotion {
         <Self as RtActivatable<IInteractionTrackerInertiaMotionStatics>>::get_activation_factory().create(compositor)
     }}
 }
-DEFINE_CLSID!(InteractionTrackerInertiaMotion(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,73,110,116,101,114,97,99,116,105,111,110,84,114,97,99,107,101,114,73,110,101,114,116,105,97,77,111,116,105,111,110,0]) [CLSID_InteractionTrackerInertiaMotion]);
+DEFINE_CLSID!(InteractionTrackerInertiaMotion: "Windows.UI.Composition.Interactions.InteractionTrackerInertiaMotion");
 DEFINE_IID!(IID_IInteractionTrackerInertiaMotionStatics, 2361933270, 47739, 17178, 132, 75, 110, 172, 145, 48, 249, 154);
 RT_INTERFACE!{static interface IInteractionTrackerInertiaMotionStatics(IInteractionTrackerInertiaMotionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerInertiaMotionStatics] {
     fn Create(&self, compositor: *mut super::Compositor, out: *mut *mut InteractionTrackerInertiaMotion) -> HRESULT
@@ -19280,7 +19280,7 @@ impl InteractionTrackerInertiaNaturalMotion {
         <Self as RtActivatable<IInteractionTrackerInertiaNaturalMotionStatics>>::get_activation_factory().create(compositor)
     }}
 }
-DEFINE_CLSID!(InteractionTrackerInertiaNaturalMotion(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,73,110,116,101,114,97,99,116,105,111,110,84,114,97,99,107,101,114,73,110,101,114,116,105,97,78,97,116,117,114,97,108,77,111,116,105,111,110,0]) [CLSID_InteractionTrackerInertiaNaturalMotion]);
+DEFINE_CLSID!(InteractionTrackerInertiaNaturalMotion: "Windows.UI.Composition.Interactions.InteractionTrackerInertiaNaturalMotion");
 DEFINE_IID!(IID_IInteractionTrackerInertiaNaturalMotionStatics, 3487192496, 24126, 17033, 147, 45, 238, 95, 80, 231, 66, 131);
 RT_INTERFACE!{static interface IInteractionTrackerInertiaNaturalMotionStatics(IInteractionTrackerInertiaNaturalMotionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerInertiaNaturalMotionStatics] {
     fn Create(&self, compositor: *mut super::Compositor, out: *mut *mut InteractionTrackerInertiaNaturalMotion) -> HRESULT
@@ -19326,7 +19326,7 @@ impl InteractionTrackerInertiaRestingValue {
         <Self as RtActivatable<IInteractionTrackerInertiaRestingValueStatics>>::get_activation_factory().create(compositor)
     }}
 }
-DEFINE_CLSID!(InteractionTrackerInertiaRestingValue(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,73,110,116,101,114,97,99,116,105,111,110,84,114,97,99,107,101,114,73,110,101,114,116,105,97,82,101,115,116,105,110,103,86,97,108,117,101,0]) [CLSID_InteractionTrackerInertiaRestingValue]);
+DEFINE_CLSID!(InteractionTrackerInertiaRestingValue: "Windows.UI.Composition.Interactions.InteractionTrackerInertiaRestingValue");
 DEFINE_IID!(IID_IInteractionTrackerInertiaRestingValueStatics, 418203289, 1861, 16534, 188, 171, 58, 78, 153, 86, 155, 207);
 RT_INTERFACE!{static interface IInteractionTrackerInertiaRestingValueStatics(IInteractionTrackerInertiaRestingValueStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerInertiaRestingValueStatics] {
     fn Create(&self, compositor: *mut super::Compositor, out: *mut *mut InteractionTrackerInertiaRestingValue) -> HRESULT
@@ -19529,7 +19529,7 @@ impl InteractionTrackerVector2InertiaNaturalMotion {
         <Self as RtActivatable<IInteractionTrackerVector2InertiaNaturalMotionStatics>>::get_activation_factory().create(compositor)
     }}
 }
-DEFINE_CLSID!(InteractionTrackerVector2InertiaNaturalMotion(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,73,110,116,101,114,97,99,116,105,111,110,84,114,97,99,107,101,114,86,101,99,116,111,114,50,73,110,101,114,116,105,97,78,97,116,117,114,97,108,77,111,116,105,111,110,0]) [CLSID_InteractionTrackerVector2InertiaNaturalMotion]);
+DEFINE_CLSID!(InteractionTrackerVector2InertiaNaturalMotion: "Windows.UI.Composition.Interactions.InteractionTrackerVector2InertiaNaturalMotion");
 DEFINE_IID!(IID_IInteractionTrackerVector2InertiaNaturalMotionStatics, 2181044808, 2496, 17231, 129, 137, 20, 28, 102, 223, 54, 47);
 RT_INTERFACE!{static interface IInteractionTrackerVector2InertiaNaturalMotionStatics(IInteractionTrackerVector2InertiaNaturalMotionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerVector2InertiaNaturalMotionStatics] {
     fn Create(&self, compositor: *mut super::Compositor, out: *mut *mut InteractionTrackerVector2InertiaNaturalMotion) -> HRESULT
@@ -19663,7 +19663,7 @@ impl VisualInteractionSource {
         <Self as RtActivatable<IVisualInteractionSourceStatics>>::get_activation_factory().create(source)
     }}
 }
-DEFINE_CLSID!(VisualInteractionSource(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,73,110,116,101,114,97,99,116,105,111,110,115,46,86,105,115,117,97,108,73,110,116,101,114,97,99,116,105,111,110,83,111,117,114,99,101,0]) [CLSID_VisualInteractionSource]);
+DEFINE_CLSID!(VisualInteractionSource: "Windows.UI.Composition.Interactions.VisualInteractionSource");
 DEFINE_IID!(IID_IVisualInteractionSource2, 2861648019, 42812, 16717, 128, 208, 36, 155, 173, 47, 189, 147);
 RT_INTERFACE!{interface IVisualInteractionSource2(IVisualInteractionSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IVisualInteractionSource2] {
     fn get_DeltaPosition(&self, out: *mut ::rt::gen::windows::foundation::numerics::Vector3) -> HRESULT,

--- a/src/rt/gen/windows/web.rs
+++ b/src/rt/gen/windows/web.rs
@@ -17,7 +17,7 @@ impl WebError {
         <Self as RtActivatable<IWebErrorStatics>>::get_activation_factory().get_status(hresult)
     }}
 }
-DEFINE_CLSID!(WebError(&[87,105,110,100,111,119,115,46,87,101,98,46,87,101,98,69,114,114,111,114,0]) [CLSID_WebError]);
+DEFINE_CLSID!(WebError: "Windows.Web.WebError");
 DEFINE_IID!(IID_IWebErrorStatics, 4267796326, 48935, 16484, 135, 183, 101, 99, 187, 17, 206, 46);
 RT_INTERFACE!{static interface IWebErrorStatics(IWebErrorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebErrorStatics] {
     fn GetStatus(&self, hresult: i32, out: *mut WebErrorStatus) -> HRESULT
@@ -44,7 +44,7 @@ impl HttpBufferContent {
         <Self as RtActivatable<IHttpBufferContentFactory>>::get_activation_factory().create_from_buffer_with_offset(content, offset, count)
     }}
 }
-DEFINE_CLSID!(HttpBufferContent(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,66,117,102,102,101,114,67,111,110,116,101,110,116,0]) [CLSID_HttpBufferContent]);
+DEFINE_CLSID!(HttpBufferContent: "Windows.Web.Http.HttpBufferContent");
 DEFINE_IID!(IID_IHttpBufferContentFactory, 3156263315, 50207, 20471, 145, 35, 100, 53, 115, 110, 173, 194);
 RT_INTERFACE!{static interface IHttpBufferContentFactory(IHttpBufferContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpBufferContentFactory] {
     #[cfg(feature="windows-storage")] fn CreateFromBuffer(&self, content: *mut super::super::storage::streams::IBuffer, out: *mut *mut HttpBufferContent) -> HRESULT,
@@ -143,7 +143,7 @@ impl HttpClient {
         <Self as RtActivatable<IHttpClientFactory>>::get_activation_factory().create(filter)
     }}
 }
-DEFINE_CLSID!(HttpClient(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,67,108,105,101,110,116,0]) [CLSID_HttpClient]);
+DEFINE_CLSID!(HttpClient: "Windows.Web.Http.HttpClient");
 DEFINE_IID!(IID_IHttpClientFactory, 3272363722, 58362, 20377, 175, 180, 99, 204, 101, 0, 148, 98);
 RT_INTERFACE!{static interface IHttpClientFactory(IHttpClientFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpClientFactory] {
     fn Create(&self, filter: *mut filters::IHttpFilter, out: *mut *mut HttpClient) -> HRESULT
@@ -279,7 +279,7 @@ impl HttpCookie {
         <Self as RtActivatable<IHttpCookieFactory>>::get_activation_factory().create(name, domain, path)
     }}
 }
-DEFINE_CLSID!(HttpCookie(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,67,111,111,107,105,101,0]) [CLSID_HttpCookie]);
+DEFINE_CLSID!(HttpCookie: "Windows.Web.Http.HttpCookie");
 RT_CLASS!{class HttpCookieCollection: super::super::foundation::collections::IVectorView<HttpCookie>}
 DEFINE_IID!(IID_IHttpCookieFactory, 1778746793, 37660, 19665, 169, 109, 194, 23, 1, 120, 92, 95);
 RT_INTERFACE!{static interface IHttpCookieFactory(IHttpCookieFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpCookieFactory] {
@@ -328,7 +328,7 @@ impl HttpFormUrlEncodedContent {
         <Self as RtActivatable<IHttpFormUrlEncodedContentFactory>>::get_activation_factory().create(content)
     }}
 }
-DEFINE_CLSID!(HttpFormUrlEncodedContent(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,70,111,114,109,85,114,108,69,110,99,111,100,101,100,67,111,110,116,101,110,116,0]) [CLSID_HttpFormUrlEncodedContent]);
+DEFINE_CLSID!(HttpFormUrlEncodedContent: "Windows.Web.Http.HttpFormUrlEncodedContent");
 DEFINE_IID!(IID_IHttpFormUrlEncodedContentFactory, 1139807116, 12147, 17154, 181, 243, 234, 233, 35, 138, 94, 1);
 RT_INTERFACE!{static interface IHttpFormUrlEncodedContentFactory(IHttpFormUrlEncodedContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpFormUrlEncodedContentFactory] {
     fn Create(&self, content: *mut super::super::foundation::collections::IIterable<super::super::foundation::collections::IKeyValuePair<HString, HString>>, out: *mut *mut HttpFormUrlEncodedContent) -> HRESULT
@@ -380,7 +380,7 @@ impl HttpMethod {
         <Self as RtActivatable<IHttpMethodStatics>>::get_activation_factory().get_put()
     }}
 }
-DEFINE_CLSID!(HttpMethod(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,77,101,116,104,111,100,0]) [CLSID_HttpMethod]);
+DEFINE_CLSID!(HttpMethod: "Windows.Web.Http.HttpMethod");
 DEFINE_IID!(IID_IHttpMethodFactory, 1011994893, 14039, 16632, 168, 109, 231, 89, 202, 242, 248, 63);
 RT_INTERFACE!{static interface IHttpMethodFactory(IHttpMethodFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpMethodFactory] {
     fn Create(&self, method: HSTRING, out: *mut *mut HttpMethod) -> HRESULT
@@ -460,7 +460,7 @@ impl HttpMultipartContent {
         <Self as RtActivatable<IHttpMultipartContentFactory>>::get_activation_factory().create_with_subtype_and_boundary(subtype, boundary)
     }}
 }
-DEFINE_CLSID!(HttpMultipartContent(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,77,117,108,116,105,112,97,114,116,67,111,110,116,101,110,116,0]) [CLSID_HttpMultipartContent]);
+DEFINE_CLSID!(HttpMultipartContent: "Windows.Web.Http.HttpMultipartContent");
 DEFINE_IID!(IID_IHttpMultipartContentFactory, 2125737570, 546, 20256, 179, 114, 71, 213, 219, 93, 51, 180);
 RT_INTERFACE!{static interface IHttpMultipartContentFactory(IHttpMultipartContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpMultipartContentFactory] {
     fn CreateWithSubtype(&self, subtype: HSTRING, out: *mut *mut HttpMultipartContent) -> HRESULT,
@@ -506,7 +506,7 @@ impl HttpMultipartFormDataContent {
         <Self as RtActivatable<IHttpMultipartFormDataContentFactory>>::get_activation_factory().create_with_boundary(boundary)
     }}
 }
-DEFINE_CLSID!(HttpMultipartFormDataContent(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,77,117,108,116,105,112,97,114,116,70,111,114,109,68,97,116,97,67,111,110,116,101,110,116,0]) [CLSID_HttpMultipartFormDataContent]);
+DEFINE_CLSID!(HttpMultipartFormDataContent: "Windows.Web.Http.HttpMultipartFormDataContent");
 DEFINE_IID!(IID_IHttpMultipartFormDataContentFactory, 2689430289, 20503, 17954, 147, 168, 73, 178, 74, 79, 203, 252);
 RT_INTERFACE!{static interface IHttpMultipartFormDataContentFactory(IHttpMultipartFormDataContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpMultipartFormDataContentFactory] {
     fn CreateWithBoundary(&self, boundary: HSTRING, out: *mut *mut HttpMultipartFormDataContent) -> HRESULT
@@ -588,7 +588,7 @@ impl HttpRequestMessage {
         <Self as RtActivatable<IHttpRequestMessageFactory>>::get_activation_factory().create(method, uri)
     }}
 }
-DEFINE_CLSID!(HttpRequestMessage(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,82,101,113,117,101,115,116,77,101,115,115,97,103,101,0]) [CLSID_HttpRequestMessage]);
+DEFINE_CLSID!(HttpRequestMessage: "Windows.Web.Http.HttpRequestMessage");
 DEFINE_IID!(IID_IHttpRequestMessageFactory, 1538038094, 14470, 16686, 174, 195, 82, 236, 127, 37, 97, 111);
 RT_INTERFACE!{static interface IHttpRequestMessageFactory(IHttpRequestMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpRequestMessageFactory] {
     fn Create(&self, method: *mut HttpMethod, uri: *mut super::super::foundation::Uri, out: *mut *mut HttpRequestMessage) -> HRESULT
@@ -697,7 +697,7 @@ impl HttpResponseMessage {
         <Self as RtActivatable<IHttpResponseMessageFactory>>::get_activation_factory().create(statusCode)
     }}
 }
-DEFINE_CLSID!(HttpResponseMessage(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,82,101,115,112,111,110,115,101,77,101,115,115,97,103,101,0]) [CLSID_HttpResponseMessage]);
+DEFINE_CLSID!(HttpResponseMessage: "Windows.Web.Http.HttpResponseMessage");
 DEFINE_IID!(IID_IHttpResponseMessageFactory, 1386786713, 61589, 17370, 182, 15, 124, 252, 43, 199, 234, 47);
 RT_INTERFACE!{static interface IHttpResponseMessageFactory(IHttpResponseMessageFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpResponseMessageFactory] {
     fn Create(&self, statusCode: HttpStatusCode, out: *mut *mut HttpResponseMessage) -> HRESULT
@@ -722,7 +722,7 @@ impl HttpStreamContent {
         <Self as RtActivatable<IHttpStreamContentFactory>>::get_activation_factory().create_from_input_stream(content)
     }}
 }
-DEFINE_CLSID!(HttpStreamContent(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,83,116,114,101,97,109,67,111,110,116,101,110,116,0]) [CLSID_HttpStreamContent]);
+DEFINE_CLSID!(HttpStreamContent: "Windows.Web.Http.HttpStreamContent");
 DEFINE_IID!(IID_IHttpStreamContentFactory, 4091956637, 63269, 16510, 148, 47, 14, 218, 24, 152, 9, 244);
 RT_INTERFACE!{static interface IHttpStreamContentFactory(IHttpStreamContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpStreamContentFactory] {
     #[cfg(feature="windows-storage")] fn CreateFromInputStream(&self, content: *mut super::super::storage::streams::IInputStream, out: *mut *mut HttpStreamContent) -> HRESULT
@@ -747,7 +747,7 @@ impl HttpStringContent {
         <Self as RtActivatable<IHttpStringContentFactory>>::get_activation_factory().create_from_string_with_encoding_and_media_type(content, encoding, mediaType)
     }}
 }
-DEFINE_CLSID!(HttpStringContent(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,83,116,114,105,110,103,67,111,110,116,101,110,116,0]) [CLSID_HttpStringContent]);
+DEFINE_CLSID!(HttpStringContent: "Windows.Web.Http.HttpStringContent");
 DEFINE_IID!(IID_IHttpStringContentFactory, 1180999003, 11923, 18667, 142, 97, 25, 103, 120, 120, 229, 127);
 RT_INTERFACE!{static interface IHttpStringContentFactory(IHttpStringContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpStringContentFactory] {
     fn CreateFromString(&self, content: HSTRING, out: *mut *mut HttpStringContent) -> HRESULT,
@@ -927,7 +927,7 @@ impl IHttpBaseProtocolFilter {
 }
 RT_CLASS!{class HttpBaseProtocolFilter: IHttpBaseProtocolFilter}
 impl RtActivatable<IActivationFactory> for HttpBaseProtocolFilter {}
-DEFINE_CLSID!(HttpBaseProtocolFilter(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,70,105,108,116,101,114,115,46,72,116,116,112,66,97,115,101,80,114,111,116,111,99,111,108,70,105,108,116,101,114,0]) [CLSID_HttpBaseProtocolFilter]);
+DEFINE_CLSID!(HttpBaseProtocolFilter: "Windows.Web.Http.Filters.HttpBaseProtocolFilter");
 DEFINE_IID!(IID_IHttpBaseProtocolFilter2, 784531475, 37927, 18688, 160, 23, 250, 125, 163, 181, 201, 174);
 RT_INTERFACE!{interface IHttpBaseProtocolFilter2(IHttpBaseProtocolFilter2Vtbl): IInspectable(IInspectableVtbl) [IID_IHttpBaseProtocolFilter2] {
     fn get_MaxVersion(&self, out: *mut super::HttpVersion) -> HRESULT,
@@ -1184,7 +1184,7 @@ impl HttpChallengeHeaderValue {
         <Self as RtActivatable<IHttpChallengeHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpChallengeHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,104,97,108,108,101,110,103,101,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpChallengeHeaderValue]);
+DEFINE_CLSID!(HttpChallengeHeaderValue: "Windows.Web.Http.Headers.HttpChallengeHeaderValue");
 DEFINE_IID!(IID_IHttpChallengeHeaderValueCollection, 3399376769, 44768, 17235, 161, 11, 230, 37, 186, 189, 100, 194);
 RT_INTERFACE!{interface IHttpChallengeHeaderValueCollection(IHttpChallengeHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpChallengeHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -1261,7 +1261,7 @@ impl HttpConnectionOptionHeaderValue {
         <Self as RtActivatable<IHttpConnectionOptionHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpConnectionOptionHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,110,101,99,116,105,111,110,79,112,116,105,111,110,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpConnectionOptionHeaderValue]);
+DEFINE_CLSID!(HttpConnectionOptionHeaderValue: "Windows.Web.Http.Headers.HttpConnectionOptionHeaderValue");
 DEFINE_IID!(IID_IHttpConnectionOptionHeaderValueCollection, 3841289245, 20802, 19968, 142, 15, 1, 149, 9, 51, 118, 41);
 RT_INTERFACE!{interface IHttpConnectionOptionHeaderValueCollection(IHttpConnectionOptionHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpConnectionOptionHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -1332,7 +1332,7 @@ impl HttpContentCodingHeaderValue {
         <Self as RtActivatable<IHttpContentCodingHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpContentCodingHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,116,101,110,116,67,111,100,105,110,103,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpContentCodingHeaderValue]);
+DEFINE_CLSID!(HttpContentCodingHeaderValue: "Windows.Web.Http.Headers.HttpContentCodingHeaderValue");
 DEFINE_IID!(IID_IHttpContentCodingHeaderValueCollection, 2099386145, 42715, 17262, 142, 131, 145, 89, 97, 146, 129, 156);
 RT_INTERFACE!{interface IHttpContentCodingHeaderValueCollection(IHttpContentCodingHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentCodingHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -1412,7 +1412,7 @@ impl HttpContentCodingWithQualityHeaderValue {
         <Self as RtActivatable<IHttpContentCodingWithQualityHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpContentCodingWithQualityHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,116,101,110,116,67,111,100,105,110,103,87,105,116,104,81,117,97,108,105,116,121,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpContentCodingWithQualityHeaderValue]);
+DEFINE_CLSID!(HttpContentCodingWithQualityHeaderValue: "Windows.Web.Http.Headers.HttpContentCodingWithQualityHeaderValue");
 DEFINE_IID!(IID_IHttpContentCodingWithQualityHeaderValueCollection, 2081256766, 59545, 17272, 181, 200, 65, 45, 130, 7, 17, 204);
 RT_INTERFACE!{interface IHttpContentCodingWithQualityHeaderValueCollection(IHttpContentCodingWithQualityHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentCodingWithQualityHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -1544,7 +1544,7 @@ impl HttpContentDispositionHeaderValue {
         <Self as RtActivatable<IHttpContentDispositionHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpContentDispositionHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,116,101,110,116,68,105,115,112,111,115,105,116,105,111,110,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpContentDispositionHeaderValue]);
+DEFINE_CLSID!(HttpContentDispositionHeaderValue: "Windows.Web.Http.Headers.HttpContentDispositionHeaderValue");
 DEFINE_IID!(IID_IHttpContentDispositionHeaderValueFactory, 2568338372, 17772, 20097, 130, 149, 178, 171, 60, 188, 245, 69);
 RT_INTERFACE!{static interface IHttpContentDispositionHeaderValueFactory(IHttpContentDispositionHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentDispositionHeaderValueFactory] {
     fn Create(&self, dispositionType: HSTRING, out: *mut *mut HttpContentDispositionHeaderValue) -> HRESULT
@@ -1693,7 +1693,7 @@ impl IHttpContentHeaderCollection {
 }
 RT_CLASS!{class HttpContentHeaderCollection: IHttpContentHeaderCollection}
 impl RtActivatable<IActivationFactory> for HttpContentHeaderCollection {}
-DEFINE_CLSID!(HttpContentHeaderCollection(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,116,101,110,116,72,101,97,100,101,114,67,111,108,108,101,99,116,105,111,110,0]) [CLSID_HttpContentHeaderCollection]);
+DEFINE_CLSID!(HttpContentHeaderCollection: "Windows.Web.Http.Headers.HttpContentHeaderCollection");
 DEFINE_IID!(IID_IHttpContentRangeHeaderValue, 81356755, 42230, 18780, 149, 48, 133, 121, 252, 186, 138, 169);
 RT_INTERFACE!{interface IHttpContentRangeHeaderValue(IHttpContentRangeHeaderValueVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentRangeHeaderValue] {
     fn get_FirstBytePosition(&self, out: *mut *mut ::rt::gen::windows::foundation::IReference<u64>) -> HRESULT,
@@ -1748,7 +1748,7 @@ impl HttpContentRangeHeaderValue {
         <Self as RtActivatable<IHttpContentRangeHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpContentRangeHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,116,101,110,116,82,97,110,103,101,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpContentRangeHeaderValue]);
+DEFINE_CLSID!(HttpContentRangeHeaderValue: "Windows.Web.Http.Headers.HttpContentRangeHeaderValue");
 DEFINE_IID!(IID_IHttpContentRangeHeaderValueFactory, 1062983313, 41020, 17494, 154, 111, 239, 39, 236, 208, 60, 174);
 RT_INTERFACE!{static interface IHttpContentRangeHeaderValueFactory(IHttpContentRangeHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentRangeHeaderValueFactory] {
     fn CreateFromLength(&self, length: u64, out: *mut *mut HttpContentRangeHeaderValue) -> HRESULT,
@@ -1828,7 +1828,7 @@ impl HttpCookiePairHeaderValue {
         <Self as RtActivatable<IHttpCookiePairHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpCookiePairHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,111,107,105,101,80,97,105,114,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpCookiePairHeaderValue]);
+DEFINE_CLSID!(HttpCookiePairHeaderValue: "Windows.Web.Http.Headers.HttpCookiePairHeaderValue");
 DEFINE_IID!(IID_IHttpCookiePairHeaderValueCollection, 4092871504, 22558, 20172, 159, 89, 229, 7, 208, 79, 6, 230);
 RT_INTERFACE!{interface IHttpCookiePairHeaderValueCollection(IHttpCookiePairHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpCookiePairHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -1920,7 +1920,7 @@ impl HttpCredentialsHeaderValue {
         <Self as RtActivatable<IHttpCredentialsHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpCredentialsHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,114,101,100,101,110,116,105,97,108,115,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpCredentialsHeaderValue]);
+DEFINE_CLSID!(HttpCredentialsHeaderValue: "Windows.Web.Http.Headers.HttpCredentialsHeaderValue");
 DEFINE_IID!(IID_IHttpCredentialsHeaderValueFactory, 4062027409, 19740, 16770, 191, 209, 52, 71, 10, 98, 249, 80);
 RT_INTERFACE!{static interface IHttpCredentialsHeaderValueFactory(IHttpCredentialsHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpCredentialsHeaderValueFactory] {
     fn CreateFromScheme(&self, scheme: HSTRING, out: *mut *mut HttpCredentialsHeaderValue) -> HRESULT,
@@ -1982,7 +1982,7 @@ impl HttpDateOrDeltaHeaderValue {
         <Self as RtActivatable<IHttpDateOrDeltaHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpDateOrDeltaHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,68,97,116,101,79,114,68,101,108,116,97,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpDateOrDeltaHeaderValue]);
+DEFINE_CLSID!(HttpDateOrDeltaHeaderValue: "Windows.Web.Http.Headers.HttpDateOrDeltaHeaderValue");
 DEFINE_IID!(IID_IHttpDateOrDeltaHeaderValueStatics, 2082888104, 26226, 20112, 154, 154, 243, 151, 102, 247, 245, 118);
 RT_INTERFACE!{static interface IHttpDateOrDeltaHeaderValueStatics(IHttpDateOrDeltaHeaderValueStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDateOrDeltaHeaderValueStatics] {
     fn Parse(&self, input: HSTRING, out: *mut *mut HttpDateOrDeltaHeaderValue) -> HRESULT,
@@ -2045,7 +2045,7 @@ impl HttpExpectationHeaderValue {
         <Self as RtActivatable<IHttpExpectationHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpExpectationHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,69,120,112,101,99,116,97,116,105,111,110,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpExpectationHeaderValue]);
+DEFINE_CLSID!(HttpExpectationHeaderValue: "Windows.Web.Http.Headers.HttpExpectationHeaderValue");
 DEFINE_IID!(IID_IHttpExpectationHeaderValueCollection, 3884261811, 41186, 19140, 158, 102, 121, 112, 108, 185, 253, 88);
 RT_INTERFACE!{interface IHttpExpectationHeaderValueCollection(IHttpExpectationHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpExpectationHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -2148,7 +2148,7 @@ impl HttpLanguageRangeWithQualityHeaderValue {
         <Self as RtActivatable<IHttpLanguageRangeWithQualityHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpLanguageRangeWithQualityHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,76,97,110,103,117,97,103,101,82,97,110,103,101,87,105,116,104,81,117,97,108,105,116,121,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpLanguageRangeWithQualityHeaderValue]);
+DEFINE_CLSID!(HttpLanguageRangeWithQualityHeaderValue: "Windows.Web.Http.Headers.HttpLanguageRangeWithQualityHeaderValue");
 DEFINE_IID!(IID_IHttpLanguageRangeWithQualityHeaderValueCollection, 2287819453, 19279, 18442, 137, 206, 138, 237, 206, 230, 227, 160);
 RT_INTERFACE!{interface IHttpLanguageRangeWithQualityHeaderValueCollection(IHttpLanguageRangeWithQualityHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpLanguageRangeWithQualityHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -2247,7 +2247,7 @@ impl HttpMediaTypeHeaderValue {
         <Self as RtActivatable<IHttpMediaTypeHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpMediaTypeHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,77,101,100,105,97,84,121,112,101,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpMediaTypeHeaderValue]);
+DEFINE_CLSID!(HttpMediaTypeHeaderValue: "Windows.Web.Http.Headers.HttpMediaTypeHeaderValue");
 DEFINE_IID!(IID_IHttpMediaTypeHeaderValueFactory, 3201779624, 52503, 17117, 147, 103, 171, 156, 91, 86, 221, 125);
 RT_INTERFACE!{static interface IHttpMediaTypeHeaderValueFactory(IHttpMediaTypeHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpMediaTypeHeaderValueFactory] {
     fn Create(&self, mediaType: HSTRING, out: *mut *mut HttpMediaTypeHeaderValue) -> HRESULT
@@ -2337,7 +2337,7 @@ impl HttpMediaTypeWithQualityHeaderValue {
         <Self as RtActivatable<IHttpMediaTypeWithQualityHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpMediaTypeWithQualityHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,77,101,100,105,97,84,121,112,101,87,105,116,104,81,117,97,108,105,116,121,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpMediaTypeWithQualityHeaderValue]);
+DEFINE_CLSID!(HttpMediaTypeWithQualityHeaderValue: "Windows.Web.Http.Headers.HttpMediaTypeWithQualityHeaderValue");
 DEFINE_IID!(IID_IHttpMediaTypeWithQualityHeaderValueCollection, 1007446899, 4930, 17799, 160, 86, 24, 208, 47, 246, 113, 101);
 RT_INTERFACE!{interface IHttpMediaTypeWithQualityHeaderValueCollection(IHttpMediaTypeWithQualityHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpMediaTypeWithQualityHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -2445,7 +2445,7 @@ impl HttpNameValueHeaderValue {
         <Self as RtActivatable<IHttpNameValueHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpNameValueHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,78,97,109,101,86,97,108,117,101,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpNameValueHeaderValue]);
+DEFINE_CLSID!(HttpNameValueHeaderValue: "Windows.Web.Http.Headers.HttpNameValueHeaderValue");
 DEFINE_IID!(IID_IHttpNameValueHeaderValueFactory, 1997415015, 52216, 18230, 169, 37, 147, 251, 225, 12, 124, 168);
 RT_INTERFACE!{static interface IHttpNameValueHeaderValueFactory(IHttpNameValueHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpNameValueHeaderValueFactory] {
     fn CreateFromName(&self, name: HSTRING, out: *mut *mut HttpNameValueHeaderValue) -> HRESULT,
@@ -2514,7 +2514,7 @@ impl HttpProductHeaderValue {
         <Self as RtActivatable<IHttpProductHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpProductHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,80,114,111,100,117,99,116,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpProductHeaderValue]);
+DEFINE_CLSID!(HttpProductHeaderValue: "Windows.Web.Http.Headers.HttpProductHeaderValue");
 DEFINE_IID!(IID_IHttpProductHeaderValueFactory, 1629136117, 33468, 17147, 151, 123, 220, 0, 83, 110, 94, 134);
 RT_INTERFACE!{static interface IHttpProductHeaderValueFactory(IHttpProductHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpProductHeaderValueFactory] {
     fn CreateFromName(&self, productName: HSTRING, out: *mut *mut HttpProductHeaderValue) -> HRESULT,
@@ -2583,7 +2583,7 @@ impl HttpProductInfoHeaderValue {
         <Self as RtActivatable<IHttpProductInfoHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpProductInfoHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,80,114,111,100,117,99,116,73,110,102,111,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpProductInfoHeaderValue]);
+DEFINE_CLSID!(HttpProductInfoHeaderValue: "Windows.Web.Http.Headers.HttpProductInfoHeaderValue");
 DEFINE_IID!(IID_IHttpProductInfoHeaderValueCollection, 2273179466, 54939, 17656, 173, 79, 69, 58, 249, 196, 46, 208);
 RT_INTERFACE!{interface IHttpProductInfoHeaderValueCollection(IHttpProductInfoHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpProductInfoHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -2935,7 +2935,7 @@ impl HttpTransferCodingHeaderValue {
         <Self as RtActivatable<IHttpTransferCodingHeaderValueStatics>>::get_activation_factory().try_parse(input)
     }}
 }
-DEFINE_CLSID!(HttpTransferCodingHeaderValue(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,84,114,97,110,115,102,101,114,67,111,100,105,110,103,72,101,97,100,101,114,86,97,108,117,101,0]) [CLSID_HttpTransferCodingHeaderValue]);
+DEFINE_CLSID!(HttpTransferCodingHeaderValue: "Windows.Web.Http.Headers.HttpTransferCodingHeaderValue");
 DEFINE_IID!(IID_IHttpTransferCodingHeaderValueCollection, 539790388, 11267, 18872, 150, 101, 115, 226, 124, 178, 252, 121);
 RT_INTERFACE!{interface IHttpTransferCodingHeaderValueCollection(IHttpTransferCodingHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpTransferCodingHeaderValueCollection] {
     fn ParseAdd(&self, input: HSTRING) -> HRESULT,
@@ -3039,7 +3039,7 @@ impl HttpDiagnosticProvider {
         <Self as RtActivatable<IHttpDiagnosticProviderStatics>>::get_activation_factory().create_from_process_diagnostic_info(processDiagnosticInfo)
     }}
 }
-DEFINE_CLSID!(HttpDiagnosticProvider(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,68,105,97,103,110,111,115,116,105,99,115,46,72,116,116,112,68,105,97,103,110,111,115,116,105,99,80,114,111,118,105,100,101,114,0]) [CLSID_HttpDiagnosticProvider]);
+DEFINE_CLSID!(HttpDiagnosticProvider: "Windows.Web.Http.Diagnostics.HttpDiagnosticProvider");
 DEFINE_IID!(IID_IHttpDiagnosticProviderRequestResponseCompletedEventArgs, 1935644910, 38134, 17714, 178, 110, 97, 225, 177, 228, 239, 212);
 RT_INTERFACE!{interface IHttpDiagnosticProviderRequestResponseCompletedEventArgs(IHttpDiagnosticProviderRequestResponseCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProviderRequestResponseCompletedEventArgs] {
     fn get_ActivityId(&self, out: *mut Guid) -> HRESULT,
@@ -3311,7 +3311,7 @@ impl SyndicationAttribute {
         <Self as RtActivatable<ISyndicationAttributeFactory>>::get_activation_factory().create_syndication_attribute(attributeName, attributeNamespace, attributeValue)
     }}
 }
-DEFINE_CLSID!(SyndicationAttribute(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,65,116,116,114,105,98,117,116,101,0]) [CLSID_SyndicationAttribute]);
+DEFINE_CLSID!(SyndicationAttribute: "Windows.Web.Syndication.SyndicationAttribute");
 DEFINE_IID!(IID_ISyndicationAttributeFactory, 1649350041, 60734, 16911, 190, 134, 100, 4, 20, 136, 110, 75);
 RT_INTERFACE!{static interface ISyndicationAttributeFactory(ISyndicationAttributeFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationAttributeFactory] {
     fn CreateSyndicationAttribute(&self, attributeName: HSTRING, attributeNamespace: HSTRING, attributeValue: HSTRING, out: *mut *mut SyndicationAttribute) -> HRESULT
@@ -3372,7 +3372,7 @@ impl SyndicationCategory {
         <Self as RtActivatable<ISyndicationCategoryFactory>>::get_activation_factory().create_syndication_category_ex(term, scheme, label)
     }}
 }
-DEFINE_CLSID!(SyndicationCategory(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,67,97,116,101,103,111,114,121,0]) [CLSID_SyndicationCategory]);
+DEFINE_CLSID!(SyndicationCategory: "Windows.Web.Syndication.SyndicationCategory");
 DEFINE_IID!(IID_ISyndicationCategoryFactory, 2873262127, 18912, 17701, 138, 178, 171, 69, 192, 37, 40, 255);
 RT_INTERFACE!{static interface ISyndicationCategoryFactory(ISyndicationCategoryFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationCategoryFactory] {
     fn CreateSyndicationCategory(&self, term: HSTRING, out: *mut *mut SyndicationCategory) -> HRESULT,
@@ -3473,7 +3473,7 @@ impl SyndicationClient {
         <Self as RtActivatable<ISyndicationClientFactory>>::get_activation_factory().create_syndication_client(serverCredential)
     }}
 }
-DEFINE_CLSID!(SyndicationClient(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,67,108,105,101,110,116,0]) [CLSID_SyndicationClient]);
+DEFINE_CLSID!(SyndicationClient: "Windows.Web.Syndication.SyndicationClient");
 DEFINE_IID!(IID_ISyndicationClientFactory, 784642860, 42907, 16660, 178, 154, 5, 223, 251, 175, 185, 164);
 RT_INTERFACE!{static interface ISyndicationClientFactory(ISyndicationClientFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationClientFactory] {
     #[cfg(feature="windows-security")] fn CreateSyndicationClient(&self, serverCredential: *mut super::super::security::credentials::PasswordCredential, out: *mut *mut SyndicationClient) -> HRESULT
@@ -3512,7 +3512,7 @@ impl SyndicationContent {
         <Self as RtActivatable<ISyndicationContentFactory>>::get_activation_factory().create_syndication_content_with_source_uri(sourceUri)
     }}
 }
-DEFINE_CLSID!(SyndicationContent(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,67,111,110,116,101,110,116,0]) [CLSID_SyndicationContent]);
+DEFINE_CLSID!(SyndicationContent: "Windows.Web.Syndication.SyndicationContent");
 DEFINE_IID!(IID_ISyndicationContentFactory, 1026538387, 38176, 16755, 147, 136, 126, 45, 243, 36, 168, 160);
 RT_INTERFACE!{static interface ISyndicationContentFactory(ISyndicationContentFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationContentFactory] {
     fn CreateSyndicationContent(&self, text: HSTRING, type_: SyndicationTextType, out: *mut *mut SyndicationContent) -> HRESULT,
@@ -3537,7 +3537,7 @@ impl SyndicationError {
         <Self as RtActivatable<ISyndicationErrorStatics>>::get_activation_factory().get_status(hresult)
     }}
 }
-DEFINE_CLSID!(SyndicationError(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,69,114,114,111,114,0]) [CLSID_SyndicationError]);
+DEFINE_CLSID!(SyndicationError: "Windows.Web.Syndication.SyndicationError");
 DEFINE_IID!(IID_ISyndicationErrorStatics, 532357985, 17863, 18483, 138, 160, 190, 95, 59, 88, 167, 244);
 RT_INTERFACE!{static interface ISyndicationErrorStatics(ISyndicationErrorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationErrorStatics] {
     fn GetStatus(&self, hresult: i32, out: *mut SyndicationErrorStatus) -> HRESULT
@@ -3723,7 +3723,7 @@ impl SyndicationFeed {
         <Self as RtActivatable<ISyndicationFeedFactory>>::get_activation_factory().create_syndication_feed(title, subtitle, uri)
     }}
 }
-DEFINE_CLSID!(SyndicationFeed(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,70,101,101,100,0]) [CLSID_SyndicationFeed]);
+DEFINE_CLSID!(SyndicationFeed: "Windows.Web.Syndication.SyndicationFeed");
 DEFINE_IID!(IID_ISyndicationFeedFactory, 591864370, 35817, 18615, 137, 52, 98, 5, 19, 29, 147, 87);
 RT_INTERFACE!{static interface ISyndicationFeedFactory(ISyndicationFeedFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationFeedFactory] {
     fn CreateSyndicationFeed(&self, title: HSTRING, subtitle: HSTRING, uri: *mut super::super::foundation::Uri, out: *mut *mut SyndicationFeed) -> HRESULT
@@ -3784,7 +3784,7 @@ impl SyndicationGenerator {
         <Self as RtActivatable<ISyndicationGeneratorFactory>>::get_activation_factory().create_syndication_generator(text)
     }}
 }
-DEFINE_CLSID!(SyndicationGenerator(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,71,101,110,101,114,97,116,111,114,0]) [CLSID_SyndicationGenerator]);
+DEFINE_CLSID!(SyndicationGenerator: "Windows.Web.Syndication.SyndicationGenerator");
 DEFINE_IID!(IID_ISyndicationGeneratorFactory, 2738914275, 7718, 19900, 186, 157, 26, 184, 75, 239, 249, 123);
 RT_INTERFACE!{static interface ISyndicationGeneratorFactory(ISyndicationGeneratorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationGeneratorFactory] {
     fn CreateSyndicationGenerator(&self, text: HSTRING, out: *mut *mut SyndicationGenerator) -> HRESULT
@@ -3966,7 +3966,7 @@ impl SyndicationItem {
         <Self as RtActivatable<ISyndicationItemFactory>>::get_activation_factory().create_syndication_item(title, content, uri)
     }}
 }
-DEFINE_CLSID!(SyndicationItem(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,73,116,101,109,0]) [CLSID_SyndicationItem]);
+DEFINE_CLSID!(SyndicationItem: "Windows.Web.Syndication.SyndicationItem");
 DEFINE_IID!(IID_ISyndicationItemFactory, 622674767, 32184, 18554, 133, 228, 16, 209, 145, 230, 110, 187);
 RT_INTERFACE!{static interface ISyndicationItemFactory(ISyndicationItemFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationItemFactory] {
     fn CreateSyndicationItem(&self, title: HSTRING, content: *mut SyndicationContent, uri: *mut super::super::foundation::Uri, out: *mut *mut SyndicationItem) -> HRESULT
@@ -4060,7 +4060,7 @@ impl SyndicationLink {
         <Self as RtActivatable<ISyndicationLinkFactory>>::get_activation_factory().create_syndication_link_ex(uri, relationship, title, mediaType, length)
     }}
 }
-DEFINE_CLSID!(SyndicationLink(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,76,105,110,107,0]) [CLSID_SyndicationLink]);
+DEFINE_CLSID!(SyndicationLink: "Windows.Web.Syndication.SyndicationLink");
 DEFINE_IID!(IID_ISyndicationLinkFactory, 1591239636, 21813, 18604, 152, 212, 193, 144, 153, 80, 128, 179);
 RT_INTERFACE!{static interface ISyndicationLinkFactory(ISyndicationLinkFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationLinkFactory] {
     fn CreateSyndicationLink(&self, uri: *mut super::super::foundation::Uri, out: *mut *mut SyndicationLink) -> HRESULT,
@@ -4164,7 +4164,7 @@ impl SyndicationNode {
         <Self as RtActivatable<ISyndicationNodeFactory>>::get_activation_factory().create_syndication_node(nodeName, nodeNamespace, nodeValue)
     }}
 }
-DEFINE_CLSID!(SyndicationNode(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,78,111,100,101,0]) [CLSID_SyndicationNode]);
+DEFINE_CLSID!(SyndicationNode: "Windows.Web.Syndication.SyndicationNode");
 DEFINE_IID!(IID_ISyndicationNodeFactory, 311435656, 19147, 18856, 183, 119, 165, 235, 146, 225, 138, 121);
 RT_INTERFACE!{static interface ISyndicationNodeFactory(ISyndicationNodeFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationNodeFactory] {
     fn CreateSyndicationNode(&self, nodeName: HSTRING, nodeNamespace: HSTRING, nodeValue: HSTRING, out: *mut *mut SyndicationNode) -> HRESULT
@@ -4225,7 +4225,7 @@ impl SyndicationPerson {
         <Self as RtActivatable<ISyndicationPersonFactory>>::get_activation_factory().create_syndication_person_ex(name, email, uri)
     }}
 }
-DEFINE_CLSID!(SyndicationPerson(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,80,101,114,115,111,110,0]) [CLSID_SyndicationPerson]);
+DEFINE_CLSID!(SyndicationPerson: "Windows.Web.Syndication.SyndicationPerson");
 DEFINE_IID!(IID_ISyndicationPersonFactory, 3707013229, 8861, 19288, 164, 155, 243, 210, 240, 245, 201, 159);
 RT_INTERFACE!{static interface ISyndicationPersonFactory(ISyndicationPersonFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationPersonFactory] {
     fn CreateSyndicationPerson(&self, name: HSTRING, out: *mut *mut SyndicationPerson) -> HRESULT,
@@ -4292,7 +4292,7 @@ impl SyndicationText {
         <Self as RtActivatable<ISyndicationTextFactory>>::get_activation_factory().create_syndication_text_ex(text, type_)
     }}
 }
-DEFINE_CLSID!(SyndicationText(&[87,105,110,100,111,119,115,46,87,101,98,46,83,121,110,100,105,99,97,116,105,111,110,46,83,121,110,100,105,99,97,116,105,111,110,84,101,120,116,0]) [CLSID_SyndicationText]);
+DEFINE_CLSID!(SyndicationText: "Windows.Web.Syndication.SyndicationText");
 DEFINE_IID!(IID_ISyndicationTextFactory, 4000531191, 4550, 19237, 171, 98, 229, 150, 189, 22, 41, 70);
 RT_INTERFACE!{static interface ISyndicationTextFactory(ISyndicationTextFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISyndicationTextFactory] {
     fn CreateSyndicationText(&self, text: HSTRING, out: *mut *mut SyndicationText) -> HRESULT,
@@ -4400,7 +4400,7 @@ impl AtomPubClient {
         <Self as RtActivatable<IAtomPubClientFactory>>::get_activation_factory().create_atom_pub_client_with_credentials(serverCredential)
     }}
 }
-DEFINE_CLSID!(AtomPubClient(&[87,105,110,100,111,119,115,46,87,101,98,46,65,116,111,109,80,117,98,46,65,116,111,109,80,117,98,67,108,105,101,110,116,0]) [CLSID_AtomPubClient]);
+DEFINE_CLSID!(AtomPubClient: "Windows.Web.AtomPub.AtomPubClient");
 DEFINE_IID!(IID_IAtomPubClientFactory, 1238716434, 22475, 19422, 171, 159, 38, 16, 177, 114, 119, 123);
 RT_INTERFACE!{static interface IAtomPubClientFactory(IAtomPubClientFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IAtomPubClientFactory] {
     #[cfg(feature="windows-security")] fn CreateAtomPubClientWithCredentials(&self, serverCredential: *mut super::super::security::credentials::PasswordCredential, out: *mut *mut AtomPubClient) -> HRESULT

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -565,15 +565,13 @@ macro_rules! RT_CLASS {
 }
 
 macro_rules! DEFINE_CLSID {
-    ($clsname:ident($id:expr) [$idname:ident]) => {
-        const $idname: &'static [u16] = $id; // Full name of the class as null-terminated UTF16 string
+    ($clsname:ident : $namestr:tt) => {
         impl ::RtNamedClass for $clsname {
             #[inline]
-            fn name() -> &'static [u16] { $idname } 
+            fn name() -> &'static [u16] { wstrz!($namestr) }
         }
     }
 }
-
 
 macro_rules! RT_ENUM {
     {enum $name:ident : $t:ty { $($variant:ident ($longvariant:ident) = $value:expr,)+ }} => {


### PR DESCRIPTION
Using the [wstr crate](https://github.com/nitric1/wstr-rs) for UTF16 literals, we can now provide a macro that enables `HString` literals without any heap allocation.

Fixes #30 