### PR TITLE
Don't construct a tmp slice with a null ptr

### DIFF
--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -58,10 +58,14 @@ impl BStr {
     
     #[inline(always)]
     fn internal_to_string(&self) -> String {
-        unsafe {
-            let len = self.len();
-            let slice: &[u16] = ::std::slice::from_raw_parts(self.0, len as usize);
-            String::from_utf16_lossy(slice)
+        if self.0.is_null() {
+            String::new()
+        } else {
+            unsafe {
+                let len = self.len();
+                let slice: &[u16] = ::std::slice::from_raw_parts(self.0, len as usize);
+                String::from_utf16_lossy(slice)
+            }
         }
     }
 }


### PR DESCRIPTION
According to the docs for `std::slice::from_raw_parts`, "`data` must be non-null and aligned, even for zero-length slices". Doesn't cause any issues currently, but it's worthwhile to be pedantic about nulls.