### PR TITLE
Upgrade to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["winrt", "uwp", "windows", "runtime", "com"]
 categories = ["os::windows-apis", "api-bindings", "external-ffi-bindings"]
 license = "MIT OR Apache-2.0"
 exclude = ["Generator/**"]
+edition = "2018"
 
 [dependencies]
 winapi = { version = "0.3", features = ["winnt", "combaseapi", "oleauto", "roapi", "roerrorapi", "hstring", "winstring", "winerror", "restrictederrorinfo"] }

--- a/Generator/Generator.cs
+++ b/Generator/Generator.cs
@@ -130,7 +130,7 @@ namespace Generator
         {
             if (mod.IsEmpty) return;
 
-            const string IMPORTS = "use ::prelude::*;";
+            const string IMPORTS = "use crate::prelude::*;";
 
             string name = mod.Name.ToLower();
             string newPath = path == null ? mod.Name : (path + "." + mod.Name);

--- a/Generator/Types/TypeDef.cs
+++ b/Generator/Types/TypeDef.cs
@@ -214,7 +214,7 @@ namespace Generator.Types
                 }
                 else
                 {
-                    name = $"::rt::gen::{ Module.Path }::{ Name }";
+                    name = $"crate::{ Module.Path }::{ Name }";
                 }
                 var relative = $"{ Module.GetRelativePath(requestingModule) }::{ Name }";
                 if (relative.Length < name.Length)

--- a/examples/hexdump.rs
+++ b/examples/hexdump.rs
@@ -15,7 +15,7 @@ const CHUNK_SIZE: usize = 4096;
 
 fn main() {
     // Use the current executable as source file (because we know that will exist).
-    let exe_path = ::std::env::current_exe().expect("current_exe failed");
+    let exe_path = std::env::current_exe().expect("current_exe failed");
     let exe_path_str = exe_path.to_str().expect("invalid unicode path");
 
     let file = StorageFile::get_file_from_path_async(&*FastHString::new(&exe_path_str)).unwrap().blocking_get().expect("get_file_from_path_async failed").unwrap();

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -144,7 +144,7 @@ fn main() {
     assert!(asi.close().is_ok());
 
     // Walk directories up to root
-    let exe_path = ::std::env::current_exe().expect("current_exe failed");
+    let exe_path = std::env::current_exe().expect("current_exe failed");
     let exe_path_str = exe_path.to_str().expect("invalid unicode path");
     let file = StorageFile::get_file_from_path_async(&*FastHString::new(&exe_path_str)).unwrap().blocking_get().expect("get_file_from_path_async failed").unwrap();
     println!("Executable file: {}", file.query_interface::<IStorageItem>().unwrap().get_path().unwrap());

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,5 +1,5 @@
-use ::std::ptr;
-use ::std::fmt;
+use std::ptr;
+use std::fmt;
 
 use w::shared::wtypes::BSTR;
 use w::shared::basetsd::UINT32;
@@ -63,7 +63,7 @@ impl BStr {
         } else {
             unsafe {
                 let len = self.len();
-                let slice: &[u16] = ::std::slice::from_raw_parts(self.0, len as usize);
+                let slice: &[u16] = std::slice::from_raw_parts(self.0, len as usize);
                 String::from_utf16_lossy(slice)
             }
         }

--- a/src/cominterfaces.rs
+++ b/src/cominterfaces.rs
@@ -1,4 +1,4 @@
-use Guid;
+use crate::Guid;
 use w::um::unknwnbase::IUnknownVtbl;
 
 /// Marker trait for all COM-compatible interfaces.
@@ -21,15 +21,15 @@ pub trait ComIid {
 DEFINE_IID!(IID_IUnknown, 0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
 
 /// Re-export from WinAPI crate
-pub type IUnknown = ::w::um::unknwnbase::IUnknown;
+pub type IUnknown = w::um::unknwnbase::IUnknown;
 impl ComIid for IUnknown { #[inline] fn iid() -> &'static Guid { &IID_IUnknown } }
 impl ComInterface for IUnknown { type Vtbl = IUnknownVtbl; }
 
 DEFINE_IID!(IID_IRestrictedErrorInfo, 0x82BA7092, 0x4C88, 0x427D, 0xA7, 0xBC, 0x16, 0xDD, 0x93, 0xFE, 0xB6, 0x7E);
 
 /// Re-export from WinAPI crate
-pub type IRestrictedErrorInfo = ::w::um::restrictederrorinfo::IRestrictedErrorInfo;
-pub type IRestrictedErrorInfoVtbl = ::w::um::restrictederrorinfo::IRestrictedErrorInfoVtbl;
+pub type IRestrictedErrorInfo = w::um::restrictederrorinfo::IRestrictedErrorInfo;
+pub type IRestrictedErrorInfoVtbl = w::um::restrictederrorinfo::IRestrictedErrorInfoVtbl;
 impl ComIid for IRestrictedErrorInfo { #[inline] fn iid() -> &'static Guid { &IID_IRestrictedErrorInfo } }
 impl ComInterface for IRestrictedErrorInfo { type Vtbl = IRestrictedErrorInfoVtbl; }
 
@@ -42,17 +42,17 @@ DEFINE_IID!(IID_IAgileObject, 0x94EA2B94, 0xE9CC, 0x49E0, 0xC0, 0xFF, 0xEE, 0x64
 pub struct IAgileObject {
     lpVtbl: *const IUnknownVtbl // IAgileObject has no methods besides what IUnknown has
 }
-impl ::std::ops::Deref for IAgileObject {
+impl std::ops::Deref for IAgileObject {
     type Target = IUnknown;
     #[inline]
     fn deref(&self) -> &IUnknown {
-        unsafe { ::std::mem::transmute(self) }
+        unsafe { std::mem::transmute(self) }
     }
 }
-impl ::std::ops::DerefMut for IAgileObject {
+impl std::ops::DerefMut for IAgileObject {
     #[inline]
     fn deref_mut(&mut self) -> &mut IUnknown {
-        unsafe { ::std::mem::transmute(self) }
+        unsafe { std::mem::transmute(self) }
     }
 }
 impl ComIid for IAgileObject { #[inline] fn iid() -> &'static Guid { &IID_IAgileObject } }

--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 use std::fmt;
 use std::ptr;
-use ::{ComIid, ComInterface, RtInterface, RtClassInterface, IInspectable, Guid};
+use crate::{ComIid, ComInterface, RtInterface, RtClassInterface, IInspectable, Guid};
 
 use w::shared::ntdef::VOID;
 use w::shared::minwindef::LPVOID;
@@ -38,7 +38,7 @@ pub fn query_interface<T, Target>(interface: &T) -> Option<ComPtr<Target>> where
 
 // This trait is not exported in the library interface
 pub trait HiddenGetRuntimeClassName {
-    fn get_runtime_class_name(&self) -> ::HString;
+    fn get_runtime_class_name(&self) -> crate::HString;
 }
 
 impl<T> ComPtr<T> {
@@ -80,7 +80,7 @@ impl<T> ComPtr<T> {
     /// This is a runtime no-op, but you need to be sure that the interface is compatible.
     #[inline]
     pub unsafe fn into_unchecked<Interface>(self) -> ComPtr<Interface> where Interface: ComInterface {
-        ::std::mem::transmute(self)
+        std::mem::transmute(self)
     }
     
     /// Gets the fully qualified name of the current Windows Runtime object.
@@ -100,7 +100,7 @@ impl<T> ComPtr<T> {
     /// assert_eq!("Windows.Foundation.Uri", uri.get_runtime_class_name().to_string());
     /// ```
     #[inline]
-    pub fn get_runtime_class_name(&self) -> ::HString where T: RtClassInterface {
+    pub fn get_runtime_class_name(&self) -> crate::HString where T: RtClassInterface {
         HiddenGetRuntimeClassName::get_runtime_class_name(self.as_inspectable())
     }
     
@@ -150,12 +150,12 @@ impl<T> PartialEq<ComPtr<T>> for ComPtr<T> {
 /// Owned array type that is used as return type when WinRT methods return arrays.
 /// It wraps a block of memory that has been allocated by WinRT and will be deallocated
 /// using `CoTaskMemFree` on drop.
-pub struct ComArray<T> where T: ::RtType {
+pub struct ComArray<T> where T: crate::RtType {
     size: u32,
     first: ptr::NonNull<T::Abi>
 }
 
-impl<T> ComArray<T> where T: ::RtType {
+impl<T> ComArray<T> where T: crate::RtType {
     #[inline]
     pub unsafe fn from_raw(size: u32, first: *mut T::Abi) -> ComArray<T> {
         assert!(!first.is_null());
@@ -172,25 +172,25 @@ impl<T> ComArray<T> where T: ::RtType {
     }
 }
 
-impl<T> Deref for ComArray<T> where T: ::RtType {
+impl<T> Deref for ComArray<T> where T: crate::RtType {
     type Target = [T::OutNonNull];
     #[inline]
     fn deref(&self) -> &[T::OutNonNull] {
-        unsafe { ::std::slice::from_raw_parts(self.first.as_ptr() as *mut T::OutNonNull, self.size as usize) }
+        unsafe { std::slice::from_raw_parts(self.first.as_ptr() as *mut T::OutNonNull, self.size as usize) }
     }
 }
-impl<T> DerefMut for ComArray<T> where T: ::RtType {
+impl<T> DerefMut for ComArray<T> where T: crate::RtType {
     #[inline]
     fn deref_mut(&mut self) -> &mut [T::OutNonNull] {
-        unsafe { ::std::slice::from_raw_parts_mut(self.first.as_ptr() as *mut T::OutNonNull, self.size as usize) }
+        unsafe { std::slice::from_raw_parts_mut(self.first.as_ptr() as *mut T::OutNonNull, self.size as usize) }
     }
 }
 
-impl<T> Drop for ComArray<T> where T: ::RtType {
+impl<T> Drop for ComArray<T> where T: crate::RtType {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            ::std::ptr::drop_in_place(&mut self[..]);
+            std::ptr::drop_in_place(&mut self[..]);
             CoTaskMemFree(self.first.as_ptr() as LPVOID)
         };
     }
@@ -201,8 +201,8 @@ mod extra {
     // i.e. when a compiler version is used that still has dropflags
     #[inline]
     fn assert_no_dropflags() {
-        let p: *mut ::IInspectable = ::std::ptr::null_mut();
-        let _: ::ComPtr<::IInspectable> = unsafe { ::std::mem::transmute(p) };
+        let p: *mut crate::IInspectable = std::ptr::null_mut();
+        let _: crate::ComPtr<crate::IInspectable> = unsafe { std::mem::transmute(p) };
     }
 }
 
@@ -212,10 +212,10 @@ mod tests {
 
     #[test]
     fn check_sizes() {
-        use ::std::mem::size_of;
+        use std::mem::size_of;
 
         // make sure that ComPtr is pointer-sized
-        assert_eq!(size_of::<::ComPtr<::IInspectable>>(), size_of::<*mut ::IInspectable>());
-        assert_eq!(size_of::<Option<::ComPtr<::IInspectable>>>(), size_of::<*mut ::IInspectable>());
+        assert_eq!(size_of::<crate::ComPtr<crate::IInspectable>>(), size_of::<*mut crate::IInspectable>());
+        assert_eq!(size_of::<Option<crate::ComPtr<crate::IInspectable>>>(), size_of::<*mut crate::IInspectable>());
     }
 }

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -50,8 +50,8 @@ mod tests {
 
     #[test]
     fn check_size() {
-        use ::std::mem::size_of;
+        use std::mem::size_of;
 
-        assert_eq!(size_of::<::Guid>(), size_of::<::w::shared::guiddef::GUID>());
+        assert_eq!(size_of::<crate::Guid>(), size_of::<w::shared::guiddef::GUID>());
     }
 }

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -21,7 +21,7 @@ fn internal_to_string(hstr: HSTRING) -> String {
     unsafe {
         let mut len = 0;
         let buf = WindowsGetStringRawBuffer(hstr, &mut len);
-        let slice: &[u16] = ::std::slice::from_raw_parts(buf, len as usize);
+        let slice: &[u16] = std::slice::from_raw_parts(buf, len as usize);
         String::from_utf16_lossy(slice)
     }
 }
@@ -453,7 +453,7 @@ impl HString {
     pub fn make_reference<'a>(&'a self) -> HStringReference<'a> {
         let mut len = 0;
         let buf = unsafe { WindowsGetStringRawBuffer(self.0, &mut len) };
-        unsafe { HStringReference::from_utf16_unchecked(::std::slice::from_raw_parts(buf, len as usize + 1)) }
+        unsafe { HStringReference::from_utf16_unchecked(std::slice::from_raw_parts(buf, len as usize + 1)) }
     }
 }
 
@@ -467,7 +467,7 @@ impl Drop for HString {
 
 unsafe impl Send for HString {}
 
-impl ::std::clone::Clone for HString {
+impl std::clone::Clone for HString {
     #[inline]
     fn clone(&self) -> Self {
         let mut clone = HString::empty();
@@ -577,9 +577,9 @@ mod tests {
 
     #[test]
     fn check_sizes() {
-        use ::std::mem::size_of;
-        assert_eq!(size_of::<::HString>(), size_of::<::w::winrt::hstring::HSTRING>());
-        assert_eq!(size_of::<&::HStringArg>(), size_of::<::w::winrt::hstring::HSTRING>());
+        use std::mem::size_of;
+        assert_eq!(size_of::<crate::HString>(), size_of::<w::winrt::hstring::HSTRING>());
+        assert_eq!(size_of::<&crate::HStringArg>(), size_of::<w::winrt::hstring::HSTRING>());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod guid;
 pub use guid::Guid;
 
 ///Represents the trust level of an activatable class (re-export from WinAPI crate)
-pub type TrustLevel = ::w::winrt::inspectable::TrustLevel;
+pub type TrustLevel = w::winrt::inspectable::TrustLevel;
 
 // Compared to the DEFINE_GUID macro from winapi, this one creates a private const
 macro_rules! DEFINE_IID {
@@ -42,7 +42,7 @@ macro_rules! DEFINE_IID {
         $name:ident, $l:expr, $w1:expr, $w2:expr, $b1:expr, $b2:expr, $b3:expr, $b4:expr, $b5:expr,
         $b6:expr, $b7:expr, $b8:expr
     ) => {
-        const $name: &'static ::Guid = &::Guid {
+        const $name: &'static crate::Guid = &crate::Guid {
             Data1: $l,
             Data2: $w1,
             Data3: $w2,
@@ -67,33 +67,33 @@ pub use rt::{RtInterface, RtClassInterface, RtNamedClass, RtValueType, RtType, R
              RtDefaultConstructible, IInspectable, IInspectableVtbl, IActivationFactory,
              IMemoryBufferByteAccess, Char, IteratorAdaptor,
              ApartmentType, init_apartment, uninit_apartment};
-pub use rt::async::{RtAsyncAction, RtAsyncOperation};
+pub use rt::async_util::{RtAsyncAction, RtAsyncOperation};
 
 mod result;
 pub use result::{Result, Error, HRESULT};
 
 pub mod windows {
-    pub use rt::gen::windows::*;
+    pub use crate::rt::gen::windows::*;
 }
 
 /// This is only for internal use within the generated code
 mod prelude {
-    pub use ::rt::{RtType, RtActivatable, IInspectable, IInspectableVtbl, IActivationFactory, Char};
-    pub use ::rt::handler::IntoInterface;
-    pub use ::cominterfaces::{ComInterface, ComIid, IUnknown};
-    pub use ::comptr::{ComPtr, ComArray};
-    pub use ::hstring::{HString, HStringArg};
-    pub use ::result::{Result, HRESULT};
-    pub use ::w::winrt::hstring::HSTRING;
-    pub use ::w::shared::winerror::S_OK;
-    pub use ::w::um::unknwnbase::IUnknownVtbl;
-    pub use ::std::ptr::null_mut;
-    pub use ::std::mem::zeroed;
-    pub use ::guid::Guid;
-    pub use ::rt::gen::windows::foundation;
+    pub use crate::rt::{RtType, RtActivatable, IInspectable, IInspectableVtbl, IActivationFactory, Char};
+    pub use crate::rt::handler::IntoInterface;
+    pub use crate::cominterfaces::{ComInterface, ComIid, IUnknown};
+    pub use crate::comptr::{ComPtr, ComArray};
+    pub use crate::hstring::{HString, HStringArg};
+    pub use crate::result::{Result, HRESULT};
+    pub use w::winrt::hstring::HSTRING;
+    pub use w::shared::winerror::S_OK;
+    pub use w::um::unknwnbase::IUnknownVtbl;
+    pub use std::ptr::null_mut;
+    pub use std::mem::zeroed;
+    pub use crate::guid::Guid;
+    pub use crate::rt::gen::windows::foundation;
 
     #[inline]
-    pub fn err<T>(hr: ::result::HRESULT) -> ::result::Result<T> {
-        Err(::result::Error::from_hresult(hr))
+    pub fn err<T>(hr: crate::result::HRESULT) -> crate::result::Result<T> {
+        Err(crate::result::Error::from_hresult(hr))
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// Re-export from WinAPI crate
-pub type HRESULT = ::w::um::winnt::HRESULT;
+pub type HRESULT = w::um::winnt::HRESULT;
 
 // TODO: add more codes from https://msdn.microsoft.com/en-us/library/windows/desktop/dd542643(v=vs.85).aspx, especially the `RO_`-prefixed
 
@@ -53,7 +53,7 @@ impl Error {
     #[inline]
     pub fn from_hresult(hr: HRESULT) -> Error {
         use Error::*;
-        use ::w::shared::winerror::*;
+        use w::shared::winerror::*;
 
         match hr {
             E_ABORT => OperationAborted,
@@ -77,7 +77,7 @@ impl Error {
     #[inline]
     pub fn as_hresult(&self) -> HRESULT {
         use Error::*;
-        use ::w::shared::winerror::*;
+        use w::shared::winerror::*;
 
         match *self { 
             OperationAborted => E_ABORT,
@@ -100,4 +100,4 @@ impl Error {
 }
 
 /// A specialized `Result` type for Windows Runtime method calls.
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/rt/async_util.rs
+++ b/src/rt/async_util.rs
@@ -1,12 +1,12 @@
 use std::sync::{Arc, Mutex, Condvar};
 
-use ::{
+use crate::{
     RtType,
     ComIid,
     Result
 };
 
-use ::windows::foundation::{
+use crate::windows::foundation::{
     IAsyncInfo,
     IAsyncAction,
     AsyncActionCompletedHandler,
@@ -44,10 +44,10 @@ macro_rules! impl_blocking_wait {
     ($handler:ident) => {
         #[inline]
         fn blocking_wait(&self) {
-            let info = ::comptr::query_interface::<_, IAsyncInfo>(self).expect("query_interface failed");
+            let info = crate::comptr::query_interface::<_, IAsyncInfo>(self).expect("query_interface failed");
             let status = info.get_status().expect("get_status failed");
 
-            if status == ::windows::foundation::AsyncStatus::Completed {
+            if status == crate::windows::foundation::AsyncStatus::Completed {
                 return;
             }
             

--- a/src/rt/gen/windows/ai.rs
+++ b/src/rt/gen/windows/ai.rs
@@ -1,5 +1,5 @@
 pub mod machinelearning { // Windows.AI.MachineLearning
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IImageFeatureDescriptor, 911574437, 5914, 18986, 152, 95, 38, 81, 89, 211, 137, 90);
 RT_INTERFACE!{interface IImageFeatureDescriptor(IImageFeatureDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IImageFeatureDescriptor] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -1252,19 +1252,19 @@ impl ITensorUInt8BitStatics {
     }}
 }
 pub mod preview { // Windows.AI.MachineLearning.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum FeatureElementKindPreview: i32 {
     Undefined = 0, Float = 1, UInt8 = 2, Int8 = 3, UInt16 = 4, Int16 = 5, Int32 = 6, Int64 = 7, String = 8, Boolean = 9, Float16 = 10, Double = 11, UInt32 = 12, UInt64 = 13, Complex64 = 14, Complex128 = 15,
 }}
 DEFINE_IID!(IID_IImageVariableDescriptorPreview, 2061630066, 670, 19909, 162, 248, 95, 183, 99, 21, 65, 80);
 RT_INTERFACE!{interface IImageVariableDescriptorPreview(IImageVariableDescriptorPreviewVtbl): IInspectable(IInspectableVtbl) [IID_IImageVariableDescriptorPreview] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_BitmapPixelFormat(&self, out: *mut ::rt::gen::windows::graphics::imaging::BitmapPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_BitmapPixelFormat(&self, out: *mut crate::windows::graphics::imaging::BitmapPixelFormat) -> HRESULT,
     fn get_Width(&self, out: *mut u32) -> HRESULT,
     fn get_Height(&self, out: *mut u32) -> HRESULT
 }}
 impl IImageVariableDescriptorPreview {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_bitmap_pixel_format(&self) -> Result<::rt::gen::windows::graphics::imaging::BitmapPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_bitmap_pixel_format(&self) -> Result<crate::windows::graphics::imaging::BitmapPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_BitmapPixelFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -1496,26 +1496,26 @@ impl ILearningModelPreview {
 RT_CLASS!{class LearningModelPreview: ILearningModelPreview}
 impl RtActivatable<ILearningModelPreviewStatics> for LearningModelPreview {}
 impl LearningModelPreview {
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_storage_file_async(modelFile: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_storage_file_async(modelFile: &crate::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> {
         <Self as RtActivatable<ILearningModelPreviewStatics>>::get_activation_factory().load_model_from_storage_file_async(modelFile)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_stream_async(modelStream: &::rt::gen::windows::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_stream_async(modelStream: &crate::windows::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> {
         <Self as RtActivatable<ILearningModelPreviewStatics>>::get_activation_factory().load_model_from_stream_async(modelStream)
     }
 }
 DEFINE_CLSID!(LearningModelPreview(&[87,105,110,100,111,119,115,46,65,73,46,77,97,99,104,105,110,101,76,101,97,114,110,105,110,103,46,80,114,101,118,105,101,119,46,76,101,97,114,110,105,110,103,77,111,100,101,108,80,114,101,118,105,101,119,0]) [CLSID_LearningModelPreview]);
 DEFINE_IID!(IID_ILearningModelPreviewStatics, 374061920, 33893, 18310, 139, 147, 44, 22, 168, 146, 137, 215);
 RT_INTERFACE!{static interface ILearningModelPreviewStatics(ILearningModelPreviewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILearningModelPreviewStatics] {
-    #[cfg(feature="windows-storage")] fn LoadModelFromStorageFileAsync(&self, modelFile: *mut ::rt::gen::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncOperation<LearningModelPreview>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn LoadModelFromStreamAsync(&self, modelStream: *mut ::rt::gen::windows::storage::streams::IRandomAccessStreamReference, out: *mut *mut foundation::IAsyncOperation<LearningModelPreview>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn LoadModelFromStorageFileAsync(&self, modelFile: *mut crate::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncOperation<LearningModelPreview>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn LoadModelFromStreamAsync(&self, modelStream: *mut crate::windows::storage::streams::IRandomAccessStreamReference, out: *mut *mut foundation::IAsyncOperation<LearningModelPreview>) -> HRESULT
 }}
 impl ILearningModelPreviewStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_storage_file_async(&self, modelFile: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_storage_file_async(&self, modelFile: &crate::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).LoadModelFromStorageFileAsync)(self as *const _ as *mut _, modelFile as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_stream_async(&self, modelStream: &::rt::gen::windows::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_stream_async(&self, modelStream: &crate::windows::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).LoadModelFromStreamAsync)(self as *const _ as *mut _, modelStream as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }

--- a/src/rt/gen/windows/applicationmodel.rs
+++ b/src/rt/gen/windows/applicationmodel.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AddResourcePackageOptions: u32 {
     None = 0, ForceTargetAppShutdown = 1, ApplyUpdateIfAvailable = 2,
 }}
@@ -1279,7 +1279,7 @@ impl ISuspendingOperation {
 }
 RT_CLASS!{class SuspendingOperation: ISuspendingOperation}
 pub mod activation { // Windows.ApplicationModel.Activation
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IActivatedEventArgs, 3479508755, 52488, 20440, 182, 151, 162, 129, 182, 84, 78, 46);
 RT_INTERFACE!{interface IActivatedEventArgs(IActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IActivatedEventArgs] {
     fn get_Kind(&self, out: *mut ActivationKind) -> HRESULT,
@@ -2214,7 +2214,7 @@ impl IWebAuthenticationBrokerContinuationEventArgs {
 RT_CLASS!{class WebAuthenticationBrokerContinuationEventArgs: IWebAuthenticationBrokerContinuationEventArgs}
 } // Windows.ApplicationModel.Activation
 pub mod appextensions { // Windows.ApplicationModel.AppExtensions
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppExtension, 2219872300, 5613, 20399, 147, 234, 34, 55, 187, 248, 203, 214);
 RT_INTERFACE!{interface IAppExtension(IAppExtensionVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtension] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -2458,7 +2458,7 @@ impl IAppExtensionPackageUpdatingEventArgs {
 RT_CLASS!{class AppExtensionPackageUpdatingEventArgs: IAppExtensionPackageUpdatingEventArgs}
 } // Windows.ApplicationModel.AppExtensions
 pub mod appservice { // Windows.ApplicationModel.AppService
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class AppServiceCatalog}
 impl RtActivatable<IAppServiceCatalogStatics> for AppServiceCatalog {}
 impl AppServiceCatalog {
@@ -2698,7 +2698,7 @@ impl IAppServiceTriggerDetails3 {
 }
 } // Windows.ApplicationModel.AppService
 pub mod appointments { // Windows.ApplicationModel.Appointments
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppointment, 3707776815, 11229, 16502, 144, 163, 34, 194, 117, 49, 41, 101);
 RT_INTERFACE!{interface IAppointment(IAppointmentVtbl): IInspectable(IInspectableVtbl) [IID_IAppointment] {
     fn get_StartTime(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -4474,7 +4474,7 @@ RT_ENUM! { enum RecurrenceType: i32 {
     Master = 0, Instance = 1, ExceptionInstance = 2,
 }}
 pub mod appointmentsprovider { // Windows.ApplicationModel.Appointments.AppointmentsProvider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAddAppointmentOperation, 3964312307, 25101, 19561, 173, 215, 151, 148, 233, 24, 8, 31);
 RT_INTERFACE!{interface IAddAppointmentOperation(IAddAppointmentOperationVtbl): IInspectable(IInspectableVtbl) [IID_IAddAppointmentOperation] {
     fn get_AppointmentInformation(&self, out: *mut *mut super::Appointment) -> HRESULT,
@@ -4670,7 +4670,7 @@ impl IReplaceAppointmentOperation {
 RT_CLASS!{class ReplaceAppointmentOperation: IReplaceAppointmentOperation}
 } // Windows.ApplicationModel.Appointments.AppointmentsProvider
 pub mod dataprovider { // Windows.ApplicationModel.Appointments.DataProvider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppointmentCalendarCancelMeetingRequest, 1229328269, 25652, 16599, 173, 70, 98, 151, 65, 147, 20, 209);
 RT_INTERFACE!{interface IAppointmentCalendarCancelMeetingRequest(IAppointmentCalendarCancelMeetingRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarCancelMeetingRequest] {
     fn get_AppointmentCalendarLocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -5171,7 +5171,7 @@ RT_CLASS!{class AppointmentDataProviderTriggerDetails: IAppointmentDataProviderT
 } // Windows.ApplicationModel.Appointments.DataProvider
 } // Windows.ApplicationModel.Appointments
 pub mod background { // Windows.ApplicationModel.Background
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IActivitySensorTrigger, 3504161602, 58235, 18467, 165, 254, 107, 49, 223, 239, 222, 176);
 RT_INTERFACE!{interface IActivitySensorTrigger(IActivitySensorTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IActivitySensorTrigger] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -7012,7 +7012,7 @@ impl IUserNotificationChangedTriggerFactory {
 }
 } // Windows.ApplicationModel.Background
 pub mod calls { // Windows.ApplicationModel.Calls
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICallAnswerEventArgs, 4252538391, 11735, 19596, 178, 189, 149, 209, 122, 91, 183, 51);
 RT_INTERFACE!{interface ICallAnswerEventArgs(ICallAnswerEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICallAnswerEventArgs] {
     fn get_AcceptedMedia(&self, out: *mut VoipPhoneCallMedia) -> HRESULT
@@ -8437,7 +8437,7 @@ RT_ENUM! { enum VoipPhoneCallState: i32 {
     Ended = 0, Held = 1, Active = 2, Incoming = 3, Outgoing = 4,
 }}
 pub mod background { // Windows.ApplicationModel.Calls.Background
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum PhoneCallBlockedReason: i32 {
     InCallBlockingList = 0, PrivateNumber = 1, UnknownNumber = 2,
 }}
@@ -8542,7 +8542,7 @@ RT_ENUM! { enum PhoneTriggerType: i32 {
 }}
 } // Windows.ApplicationModel.Calls.Background
 pub mod provider { // Windows.ApplicationModel.Calls.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPhoneCallOrigin, 543241337, 3833, 17492, 135, 28, 175, 182, 106, 20, 182, 165);
 RT_INTERFACE!{interface IPhoneCallOrigin(IPhoneCallOriginVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallOrigin] {
     fn get_Category(&self, out: *mut HSTRING) -> HRESULT,
@@ -8602,16 +8602,16 @@ impl IPhoneCallOrigin2 {
 }
 DEFINE_IID!(IID_IPhoneCallOrigin3, 1228083124, 53671, 17314, 174, 238, 192, 123, 109, 186, 240, 104);
 RT_INTERFACE!{interface IPhoneCallOrigin3(IPhoneCallOrigin3Vtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallOrigin3] {
-    #[cfg(feature="windows-storage")] fn get_DisplayPicture(&self, out: *mut *mut ::rt::gen::windows::storage::StorageFile) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn put_DisplayPicture(&self, value: *mut ::rt::gen::windows::storage::StorageFile) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_DisplayPicture(&self, out: *mut *mut crate::windows::storage::StorageFile) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_DisplayPicture(&self, value: *mut crate::windows::storage::StorageFile) -> HRESULT
 }}
 impl IPhoneCallOrigin3 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_display_picture(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::StorageFile>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_display_picture(&self) -> Result<Option<ComPtr<crate::windows::storage::StorageFile>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DisplayPicture)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_display_picture(&self, value: &::rt::gen::windows::storage::StorageFile) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_display_picture(&self, value: &crate::windows::storage::StorageFile) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_DisplayPicture)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -8669,7 +8669,7 @@ impl IPhoneCallOriginManagerStatics2 {
 } // Windows.ApplicationModel.Calls.Provider
 } // Windows.ApplicationModel.Calls
 pub mod chat { // Windows.ApplicationModel.Chat
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IChatCapabilities, 989820860, 14793, 19921, 173, 45, 57, 100, 221, 157, 64, 63);
 RT_INTERFACE!{interface IChatCapabilities(IChatCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IChatCapabilities] {
     fn get_IsOnline(&self, out: *mut bool) -> HRESULT,
@@ -10494,7 +10494,7 @@ impl IRemoteParticipantComposingChangedEventArgs {
 RT_CLASS!{class RemoteParticipantComposingChangedEventArgs: IRemoteParticipantComposingChangedEventArgs}
 } // Windows.ApplicationModel.Chat
 pub mod communicationblocking { // Windows.ApplicationModel.CommunicationBlocking
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class CommunicationBlockingAccessManager}
 impl RtActivatable<ICommunicationBlockingAccessManagerStatics> for CommunicationBlockingAccessManager {}
 impl CommunicationBlockingAccessManager {
@@ -10601,7 +10601,7 @@ impl ICommunicationBlockingAppManagerStatics2 {
 }
 } // Windows.ApplicationModel.CommunicationBlocking
 pub mod contacts { // Windows.ApplicationModel.Contacts
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAggregateContactManager, 58316253, 56154, 20435, 181, 78, 77, 241, 121, 23, 162, 18);
 RT_INTERFACE!{interface IAggregateContactManager(IAggregateContactManagerVtbl): IInspectable(IInspectableVtbl) [IID_IAggregateContactManager] {
     fn FindRawContactsAsync(&self, contact: *mut Contact, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<Contact>>) -> HRESULT,
@@ -13760,7 +13760,7 @@ RT_ENUM! { enum PinnedContactSurface: i32 {
     StartMenu = 0, Taskbar = 1,
 }}
 pub mod dataprovider { // Windows.ApplicationModel.Contacts.DataProvider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IContactDataProviderConnection, 439978578, 35997, 19823, 164, 224, 17, 30, 154, 18, 90, 48);
 RT_INTERFACE!{interface IContactDataProviderConnection(IContactDataProviderConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IContactDataProviderConnection] {
     fn add_SyncRequested(&self, handler: *mut foundation::TypedEventHandler<ContactDataProviderConnection, ContactListSyncManagerSyncRequestEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -14039,7 +14039,7 @@ impl IContactListSyncManagerSyncRequestEventArgs {
 RT_CLASS!{class ContactListSyncManagerSyncRequestEventArgs: IContactListSyncManagerSyncRequestEventArgs}
 } // Windows.ApplicationModel.Contacts.DataProvider
 pub mod provider { // Windows.ApplicationModel.Contacts.Provider
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AddContactResult: i32 {
     Added = 0, AlreadyAdded = 1, Unavailable = 2,
 }}
@@ -14121,7 +14121,7 @@ RT_CLASS!{class ContactRemovedEventArgs: IContactRemovedEventArgs}
 } // Windows.ApplicationModel.Contacts.Provider
 } // Windows.ApplicationModel.Contacts
 pub mod core { // Windows.ApplicationModel.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppListEntry, 4009816191, 8456, 18698, 135, 122, 138, 159, 23, 194, 95, 173);
 RT_INTERFACE!{interface IAppListEntry(IAppListEntryVtbl): IInspectable(IInspectableVtbl) [IID_IAppListEntry] {
     fn get_DisplayInfo(&self, out: *mut *mut super::AppDisplayInfo) -> HRESULT,
@@ -14725,7 +14725,7 @@ impl IUnhandledErrorDetectedEventArgs {
 RT_CLASS!{class UnhandledErrorDetectedEventArgs: IUnhandledErrorDetectedEventArgs}
 } // Windows.ApplicationModel.Core
 pub mod datatransfer { // Windows.ApplicationModel.DataTransfer
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class Clipboard}
 impl RtActivatable<IClipboardStatics> for Clipboard {}
 impl RtActivatable<IClipboardStatics2> for Clipboard {}
@@ -16139,12 +16139,12 @@ impl ITargetApplicationChosenEventArgs {
 }
 RT_CLASS!{class TargetApplicationChosenEventArgs: ITargetApplicationChosenEventArgs}
 pub mod dragdrop { // Windows.ApplicationModel.DataTransfer.DragDrop
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum DragDropModifiers: u32 {
     None = 0, Shift = 1, Control = 2, Alt = 4, LeftButton = 8, MiddleButton = 16, RightButton = 32,
 }}
 pub mod core { // Windows.ApplicationModel.DataTransfer.DragDrop.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICoreDragDropManager, 2102842180, 33892, 20399, 170, 73, 55, 234, 110, 45, 123, 209);
 RT_INTERFACE!{interface ICoreDragDropManager(ICoreDragDropManagerVtbl): IInspectable(IInspectableVtbl) [IID_ICoreDragDropManager] {
     fn add_TargetRequested(&self, value: *mut foundation::TypedEventHandler<CoreDragDropManager, CoreDropOperationTargetRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -16231,9 +16231,9 @@ RT_INTERFACE!{interface ICoreDragOperation(ICoreDragOperationVtbl): IInspectable
     fn get_Data(&self, out: *mut *mut super::super::DataPackage) -> HRESULT,
     fn SetPointerId(&self, pointerId: u32) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn SetDragUIContentFromSoftwareBitmap(&self, softwareBitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn SetDragUIContentFromSoftwareBitmap(&self, softwareBitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn SetDragUIContentFromSoftwareBitmapWithAnchorPoint(&self, softwareBitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn SetDragUIContentFromSoftwareBitmapWithAnchorPoint(&self, softwareBitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> HRESULT,
     fn get_DragUIContentMode(&self, out: *mut CoreDragUIContentMode) -> HRESULT,
     fn put_DragUIContentMode(&self, value: CoreDragUIContentMode) -> HRESULT,
     fn StartAsync(&self, out: *mut *mut foundation::IAsyncOperation<super::super::DataPackageOperation>) -> HRESULT
@@ -16248,11 +16248,11 @@ impl ICoreDragOperation {
         let hr = ((*self.lpVtbl).SetPointerId)(self as *const _ as *mut _, pointerId);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_drag_ui_content_from_software_bitmap(&self, softwareBitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_drag_ui_content_from_software_bitmap(&self, softwareBitmap: &crate::windows::graphics::imaging::SoftwareBitmap) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetDragUIContentFromSoftwareBitmap)(self as *const _ as *mut _, softwareBitmap as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_drag_ui_content_from_software_bitmap_with_anchor_point(&self, softwareBitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_drag_ui_content_from_software_bitmap_with_anchor_point(&self, softwareBitmap: &crate::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetDragUIContentFromSoftwareBitmapWithAnchorPoint)(self as *const _ as *mut _, softwareBitmap as *const _ as *mut _, anchorPoint);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -16296,9 +16296,9 @@ RT_ENUM! { enum CoreDragUIContentMode: u32 {
 DEFINE_IID!(IID_ICoreDragUIOverride, 2309509220, 13193, 20303, 136, 151, 126, 138, 63, 251, 60, 147);
 RT_INTERFACE!{interface ICoreDragUIOverride(ICoreDragUIOverrideVtbl): IInspectable(IInspectableVtbl) [IID_ICoreDragUIOverride] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn SetContentFromSoftwareBitmap(&self, softwareBitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn SetContentFromSoftwareBitmap(&self, softwareBitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn SetContentFromSoftwareBitmapWithAnchorPoint(&self, softwareBitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn SetContentFromSoftwareBitmapWithAnchorPoint(&self, softwareBitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> HRESULT,
     fn get_IsContentVisible(&self, out: *mut bool) -> HRESULT,
     fn put_IsContentVisible(&self, value: bool) -> HRESULT,
     fn get_Caption(&self, out: *mut HSTRING) -> HRESULT,
@@ -16310,11 +16310,11 @@ RT_INTERFACE!{interface ICoreDragUIOverride(ICoreDragUIOverrideVtbl): IInspectab
     fn Clear(&self) -> HRESULT
 }}
 impl ICoreDragUIOverride {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_content_from_software_bitmap(&self, softwareBitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_content_from_software_bitmap(&self, softwareBitmap: &crate::windows::graphics::imaging::SoftwareBitmap) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetContentFromSoftwareBitmap)(self as *const _ as *mut _, softwareBitmap as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_content_from_software_bitmap_with_anchor_point(&self, softwareBitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_content_from_software_bitmap_with_anchor_point(&self, softwareBitmap: &crate::windows::graphics::imaging::SoftwareBitmap, anchorPoint: foundation::Point) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetContentFromSoftwareBitmapWithAnchorPoint)(self as *const _ as *mut _, softwareBitmap as *const _ as *mut _, anchorPoint);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -16403,15 +16403,15 @@ RT_CLASS!{class CoreDropOperationTargetRequestedEventArgs: ICoreDropOperationTar
 } // Windows.ApplicationModel.DataTransfer.DragDrop.Core
 } // Windows.ApplicationModel.DataTransfer.DragDrop
 pub mod sharetarget { // Windows.ApplicationModel.DataTransfer.ShareTarget
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IQuickLink, 1614693128, 61630, 19164, 172, 201, 139, 39, 171, 156, 245, 86);
 RT_INTERFACE!{interface IQuickLink(IQuickLinkVtbl): IInspectable(IInspectableVtbl) [IID_IQuickLink] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
     fn put_Title(&self, value: HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_Thumbnail(&self, out: *mut *mut ::rt::gen::windows::storage::streams::RandomAccessStreamReference) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_Thumbnail(&self, out: *mut *mut crate::windows::storage::streams::RandomAccessStreamReference) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_Thumbnail(&self, value: *mut ::rt::gen::windows::storage::streams::RandomAccessStreamReference) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_Thumbnail(&self, value: *mut crate::windows::storage::streams::RandomAccessStreamReference) -> HRESULT,
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
     fn put_Id(&self, value: HSTRING) -> HRESULT,
     fn get_SupportedDataFormats(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT,
@@ -16427,12 +16427,12 @@ impl IQuickLink {
         let hr = ((*self.lpVtbl).put_Title)(self as *const _ as *mut _, value.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_thumbnail(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::RandomAccessStreamReference>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_thumbnail(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::RandomAccessStreamReference>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Thumbnail)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_thumbnail(&self, value: &::rt::gen::windows::storage::streams::RandomAccessStreamReference) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_thumbnail(&self, value: &crate::windows::storage::streams::RandomAccessStreamReference) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Thumbnail)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -16536,7 +16536,7 @@ impl IShareOperation3 {
 } // Windows.ApplicationModel.DataTransfer.ShareTarget
 } // Windows.ApplicationModel.DataTransfer
 pub mod email { // Windows.ApplicationModel.Email
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IEmailAttachment, 4082354937, 22472, 19163, 185, 146, 96, 252, 235, 88, 79, 84);
 RT_INTERFACE!{interface IEmailAttachment(IEmailAttachmentVtbl): IInspectable(IInspectableVtbl) [IID_IEmailAttachment] {
     fn get_FileName(&self, out: *mut HSTRING) -> HRESULT,
@@ -19142,7 +19142,7 @@ RT_INTERFACE!{interface IEmailStoreNotificationTriggerDetails(IEmailStoreNotific
 }}
 RT_CLASS!{class EmailStoreNotificationTriggerDetails: IEmailStoreNotificationTriggerDetails}
 pub mod dataprovider { // Windows.ApplicationModel.Email.DataProvider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IEmailDataProviderConnection, 1000119751, 14258, 19440, 174, 48, 123, 100, 74, 28, 150, 225);
 RT_INTERFACE!{interface IEmailDataProviderConnection(IEmailDataProviderConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IEmailDataProviderConnection] {
     fn add_MailboxSyncRequested(&self, handler: *mut foundation::TypedEventHandler<EmailDataProviderConnection, EmailMailboxSyncManagerSyncRequestEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -20127,7 +20127,7 @@ DEFINE_IID!(IID_IEmailMailboxValidateCertificatesRequest, 2840410417, 57626, 203
 RT_INTERFACE!{interface IEmailMailboxValidateCertificatesRequest(IEmailMailboxValidateCertificatesRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxValidateCertificatesRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_Certificates(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::security::cryptography::certificates::Certificate>) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_Certificates(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::security::cryptography::certificates::Certificate>) -> HRESULT,
     fn ReportCompletedAsync(&self, validationStatuses: *mut foundation::collections::IIterable<super::EmailCertificateValidationStatus>, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn ReportFailedAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
@@ -20137,7 +20137,7 @@ impl IEmailMailboxValidateCertificatesRequest {
         let hr = ((*self.lpVtbl).get_EmailMailboxId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_certificates(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::security::cryptography::certificates::Certificate>>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_certificates(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::security::cryptography::certificates::Certificate>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Certificates)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -20175,7 +20175,7 @@ RT_CLASS!{class EmailMailboxValidateCertificatesRequestEventArgs: IEmailMailboxV
 } // Windows.ApplicationModel.Email.DataProvider
 } // Windows.ApplicationModel.Email
 pub mod extendedexecution { // Windows.ApplicationModel.ExtendedExecution
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum ExtendedExecutionReason: i32 {
     Unspecified = 0, LocationTracking = 1, SavingData = 2,
 }}
@@ -20256,7 +20256,7 @@ RT_CLASS!{class ExtendedExecutionSession: IExtendedExecutionSession}
 impl RtActivatable<IActivationFactory> for ExtendedExecutionSession {}
 DEFINE_CLSID!(ExtendedExecutionSession(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,83,101,115,115,105,111,110,0]) [CLSID_ExtendedExecutionSession]);
 pub mod foreground { // Windows.ApplicationModel.ExtendedExecution.Foreground
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum ExtendedExecutionForegroundReason: i32 {
     Unspecified = 0, SavingData = 1, BackgroundAudio = 2, Unconstrained = 3,
 }}
@@ -20328,7 +20328,7 @@ DEFINE_CLSID!(ExtendedExecutionForegroundSession(&[87,105,110,100,111,119,115,46
 } // Windows.ApplicationModel.ExtendedExecution.Foreground
 } // Windows.ApplicationModel.ExtendedExecution
 pub mod lockscreen { // Windows.ApplicationModel.LockScreen
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ILockApplicationHost, 955134381, 55631, 20092, 129, 250, 79, 68, 54, 80, 98, 129);
 RT_INTERFACE!{interface ILockApplicationHost(ILockApplicationHostVtbl): IInspectable(IInspectableVtbl) [IID_ILockApplicationHost] {
     fn RequestUnlock(&self) -> HRESULT,
@@ -20511,7 +20511,7 @@ impl ILockScreenUnlockingEventArgs {
 RT_CLASS!{class LockScreenUnlockingEventArgs: ILockScreenUnlockingEventArgs}
 } // Windows.ApplicationModel.LockScreen
 pub mod payments { // Windows.ApplicationModel.Payments
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPaymentAddress, 1596089577, 28474, 16742, 160, 24, 10, 11, 6, 187, 50, 181);
 RT_INTERFACE!{interface IPaymentAddress(IPaymentAddressVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentAddress] {
     fn get_Country(&self, out: *mut HSTRING) -> HRESULT,
@@ -21539,7 +21539,7 @@ impl IPaymentTokenFactory {
     }}
 }
 pub mod provider { // Windows.ApplicationModel.Payments.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPaymentAppCanMakePaymentTriggerDetails, 216138224, 35731, 20150, 140, 70, 46, 74, 108, 106, 38, 246);
 RT_INTERFACE!{interface IPaymentAppCanMakePaymentTriggerDetails(IPaymentAppCanMakePaymentTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentAppCanMakePaymentTriggerDetails] {
     fn get_Request(&self, out: *mut *mut super::PaymentRequest) -> HRESULT,
@@ -21695,7 +21695,7 @@ impl IPaymentTransactionStatics {
 } // Windows.ApplicationModel.Payments
 pub mod preview { // Windows.ApplicationModel.Preview
 pub mod holographic { // Windows.ApplicationModel.Preview.Holographic
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class HolographicApplicationPreview}
 impl RtActivatable<IHolographicApplicationPreviewStatics> for HolographicApplicationPreview {}
 impl HolographicApplicationPreview {
@@ -21726,13 +21726,13 @@ impl IHolographicApplicationPreviewStatics {
 }
 } // Windows.ApplicationModel.Preview.Holographic
 pub mod inkworkspace { // Windows.ApplicationModel.Preview.InkWorkspace
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IInkWorkspaceHostedAppManager, 4262099344, 24153, 19383, 138, 99, 125, 33, 140, 217, 99, 0);
 RT_INTERFACE!{interface IInkWorkspaceHostedAppManager(IInkWorkspaceHostedAppManagerVtbl): IInspectable(IInspectableVtbl) [IID_IInkWorkspaceHostedAppManager] {
-    #[cfg(feature="windows-graphics")] fn SetThumbnailAsync(&self, bitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap, out: *mut *mut foundation::IAsyncAction) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn SetThumbnailAsync(&self, bitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl IInkWorkspaceHostedAppManager {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_thumbnail_async(&self, bitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_thumbnail_async(&self, bitmap: &crate::windows::graphics::imaging::SoftwareBitmap) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SetThumbnailAsync)(self as *const _ as *mut _, bitmap as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -21759,7 +21759,7 @@ impl IInkWorkspaceHostedAppManagerStatics {
 }
 } // Windows.ApplicationModel.Preview.InkWorkspace
 pub mod notes { // Windows.ApplicationModel.Preview.Notes
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_INotePlacementChangedPreviewEventArgs, 1226659767, 63360, 20095, 169, 57, 154, 76, 175, 150, 82, 20);
 RT_INTERFACE!{interface INotePlacementChangedPreviewEventArgs(INotePlacementChangedPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_INotePlacementChangedPreviewEventArgs] {
     fn get_ViewId(&self, out: *mut i32) -> HRESULT
@@ -21778,14 +21778,14 @@ RT_INTERFACE!{interface INotesWindowManagerPreview(INotesWindowManagerPreviewVtb
     fn ShowNote(&self, noteViewId: i32) -> HRESULT,
     fn ShowNoteRelativeTo(&self, noteViewId: i32, anchorNoteViewId: i32) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn ShowNoteWithPlacement(&self, noteViewId: i32, data: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ShowNoteWithPlacement(&self, noteViewId: i32, data: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn HideNote(&self, noteViewId: i32) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn GetNotePlacement(&self, noteViewId: i32, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetNotePlacement(&self, noteViewId: i32, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn TrySetNoteSize(&self, noteViewId: i32, size: foundation::Size, out: *mut bool) -> HRESULT,
     fn SetFocusToNextView(&self) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy8(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SetNotesThumbnailAsync(&self, thumbnail: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SetNotesThumbnailAsync(&self, thumbnail: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn add_SystemLockStateChanged(&self, handler: *mut foundation::TypedEventHandler<NotesWindowManagerPreview, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_SystemLockStateChanged(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     fn add_NotePlacementChanged(&self, handler: *mut foundation::TypedEventHandler<NotesWindowManagerPreview, NotePlacementChangedPreviewEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -21807,7 +21807,7 @@ impl INotesWindowManagerPreview {
         let hr = ((*self.lpVtbl).ShowNoteRelativeTo)(self as *const _ as *mut _, noteViewId, anchorNoteViewId);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn show_note_with_placement(&self, noteViewId: i32, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn show_note_with_placement(&self, noteViewId: i32, data: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).ShowNoteWithPlacement)(self as *const _ as *mut _, noteViewId, data as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -21815,7 +21815,7 @@ impl INotesWindowManagerPreview {
         let hr = ((*self.lpVtbl).HideNote)(self as *const _ as *mut _, noteViewId);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_note_placement(&self, noteViewId: i32) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_note_placement(&self, noteViewId: i32) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetNotePlacement)(self as *const _ as *mut _, noteViewId, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -21829,7 +21829,7 @@ impl INotesWindowManagerPreview {
         let hr = ((*self.lpVtbl).SetFocusToNextView)(self as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_notes_thumbnail_async(&self, thumbnail: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_notes_thumbnail_async(&self, thumbnail: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SetNotesThumbnailAsync)(self as *const _ as *mut _, thumbnail as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -21874,16 +21874,16 @@ DEFINE_IID!(IID_INotesWindowManagerPreview2, 3992880714, 8020, 19209, 152, 35, 2
 RT_INTERFACE!{interface INotesWindowManagerPreview2(INotesWindowManagerPreview2Vtbl): IInspectable(IInspectableVtbl) [IID_INotesWindowManagerPreview2] {
     fn ShowNoteRelativeToWithOptions(&self, noteViewId: i32, anchorNoteViewId: i32, options: *mut NotesWindowManagerPreviewShowNoteOptions) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn ShowNoteWithPlacementWithOptions(&self, noteViewId: i32, data: *mut ::rt::gen::windows::storage::streams::IBuffer, options: *mut NotesWindowManagerPreviewShowNoteOptions) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ShowNoteWithPlacementWithOptions(&self, noteViewId: i32, data: *mut crate::windows::storage::streams::IBuffer, options: *mut NotesWindowManagerPreviewShowNoteOptions) -> HRESULT,
     fn SetFocusToPreviousView(&self) -> HRESULT,
-    #[cfg(feature="windows-graphics")] fn SetThumbnailImageForTaskSwitcherAsync(&self, bitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap, out: *mut *mut foundation::IAsyncAction) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn SetThumbnailImageForTaskSwitcherAsync(&self, bitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl INotesWindowManagerPreview2 {
     #[inline] pub fn show_note_relative_to_with_options(&self, noteViewId: i32, anchorNoteViewId: i32, options: &NotesWindowManagerPreviewShowNoteOptions) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).ShowNoteRelativeToWithOptions)(self as *const _ as *mut _, noteViewId, anchorNoteViewId, options as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn show_note_with_placement_with_options(&self, noteViewId: i32, data: &::rt::gen::windows::storage::streams::IBuffer, options: &NotesWindowManagerPreviewShowNoteOptions) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn show_note_with_placement_with_options(&self, noteViewId: i32, data: &crate::windows::storage::streams::IBuffer, options: &NotesWindowManagerPreviewShowNoteOptions) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).ShowNoteWithPlacementWithOptions)(self as *const _ as *mut _, noteViewId, data as *const _ as *mut _, options as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -21891,7 +21891,7 @@ impl INotesWindowManagerPreview2 {
         let hr = ((*self.lpVtbl).SetFocusToPreviousView)(self as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_thumbnail_image_for_task_switcher_async(&self, bitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_thumbnail_image_for_task_switcher_async(&self, bitmap: &crate::windows::graphics::imaging::SoftwareBitmap) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SetThumbnailImageForTaskSwitcherAsync)(self as *const _ as *mut _, bitmap as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -21948,7 +21948,7 @@ RT_CLASS!{class NoteVisibilityChangedPreviewEventArgs: INoteVisibilityChangedPre
 } // Windows.ApplicationModel.Preview.Notes
 } // Windows.ApplicationModel.Preview
 pub mod resources { // Windows.ApplicationModel.Resources
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IResourceLoader, 139610376, 5871, 17837, 166, 2, 41, 54, 55, 215, 230, 26);
 RT_INTERFACE!{interface IResourceLoader(IResourceLoaderVtbl): IInspectable(IInspectableVtbl) [IID_IResourceLoader] {
     fn GetString(&self, resource: HSTRING, out: *mut HSTRING) -> HRESULT
@@ -22049,7 +22049,7 @@ impl IResourceLoaderStatics2 {
     }}
 }
 pub mod core { // Windows.ApplicationModel.Resources.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_INamedResource, 479773209, 2835, 16960, 137, 165, 212, 149, 220, 24, 154, 0);
 RT_INTERFACE!{interface INamedResource(INamedResourceVtbl): IInspectable(IInspectableVtbl) [IID_INamedResource] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -22100,7 +22100,7 @@ RT_INTERFACE!{interface IResourceCandidate(IResourceCandidateVtbl): IInspectable
     fn get_IsDefault(&self, out: *mut bool) -> HRESULT,
     fn get_ValueAsString(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn GetValueAsFileAsync(&self, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::StorageFile>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetValueAsFileAsync(&self, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::StorageFile>) -> HRESULT,
     fn GetQualifierValue(&self, qualifierName: HSTRING, out: *mut HSTRING) -> HRESULT
 }}
 impl IResourceCandidate {
@@ -22129,7 +22129,7 @@ impl IResourceCandidate {
         let hr = ((*self.lpVtbl).get_ValueAsString)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value_as_file_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::StorageFile>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value_as_file_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::StorageFile>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetValueAsFileAsync)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -22143,10 +22143,10 @@ impl IResourceCandidate {
 RT_CLASS!{class ResourceCandidate: IResourceCandidate}
 DEFINE_IID!(IID_IResourceCandidate2, 1776661608, 63228, 16403, 170, 162, 213, 63, 23, 87, 211, 181);
 RT_INTERFACE!{interface IResourceCandidate2(IResourceCandidate2Vtbl): IInspectable(IInspectableVtbl) [IID_IResourceCandidate2] {
-    #[cfg(feature="windows-storage")] fn GetValueAsStreamAsync(&self, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStream>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetValueAsStreamAsync(&self, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStream>) -> HRESULT
 }}
 impl IResourceCandidate2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value_as_stream_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStream>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value_as_stream_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStream>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetValueAsStreamAsync)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -22287,8 +22287,8 @@ RT_INTERFACE!{interface IResourceManager(IResourceManagerVtbl): IInspectable(IIn
     fn get_MainResourceMap(&self, out: *mut *mut ResourceMap) -> HRESULT,
     fn get_AllResourceMaps(&self, out: *mut *mut foundation::collections::IMapView<HString, ResourceMap>) -> HRESULT,
     fn get_DefaultContext(&self, out: *mut *mut ResourceContext) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn LoadPriFiles(&self, files: *mut foundation::collections::IIterable<::rt::gen::windows::storage::IStorageFile>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn UnloadPriFiles(&self, files: *mut foundation::collections::IIterable<::rt::gen::windows::storage::IStorageFile>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn LoadPriFiles(&self, files: *mut foundation::collections::IIterable<crate::windows::storage::IStorageFile>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn UnloadPriFiles(&self, files: *mut foundation::collections::IIterable<crate::windows::storage::IStorageFile>) -> HRESULT
 }}
 impl IResourceManager {
     #[inline] pub fn get_main_resource_map(&self) -> Result<Option<ComPtr<ResourceMap>>> { unsafe { 
@@ -22306,11 +22306,11 @@ impl IResourceManager {
         let hr = ((*self.lpVtbl).get_DefaultContext)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_pri_files(&self, files: &foundation::collections::IIterable<::rt::gen::windows::storage::IStorageFile>) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_pri_files(&self, files: &foundation::collections::IIterable<crate::windows::storage::IStorageFile>) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).LoadPriFiles)(self as *const _ as *mut _, files as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn unload_pri_files(&self, files: &foundation::collections::IIterable<::rt::gen::windows::storage::IStorageFile>) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn unload_pri_files(&self, files: &foundation::collections::IIterable<crate::windows::storage::IStorageFile>) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).UnloadPriFiles)(self as *const _ as *mut _, files as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -22437,7 +22437,7 @@ RT_ENUM! { enum ResourceQualifierPersistence: i32 {
 RT_CLASS!{class ResourceQualifierVectorView: foundation::collections::IVectorView<ResourceQualifier>}
 } // Windows.ApplicationModel.Resources.Core
 pub mod management { // Windows.ApplicationModel.Resources.Management
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IIndexedResourceCandidate, 241278707, 64236, 17428, 169, 215, 84, 172, 213, 149, 63, 41);
 RT_INTERFACE!{interface IIndexedResourceCandidate(IIndexedResourceCandidateVtbl): IInspectable(IInspectableVtbl) [IID_IIndexedResourceCandidate] {
     fn get_Type(&self, out: *mut IndexedResourceType) -> HRESULT,
@@ -22555,7 +22555,7 @@ impl IResourceIndexerFactory2 {
 } // Windows.ApplicationModel.Resources.Management
 } // Windows.ApplicationModel.Resources
 pub mod search { // Windows.ApplicationModel.Search
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ILocalContentSuggestionSettings, 4004425826, 29757, 17774, 132, 163, 35, 240, 111, 45, 21, 215);
 RT_INTERFACE!{interface ILocalContentSuggestionSettings(ILocalContentSuggestionSettingsVtbl): IInspectable(IInspectableVtbl) [IID_ILocalContentSuggestionSettings] {
     fn put_Enabled(&self, value: bool) -> HRESULT,
@@ -23034,7 +23034,7 @@ impl ISearchSuggestionsRequestDeferral {
 }
 RT_CLASS!{class SearchSuggestionsRequestDeferral: ISearchSuggestionsRequestDeferral}
 pub mod core { // Windows.ApplicationModel.Search.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IRequestingFocusOnKeyboardInputEventArgs, 2702794535, 45479, 16802, 135, 157, 106, 104, 104, 126, 89, 133);
 RT_INTERFACE!{interface IRequestingFocusOnKeyboardInputEventArgs(IRequestingFocusOnKeyboardInputEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRequestingFocusOnKeyboardInputEventArgs] {
     
@@ -23047,7 +23047,7 @@ RT_INTERFACE!{interface ISearchSuggestion(ISearchSuggestionVtbl): IInspectable(I
     fn get_Tag(&self, out: *mut HSTRING) -> HRESULT,
     fn get_DetailText(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_Image(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IRandomAccessStreamReference) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_Image(&self, out: *mut *mut crate::windows::storage::streams::IRandomAccessStreamReference) -> HRESULT,
     fn get_ImageAlternateText(&self, out: *mut HSTRING) -> HRESULT
 }}
 impl ISearchSuggestion {
@@ -23071,7 +23071,7 @@ impl ISearchSuggestion {
         let hr = ((*self.lpVtbl).get_DetailText)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_image(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IRandomAccessStreamReference>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_image(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IRandomAccessStreamReference>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Image)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -23212,7 +23212,7 @@ RT_CLASS!{class SearchSuggestionsRequestedEventArgs: ISearchSuggestionsRequested
 } // Windows.ApplicationModel.Search.Core
 } // Windows.ApplicationModel.Search
 pub mod socialinfo { // Windows.ApplicationModel.SocialInfo
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISocialFeedChildItem, 191535194, 54685, 16574, 152, 12, 72, 138, 42, 179, 10, 131);
 RT_INTERFACE!{interface ISocialFeedChildItem(ISocialFeedChildItemVtbl): IInspectable(IInspectableVtbl) [IID_ISocialFeedChildItem] {
     fn get_Author(&self, out: *mut *mut SocialUserInfo) -> HRESULT,
@@ -23607,7 +23607,7 @@ impl ISocialUserInfo {
 }
 RT_CLASS!{class SocialUserInfo: ISocialUserInfo}
 pub mod provider { // Windows.ApplicationModel.SocialInfo.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISocialDashboardItemUpdater, 1021222345, 18432, 18125, 134, 155, 25, 115, 236, 104, 91, 222);
 RT_INTERFACE!{interface ISocialDashboardItemUpdater(ISocialDashboardItemUpdaterVtbl): IInspectable(IInspectableVtbl) [IID_ISocialDashboardItemUpdater] {
     fn get_OwnerRemoteId(&self, out: *mut HSTRING) -> HRESULT,
@@ -23760,7 +23760,7 @@ impl ISocialInfoProviderManagerStatics {
 } // Windows.ApplicationModel.SocialInfo.Provider
 } // Windows.ApplicationModel.SocialInfo
 pub mod store { // Windows.ApplicationModel.Store
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICurrentApp, 3576545381, 55871, 18053, 153, 94, 155, 72, 46, 181, 230, 3);
 RT_INTERFACE!{static interface ICurrentApp(ICurrentAppVtbl): IInspectable(IInspectableVtbl) [IID_ICurrentApp] {
     fn get_LicenseInformation(&self, out: *mut *mut LicenseInformation) -> HRESULT,
@@ -24506,12 +24506,12 @@ impl IUnfulfilledConsumable {
 }
 RT_CLASS!{class UnfulfilledConsumable: IUnfulfilledConsumable}
 pub mod licensemanagement { // Windows.ApplicationModel.Store.LicenseManagement
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class LicenseManager}
 impl RtActivatable<ILicenseManagerStatics> for LicenseManager {}
 impl RtActivatable<ILicenseManagerStatics2> for LicenseManager {}
 impl LicenseManager {
-    #[cfg(feature="windows-storage")] #[inline] pub fn add_license_async(license: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn add_license_async(license: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<ILicenseManagerStatics>>::get_activation_factory().add_license_async(license)
     }
     #[inline] pub fn get_satisfaction_infos_async(contentIds: &foundation::collections::IIterable<HString>, keyIds: &foundation::collections::IIterable<HString>) -> Result<ComPtr<foundation::IAsyncOperation<LicenseSatisfactionResult>>> {
@@ -24525,11 +24525,11 @@ DEFINE_CLSID!(LicenseManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,
 DEFINE_IID!(IID_ILicenseManagerStatics, 3047963360, 55879, 20256, 154, 35, 9, 24, 44, 148, 118, 255);
 RT_INTERFACE!{static interface ILicenseManagerStatics(ILicenseManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILicenseManagerStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn AddLicenseAsync(&self, license: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn AddLicenseAsync(&self, license: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn GetSatisfactionInfosAsync(&self, contentIds: *mut foundation::collections::IIterable<HString>, keyIds: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncOperation<LicenseSatisfactionResult>) -> HRESULT
 }}
 impl ILicenseManagerStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn add_license_async(&self, license: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn add_license_async(&self, license: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).AddLicenseAsync)(self as *const _ as *mut _, license as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -24622,7 +24622,7 @@ impl ILicenseSatisfactionResult {
 RT_CLASS!{class LicenseSatisfactionResult: ILicenseSatisfactionResult}
 } // Windows.ApplicationModel.Store.LicenseManagement
 pub mod preview { // Windows.ApplicationModel.Store.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum DeliveryOptimizationDownloadMode: i32 {
     Simple = 0, HttpOnly = 1, Lan = 2, Group = 3, Internet = 4, Bypass = 5,
 }}
@@ -24699,46 +24699,46 @@ impl StoreConfiguration {
     #[inline] pub fn has_store_web_account() -> Result<bool> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().has_store_web_account()
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn has_store_web_account_for_user(user: &::rt::gen::windows::system::User) -> Result<bool> {
+    #[cfg(feature="windows-system")] #[inline] pub fn has_store_web_account_for_user(user: &crate::windows::system::User) -> Result<bool> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().has_store_web_account_for_user(user)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_store_log_data_async(options: StoreLogOptions) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStreamReference>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_store_log_data_async(options: StoreLogOptions) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStreamReference>>> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().get_store_log_data_async(options)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn set_store_web_account_id_for_user(user: &::rt::gen::windows::system::User, webAccountId: &HStringArg) -> Result<()> {
+    #[cfg(feature="windows-system")] #[inline] pub fn set_store_web_account_id_for_user(user: &crate::windows::system::User, webAccountId: &HStringArg) -> Result<()> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().set_store_web_account_id_for_user(user, webAccountId)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn is_store_web_account_id_for_user(user: &::rt::gen::windows::system::User, webAccountId: &HStringArg) -> Result<bool> {
+    #[cfg(feature="windows-system")] #[inline] pub fn is_store_web_account_id_for_user(user: &crate::windows::system::User, webAccountId: &HStringArg) -> Result<bool> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().is_store_web_account_id_for_user(user, webAccountId)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn get_purchase_prompting_policy_for_user(user: &::rt::gen::windows::system::User) -> Result<Option<ComPtr<foundation::IReference<u32>>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn get_purchase_prompting_policy_for_user(user: &crate::windows::system::User) -> Result<Option<ComPtr<foundation::IReference<u32>>>> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().get_purchase_prompting_policy_for_user(user)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn set_purchase_prompting_policy_for_user(user: &::rt::gen::windows::system::User, value: &foundation::IReference<u32>) -> Result<()> {
+    #[cfg(feature="windows-system")] #[inline] pub fn set_purchase_prompting_policy_for_user(user: &crate::windows::system::User, value: &foundation::IReference<u32>) -> Result<()> {
         <Self as RtActivatable<IStoreConfigurationStatics3>>::get_activation_factory().set_purchase_prompting_policy_for_user(user, value)
     }
     #[inline] pub fn get_store_web_account_id() -> Result<HString> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().get_store_web_account_id()
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn get_store_web_account_id_for_user(user: &::rt::gen::windows::system::User) -> Result<HString> {
+    #[cfg(feature="windows-system")] #[inline] pub fn get_store_web_account_id_for_user(user: &crate::windows::system::User) -> Result<HString> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().get_store_web_account_id_for_user(user)
     }
     #[inline] pub fn set_enterprise_store_web_account_id(webAccountId: &HStringArg) -> Result<()> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().set_enterprise_store_web_account_id(webAccountId)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn set_enterprise_store_web_account_id_for_user(user: &::rt::gen::windows::system::User, webAccountId: &HStringArg) -> Result<()> {
+    #[cfg(feature="windows-system")] #[inline] pub fn set_enterprise_store_web_account_id_for_user(user: &crate::windows::system::User, webAccountId: &HStringArg) -> Result<()> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().set_enterprise_store_web_account_id_for_user(user, webAccountId)
     }
     #[inline] pub fn get_enterprise_store_web_account_id() -> Result<HString> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().get_enterprise_store_web_account_id()
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn get_enterprise_store_web_account_id_for_user(user: &::rt::gen::windows::system::User) -> Result<HString> {
+    #[cfg(feature="windows-system")] #[inline] pub fn get_enterprise_store_web_account_id_for_user(user: &crate::windows::system::User) -> Result<HString> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().get_enterprise_store_web_account_id_for_user(user)
     }
     #[inline] pub fn should_restrict_to_enterprise_store_only() -> Result<bool> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().should_restrict_to_enterprise_store_only()
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn should_restrict_to_enterprise_store_only_for_user(user: &::rt::gen::windows::system::User) -> Result<bool> {
+    #[cfg(feature="windows-system")] #[inline] pub fn should_restrict_to_enterprise_store_only_for_user(user: &crate::windows::system::User) -> Result<bool> {
         <Self as RtActivatable<IStoreConfigurationStatics4>>::get_activation_factory().should_restrict_to_enterprise_store_only_for_user(user)
     }
     #[inline] pub fn is_pin_to_desktop_supported() -> Result<bool> {
@@ -24753,7 +24753,7 @@ impl StoreConfiguration {
     #[inline] pub fn pin_to_desktop(appPackageFamilyName: &HStringArg) -> Result<()> {
         <Self as RtActivatable<IStoreConfigurationStatics5>>::get_activation_factory().pin_to_desktop(appPackageFamilyName)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn pin_to_desktop_for_user(user: &::rt::gen::windows::system::User, appPackageFamilyName: &HStringArg) -> Result<()> {
+    #[cfg(feature="windows-system")] #[inline] pub fn pin_to_desktop_for_user(user: &crate::windows::system::User, appPackageFamilyName: &HStringArg) -> Result<()> {
         <Self as RtActivatable<IStoreConfigurationStatics5>>::get_activation_factory().pin_to_desktop_for_user(user, appPackageFamilyName)
     }
 }
@@ -24815,13 +24815,13 @@ impl IStoreConfigurationStatics2 {
 DEFINE_IID!(IID_IStoreConfigurationStatics3, 1833301372, 61764, 19637, 157, 63, 78, 176, 94, 48, 182, 211);
 RT_INTERFACE!{static interface IStoreConfigurationStatics3(IStoreConfigurationStatics3Vtbl): IInspectable(IInspectableVtbl) [IID_IStoreConfigurationStatics3] {
     fn HasStoreWebAccount(&self, out: *mut bool) -> HRESULT,
-    #[cfg(feature="windows-system")] fn HasStoreWebAccountForUser(&self, user: *mut ::rt::gen::windows::system::User, out: *mut bool) -> HRESULT,
+    #[cfg(feature="windows-system")] fn HasStoreWebAccountForUser(&self, user: *mut crate::windows::system::User, out: *mut bool) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn GetStoreLogDataAsync(&self, options: StoreLogOptions, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStreamReference>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn SetStoreWebAccountIdForUser(&self, user: *mut ::rt::gen::windows::system::User, webAccountId: HSTRING) -> HRESULT,
-    #[cfg(feature="windows-system")] fn IsStoreWebAccountIdForUser(&self, user: *mut ::rt::gen::windows::system::User, webAccountId: HSTRING, out: *mut bool) -> HRESULT,
-    #[cfg(feature="windows-system")] fn GetPurchasePromptingPolicyForUser(&self, user: *mut ::rt::gen::windows::system::User, out: *mut *mut foundation::IReference<u32>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn SetPurchasePromptingPolicyForUser(&self, user: *mut ::rt::gen::windows::system::User, value: *mut foundation::IReference<u32>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetStoreLogDataAsync(&self, options: StoreLogOptions, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStreamReference>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SetStoreWebAccountIdForUser(&self, user: *mut crate::windows::system::User, webAccountId: HSTRING) -> HRESULT,
+    #[cfg(feature="windows-system")] fn IsStoreWebAccountIdForUser(&self, user: *mut crate::windows::system::User, webAccountId: HSTRING, out: *mut bool) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetPurchasePromptingPolicyForUser(&self, user: *mut crate::windows::system::User, out: *mut *mut foundation::IReference<u32>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SetPurchasePromptingPolicyForUser(&self, user: *mut crate::windows::system::User, value: *mut foundation::IReference<u32>) -> HRESULT
 }}
 impl IStoreConfigurationStatics3 {
     #[inline] pub fn has_store_web_account(&self) -> Result<bool> { unsafe { 
@@ -24829,31 +24829,31 @@ impl IStoreConfigurationStatics3 {
         let hr = ((*self.lpVtbl).HasStoreWebAccount)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn has_store_web_account_for_user(&self, user: &::rt::gen::windows::system::User) -> Result<bool> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn has_store_web_account_for_user(&self, user: &crate::windows::system::User) -> Result<bool> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).HasStoreWebAccountForUser)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_store_log_data_async(&self, options: StoreLogOptions) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStreamReference>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_store_log_data_async(&self, options: StoreLogOptions) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStreamReference>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetStoreLogDataAsync)(self as *const _ as *mut _, options, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn set_store_web_account_id_for_user(&self, user: &::rt::gen::windows::system::User, webAccountId: &HStringArg) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn set_store_web_account_id_for_user(&self, user: &crate::windows::system::User, webAccountId: &HStringArg) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetStoreWebAccountIdForUser)(self as *const _ as *mut _, user as *const _ as *mut _, webAccountId.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn is_store_web_account_id_for_user(&self, user: &::rt::gen::windows::system::User, webAccountId: &HStringArg) -> Result<bool> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn is_store_web_account_id_for_user(&self, user: &crate::windows::system::User, webAccountId: &HStringArg) -> Result<bool> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).IsStoreWebAccountIdForUser)(self as *const _ as *mut _, user as *const _ as *mut _, webAccountId.get(), &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_purchase_prompting_policy_for_user(&self, user: &::rt::gen::windows::system::User) -> Result<Option<ComPtr<foundation::IReference<u32>>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_purchase_prompting_policy_for_user(&self, user: &crate::windows::system::User) -> Result<Option<ComPtr<foundation::IReference<u32>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetPurchasePromptingPolicyForUser)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn set_purchase_prompting_policy_for_user(&self, user: &::rt::gen::windows::system::User, value: &foundation::IReference<u32>) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn set_purchase_prompting_policy_for_user(&self, user: &crate::windows::system::User, value: &foundation::IReference<u32>) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetPurchasePromptingPolicyForUser)(self as *const _ as *mut _, user as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -24861,13 +24861,13 @@ impl IStoreConfigurationStatics3 {
 DEFINE_IID!(IID_IStoreConfigurationStatics4, 553604818, 20195, 19696, 155, 18, 85, 44, 3, 49, 15, 117);
 RT_INTERFACE!{static interface IStoreConfigurationStatics4(IStoreConfigurationStatics4Vtbl): IInspectable(IInspectableVtbl) [IID_IStoreConfigurationStatics4] {
     fn GetStoreWebAccountId(&self, out: *mut HSTRING) -> HRESULT,
-    #[cfg(feature="windows-system")] fn GetStoreWebAccountIdForUser(&self, user: *mut ::rt::gen::windows::system::User, out: *mut HSTRING) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetStoreWebAccountIdForUser(&self, user: *mut crate::windows::system::User, out: *mut HSTRING) -> HRESULT,
     fn SetEnterpriseStoreWebAccountId(&self, webAccountId: HSTRING) -> HRESULT,
-    #[cfg(feature="windows-system")] fn SetEnterpriseStoreWebAccountIdForUser(&self, user: *mut ::rt::gen::windows::system::User, webAccountId: HSTRING) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SetEnterpriseStoreWebAccountIdForUser(&self, user: *mut crate::windows::system::User, webAccountId: HSTRING) -> HRESULT,
     fn GetEnterpriseStoreWebAccountId(&self, out: *mut HSTRING) -> HRESULT,
-    #[cfg(feature="windows-system")] fn GetEnterpriseStoreWebAccountIdForUser(&self, user: *mut ::rt::gen::windows::system::User, out: *mut HSTRING) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetEnterpriseStoreWebAccountIdForUser(&self, user: *mut crate::windows::system::User, out: *mut HSTRING) -> HRESULT,
     fn ShouldRestrictToEnterpriseStoreOnly(&self, out: *mut bool) -> HRESULT,
-    #[cfg(feature="windows-system")] fn ShouldRestrictToEnterpriseStoreOnlyForUser(&self, user: *mut ::rt::gen::windows::system::User, out: *mut bool) -> HRESULT
+    #[cfg(feature="windows-system")] fn ShouldRestrictToEnterpriseStoreOnlyForUser(&self, user: *mut crate::windows::system::User, out: *mut bool) -> HRESULT
 }}
 impl IStoreConfigurationStatics4 {
     #[inline] pub fn get_store_web_account_id(&self) -> Result<HString> { unsafe { 
@@ -24875,7 +24875,7 @@ impl IStoreConfigurationStatics4 {
         let hr = ((*self.lpVtbl).GetStoreWebAccountId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_store_web_account_id_for_user(&self, user: &::rt::gen::windows::system::User) -> Result<HString> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_store_web_account_id_for_user(&self, user: &crate::windows::system::User) -> Result<HString> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetStoreWebAccountIdForUser)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
@@ -24884,7 +24884,7 @@ impl IStoreConfigurationStatics4 {
         let hr = ((*self.lpVtbl).SetEnterpriseStoreWebAccountId)(self as *const _ as *mut _, webAccountId.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn set_enterprise_store_web_account_id_for_user(&self, user: &::rt::gen::windows::system::User, webAccountId: &HStringArg) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn set_enterprise_store_web_account_id_for_user(&self, user: &crate::windows::system::User, webAccountId: &HStringArg) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetEnterpriseStoreWebAccountIdForUser)(self as *const _ as *mut _, user as *const _ as *mut _, webAccountId.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -24893,7 +24893,7 @@ impl IStoreConfigurationStatics4 {
         let hr = ((*self.lpVtbl).GetEnterpriseStoreWebAccountId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_enterprise_store_web_account_id_for_user(&self, user: &::rt::gen::windows::system::User) -> Result<HString> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_enterprise_store_web_account_id_for_user(&self, user: &crate::windows::system::User) -> Result<HString> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetEnterpriseStoreWebAccountIdForUser)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
@@ -24903,7 +24903,7 @@ impl IStoreConfigurationStatics4 {
         let hr = ((*self.lpVtbl).ShouldRestrictToEnterpriseStoreOnly)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn should_restrict_to_enterprise_store_only_for_user(&self, user: &::rt::gen::windows::system::User) -> Result<bool> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn should_restrict_to_enterprise_store_only_for_user(&self, user: &crate::windows::system::User) -> Result<bool> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).ShouldRestrictToEnterpriseStoreOnlyForUser)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -24915,7 +24915,7 @@ RT_INTERFACE!{static interface IStoreConfigurationStatics5(IStoreConfigurationSt
     fn IsPinToTaskbarSupported(&self, out: *mut bool) -> HRESULT,
     fn IsPinToStartSupported(&self, out: *mut bool) -> HRESULT,
     fn PinToDesktop(&self, appPackageFamilyName: HSTRING) -> HRESULT,
-    #[cfg(feature="windows-system")] fn PinToDesktopForUser(&self, user: *mut ::rt::gen::windows::system::User, appPackageFamilyName: HSTRING) -> HRESULT
+    #[cfg(feature="windows-system")] fn PinToDesktopForUser(&self, user: *mut crate::windows::system::User, appPackageFamilyName: HSTRING) -> HRESULT
 }}
 impl IStoreConfigurationStatics5 {
     #[inline] pub fn is_pin_to_desktop_supported(&self) -> Result<bool> { unsafe { 
@@ -24937,7 +24937,7 @@ impl IStoreConfigurationStatics5 {
         let hr = ((*self.lpVtbl).PinToDesktop)(self as *const _ as *mut _, appPackageFamilyName.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn pin_to_desktop_for_user(&self, user: &::rt::gen::windows::system::User, appPackageFamilyName: &HStringArg) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn pin_to_desktop_for_user(&self, user: &crate::windows::system::User, appPackageFamilyName: &HStringArg) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).PinToDesktopForUser)(self as *const _ as *mut _, user as *const _ as *mut _, appPackageFamilyName.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -25119,16 +25119,16 @@ RT_ENUM! { enum StoreSystemFeature: i32 {
 }}
 DEFINE_IID!(IID_IWebAuthenticationCoreManagerHelper, 111478053, 59157, 16675, 146, 118, 157, 111, 134, 91, 165, 95);
 RT_INTERFACE!{static interface IWebAuthenticationCoreManagerHelper(IWebAuthenticationCoreManagerHelperVtbl): IInspectable(IInspectableVtbl) [IID_IWebAuthenticationCoreManagerHelper] {
-    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] fn RequestTokenWithUIElementHostingAsync(&self, request: *mut ::rt::gen::windows::security::authentication::web::core::WebTokenRequest, uiElement: *mut ::rt::gen::windows::ui::xaml::UIElement, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::security::authentication::web::core::WebTokenRequestResult>) -> HRESULT,
-    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] fn RequestTokenWithUIElementHostingAndWebAccountAsync(&self, request: *mut ::rt::gen::windows::security::authentication::web::core::WebTokenRequest, webAccount: *mut ::rt::gen::windows::security::credentials::WebAccount, uiElement: *mut ::rt::gen::windows::ui::xaml::UIElement, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::security::authentication::web::core::WebTokenRequestResult>) -> HRESULT
+    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] fn RequestTokenWithUIElementHostingAsync(&self, request: *mut crate::windows::security::authentication::web::core::WebTokenRequest, uiElement: *mut crate::windows::ui::xaml::UIElement, out: *mut *mut foundation::IAsyncOperation<crate::windows::security::authentication::web::core::WebTokenRequestResult>) -> HRESULT,
+    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] fn RequestTokenWithUIElementHostingAndWebAccountAsync(&self, request: *mut crate::windows::security::authentication::web::core::WebTokenRequest, webAccount: *mut crate::windows::security::credentials::WebAccount, uiElement: *mut crate::windows::ui::xaml::UIElement, out: *mut *mut foundation::IAsyncOperation<crate::windows::security::authentication::web::core::WebTokenRequestResult>) -> HRESULT
 }}
 impl IWebAuthenticationCoreManagerHelper {
-    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_async(&self, request: &::rt::gen::windows::security::authentication::web::core::WebTokenRequest, uiElement: &::rt::gen::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::security::authentication::web::core::WebTokenRequestResult>>> { unsafe { 
+    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_async(&self, request: &crate::windows::security::authentication::web::core::WebTokenRequest, uiElement: &crate::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::security::authentication::web::core::WebTokenRequestResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).RequestTokenWithUIElementHostingAsync)(self as *const _ as *mut _, request as *const _ as *mut _, uiElement as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_and_web_account_async(&self, request: &::rt::gen::windows::security::authentication::web::core::WebTokenRequest, webAccount: &::rt::gen::windows::security::credentials::WebAccount, uiElement: &::rt::gen::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::security::authentication::web::core::WebTokenRequestResult>>> { unsafe { 
+    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_and_web_account_async(&self, request: &crate::windows::security::authentication::web::core::WebTokenRequest, webAccount: &crate::windows::security::credentials::WebAccount, uiElement: &crate::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::security::authentication::web::core::WebTokenRequestResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).RequestTokenWithUIElementHostingAndWebAccountAsync)(self as *const _ as *mut _, request as *const _ as *mut _, webAccount as *const _ as *mut _, uiElement as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25137,16 +25137,16 @@ impl IWebAuthenticationCoreManagerHelper {
 RT_CLASS!{static class WebAuthenticationCoreManagerHelper}
 impl RtActivatable<IWebAuthenticationCoreManagerHelper> for WebAuthenticationCoreManagerHelper {}
 impl WebAuthenticationCoreManagerHelper {
-    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_async(request: &::rt::gen::windows::security::authentication::web::core::WebTokenRequest, uiElement: &::rt::gen::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::security::authentication::web::core::WebTokenRequestResult>>> {
+    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_async(request: &crate::windows::security::authentication::web::core::WebTokenRequest, uiElement: &crate::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::security::authentication::web::core::WebTokenRequestResult>>> {
         <Self as RtActivatable<IWebAuthenticationCoreManagerHelper>>::get_activation_factory().request_token_with_uielement_hosting_async(request, uiElement)
     }
-    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_and_web_account_async(request: &::rt::gen::windows::security::authentication::web::core::WebTokenRequest, webAccount: &::rt::gen::windows::security::credentials::WebAccount, uiElement: &::rt::gen::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::security::authentication::web::core::WebTokenRequestResult>>> {
+    #[cfg(all(feature="windows-security",feature="windows-ui-xaml"))] #[inline] pub fn request_token_with_uielement_hosting_and_web_account_async(request: &crate::windows::security::authentication::web::core::WebTokenRequest, webAccount: &crate::windows::security::credentials::WebAccount, uiElement: &crate::windows::ui::xaml::UIElement) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::security::authentication::web::core::WebTokenRequestResult>>> {
         <Self as RtActivatable<IWebAuthenticationCoreManagerHelper>>::get_activation_factory().request_token_with_uielement_hosting_and_web_account_async(request, webAccount, uiElement)
     }
 }
 DEFINE_CLSID!(WebAuthenticationCoreManagerHelper(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,87,101,98,65,117,116,104,101,110,116,105,99,97,116,105,111,110,67,111,114,101,77,97,110,97,103,101,114,72,101,108,112,101,114,0]) [CLSID_WebAuthenticationCoreManagerHelper]);
 pub mod installcontrol { // Windows.ApplicationModel.Store.Preview.InstallControl
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AppInstallationToastNotificationMode: i32 {
     Default = 0, Toast = 1, ToastWithoutPopup = 2, NoToast = 3,
 }}
@@ -25504,53 +25504,53 @@ impl IAppInstallManager2 {
 DEFINE_IID!(IID_IAppInstallManager3, 2511489815, 59754, 19726, 132, 225, 200, 203, 65, 122, 1, 120);
 RT_INTERFACE!{interface IAppInstallManager3(IAppInstallManager3Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallManager3] {
     #[cfg(not(feature="windows-management"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-management")] fn StartProductInstallAsync(&self, productId: HSTRING, catalogId: HSTRING, flightId: HSTRING, clientId: HSTRING, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: HSTRING, targetVolume: *mut ::rt::gen::windows::management::deployment::PackageVolume, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
+    #[cfg(feature="windows-management")] fn StartProductInstallAsync(&self, productId: HSTRING, catalogId: HSTRING, flightId: HSTRING, clientId: HSTRING, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: HSTRING, targetVolume: *mut crate::windows::management::deployment::PackageVolume, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
     #[cfg(not(all(feature="windows-management",feature="windows-system")))] fn __Dummy1(&self) -> (),
-    #[cfg(all(feature="windows-management",feature="windows-system"))] fn StartProductInstallForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, productId: HSTRING, catalogId: HSTRING, flightId: HSTRING, clientId: HSTRING, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: HSTRING, targetVolume: *mut ::rt::gen::windows::management::deployment::PackageVolume, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
+    #[cfg(all(feature="windows-management",feature="windows-system"))] fn StartProductInstallForUserAsync(&self, user: *mut crate::windows::system::User, productId: HSTRING, catalogId: HSTRING, flightId: HSTRING, clientId: HSTRING, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: HSTRING, targetVolume: *mut crate::windows::management::deployment::PackageVolume, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-system")] fn UpdateAppByPackageFamilyNameForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, packageFamilyName: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn UpdateAppByPackageFamilyNameForUserAsync(&self, user: *mut crate::windows::system::User, packageFamilyName: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-system")] fn SearchForUpdatesForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, productId: HSTRING, skuId: HSTRING, catalogId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SearchForUpdatesForUserAsync(&self, user: *mut crate::windows::system::User, productId: HSTRING, skuId: HSTRING, catalogId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-system")] fn SearchForAllUpdatesForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SearchForAllUpdatesForUserAsync(&self, user: *mut crate::windows::system::User, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-system")] fn GetIsAppAllowedToInstallForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, productId: HSTRING, skuId: HSTRING, catalogId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetIsAppAllowedToInstallForUserAsync(&self, user: *mut crate::windows::system::User, productId: HSTRING, skuId: HSTRING, catalogId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy6(&self) -> (),
-    #[cfg(feature="windows-system")] fn GetIsApplicableForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, productId: HSTRING, skuId: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetIsApplicableForUserAsync(&self, user: *mut crate::windows::system::User, productId: HSTRING, skuId: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
     fn MoveToFrontOfDownloadQueue(&self, productId: HSTRING, correlationVector: HSTRING) -> HRESULT
 }}
 impl IAppInstallManager3 {
-    #[cfg(feature="windows-management")] #[inline] pub fn start_product_install_async(&self, productId: &HStringArg, catalogId: &HStringArg, flightId: &HStringArg, clientId: &HStringArg, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: &HStringArg, targetVolume: &::rt::gen::windows::management::deployment::PackageVolume) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
+    #[cfg(feature="windows-management")] #[inline] pub fn start_product_install_async(&self, productId: &HStringArg, catalogId: &HStringArg, flightId: &HStringArg, clientId: &HStringArg, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: &HStringArg, targetVolume: &crate::windows::management::deployment::PackageVolume) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).StartProductInstallAsync)(self as *const _ as *mut _, productId.get(), catalogId.get(), flightId.get(), clientId.get(), repair, forceUseOfNonRemovableStorage, correlationVector.get(), targetVolume as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-management",feature="windows-system"))] #[inline] pub fn start_product_install_for_user_async(&self, user: &::rt::gen::windows::system::User, productId: &HStringArg, catalogId: &HStringArg, flightId: &HStringArg, clientId: &HStringArg, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: &HStringArg, targetVolume: &::rt::gen::windows::management::deployment::PackageVolume) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
+    #[cfg(all(feature="windows-management",feature="windows-system"))] #[inline] pub fn start_product_install_for_user_async(&self, user: &crate::windows::system::User, productId: &HStringArg, catalogId: &HStringArg, flightId: &HStringArg, clientId: &HStringArg, repair: bool, forceUseOfNonRemovableStorage: bool, correlationVector: &HStringArg, targetVolume: &crate::windows::management::deployment::PackageVolume) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).StartProductInstallForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, productId.get(), catalogId.get(), flightId.get(), clientId.get(), repair, forceUseOfNonRemovableStorage, correlationVector.get(), targetVolume as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn update_app_by_package_family_name_for_user_async(&self, user: &::rt::gen::windows::system::User, packageFamilyName: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AppInstallItem>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn update_app_by_package_family_name_for_user_async(&self, user: &crate::windows::system::User, packageFamilyName: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AppInstallItem>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).UpdateAppByPackageFamilyNameForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, packageFamilyName.get(), correlationVector.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn search_for_updates_for_user_async(&self, user: &::rt::gen::windows::system::User, productId: &HStringArg, skuId: &HStringArg, catalogId: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AppInstallItem>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn search_for_updates_for_user_async(&self, user: &crate::windows::system::User, productId: &HStringArg, skuId: &HStringArg, catalogId: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AppInstallItem>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SearchForUpdatesForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, productId.get(), skuId.get(), catalogId.get(), correlationVector.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn search_for_all_updates_for_user_async(&self, user: &::rt::gen::windows::system::User, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn search_for_all_updates_for_user_async(&self, user: &crate::windows::system::User, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SearchForAllUpdatesForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, correlationVector.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_is_app_allowed_to_install_for_user_async(&self, user: &::rt::gen::windows::system::User, productId: &HStringArg, skuId: &HStringArg, catalogId: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<bool>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_is_app_allowed_to_install_for_user_async(&self, user: &crate::windows::system::User, productId: &HStringArg, skuId: &HStringArg, catalogId: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<bool>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetIsAppAllowedToInstallForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, productId.get(), skuId.get(), catalogId.get(), correlationVector.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_is_applicable_for_user_async(&self, user: &::rt::gen::windows::system::User, productId: &HStringArg, skuId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<bool>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_is_applicable_for_user_async(&self, user: &crate::windows::system::User, productId: &HStringArg, skuId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<bool>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetIsApplicableForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, productId.get(), skuId.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25564,7 +25564,7 @@ DEFINE_IID!(IID_IAppInstallManager4, 638200342, 23198, 20157, 185, 68, 242, 186,
 RT_INTERFACE!{interface IAppInstallManager4(IAppInstallManager4Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallManager4] {
     fn GetFreeUserEntitlementAsync(&self, storeId: HSTRING, campaignId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<GetEntitlementResult>) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-system")] fn GetFreeUserEntitlementForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, storeId: HSTRING, campaignId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<GetEntitlementResult>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetFreeUserEntitlementForUserAsync(&self, user: *mut crate::windows::system::User, storeId: HSTRING, campaignId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<GetEntitlementResult>) -> HRESULT,
     fn GetFreeDeviceEntitlementAsync(&self, storeId: HSTRING, campaignId: HSTRING, correlationVector: HSTRING, out: *mut *mut foundation::IAsyncOperation<GetEntitlementResult>) -> HRESULT
 }}
 impl IAppInstallManager4 {
@@ -25573,7 +25573,7 @@ impl IAppInstallManager4 {
         let hr = ((*self.lpVtbl).GetFreeUserEntitlementAsync)(self as *const _ as *mut _, storeId.get(), campaignId.get(), correlationVector.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_free_user_entitlement_for_user_async(&self, user: &::rt::gen::windows::system::User, storeId: &HStringArg, campaignId: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GetEntitlementResult>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_free_user_entitlement_for_user_async(&self, user: &crate::windows::system::User, storeId: &HStringArg, campaignId: &HStringArg, correlationVector: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GetEntitlementResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetFreeUserEntitlementForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, storeId.get(), campaignId.get(), correlationVector.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25598,13 +25598,13 @@ impl IAppInstallManager5 {
 DEFINE_IID!(IID_IAppInstallManager6, 3387413512, 62074, 17521, 178, 244, 231, 110, 252, 190, 188, 202);
 RT_INTERFACE!{interface IAppInstallManager6(IAppInstallManager6Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallManager6] {
     fn SearchForAllUpdatesWithUpdateOptionsAsync(&self, correlationVector: HSTRING, clientId: HSTRING, updateOptions: *mut AppUpdateOptions, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn SearchForAllUpdatesWithUpdateOptionsForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, correlationVector: HSTRING, clientId: HSTRING, updateOptions: *mut AppUpdateOptions, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SearchForAllUpdatesWithUpdateOptionsForUserAsync(&self, user: *mut crate::windows::system::User, correlationVector: HSTRING, clientId: HSTRING, updateOptions: *mut AppUpdateOptions, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
     fn SearchForUpdatesWithUpdateOptionsAsync(&self, productId: HSTRING, skuId: HSTRING, correlationVector: HSTRING, clientId: HSTRING, updateOptions: *mut AppUpdateOptions, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn SearchForUpdatesWithUpdateOptionsForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, productId: HSTRING, skuId: HSTRING, correlationVector: HSTRING, clientId: HSTRING, updateOptions: *mut AppUpdateOptions, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn SearchForUpdatesWithUpdateOptionsForUserAsync(&self, user: *mut crate::windows::system::User, productId: HSTRING, skuId: HSTRING, correlationVector: HSTRING, clientId: HSTRING, updateOptions: *mut AppUpdateOptions, out: *mut *mut foundation::IAsyncOperation<AppInstallItem>) -> HRESULT,
     fn StartProductInstallWithOptionsAsync(&self, productId: HSTRING, flightId: HSTRING, clientId: HSTRING, correlationVector: HSTRING, installOptions: *mut AppInstallOptions, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn StartProductInstallWithOptionsForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, productId: HSTRING, flightId: HSTRING, clientId: HSTRING, correlationVector: HSTRING, installOptions: *mut AppInstallOptions, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn StartProductInstallWithOptionsForUserAsync(&self, user: *mut crate::windows::system::User, productId: HSTRING, flightId: HSTRING, clientId: HSTRING, correlationVector: HSTRING, installOptions: *mut AppInstallOptions, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>) -> HRESULT,
     fn GetIsPackageIdentityAllowedToInstallAsync(&self, correlationVector: HSTRING, packageIdentityName: HSTRING, publisherCertificateName: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn GetIsPackageIdentityAllowedToInstallForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, correlationVector: HSTRING, packageIdentityName: HSTRING, publisherCertificateName: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT
+    #[cfg(feature="windows-system")] fn GetIsPackageIdentityAllowedToInstallForUserAsync(&self, user: *mut crate::windows::system::User, correlationVector: HSTRING, packageIdentityName: HSTRING, publisherCertificateName: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT
 }}
 impl IAppInstallManager6 {
     #[inline] pub fn search_for_all_updates_with_update_options_async(&self, correlationVector: &HStringArg, clientId: &HStringArg, updateOptions: &AppUpdateOptions) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
@@ -25612,7 +25612,7 @@ impl IAppInstallManager6 {
         let hr = ((*self.lpVtbl).SearchForAllUpdatesWithUpdateOptionsAsync)(self as *const _ as *mut _, correlationVector.get(), clientId.get(), updateOptions as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn search_for_all_updates_with_update_options_for_user_async(&self, user: &::rt::gen::windows::system::User, correlationVector: &HStringArg, clientId: &HStringArg, updateOptions: &AppUpdateOptions) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn search_for_all_updates_with_update_options_for_user_async(&self, user: &crate::windows::system::User, correlationVector: &HStringArg, clientId: &HStringArg, updateOptions: &AppUpdateOptions) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SearchForAllUpdatesWithUpdateOptionsForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, correlationVector.get(), clientId.get(), updateOptions as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25622,7 +25622,7 @@ impl IAppInstallManager6 {
         let hr = ((*self.lpVtbl).SearchForUpdatesWithUpdateOptionsAsync)(self as *const _ as *mut _, productId.get(), skuId.get(), correlationVector.get(), clientId.get(), updateOptions as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn search_for_updates_with_update_options_for_user_async(&self, user: &::rt::gen::windows::system::User, productId: &HStringArg, skuId: &HStringArg, correlationVector: &HStringArg, clientId: &HStringArg, updateOptions: &AppUpdateOptions) -> Result<ComPtr<foundation::IAsyncOperation<AppInstallItem>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn search_for_updates_with_update_options_for_user_async(&self, user: &crate::windows::system::User, productId: &HStringArg, skuId: &HStringArg, correlationVector: &HStringArg, clientId: &HStringArg, updateOptions: &AppUpdateOptions) -> Result<ComPtr<foundation::IAsyncOperation<AppInstallItem>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SearchForUpdatesWithUpdateOptionsForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, productId.get(), skuId.get(), correlationVector.get(), clientId.get(), updateOptions as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25632,7 +25632,7 @@ impl IAppInstallManager6 {
         let hr = ((*self.lpVtbl).StartProductInstallWithOptionsAsync)(self as *const _ as *mut _, productId.get(), flightId.get(), clientId.get(), correlationVector.get(), installOptions as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn start_product_install_with_options_for_user_async(&self, user: &::rt::gen::windows::system::User, productId: &HStringArg, flightId: &HStringArg, clientId: &HStringArg, correlationVector: &HStringArg, installOptions: &AppInstallOptions) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn start_product_install_with_options_for_user_async(&self, user: &crate::windows::system::User, productId: &HStringArg, flightId: &HStringArg, clientId: &HStringArg, correlationVector: &HStringArg, installOptions: &AppInstallOptions) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<AppInstallItem>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).StartProductInstallWithOptionsForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, productId.get(), flightId.get(), clientId.get(), correlationVector.get(), installOptions as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25642,7 +25642,7 @@ impl IAppInstallManager6 {
         let hr = ((*self.lpVtbl).GetIsPackageIdentityAllowedToInstallAsync)(self as *const _ as *mut _, correlationVector.get(), packageIdentityName.get(), publisherCertificateName.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_is_package_identity_allowed_to_install_for_user_async(&self, user: &::rt::gen::windows::system::User, correlationVector: &HStringArg, packageIdentityName: &HStringArg, publisherCertificateName: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<bool>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_is_package_identity_allowed_to_install_for_user_async(&self, user: &crate::windows::system::User, correlationVector: &HStringArg, packageIdentityName: &HStringArg, publisherCertificateName: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<bool>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetIsPackageIdentityAllowedToInstallForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, correlationVector.get(), packageIdentityName.get(), publisherCertificateName.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -25682,9 +25682,9 @@ RT_INTERFACE!{interface IAppInstallOptions(IAppInstallOptionsVtbl): IInspectable
     fn get_Repair(&self, out: *mut bool) -> HRESULT,
     fn put_Repair(&self, value: bool) -> HRESULT,
     #[cfg(not(feature="windows-management"))] fn __Dummy8(&self) -> (),
-    #[cfg(feature="windows-management")] fn get_TargetVolume(&self, out: *mut *mut ::rt::gen::windows::management::deployment::PackageVolume) -> HRESULT,
+    #[cfg(feature="windows-management")] fn get_TargetVolume(&self, out: *mut *mut crate::windows::management::deployment::PackageVolume) -> HRESULT,
     #[cfg(not(feature="windows-management"))] fn __Dummy9(&self) -> (),
-    #[cfg(feature="windows-management")] fn put_TargetVolume(&self, value: *mut ::rt::gen::windows::management::deployment::PackageVolume) -> HRESULT,
+    #[cfg(feature="windows-management")] fn put_TargetVolume(&self, value: *mut crate::windows::management::deployment::PackageVolume) -> HRESULT,
     fn get_LaunchAfterInstall(&self, out: *mut bool) -> HRESULT,
     fn put_LaunchAfterInstall(&self, value: bool) -> HRESULT
 }}
@@ -25725,12 +25725,12 @@ impl IAppInstallOptions {
         let hr = ((*self.lpVtbl).put_Repair)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-management")] #[inline] pub fn get_target_volume(&self) -> Result<Option<ComPtr<::rt::gen::windows::management::deployment::PackageVolume>>> { unsafe { 
+    #[cfg(feature="windows-management")] #[inline] pub fn get_target_volume(&self) -> Result<Option<ComPtr<crate::windows::management::deployment::PackageVolume>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_TargetVolume)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-management")] #[inline] pub fn set_target_volume(&self, value: &::rt::gen::windows::management::deployment::PackageVolume) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-management")] #[inline] pub fn set_target_volume(&self, value: &crate::windows::management::deployment::PackageVolume) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_TargetVolume)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -25893,11 +25893,11 @@ RT_CLASS!{class AppInstallStatus: IAppInstallStatus}
 DEFINE_IID!(IID_IAppInstallStatus2, 2531754378, 24210, 19113, 142, 220, 88, 254, 212, 184, 126, 0);
 RT_INTERFACE!{interface IAppInstallStatus2(IAppInstallStatus2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallStatus2] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut ::rt::gen::windows::system::User) -> HRESULT,
+    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut crate::windows::system::User) -> HRESULT,
     fn get_ReadyForLaunch(&self, out: *mut bool) -> HRESULT
 }}
 impl IAppInstallStatus2 {
-    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<::rt::gen::windows::system::User>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<crate::windows::system::User>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_User)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -25990,7 +25990,7 @@ RT_ENUM! { enum GetEntitlementStatus: i32 {
 } // Windows.ApplicationModel.Store.Preview
 } // Windows.ApplicationModel.Store
 pub mod useractivities { // Windows.ApplicationModel.UserActivities
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUserActivity, 4228923038, 11435, 19766, 174, 162, 180, 187, 85, 108, 239, 15);
 RT_INTERFACE!{interface IUserActivity(IUserActivityVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivity] {
     fn get_State(&self, out: *mut UserActivityState) -> HRESULT,
@@ -26511,7 +26511,7 @@ impl IUserActivityVisualElements2 {
     }}
 }
 pub mod core { // Windows.ApplicationModel.UserActivities.Core
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class CoreUserActivityManager}
 impl RtActivatable<ICoreUserActivityManagerStatics> for CoreUserActivityManager {}
 impl CoreUserActivityManager {
@@ -26543,7 +26543,7 @@ impl ICoreUserActivityManagerStatics {
 } // Windows.ApplicationModel.UserActivities.Core
 } // Windows.ApplicationModel.UserActivities
 pub mod userdataaccounts { // Windows.ApplicationModel.UserDataAccounts
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUserDataAccount, 3116643966, 45896, 18704, 190, 148, 74, 212, 187, 166, 222, 167);
 RT_INTERFACE!{interface IUserDataAccount(IUserDataAccountVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccount] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -26880,7 +26880,7 @@ impl IUserDataAccountStoreChangedEventArgs {
 }
 RT_CLASS!{class UserDataAccountStoreChangedEventArgs: IUserDataAccountStoreChangedEventArgs}
 pub mod provider { // Windows.ApplicationModel.UserDataAccounts.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUserDataAccountPartnerAccountInfo, 1595932727, 63215, 20163, 134, 48, 1, 44, 89, 193, 20, 159);
 RT_INTERFACE!{interface IUserDataAccountPartnerAccountInfo(IUserDataAccountPartnerAccountInfoVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountPartnerAccountInfo] {
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -26981,7 +26981,7 @@ impl IUserDataAccountProviderSettingsOperation {
 RT_CLASS!{class UserDataAccountProviderSettingsOperation: IUserDataAccountProviderSettingsOperation}
 } // Windows.ApplicationModel.UserDataAccounts.Provider
 pub mod systemaccess { // Windows.ApplicationModel.UserDataAccounts.SystemAccess
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum DeviceAccountAuthenticationType: i32 {
     Basic = 0, OAuth = 1, SingleSignOn = 2,
 }}
@@ -27172,13 +27172,13 @@ DEFINE_CLSID!(DeviceAccountConfiguration(&[87,105,110,100,111,119,115,46,65,112,
 DEFINE_IID!(IID_IDeviceAccountConfiguration2, 4071810470, 29325, 19018, 137, 69, 43, 248, 88, 1, 54, 222);
 RT_INTERFACE!{interface IDeviceAccountConfiguration2(IDeviceAccountConfiguration2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceAccountConfiguration2] {
     #[cfg(not(feature="windows-security"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_IncomingServerCredential(&self, out: *mut *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_IncomingServerCredential(&self, out: *mut *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-security")] fn put_IncomingServerCredential(&self, value: *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn put_IncomingServerCredential(&self, value: *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_OutgoingServerCredential(&self, out: *mut *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_OutgoingServerCredential(&self, out: *mut *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-security")] fn put_OutgoingServerCredential(&self, value: *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn put_OutgoingServerCredential(&self, value: *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     fn get_OAuthRefreshToken(&self, out: *mut HSTRING) -> HRESULT,
     fn put_OAuthRefreshToken(&self, value: HSTRING) -> HRESULT,
     fn get_IsExternallyManaged(&self, out: *mut bool) -> HRESULT,
@@ -27233,21 +27233,21 @@ RT_INTERFACE!{interface IDeviceAccountConfiguration2(IDeviceAccountConfiguration
     fn put_IsSyncScheduleManagedBySystem(&self, value: bool) -> HRESULT
 }}
 impl IDeviceAccountConfiguration2 {
-    #[cfg(feature="windows-security")] #[inline] pub fn get_incoming_server_credential(&self) -> Result<Option<ComPtr<::rt::gen::windows::security::credentials::PasswordCredential>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_incoming_server_credential(&self) -> Result<Option<ComPtr<crate::windows::security::credentials::PasswordCredential>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_IncomingServerCredential)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn set_incoming_server_credential(&self, value: &::rt::gen::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn set_incoming_server_credential(&self, value: &crate::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_IncomingServerCredential)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_outgoing_server_credential(&self) -> Result<Option<ComPtr<::rt::gen::windows::security::credentials::PasswordCredential>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_outgoing_server_credential(&self) -> Result<Option<ComPtr<crate::windows::security::credentials::PasswordCredential>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_OutgoingServerCredential)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn set_outgoing_server_credential(&self, value: &::rt::gen::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn set_outgoing_server_credential(&self, value: &crate::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_OutgoingServerCredential)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -27563,7 +27563,7 @@ impl IUserDataAccountSystemAccessManagerStatics2 {
 } // Windows.ApplicationModel.UserDataAccounts.SystemAccess
 } // Windows.ApplicationModel.UserDataAccounts
 pub mod userdatatasks { // Windows.ApplicationModel.UserDataTasks
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUserDataTask, 2087028177, 57556, 20377, 174, 226, 188, 45, 93, 218, 223, 76);
 RT_INTERFACE!{interface IUserDataTask(IUserDataTaskVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTask] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -28245,7 +28245,7 @@ RT_ENUM! { enum UserDataTaskWeekOfMonth: i32 {
     First = 0, Second = 1, Third = 2, Fourth = 3, Last = 4,
 }}
 pub mod dataprovider { // Windows.ApplicationModel.UserDataTasks.DataProvider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUserDataTaskDataProviderConnection, 2683542813, 42055, 17035, 175, 233, 229, 64, 43, 222, 176, 65);
 RT_INTERFACE!{interface IUserDataTaskDataProviderConnection(IUserDataTaskDataProviderConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskDataProviderConnection] {
     fn add_CreateOrUpdateTaskRequested(&self, handler: *mut foundation::TypedEventHandler<UserDataTaskDataProviderConnection, UserDataTaskListCreateOrUpdateTaskRequestEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -28561,7 +28561,7 @@ RT_CLASS!{class UserDataTaskListSyncManagerSyncRequestEventArgs: IUserDataTaskLi
 } // Windows.ApplicationModel.UserDataTasks.DataProvider
 } // Windows.ApplicationModel.UserDataTasks
 pub mod voicecommands { // Windows.ApplicationModel.VoiceCommands
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IVoiceCommand, 2473546355, 60546, 17062, 165, 92, 210, 215, 158, 198, 249, 32);
 RT_INTERFACE!{interface IVoiceCommand(IVoiceCommandVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommand] {
     fn get_CommandName(&self, out: *mut HSTRING) -> HRESULT,
@@ -28994,7 +28994,7 @@ impl RtActivatable<IActivationFactory> for VoiceCommandUserMessage {}
 DEFINE_CLSID!(VoiceCommandUserMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,85,115,101,114,77,101,115,115,97,103,101,0]) [CLSID_VoiceCommandUserMessage]);
 } // Windows.ApplicationModel.VoiceCommands
 pub mod wallet { // Windows.ApplicationModel.Wallet
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum WalletActionKind: i32 {
     OpenItem = 0, Transaction = 1, MoreTransactions = 2, Message = 3, Verb = 4,
 }}
@@ -29719,7 +29719,7 @@ impl IWalletVerbFactory {
     }}
 }
 pub mod system { // Windows.ApplicationModel.Wallet.System
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum WalletItemAppAssociation: i32 {
     None = 0, AppInstalled = 1, AppNotInstalled = 2,
 }}
@@ -29728,7 +29728,7 @@ RT_INTERFACE!{interface IWalletItemSystemStore(IWalletItemSystemStoreVtbl): IIns
     fn GetItemsAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::WalletItem>>) -> HRESULT,
     fn DeleteAsync(&self, item: *mut super::WalletItem, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn ImportItemAsync(&self, stream: *mut ::rt::gen::windows::storage::streams::IRandomAccessStreamReference, out: *mut *mut foundation::IAsyncOperation<super::WalletItem>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ImportItemAsync(&self, stream: *mut crate::windows::storage::streams::IRandomAccessStreamReference, out: *mut *mut foundation::IAsyncOperation<super::WalletItem>) -> HRESULT,
     fn GetAppStatusForItem(&self, item: *mut super::WalletItem, out: *mut WalletItemAppAssociation) -> HRESULT,
     fn LaunchAppForItemAsync(&self, item: *mut super::WalletItem, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT
 }}
@@ -29743,7 +29743,7 @@ impl IWalletItemSystemStore {
         let hr = ((*self.lpVtbl).DeleteAsync)(self as *const _ as *mut _, item as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn import_item_async(&self, stream: &::rt::gen::windows::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<foundation::IAsyncOperation<super::WalletItem>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn import_item_async(&self, stream: &crate::windows::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<foundation::IAsyncOperation<super::WalletItem>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ImportItemAsync)(self as *const _ as *mut _, stream as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }

--- a/src/rt/gen/windows/data.rs
+++ b/src/rt/gen/windows/data.rs
@@ -1,5 +1,5 @@
 pub mod html { // Windows.Data.Html
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IHtmlUtilities, 4273998557, 9113, 20396, 181, 167, 5, 233, 172, 215, 24, 29);
 RT_INTERFACE!{static interface IHtmlUtilities(IHtmlUtilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IHtmlUtilities] {
     fn ConvertToText(&self, html: HSTRING, out: *mut HSTRING) -> HRESULT
@@ -21,7 +21,7 @@ impl HtmlUtilities {
 DEFINE_CLSID!(HtmlUtilities(&[87,105,110,100,111,119,115,46,68,97,116,97,46,72,116,109,108,46,72,116,109,108,85,116,105,108,105,116,105,101,115,0]) [CLSID_HtmlUtilities]);
 } // Windows.Data.Html
 pub mod json { // Windows.Data.Json
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IJsonArray, 146922934, 3261, 19098, 181, 211, 47, 133, 45, 195, 126, 129);
 RT_INTERFACE!{interface IJsonArray(IJsonArrayVtbl): IInspectable(IInspectableVtbl) [IID_IJsonArray] {
     fn GetObjectAt(&self, index: u32, out: *mut *mut JsonObject) -> HRESULT,
@@ -346,7 +346,7 @@ RT_ENUM! { enum JsonValueType: i32 {
 }}
 } // Windows.Data.Json
 pub mod pdf { // Windows.Data.Pdf
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPdfDocument, 2893987549, 33018, 16521, 132, 110, 129, 183, 127, 245, 168, 108);
 RT_INTERFACE!{interface IPdfDocument(IPdfDocumentVtbl): IInspectable(IInspectableVtbl) [IID_IPdfDocument] {
     fn GetPage(&self, pageIndex: u32, out: *mut *mut PdfPage) -> HRESULT,
@@ -589,7 +589,7 @@ RT_ENUM! { enum PdfPageRotation: i32 {
 }}
 } // Windows.Data.Pdf
 pub mod text { // Windows.Data.Text
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AlternateNormalizationFormat: i32 {
     NotNormalized = 0, Number = 1, Currency = 3, Date = 4, Time = 5,
 }}
@@ -1191,7 +1191,7 @@ impl IWordsSegmenterFactory {
 } // Windows.Data.Text
 pub mod xml { // Windows.Data.Xml
 pub mod dom { // Windows.Data.Xml.Dom
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDtdEntity, 1779130364, 25524, 18447, 158, 106, 138, 146, 129, 106, 173, 228);
 RT_INTERFACE!{interface IDtdEntity(IDtdEntityVtbl): IInspectable(IInspectableVtbl) [IID_IDtdEntity] {
     fn get_PublicId(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -1441,10 +1441,10 @@ impl XmlDocument {
     #[inline] pub fn load_from_uri_with_settings_async(uri: &foundation::Uri, loadSettings: &XmlLoadSettings) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> {
         <Self as RtActivatable<IXmlDocumentStatics>>::get_activation_factory().load_from_uri_with_settings_async(uri, loadSettings)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_async(file: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_async(file: &crate::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> {
         <Self as RtActivatable<IXmlDocumentStatics>>::get_activation_factory().load_from_file_async(file)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_with_settings_async(file: &::rt::gen::windows::storage::IStorageFile, loadSettings: &XmlLoadSettings) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_with_settings_async(file: &crate::windows::storage::IStorageFile, loadSettings: &XmlLoadSettings) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> {
         <Self as RtActivatable<IXmlDocumentStatics>>::get_activation_factory().load_from_file_with_settings_async(file, loadSettings)
     }
 }
@@ -1458,7 +1458,7 @@ DEFINE_IID!(IID_IXmlDocumentIO, 1825630030, 61029, 17545, 158, 191, 202, 67, 232
 RT_INTERFACE!{interface IXmlDocumentIO(IXmlDocumentIOVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocumentIO] {
     fn LoadXml(&self, xml: HSTRING) -> HRESULT,
     fn LoadXmlWithSettings(&self, xml: HSTRING, loadSettings: *mut XmlLoadSettings) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn SaveToFileAsync(&self, file: *mut ::rt::gen::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncAction) -> HRESULT
+    #[cfg(feature="windows-storage")] fn SaveToFileAsync(&self, file: *mut crate::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl IXmlDocumentIO {
     #[inline] pub fn load_xml(&self, xml: &HStringArg) -> Result<()> { unsafe { 
@@ -1469,7 +1469,7 @@ impl IXmlDocumentIO {
         let hr = ((*self.lpVtbl).LoadXmlWithSettings)(self as *const _ as *mut _, xml.get(), loadSettings as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn save_to_file_async(&self, file: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn save_to_file_async(&self, file: &crate::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SaveToFileAsync)(self as *const _ as *mut _, file as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1477,15 +1477,15 @@ impl IXmlDocumentIO {
 }
 DEFINE_IID!(IID_IXmlDocumentIO2, 1560495713, 31704, 19157, 158, 191, 129, 230, 52, 114, 99, 177);
 RT_INTERFACE!{interface IXmlDocumentIO2(IXmlDocumentIO2Vtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocumentIO2] {
-    #[cfg(feature="windows-storage")] fn LoadXmlFromBuffer(&self, buffer: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn LoadXmlFromBufferWithSettings(&self, buffer: *mut ::rt::gen::windows::storage::streams::IBuffer, loadSettings: *mut XmlLoadSettings) -> HRESULT
+    #[cfg(feature="windows-storage")] fn LoadXmlFromBuffer(&self, buffer: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn LoadXmlFromBufferWithSettings(&self, buffer: *mut crate::windows::storage::streams::IBuffer, loadSettings: *mut XmlLoadSettings) -> HRESULT
 }}
 impl IXmlDocumentIO2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_xml_from_buffer(&self, buffer: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_xml_from_buffer(&self, buffer: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).LoadXmlFromBuffer)(self as *const _ as *mut _, buffer as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_xml_from_buffer_with_settings(&self, buffer: &::rt::gen::windows::storage::streams::IBuffer, loadSettings: &XmlLoadSettings) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_xml_from_buffer_with_settings(&self, buffer: &crate::windows::storage::streams::IBuffer, loadSettings: &XmlLoadSettings) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).LoadXmlFromBufferWithSettings)(self as *const _ as *mut _, buffer as *const _ as *mut _, loadSettings as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -1494,8 +1494,8 @@ DEFINE_IID!(IID_IXmlDocumentStatics, 1430508116, 55127, 19321, 149, 57, 35, 43, 
 RT_INTERFACE!{static interface IXmlDocumentStatics(IXmlDocumentStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocumentStatics] {
     fn LoadFromUriAsync(&self, uri: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperation<XmlDocument>) -> HRESULT,
     fn LoadFromUriWithSettingsAsync(&self, uri: *mut foundation::Uri, loadSettings: *mut XmlLoadSettings, out: *mut *mut foundation::IAsyncOperation<XmlDocument>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn LoadFromFileAsync(&self, file: *mut ::rt::gen::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncOperation<XmlDocument>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn LoadFromFileWithSettingsAsync(&self, file: *mut ::rt::gen::windows::storage::IStorageFile, loadSettings: *mut XmlLoadSettings, out: *mut *mut foundation::IAsyncOperation<XmlDocument>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn LoadFromFileAsync(&self, file: *mut crate::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncOperation<XmlDocument>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn LoadFromFileWithSettingsAsync(&self, file: *mut crate::windows::storage::IStorageFile, loadSettings: *mut XmlLoadSettings, out: *mut *mut foundation::IAsyncOperation<XmlDocument>) -> HRESULT
 }}
 impl IXmlDocumentStatics {
     #[inline] pub fn load_from_uri_async(&self, uri: &foundation::Uri) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> { unsafe { 
@@ -1508,12 +1508,12 @@ impl IXmlDocumentStatics {
         let hr = ((*self.lpVtbl).LoadFromUriWithSettingsAsync)(self as *const _ as *mut _, uri as *const _ as *mut _, loadSettings as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_async(&self, file: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_async(&self, file: &crate::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).LoadFromFileAsync)(self as *const _ as *mut _, file as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_with_settings_async(&self, file: &::rt::gen::windows::storage::IStorageFile, loadSettings: &XmlLoadSettings) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_with_settings_async(&self, file: &crate::windows::storage::IStorageFile, loadSettings: &XmlLoadSettings) -> Result<ComPtr<foundation::IAsyncOperation<XmlDocument>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).LoadFromFileWithSettingsAsync)(self as *const _ as *mut _, file as *const _ as *mut _, loadSettings as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -2003,7 +2003,7 @@ impl IXmlText {
 RT_CLASS!{class XmlText: IXmlText}
 } // Windows.Data.Xml.Dom
 pub mod xsl { // Windows.Data.Xml.Xsl
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IXsltProcessor, 2070179903, 21772, 18630, 169, 15, 147, 165, 185, 100, 81, 143);
 RT_INTERFACE!{interface IXsltProcessor(IXsltProcessorVtbl): IInspectable(IInspectableVtbl) [IID_IXsltProcessor] {
     fn TransformToString(&self, inputNode: *mut super::dom::IXmlNode, out: *mut HSTRING) -> HRESULT

--- a/src/rt/gen/windows/devices.rs
+++ b/src/rt/gen/windows/devices.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ILowLevelDevicesAggregateProvider, 2805880348, 43713, 20167, 168, 82, 71, 159, 112, 96, 208, 31);
 RT_INTERFACE!{interface ILowLevelDevicesAggregateProvider(ILowLevelDevicesAggregateProviderVtbl): IInspectable(IInspectableVtbl) [IID_ILowLevelDevicesAggregateProvider] {
     fn get_AdcControllerProvider(&self, out: *mut *mut adc::provider::IAdcControllerProvider) -> HRESULT,
@@ -85,7 +85,7 @@ impl ILowLevelDevicesControllerStatics {
     }}
 }
 pub mod adc { // Windows.Devices.Adc
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdcChannel, 67892244, 9608, 19030, 171, 239, 115, 162, 96, 172, 198, 10);
 RT_INTERFACE!{interface IAdcChannel(IAdcChannelVtbl): IInspectable(IInspectableVtbl) [IID_IAdcChannel] {
     fn get_Controller(&self, out: *mut *mut AdcController) -> HRESULT,
@@ -200,7 +200,7 @@ impl IAdcControllerStatics2 {
     }}
 }
 pub mod provider { // Windows.Devices.Adc.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdcControllerProvider, 3193198632, 33133, 19941, 160, 72, 171, 160, 105, 88, 170, 168);
 RT_INTERFACE!{interface IAdcControllerProvider(IAdcControllerProviderVtbl): IInspectable(IInspectableVtbl) [IID_IAdcControllerProvider] {
     fn get_ChannelCount(&self, out: *mut i32) -> HRESULT,
@@ -280,7 +280,7 @@ RT_ENUM! { enum ProviderAdcChannelMode: i32 {
 } // Windows.Devices.Adc.Provider
 } // Windows.Devices.Adc
 pub mod alljoyn { // Windows.Devices.AllJoyn
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAllJoynAboutData, 3853106944, 8098, 18489, 147, 239, 249, 223, 64, 72, 144, 247);
 RT_INTERFACE!{interface IAllJoynAboutData(IAllJoynAboutDataVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynAboutData] {
     fn get_IsEnabled(&self, out: *mut bool) -> HRESULT,
@@ -1646,7 +1646,7 @@ impl IAllJoynWatcherStoppedEventArgsFactory {
 }
 } // Windows.Devices.AllJoyn
 pub mod background { // Windows.Devices.Background
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDeviceServicingDetails, 1252781609, 9028, 19140, 133, 39, 74, 142, 246, 144, 86, 69);
 RT_INTERFACE!{interface IDeviceServicingDetails(IDeviceServicingDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceServicingDetails] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -1691,7 +1691,7 @@ impl IDeviceUseDetails {
 RT_CLASS!{class DeviceUseDetails: IDeviceUseDetails}
 } // Windows.Devices.Background
 pub mod bluetooth { // Windows.Devices.Bluetooth
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBluetoothAdapter, 2037706828, 24442, 18996, 146, 37, 168, 85, 248, 75, 26, 139);
 RT_INTERFACE!{interface IBluetoothAdapter(IBluetoothAdapterVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothAdapter] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -3047,7 +3047,7 @@ impl IBluetoothUuidHelperStatics {
     }}
 }
 pub mod advertisement { // Windows.Devices.Bluetooth.Advertisement
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBluetoothLEAdvertisement, 107983543, 13265, 20093, 131, 103, 207, 129, 208, 247, 150, 83);
 RT_INTERFACE!{interface IBluetoothLEAdvertisement(IBluetoothLEAdvertisementVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisement] {
     fn get_Flags(&self, out: *mut *mut foundation::IReference<BluetoothLEAdvertisementFlags>) -> HRESULT,
@@ -3114,8 +3114,8 @@ RT_INTERFACE!{interface IBluetoothLEAdvertisementBytePattern(IBluetoothLEAdverti
     fn put_DataType(&self, value: u8) -> HRESULT,
     fn get_Offset(&self, out: *mut i16) -> HRESULT,
     fn put_Offset(&self, value: i16) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn put_Data(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_Data(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IBluetoothLEAdvertisementBytePattern {
     #[inline] pub fn get_data_type(&self) -> Result<u8> { unsafe { 
@@ -3136,12 +3136,12 @@ impl IBluetoothLEAdvertisementBytePattern {
         let hr = ((*self.lpVtbl).put_Offset)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Data)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_data(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_data(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Data)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3150,17 +3150,17 @@ RT_CLASS!{class BluetoothLEAdvertisementBytePattern: IBluetoothLEAdvertisementBy
 impl RtActivatable<IBluetoothLEAdvertisementBytePatternFactory> for BluetoothLEAdvertisementBytePattern {}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementBytePattern {}
 impl BluetoothLEAdvertisementBytePattern {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create(dataType: u8, offset: i16, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementBytePattern>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create(dataType: u8, offset: i16, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementBytePattern>> {
         <Self as RtActivatable<IBluetoothLEAdvertisementBytePatternFactory>>::get_activation_factory().create(dataType, offset, data)
     }
 }
 DEFINE_CLSID!(BluetoothLEAdvertisementBytePattern(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,66,121,116,101,80,97,116,116,101,114,110,0]) [CLSID_BluetoothLEAdvertisementBytePattern]);
 DEFINE_IID!(IID_IBluetoothLEAdvertisementBytePatternFactory, 3269610867, 64860, 20163, 190, 42, 156, 166, 250, 17, 183, 189);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementBytePatternFactory(IBluetoothLEAdvertisementBytePatternFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementBytePatternFactory] {
-    #[cfg(feature="windows-storage")] fn Create(&self, dataType: u8, offset: i16, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEAdvertisementBytePattern) -> HRESULT
+    #[cfg(feature="windows-storage")] fn Create(&self, dataType: u8, offset: i16, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEAdvertisementBytePattern) -> HRESULT
 }}
 impl IBluetoothLEAdvertisementBytePatternFactory {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create(&self, dataType: u8, offset: i16, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementBytePattern>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create(&self, dataType: u8, offset: i16, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementBytePattern>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Create)(self as *const _ as *mut _, dataType, offset, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -3170,8 +3170,8 @@ DEFINE_IID!(IID_IBluetoothLEAdvertisementDataSection, 3609277204, 14915, 16633, 
 RT_INTERFACE!{interface IBluetoothLEAdvertisementDataSection(IBluetoothLEAdvertisementDataSectionVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementDataSection] {
     fn get_DataType(&self, out: *mut u8) -> HRESULT,
     fn put_DataType(&self, value: u8) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn put_Data(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_Data(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IBluetoothLEAdvertisementDataSection {
     #[inline] pub fn get_data_type(&self) -> Result<u8> { unsafe { 
@@ -3183,12 +3183,12 @@ impl IBluetoothLEAdvertisementDataSection {
         let hr = ((*self.lpVtbl).put_DataType)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Data)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_data(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_data(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Data)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3197,17 +3197,17 @@ RT_CLASS!{class BluetoothLEAdvertisementDataSection: IBluetoothLEAdvertisementDa
 impl RtActivatable<IBluetoothLEAdvertisementDataSectionFactory> for BluetoothLEAdvertisementDataSection {}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementDataSection {}
 impl BluetoothLEAdvertisementDataSection {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create(dataType: u8, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementDataSection>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create(dataType: u8, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementDataSection>> {
         <Self as RtActivatable<IBluetoothLEAdvertisementDataSectionFactory>>::get_activation_factory().create(dataType, data)
     }
 }
 DEFINE_CLSID!(BluetoothLEAdvertisementDataSection(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,68,97,116,97,83,101,99,116,105,111,110,0]) [CLSID_BluetoothLEAdvertisementDataSection]);
 DEFINE_IID!(IID_IBluetoothLEAdvertisementDataSectionFactory, 3886287170, 43077, 16453, 191, 126, 62, 153, 113, 219, 138, 107);
 RT_INTERFACE!{static interface IBluetoothLEAdvertisementDataSectionFactory(IBluetoothLEAdvertisementDataSectionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementDataSectionFactory] {
-    #[cfg(feature="windows-storage")] fn Create(&self, dataType: u8, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEAdvertisementDataSection) -> HRESULT
+    #[cfg(feature="windows-storage")] fn Create(&self, dataType: u8, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEAdvertisementDataSection) -> HRESULT
 }}
 impl IBluetoothLEAdvertisementDataSectionFactory {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create(&self, dataType: u8, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementDataSection>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create(&self, dataType: u8, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEAdvertisementDataSection>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Create)(self as *const _ as *mut _, dataType, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -3706,8 +3706,8 @@ DEFINE_IID!(IID_IBluetoothLEManufacturerData, 2435693080, 26979, 17715, 176, 97,
 RT_INTERFACE!{interface IBluetoothLEManufacturerData(IBluetoothLEManufacturerDataVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEManufacturerData] {
     fn get_CompanyId(&self, out: *mut u16) -> HRESULT,
     fn put_CompanyId(&self, value: u16) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn put_Data(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_Data(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IBluetoothLEManufacturerData {
     #[inline] pub fn get_company_id(&self) -> Result<u16> { unsafe { 
@@ -3719,12 +3719,12 @@ impl IBluetoothLEManufacturerData {
         let hr = ((*self.lpVtbl).put_CompanyId)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Data)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_data(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_data(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Data)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3733,17 +3733,17 @@ RT_CLASS!{class BluetoothLEManufacturerData: IBluetoothLEManufacturerData}
 impl RtActivatable<IBluetoothLEManufacturerDataFactory> for BluetoothLEManufacturerData {}
 impl RtActivatable<IActivationFactory> for BluetoothLEManufacturerData {}
 impl BluetoothLEManufacturerData {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create(companyId: u16, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEManufacturerData>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create(companyId: u16, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEManufacturerData>> {
         <Self as RtActivatable<IBluetoothLEManufacturerDataFactory>>::get_activation_factory().create(companyId, data)
     }
 }
 DEFINE_CLSID!(BluetoothLEManufacturerData(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,77,97,110,117,102,97,99,116,117,114,101,114,68,97,116,97,0]) [CLSID_BluetoothLEManufacturerData]);
 DEFINE_IID!(IID_IBluetoothLEManufacturerDataFactory, 3231398392, 12698, 17438, 141, 229, 102, 168, 30, 135, 122, 108);
 RT_INTERFACE!{static interface IBluetoothLEManufacturerDataFactory(IBluetoothLEManufacturerDataFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEManufacturerDataFactory] {
-    #[cfg(feature="windows-storage")] fn Create(&self, companyId: u16, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEManufacturerData) -> HRESULT
+    #[cfg(feature="windows-storage")] fn Create(&self, companyId: u16, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut BluetoothLEManufacturerData) -> HRESULT
 }}
 impl IBluetoothLEManufacturerDataFactory {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create(&self, companyId: u16, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEManufacturerData>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create(&self, companyId: u16, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<BluetoothLEManufacturerData>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Create)(self as *const _ as *mut _, companyId, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -3754,7 +3754,7 @@ RT_ENUM! { enum BluetoothLEScanningMode: i32 {
 }}
 } // Windows.Devices.Bluetooth.Advertisement
 pub mod background { // Windows.Devices.Bluetooth.Background
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum BluetoothEventTriggeringMode: i32 {
     Serial = 0, Batch = 1, KeepLatest = 2,
 }}
@@ -3803,7 +3803,7 @@ RT_CLASS!{class BluetoothLEAdvertisementWatcherTriggerDetails: IBluetoothLEAdver
 DEFINE_IID!(IID_IGattCharacteristicNotificationTriggerDetails, 2610969368, 4076, 17258, 147, 177, 244, 108, 105, 117, 50, 162);
 RT_INTERFACE!{interface IGattCharacteristicNotificationTriggerDetails(IGattCharacteristicNotificationTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicNotificationTriggerDetails] {
     fn get_Characteristic(&self, out: *mut *mut super::genericattributeprofile::GattCharacteristic) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IGattCharacteristicNotificationTriggerDetails {
     #[inline] pub fn get_characteristic(&self) -> Result<Option<ComPtr<super::genericattributeprofile::GattCharacteristic>>> { unsafe { 
@@ -3811,7 +3811,7 @@ impl IGattCharacteristicNotificationTriggerDetails {
         let hr = ((*self.lpVtbl).get_Characteristic)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Value)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -3897,12 +3897,12 @@ RT_CLASS!{class GattServiceProviderTriggerDetails: IGattServiceProviderTriggerDe
 DEFINE_IID!(IID_IRfcommConnectionTriggerDetails, 4179784525, 11836, 20220, 171, 89, 252, 92, 249, 111, 151, 227);
 RT_INTERFACE!{interface IRfcommConnectionTriggerDetails(IRfcommConnectionTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommConnectionTriggerDetails] {
     #[cfg(not(feature="windows-networking"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_Socket(&self, out: *mut *mut ::rt::gen::windows::networking::sockets::StreamSocket) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn get_Socket(&self, out: *mut *mut crate::windows::networking::sockets::StreamSocket) -> HRESULT,
     fn get_Incoming(&self, out: *mut bool) -> HRESULT,
     fn get_RemoteDevice(&self, out: *mut *mut super::BluetoothDevice) -> HRESULT
 }}
 impl IRfcommConnectionTriggerDetails {
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_socket(&self) -> Result<Option<ComPtr<::rt::gen::windows::networking::sockets::StreamSocket>>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_socket(&self) -> Result<Option<ComPtr<crate::windows::networking::sockets::StreamSocket>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Socket)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -3922,21 +3922,21 @@ RT_CLASS!{class RfcommConnectionTriggerDetails: IRfcommConnectionTriggerDetails}
 DEFINE_IID!(IID_IRfcommInboundConnectionInformation, 1832809896, 21545, 16473, 146, 227, 30, 139, 101, 82, 135, 7);
 RT_INTERFACE!{interface IRfcommInboundConnectionInformation(IRfcommInboundConnectionInformationVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommInboundConnectionInformation] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_SdpRecord(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_SdpRecord(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_SdpRecord(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_SdpRecord(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_LocalServiceId(&self, out: *mut *mut super::rfcomm::RfcommServiceId) -> HRESULT,
     fn put_LocalServiceId(&self, value: *mut super::rfcomm::RfcommServiceId) -> HRESULT,
     fn get_ServiceCapabilities(&self, out: *mut super::BluetoothServiceCapabilities) -> HRESULT,
     fn put_ServiceCapabilities(&self, value: super::BluetoothServiceCapabilities) -> HRESULT
 }}
 impl IRfcommInboundConnectionInformation {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_record(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_record(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SdpRecord)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_sdp_record(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_sdp_record(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_SdpRecord)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3979,7 +3979,7 @@ impl IRfcommOutboundConnectionInformation {
 RT_CLASS!{class RfcommOutboundConnectionInformation: IRfcommOutboundConnectionInformation}
 } // Windows.Devices.Bluetooth.Background
 pub mod genericattributeprofile { // Windows.Devices.Bluetooth.GenericAttributeProfile
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IGattCharacteristic, 1506496705, 22836, 20328, 161, 152, 235, 134, 79, 164, 78, 107);
 RT_INTERFACE!{interface IGattCharacteristic(IGattCharacteristicVtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristic] {
     fn GetDescriptors(&self, descriptorUuid: Guid, out: *mut *mut foundation::collections::IVectorView<GattDescriptor>) -> HRESULT,
@@ -3993,9 +3993,9 @@ RT_INTERFACE!{interface IGattCharacteristic(IGattCharacteristicVtbl): IInspectab
     fn ReadValueAsync(&self, out: *mut *mut foundation::IAsyncOperation<GattReadResult>) -> HRESULT,
     fn ReadValueWithCacheModeAsync(&self, cacheMode: super::BluetoothCacheMode, out: *mut *mut foundation::IAsyncOperation<GattReadResult>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy10(&self) -> (),
-    #[cfg(feature="windows-storage")] fn WriteValueAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn WriteValueAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy11(&self) -> (),
-    #[cfg(feature="windows-storage")] fn WriteValueWithOptionAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, writeOption: GattWriteOption, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn WriteValueWithOptionAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, writeOption: GattWriteOption, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT,
     fn ReadClientCharacteristicConfigurationDescriptorAsync(&self, out: *mut *mut foundation::IAsyncOperation<GattReadClientCharacteristicConfigurationDescriptorResult>) -> HRESULT,
     fn WriteClientCharacteristicConfigurationDescriptorAsync(&self, clientCharacteristicConfigurationDescriptorValue: GattClientCharacteristicConfigurationDescriptorValue, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT,
     fn add_ValueChanged(&self, valueChangedHandler: *mut foundation::TypedEventHandler<GattCharacteristic, GattValueChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -4051,12 +4051,12 @@ impl IGattCharacteristic {
         let hr = ((*self.lpVtbl).ReadValueWithCacheModeAsync)(self as *const _ as *mut _, cacheMode, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattCommunicationStatus>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_async(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattCommunicationStatus>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).WriteValueAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_option_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer, writeOption: GattWriteOption) -> Result<ComPtr<foundation::IAsyncOperation<GattCommunicationStatus>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_option_async(&self, value: &crate::windows::storage::streams::IBuffer, writeOption: GattWriteOption) -> Result<ComPtr<foundation::IAsyncOperation<GattCommunicationStatus>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).WriteValueWithOptionAsync)(self as *const _ as *mut _, value as *const _ as *mut _, writeOption, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -4113,9 +4113,9 @@ RT_INTERFACE!{interface IGattCharacteristic3(IGattCharacteristic3Vtbl): IInspect
     fn GetDescriptorsForUuidAsync(&self, descriptorUuid: Guid, out: *mut *mut foundation::IAsyncOperation<GattDescriptorsResult>) -> HRESULT,
     fn GetDescriptorsForUuidWithCacheModeAsync(&self, descriptorUuid: Guid, cacheMode: super::BluetoothCacheMode, out: *mut *mut foundation::IAsyncOperation<GattDescriptorsResult>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-storage")] fn WriteValueWithResultAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn WriteValueWithResultAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn WriteValueWithResultAndOptionAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, writeOption: GattWriteOption, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn WriteValueWithResultAndOptionAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, writeOption: GattWriteOption, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT,
     fn WriteClientCharacteristicConfigurationDescriptorWithResultAsync(&self, clientCharacteristicConfigurationDescriptorValue: GattClientCharacteristicConfigurationDescriptorValue, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT
 }}
 impl IGattCharacteristic3 {
@@ -4139,12 +4139,12 @@ impl IGattCharacteristic3 {
         let hr = ((*self.lpVtbl).GetDescriptorsForUuidWithCacheModeAsync)(self as *const _ as *mut _, descriptorUuid, cacheMode, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_result_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattWriteResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_result_async(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattWriteResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).WriteValueWithResultAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_result_and_option_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer, writeOption: GattWriteOption) -> Result<ComPtr<foundation::IAsyncOperation<GattWriteResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_result_and_option_async(&self, value: &crate::windows::storage::streams::IBuffer, writeOption: GattWriteOption) -> Result<ComPtr<foundation::IAsyncOperation<GattWriteResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).WriteValueWithResultAndOptionAsync)(self as *const _ as *mut _, value as *const _ as *mut _, writeOption, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -4987,7 +4987,7 @@ RT_INTERFACE!{interface IGattDescriptor(IGattDescriptorVtbl): IInspectable(IInsp
     fn get_AttributeHandle(&self, out: *mut u16) -> HRESULT,
     fn ReadValueAsync(&self, out: *mut *mut foundation::IAsyncOperation<GattReadResult>) -> HRESULT,
     fn ReadValueWithCacheModeAsync(&self, cacheMode: super::BluetoothCacheMode, out: *mut *mut foundation::IAsyncOperation<GattReadResult>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn WriteValueAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn WriteValueAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT
 }}
 impl IGattDescriptor {
     #[inline] pub fn get_protection_level(&self) -> Result<GattProtectionLevel> { unsafe { 
@@ -5019,7 +5019,7 @@ impl IGattDescriptor {
         let hr = ((*self.lpVtbl).ReadValueWithCacheModeAsync)(self as *const _ as *mut _, cacheMode, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattCommunicationStatus>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_async(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattCommunicationStatus>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).WriteValueAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -5035,10 +5035,10 @@ impl GattDescriptor {
 DEFINE_CLSID!(GattDescriptor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,68,101,115,99,114,105,112,116,111,114,0]) [CLSID_GattDescriptor]);
 DEFINE_IID!(IID_IGattDescriptor2, 2404793657, 54832, 16492, 186, 17, 16, 205, 209, 107, 14, 94);
 RT_INTERFACE!{interface IGattDescriptor2(IGattDescriptor2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattDescriptor2] {
-    #[cfg(feature="windows-storage")] fn WriteValueWithResultAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn WriteValueWithResultAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<GattWriteResult>) -> HRESULT
 }}
 impl IGattDescriptor2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_result_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattWriteResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value_with_result_async(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<GattWriteResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).WriteValueWithResultAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -5414,7 +5414,7 @@ impl IGattDeviceServiceStatics2 {
 DEFINE_IID!(IID_IGattLocalCharacteristic, 2933798765, 21522, 19828, 146, 168, 141, 235, 133, 38, 130, 156);
 RT_INTERFACE!{interface IGattLocalCharacteristic(IGattLocalCharacteristicVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalCharacteristic] {
     fn get_Uuid(&self, out: *mut Guid) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_CharacteristicProperties(&self, out: *mut GattCharacteristicProperties) -> HRESULT,
     fn get_ReadProtectionLevel(&self, out: *mut GattProtectionLevel) -> HRESULT,
     fn get_WriteProtectionLevel(&self, out: *mut GattProtectionLevel) -> HRESULT,
@@ -5429,8 +5429,8 @@ RT_INTERFACE!{interface IGattLocalCharacteristic(IGattLocalCharacteristicVtbl): 
     fn remove_ReadRequested(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     fn add_WriteRequested(&self, handler: *mut foundation::TypedEventHandler<GattLocalCharacteristic, GattWriteRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_WriteRequested(&self, token: foundation::EventRegistrationToken) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn NotifyValueAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<GattClientNotificationResult>>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn NotifyValueForSubscribedClientAsync(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer, subscribedClient: *mut GattSubscribedClient, out: *mut *mut foundation::IAsyncOperation<GattClientNotificationResult>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn NotifyValueAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<GattClientNotificationResult>>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn NotifyValueForSubscribedClientAsync(&self, value: *mut crate::windows::storage::streams::IBuffer, subscribedClient: *mut GattSubscribedClient, out: *mut *mut foundation::IAsyncOperation<GattClientNotificationResult>) -> HRESULT
 }}
 impl IGattLocalCharacteristic {
     #[inline] pub fn get_uuid(&self) -> Result<Guid> { unsafe { 
@@ -5438,7 +5438,7 @@ impl IGattLocalCharacteristic {
         let hr = ((*self.lpVtbl).get_Uuid)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_StaticValue)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5510,12 +5510,12 @@ impl IGattLocalCharacteristic {
         let hr = ((*self.lpVtbl).remove_WriteRequested)(self as *const _ as *mut _, token);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn notify_value_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<GattClientNotificationResult>>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn notify_value_async(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<GattClientNotificationResult>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).NotifyValueAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn notify_value_for_subscribed_client_async(&self, value: &::rt::gen::windows::storage::streams::IBuffer, subscribedClient: &GattSubscribedClient) -> Result<ComPtr<foundation::IAsyncOperation<GattClientNotificationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn notify_value_for_subscribed_client_async(&self, value: &crate::windows::storage::streams::IBuffer, subscribedClient: &GattSubscribedClient) -> Result<ComPtr<foundation::IAsyncOperation<GattClientNotificationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).NotifyValueForSubscribedClientAsync)(self as *const _ as *mut _, value as *const _ as *mut _, subscribedClient as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -5525,9 +5525,9 @@ RT_CLASS!{class GattLocalCharacteristic: IGattLocalCharacteristic}
 DEFINE_IID!(IID_IGattLocalCharacteristicParameters, 4210507188, 19711, 17607, 132, 69, 4, 14, 110, 173, 0, 99);
 RT_INTERFACE!{interface IGattLocalCharacteristicParameters(IGattLocalCharacteristicParametersVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalCharacteristicParameters] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_StaticValue(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_StaticValue(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn put_CharacteristicProperties(&self, value: GattCharacteristicProperties) -> HRESULT,
     fn get_CharacteristicProperties(&self, out: *mut GattCharacteristicProperties) -> HRESULT,
     fn put_ReadProtectionLevel(&self, value: GattProtectionLevel) -> HRESULT,
@@ -5539,11 +5539,11 @@ RT_INTERFACE!{interface IGattLocalCharacteristicParameters(IGattLocalCharacteris
     fn get_PresentationFormats(&self, out: *mut *mut foundation::collections::IVector<GattPresentationFormat>) -> HRESULT
 }}
 impl IGattLocalCharacteristicParameters {
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_static_value(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_static_value(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_StaticValue)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_StaticValue)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5615,7 +5615,7 @@ DEFINE_IID!(IID_IGattLocalDescriptor, 4102995462, 30877, 19019, 134, 82, 189, 1,
 RT_INTERFACE!{interface IGattLocalDescriptor(IGattLocalDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalDescriptor] {
     fn get_Uuid(&self, out: *mut Guid) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_ReadProtectionLevel(&self, out: *mut GattProtectionLevel) -> HRESULT,
     fn get_WriteProtectionLevel(&self, out: *mut GattProtectionLevel) -> HRESULT,
     fn add_ReadRequested(&self, handler: *mut foundation::TypedEventHandler<GattLocalDescriptor, GattReadRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5629,7 +5629,7 @@ impl IGattLocalDescriptor {
         let hr = ((*self.lpVtbl).get_Uuid)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_StaticValue)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5667,20 +5667,20 @@ RT_CLASS!{class GattLocalDescriptor: IGattLocalDescriptor}
 DEFINE_IID!(IID_IGattLocalDescriptorParameters, 1608441450, 62401, 19302, 140, 75, 227, 210, 41, 59, 64, 233);
 RT_INTERFACE!{interface IGattLocalDescriptorParameters(IGattLocalDescriptorParametersVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalDescriptorParameters] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_StaticValue(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_StaticValue(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_StaticValue(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn put_ReadProtectionLevel(&self, value: GattProtectionLevel) -> HRESULT,
     fn get_ReadProtectionLevel(&self, out: *mut GattProtectionLevel) -> HRESULT,
     fn put_WriteProtectionLevel(&self, value: GattProtectionLevel) -> HRESULT,
     fn get_WriteProtectionLevel(&self, out: *mut GattProtectionLevel) -> HRESULT
 }}
 impl IGattLocalDescriptorParameters {
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_static_value(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_static_value(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_StaticValue)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_static_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_StaticValue)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6277,7 +6277,7 @@ RT_INTERFACE!{interface IGattReadRequest(IGattReadRequestVtbl): IInspectable(IIn
     fn add_StateChanged(&self, handler: *mut foundation::TypedEventHandler<GattReadRequest, GattRequestStateChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_StateChanged(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn RespondWithValue(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn RespondWithValue(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn RespondWithProtocolError(&self, protocolError: u8) -> HRESULT
 }}
 impl IGattReadRequest {
@@ -6305,7 +6305,7 @@ impl IGattReadRequest {
         let hr = ((*self.lpVtbl).remove_StateChanged)(self as *const _ as *mut _, token);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn respond_with_value(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn respond_with_value(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).RespondWithValue)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -6342,7 +6342,7 @@ RT_CLASS!{class GattReadRequestedEventArgs: IGattReadRequestedEventArgs}
 DEFINE_IID!(IID_IGattReadResult, 1671851784, 6890, 19532, 165, 15, 151, 186, 228, 116, 179, 72);
 RT_INTERFACE!{interface IGattReadResult(IGattReadResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattReadResult] {
     fn get_Status(&self, out: *mut GattCommunicationStatus) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IGattReadResult {
     #[inline] pub fn get_status(&self) -> Result<GattCommunicationStatus> { unsafe { 
@@ -6350,7 +6350,7 @@ impl IGattReadResult {
         let hr = ((*self.lpVtbl).get_Status)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Value)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6371,11 +6371,11 @@ impl IGattReadResult2 {
 DEFINE_IID!(IID_IGattReliableWriteTransaction, 1671851783, 6890, 19532, 165, 15, 151, 186, 228, 116, 179, 72);
 RT_INTERFACE!{interface IGattReliableWriteTransaction(IGattReliableWriteTransactionVtbl): IInspectable(IInspectableVtbl) [IID_IGattReliableWriteTransaction] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn WriteValue(&self, characteristic: *mut GattCharacteristic, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn WriteValue(&self, characteristic: *mut GattCharacteristic, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn CommitAsync(&self, out: *mut *mut foundation::IAsyncOperation<GattCommunicationStatus>) -> HRESULT
 }}
 impl IGattReliableWriteTransaction {
-    #[cfg(feature="windows-storage")] #[inline] pub fn write_value(&self, characteristic: &GattCharacteristic, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn write_value(&self, characteristic: &GattCharacteristic, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).WriteValue)(self as *const _ as *mut _, characteristic as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -6902,11 +6902,11 @@ RT_CLASS!{class GattSubscribedClient: IGattSubscribedClient}
 DEFINE_IID!(IID_IGattValueChangedEventArgs, 3525040980, 1763, 20184, 162, 99, 172, 250, 200, 186, 115, 19);
 RT_INTERFACE!{interface IGattValueChangedEventArgs(IGattValueChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGattValueChangedEventArgs] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_CharacteristicValue(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_CharacteristicValue(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT
 }}
 impl IGattValueChangedEventArgs {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_characteristic_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_characteristic_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_CharacteristicValue)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6924,7 +6924,7 @@ RT_ENUM! { enum GattWriteOption: i32 {
 DEFINE_IID!(IID_IGattWriteRequest, 2931206637, 56879, 20418, 169, 168, 148, 234, 120, 68, 241, 61);
 RT_INTERFACE!{interface IGattWriteRequest(IGattWriteRequestVtbl): IInspectable(IInspectableVtbl) [IID_IGattWriteRequest] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_Offset(&self, out: *mut u32) -> HRESULT,
     fn get_Option(&self, out: *mut GattWriteOption) -> HRESULT,
     fn get_State(&self, out: *mut GattRequestState) -> HRESULT,
@@ -6934,7 +6934,7 @@ RT_INTERFACE!{interface IGattWriteRequest(IGattWriteRequestVtbl): IInspectable(I
     fn RespondWithProtocolError(&self, protocolError: u8) -> HRESULT
 }}
 impl IGattWriteRequest {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Value)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -7017,22 +7017,22 @@ impl IGattWriteResult {
 RT_CLASS!{class GattWriteResult: IGattWriteResult}
 } // Windows.Devices.Bluetooth.GenericAttributeProfile
 pub mod rfcomm { // Windows.Devices.Bluetooth.Rfcomm
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IRfcommDeviceService, 2927755039, 50593, 19520, 140, 40, 243, 239, 214, 144, 98, 243);
 RT_INTERFACE!{interface IRfcommDeviceService(IRfcommDeviceServiceVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommDeviceService] {
     #[cfg(not(feature="windows-networking"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_ConnectionHostName(&self, out: *mut *mut ::rt::gen::windows::networking::HostName) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn get_ConnectionHostName(&self, out: *mut *mut crate::windows::networking::HostName) -> HRESULT,
     fn get_ConnectionServiceName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_ServiceId(&self, out: *mut *mut RfcommServiceId) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_ProtectionLevel(&self, out: *mut ::rt::gen::windows::networking::sockets::SocketProtectionLevel) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn get_ProtectionLevel(&self, out: *mut crate::windows::networking::sockets::SocketProtectionLevel) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_MaxProtectionLevel(&self, out: *mut ::rt::gen::windows::networking::sockets::SocketProtectionLevel) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn GetSdpRawAttributesAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IMapView<u32, ::rt::gen::windows::storage::streams::IBuffer>>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn GetSdpRawAttributesWithCacheModeAsync(&self, cacheMode: super::BluetoothCacheMode, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IMapView<u32, ::rt::gen::windows::storage::streams::IBuffer>>) -> HRESULT
+    #[cfg(feature="windows-networking")] fn get_MaxProtectionLevel(&self, out: *mut crate::windows::networking::sockets::SocketProtectionLevel) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetSdpRawAttributesAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IMapView<u32, crate::windows::storage::streams::IBuffer>>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetSdpRawAttributesWithCacheModeAsync(&self, cacheMode: super::BluetoothCacheMode, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IMapView<u32, crate::windows::storage::streams::IBuffer>>) -> HRESULT
 }}
 impl IRfcommDeviceService {
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_connection_host_name(&self) -> Result<Option<ComPtr<::rt::gen::windows::networking::HostName>>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_connection_host_name(&self) -> Result<Option<ComPtr<crate::windows::networking::HostName>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ConnectionHostName)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -7047,22 +7047,22 @@ impl IRfcommDeviceService {
         let hr = ((*self.lpVtbl).get_ServiceId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_protection_level(&self) -> Result<::rt::gen::windows::networking::sockets::SocketProtectionLevel> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_protection_level(&self) -> Result<crate::windows::networking::sockets::SocketProtectionLevel> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_ProtectionLevel)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_max_protection_level(&self) -> Result<::rt::gen::windows::networking::sockets::SocketProtectionLevel> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_max_protection_level(&self) -> Result<crate::windows::networking::sockets::SocketProtectionLevel> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_MaxProtectionLevel)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_raw_attributes_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IMapView<u32, ::rt::gen::windows::storage::streams::IBuffer>>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_raw_attributes_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IMapView<u32, crate::windows::storage::streams::IBuffer>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetSdpRawAttributesAsync)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_raw_attributes_with_cache_mode_async(&self, cacheMode: super::BluetoothCacheMode) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IMapView<u32, ::rt::gen::windows::storage::streams::IBuffer>>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_raw_attributes_with_cache_mode_async(&self, cacheMode: super::BluetoothCacheMode) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IMapView<u32, crate::windows::storage::streams::IBuffer>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetSdpRawAttributesWithCacheModeAsync)(self as *const _ as *mut _, cacheMode, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -7293,9 +7293,9 @@ DEFINE_IID!(IID_IRfcommServiceProvider, 3940285892, 45558, 17663, 159, 124, 231,
 RT_INTERFACE!{interface IRfcommServiceProvider(IRfcommServiceProviderVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommServiceProvider] {
     fn get_ServiceId(&self, out: *mut *mut RfcommServiceId) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_SdpRawAttributes(&self, out: *mut *mut foundation::collections::IMap<u32, ::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_SdpRawAttributes(&self, out: *mut *mut foundation::collections::IMap<u32, crate::windows::storage::streams::IBuffer>) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-networking")] fn StartAdvertising(&self, listener: *mut ::rt::gen::windows::networking::sockets::StreamSocketListener) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn StartAdvertising(&self, listener: *mut crate::windows::networking::sockets::StreamSocketListener) -> HRESULT,
     fn StopAdvertising(&self) -> HRESULT
 }}
 impl IRfcommServiceProvider {
@@ -7304,12 +7304,12 @@ impl IRfcommServiceProvider {
         let hr = ((*self.lpVtbl).get_ServiceId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_raw_attributes(&self) -> Result<Option<ComPtr<foundation::collections::IMap<u32, ::rt::gen::windows::storage::streams::IBuffer>>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_sdp_raw_attributes(&self) -> Result<Option<ComPtr<foundation::collections::IMap<u32, crate::windows::storage::streams::IBuffer>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SdpRawAttributes)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn start_advertising(&self, listener: &::rt::gen::windows::networking::sockets::StreamSocketListener) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn start_advertising(&self, listener: &crate::windows::networking::sockets::StreamSocketListener) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).StartAdvertising)(self as *const _ as *mut _, listener as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -7328,10 +7328,10 @@ impl RfcommServiceProvider {
 DEFINE_CLSID!(RfcommServiceProvider(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,82,102,99,111,109,109,46,82,102,99,111,109,109,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,0]) [CLSID_RfcommServiceProvider]);
 DEFINE_IID!(IID_IRfcommServiceProvider2, 1936449478, 15489, 19742, 186, 242, 221, 187, 129, 40, 69, 18);
 RT_INTERFACE!{interface IRfcommServiceProvider2(IRfcommServiceProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IRfcommServiceProvider2] {
-    #[cfg(feature="windows-networking")] fn StartAdvertisingWithRadioDiscoverability(&self, listener: *mut ::rt::gen::windows::networking::sockets::StreamSocketListener, radioDiscoverable: bool) -> HRESULT
+    #[cfg(feature="windows-networking")] fn StartAdvertisingWithRadioDiscoverability(&self, listener: *mut crate::windows::networking::sockets::StreamSocketListener, radioDiscoverable: bool) -> HRESULT
 }}
 impl IRfcommServiceProvider2 {
-    #[cfg(feature="windows-networking")] #[inline] pub fn start_advertising_with_radio_discoverability(&self, listener: &::rt::gen::windows::networking::sockets::StreamSocketListener, radioDiscoverable: bool) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn start_advertising_with_radio_discoverability(&self, listener: &crate::windows::networking::sockets::StreamSocketListener, radioDiscoverable: bool) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).StartAdvertisingWithRadioDiscoverability)(self as *const _ as *mut _, listener as *const _ as *mut _, radioDiscoverable);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -7350,7 +7350,7 @@ impl IRfcommServiceProviderStatics {
 } // Windows.Devices.Bluetooth.Rfcomm
 } // Windows.Devices.Bluetooth
 pub mod custom { // Windows.Devices.Custom
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICustomDevice, 3710919967, 50315, 17341, 188, 177, 222, 200, 143, 21, 20, 62);
 RT_INTERFACE!{interface ICustomDevice(ICustomDeviceVtbl): IInspectable(IInspectableVtbl) [IID_ICustomDevice] {
     #[cfg(feature="windows-storage")] fn get_InputStream(&self, out: *mut *mut super::super::storage::streams::IInputStream) -> HRESULT,
@@ -7495,7 +7495,7 @@ impl IOControlCode {
 DEFINE_CLSID!(IOControlCode(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,67,117,115,116,111,109,46,73,79,67,111,110,116,114,111,108,67,111,100,101,0]) [CLSID_IOControlCode]);
 } // Windows.Devices.Custom
 pub mod display { // Windows.Devices.Display
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDisplayMonitor, 527111636, 7425, 19537, 135, 226, 111, 149, 74, 119, 43, 89);
 RT_INTERFACE!{interface IDisplayMonitor(IDisplayMonitorVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayMonitor] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -7673,11 +7673,11 @@ RT_ENUM! { enum DisplayMonitorUsageKind: i32 {
     Standard = 0, HeadMounted = 1, SpecialPurpose = 2,
 }}
 pub mod core { // Windows.Devices.Display.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDisplayAdapter, 2775536263, 61440, 24366, 181, 172, 55, 131, 162, 182, 154, 245);
 RT_INTERFACE!{interface IDisplayAdapter(IDisplayAdapterVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayAdapter] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_Id(&self, out: *mut ::rt::gen::windows::graphics::DisplayAdapterId) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_Id(&self, out: *mut crate::windows::graphics::DisplayAdapterId) -> HRESULT,
     fn get_DeviceInterfacePath(&self, out: *mut HSTRING) -> HRESULT,
     fn get_SourceCount(&self, out: *mut u32) -> HRESULT,
     fn get_PciVendorId(&self, out: *mut u32) -> HRESULT,
@@ -7687,7 +7687,7 @@ RT_INTERFACE!{interface IDisplayAdapter(IDisplayAdapterVtbl): IInspectable(IInsp
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMapView<Guid, IInspectable>) -> HRESULT
 }}
 impl IDisplayAdapter {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_id(&self) -> Result<::rt::gen::windows::graphics::DisplayAdapterId> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_id(&self) -> Result<crate::windows::graphics::DisplayAdapterId> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Id)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -7731,17 +7731,17 @@ impl IDisplayAdapter {
 RT_CLASS!{class DisplayAdapter: IDisplayAdapter}
 impl RtActivatable<IDisplayAdapterStatics> for DisplayAdapter {}
 impl DisplayAdapter {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn from_id(id: ::rt::gen::windows::graphics::DisplayAdapterId) -> Result<Option<ComPtr<DisplayAdapter>>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn from_id(id: crate::windows::graphics::DisplayAdapterId) -> Result<Option<ComPtr<DisplayAdapter>>> {
         <Self as RtActivatable<IDisplayAdapterStatics>>::get_activation_factory().from_id(id)
     }
 }
 DEFINE_CLSID!(DisplayAdapter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,68,105,115,112,108,97,121,46,67,111,114,101,46,68,105,115,112,108,97,121,65,100,97,112,116,101,114,0]) [CLSID_DisplayAdapter]);
 DEFINE_IID!(IID_IDisplayAdapterStatics, 497827034, 18463, 21609, 132, 112, 130, 196, 186, 104, 10, 40);
 RT_INTERFACE!{static interface IDisplayAdapterStatics(IDisplayAdapterStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayAdapterStatics] {
-    #[cfg(feature="windows-graphics")] fn FromId(&self, id: ::rt::gen::windows::graphics::DisplayAdapterId, out: *mut *mut DisplayAdapter) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn FromId(&self, id: crate::windows::graphics::DisplayAdapterId, out: *mut *mut DisplayAdapter) -> HRESULT
 }}
 impl IDisplayAdapterStatics {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn from_id(&self, id: ::rt::gen::windows::graphics::DisplayAdapterId) -> Result<Option<ComPtr<DisplayAdapter>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn from_id(&self, id: crate::windows::graphics::DisplayAdapterId) -> Result<Option<ComPtr<DisplayAdapter>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FromId)(self as *const _ as *mut _, id, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8061,12 +8061,12 @@ impl IDisplayManagerStatics {
 DEFINE_IID!(IID_IDisplayModeInfo, 1221923744, 63387, 23156, 160, 94, 218, 130, 31, 71, 8, 104);
 RT_INTERFACE!{interface IDisplayModeInfo(IDisplayModeInfoVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayModeInfo] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_SourceResolution(&self, out: *mut ::rt::gen::windows::graphics::SizeInt32) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SourceResolution(&self, out: *mut crate::windows::graphics::SizeInt32) -> HRESULT,
     fn get_IsStereo(&self, out: *mut bool) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_SourcePixelFormat(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SourcePixelFormat(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_TargetResolution(&self, out: *mut ::rt::gen::windows::graphics::SizeInt32) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_TargetResolution(&self, out: *mut crate::windows::graphics::SizeInt32) -> HRESULT,
     fn get_PresentationRate(&self, out: *mut DisplayPresentationRate) -> HRESULT,
     fn get_IsInterlaced(&self, out: *mut bool) -> HRESULT,
     fn GetWireFormatSupportedBitsPerChannel(&self, encoding: DisplayWireFormatPixelEncoding, out: *mut DisplayBitsPerChannel) -> HRESULT,
@@ -8074,7 +8074,7 @@ RT_INTERFACE!{interface IDisplayModeInfo(IDisplayModeInfoVtbl): IInspectable(IIn
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMapView<Guid, IInspectable>) -> HRESULT
 }}
 impl IDisplayModeInfo {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_resolution(&self) -> Result<::rt::gen::windows::graphics::SizeInt32> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_resolution(&self) -> Result<crate::windows::graphics::SizeInt32> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_SourceResolution)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -8084,12 +8084,12 @@ impl IDisplayModeInfo {
         let hr = ((*self.lpVtbl).get_IsStereo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_pixel_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_pixel_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_SourcePixelFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_target_resolution(&self) -> Result<::rt::gen::windows::graphics::SizeInt32> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_target_resolution(&self) -> Result<crate::windows::graphics::SizeInt32> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_TargetResolution)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -8130,19 +8130,19 @@ RT_INTERFACE!{interface IDisplayPath(IDisplayPathVtbl): IInspectable(IInspectabl
     fn get_Target(&self, out: *mut *mut DisplayTarget) -> HRESULT,
     fn get_Status(&self, out: *mut DisplayPathStatus) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_SourceResolution(&self, out: *mut *mut foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SourceResolution(&self, out: *mut *mut foundation::IReference<crate::windows::graphics::SizeInt32>) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_SourceResolution(&self, value: *mut foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_SourceResolution(&self, value: *mut foundation::IReference<crate::windows::graphics::SizeInt32>) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_SourcePixelFormat(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SourcePixelFormat(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy6(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_SourcePixelFormat(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_SourcePixelFormat(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     fn get_IsStereo(&self, out: *mut bool) -> HRESULT,
     fn put_IsStereo(&self, value: bool) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy9(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_TargetResolution(&self, out: *mut *mut foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_TargetResolution(&self, out: *mut *mut foundation::IReference<crate::windows::graphics::SizeInt32>) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy10(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_TargetResolution(&self, value: *mut foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_TargetResolution(&self, value: *mut foundation::IReference<crate::windows::graphics::SizeInt32>) -> HRESULT,
     fn get_PresentationRate(&self, out: *mut *mut foundation::IReference<DisplayPresentationRate>) -> HRESULT,
     fn put_PresentationRate(&self, value: *mut foundation::IReference<DisplayPresentationRate>) -> HRESULT,
     fn get_IsInterlaced(&self, out: *mut *mut foundation::IReference<bool>) -> HRESULT,
@@ -8173,21 +8173,21 @@ impl IDisplayPath {
         let hr = ((*self.lpVtbl).get_Status)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_resolution(&self) -> Result<Option<ComPtr<foundation::IReference<::rt::gen::windows::graphics::SizeInt32>>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_resolution(&self) -> Result<Option<ComPtr<foundation::IReference<crate::windows::graphics::SizeInt32>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SourceResolution)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_source_resolution(&self, value: &foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_source_resolution(&self, value: &foundation::IReference<crate::windows::graphics::SizeInt32>) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_SourceResolution)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_pixel_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_source_pixel_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_SourcePixelFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_source_pixel_format(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_source_pixel_format(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_SourcePixelFormat)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -8200,12 +8200,12 @@ impl IDisplayPath {
         let hr = ((*self.lpVtbl).put_IsStereo)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_target_resolution(&self) -> Result<Option<ComPtr<foundation::IReference<::rt::gen::windows::graphics::SizeInt32>>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_target_resolution(&self) -> Result<Option<ComPtr<foundation::IReference<crate::windows::graphics::SizeInt32>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_TargetResolution)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_target_resolution(&self, value: &foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_target_resolution(&self, value: &foundation::IReference<crate::windows::graphics::SizeInt32>) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_TargetResolution)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -8284,12 +8284,12 @@ RT_INTERFACE!{interface IDisplayPrimaryDescription(IDisplayPrimaryDescriptionVtb
     fn get_Width(&self, out: *mut u32) -> HRESULT,
     fn get_Height(&self, out: *mut u32) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_Format(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_Format(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_ColorSpace(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXColorSpace) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_ColorSpace(&self, out: *mut crate::windows::graphics::directx::DirectXColorSpace) -> HRESULT,
     fn get_IsStereo(&self, out: *mut bool) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_MultisampleDescription(&self, out: *mut ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_MultisampleDescription(&self, out: *mut crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> HRESULT,
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMapView<Guid, IInspectable>) -> HRESULT
 }}
 impl IDisplayPrimaryDescription {
@@ -8303,12 +8303,12 @@ impl IDisplayPrimaryDescription {
         let hr = ((*self.lpVtbl).get_Height)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Format)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_color_space(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXColorSpace> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_color_space(&self) -> Result<crate::windows::graphics::directx::DirectXColorSpace> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_ColorSpace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -8318,7 +8318,7 @@ impl IDisplayPrimaryDescription {
         let hr = ((*self.lpVtbl).get_IsStereo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_multisample_description(&self) -> Result<::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_multisample_description(&self) -> Result<crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_MultisampleDescription)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -8333,20 +8333,20 @@ RT_CLASS!{class DisplayPrimaryDescription: IDisplayPrimaryDescription}
 impl RtActivatable<IDisplayPrimaryDescriptionFactory> for DisplayPrimaryDescription {}
 impl RtActivatable<IDisplayPrimaryDescriptionStatics> for DisplayPrimaryDescription {}
 impl DisplayPrimaryDescription {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create_instance(width: u32, height: u32, pixelFormat: ::rt::gen::windows::graphics::directx::DirectXPixelFormat, colorSpace: ::rt::gen::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<ComPtr<DisplayPrimaryDescription>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create_instance(width: u32, height: u32, pixelFormat: crate::windows::graphics::directx::DirectXPixelFormat, colorSpace: crate::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<ComPtr<DisplayPrimaryDescription>> {
         <Self as RtActivatable<IDisplayPrimaryDescriptionFactory>>::get_activation_factory().create_instance(width, height, pixelFormat, colorSpace, isStereo, multisampleDescription)
     }
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create_with_properties(extraProperties: &foundation::collections::IIterable<foundation::collections::IKeyValuePair<Guid, IInspectable>>, width: u32, height: u32, pixelFormat: ::rt::gen::windows::graphics::directx::DirectXPixelFormat, colorSpace: ::rt::gen::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<Option<ComPtr<DisplayPrimaryDescription>>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create_with_properties(extraProperties: &foundation::collections::IIterable<foundation::collections::IKeyValuePair<Guid, IInspectable>>, width: u32, height: u32, pixelFormat: crate::windows::graphics::directx::DirectXPixelFormat, colorSpace: crate::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<Option<ComPtr<DisplayPrimaryDescription>>> {
         <Self as RtActivatable<IDisplayPrimaryDescriptionStatics>>::get_activation_factory().create_with_properties(extraProperties, width, height, pixelFormat, colorSpace, isStereo, multisampleDescription)
     }
 }
 DEFINE_CLSID!(DisplayPrimaryDescription(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,68,105,115,112,108,97,121,46,67,111,114,101,46,68,105,115,112,108,97,121,80,114,105,109,97,114,121,68,101,115,99,114,105,112,116,105,111,110,0]) [CLSID_DisplayPrimaryDescription]);
 DEFINE_IID!(IID_IDisplayPrimaryDescriptionFactory, 443219835, 13879, 23622, 180, 121, 118, 213, 118, 33, 110, 101);
 RT_INTERFACE!{static interface IDisplayPrimaryDescriptionFactory(IDisplayPrimaryDescriptionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayPrimaryDescriptionFactory] {
-    #[cfg(feature="windows-graphics")] fn CreateInstance(&self, width: u32, height: u32, pixelFormat: ::rt::gen::windows::graphics::directx::DirectXPixelFormat, colorSpace: ::rt::gen::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription, out: *mut *mut DisplayPrimaryDescription) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn CreateInstance(&self, width: u32, height: u32, pixelFormat: crate::windows::graphics::directx::DirectXPixelFormat, colorSpace: crate::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription, out: *mut *mut DisplayPrimaryDescription) -> HRESULT
 }}
 impl IDisplayPrimaryDescriptionFactory {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create_instance(&self, width: u32, height: u32, pixelFormat: ::rt::gen::windows::graphics::directx::DirectXPixelFormat, colorSpace: ::rt::gen::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<ComPtr<DisplayPrimaryDescription>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create_instance(&self, width: u32, height: u32, pixelFormat: crate::windows::graphics::directx::DirectXPixelFormat, colorSpace: crate::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<ComPtr<DisplayPrimaryDescription>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateInstance)(self as *const _ as *mut _, width, height, pixelFormat, colorSpace, isStereo, multisampleDescription, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -8354,10 +8354,10 @@ impl IDisplayPrimaryDescriptionFactory {
 }
 DEFINE_IID!(IID_IDisplayPrimaryDescriptionStatics, 3859696891, 14025, 22237, 143, 161, 111, 248, 196, 224, 255, 7);
 RT_INTERFACE!{static interface IDisplayPrimaryDescriptionStatics(IDisplayPrimaryDescriptionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayPrimaryDescriptionStatics] {
-    #[cfg(feature="windows-graphics")] fn CreateWithProperties(&self, extraProperties: *mut foundation::collections::IIterable<foundation::collections::IKeyValuePair<Guid, IInspectable>>, width: u32, height: u32, pixelFormat: ::rt::gen::windows::graphics::directx::DirectXPixelFormat, colorSpace: ::rt::gen::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription, out: *mut *mut DisplayPrimaryDescription) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn CreateWithProperties(&self, extraProperties: *mut foundation::collections::IIterable<foundation::collections::IKeyValuePair<Guid, IInspectable>>, width: u32, height: u32, pixelFormat: crate::windows::graphics::directx::DirectXPixelFormat, colorSpace: crate::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription, out: *mut *mut DisplayPrimaryDescription) -> HRESULT
 }}
 impl IDisplayPrimaryDescriptionStatics {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create_with_properties(&self, extraProperties: &foundation::collections::IIterable<foundation::collections::IKeyValuePair<Guid, IInspectable>>, width: u32, height: u32, pixelFormat: ::rt::gen::windows::graphics::directx::DirectXPixelFormat, colorSpace: ::rt::gen::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: ::rt::gen::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<Option<ComPtr<DisplayPrimaryDescription>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create_with_properties(&self, extraProperties: &foundation::collections::IIterable<foundation::collections::IKeyValuePair<Guid, IInspectable>>, width: u32, height: u32, pixelFormat: crate::windows::graphics::directx::DirectXPixelFormat, colorSpace: crate::windows::graphics::directx::DirectXColorSpace, isStereo: bool, multisampleDescription: crate::windows::graphics::directx::direct3d11::Direct3DMultisampleDescription) -> Result<Option<ComPtr<DisplayPrimaryDescription>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateWithProperties)(self as *const _ as *mut _, extraProperties as *const _ as *mut _, width, height, pixelFormat, colorSpace, isStereo, multisampleDescription, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8374,12 +8374,12 @@ RT_CLASS!{class DisplayScanout: IDisplayScanout}
 DEFINE_IID!(IID_IDisplaySource, 3973144513, 60124, 20924, 151, 29, 59, 198, 40, 219, 45, 212);
 RT_INTERFACE!{interface IDisplaySource(IDisplaySourceVtbl): IInspectable(IInspectableVtbl) [IID_IDisplaySource] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_AdapterId(&self, out: *mut ::rt::gen::windows::graphics::DisplayAdapterId) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_AdapterId(&self, out: *mut crate::windows::graphics::DisplayAdapterId) -> HRESULT,
     fn get_SourceId(&self, out: *mut u32) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn GetMetadata(&self, key: Guid, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetMetadata(&self, key: Guid, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IDisplaySource {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_adapter_id(&self) -> Result<::rt::gen::windows::graphics::DisplayAdapterId> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_adapter_id(&self) -> Result<crate::windows::graphics::DisplayAdapterId> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_AdapterId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -8389,7 +8389,7 @@ impl IDisplaySource {
         let hr = ((*self.lpVtbl).get_SourceId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_metadata(&self, key: Guid) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_metadata(&self, key: Guid) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetMetadata)(self as *const _ as *mut _, key, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8650,9 +8650,9 @@ DEFINE_IID!(IID_IDisplayView, 2965998753, 46937, 23385, 177, 173, 240, 120, 106,
 RT_INTERFACE!{interface IDisplayView(IDisplayViewVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayView] {
     fn get_Paths(&self, out: *mut *mut foundation::collections::IVectorView<DisplayPath>) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_ContentResolution(&self, out: *mut *mut foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_ContentResolution(&self, out: *mut *mut foundation::IReference<crate::windows::graphics::SizeInt32>) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_ContentResolution(&self, value: *mut foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_ContentResolution(&self, value: *mut foundation::IReference<crate::windows::graphics::SizeInt32>) -> HRESULT,
     fn SetPrimaryPath(&self, path: *mut DisplayPath) -> HRESULT,
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMap<Guid, IInspectable>) -> HRESULT
 }}
@@ -8662,12 +8662,12 @@ impl IDisplayView {
         let hr = ((*self.lpVtbl).get_Paths)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_content_resolution(&self) -> Result<Option<ComPtr<foundation::IReference<::rt::gen::windows::graphics::SizeInt32>>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_content_resolution(&self) -> Result<Option<ComPtr<foundation::IReference<crate::windows::graphics::SizeInt32>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ContentResolution)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_content_resolution(&self, value: &foundation::IReference<::rt::gen::windows::graphics::SizeInt32>) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_content_resolution(&self, value: &foundation::IReference<crate::windows::graphics::SizeInt32>) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ContentResolution)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -8772,7 +8772,7 @@ impl IDisplayWireFormatStatics {
 } // Windows.Devices.Display.Core
 } // Windows.Devices.Display
 pub mod enumeration { // Windows.Devices.Enumeration
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDeviceAccessChangedEventArgs, 3738831820, 20381, 20312, 157, 186, 169, 188, 128, 4, 8, 213);
 RT_INTERFACE!{interface IDeviceAccessChangedEventArgs(IDeviceAccessChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceAccessChangedEventArgs] {
     fn get_Status(&self, out: *mut DeviceAccessStatus) -> HRESULT
@@ -9728,7 +9728,7 @@ RT_ENUM! { enum Panel: i32 {
     Unknown = 0, Front = 1, Back = 2, Top = 3, Bottom = 4, Left = 5, Right = 6,
 }}
 pub mod pnp { // Windows.Devices.Enumeration.Pnp
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPnpObject, 2512806488, 29499, 19087, 147, 163, 219, 7, 138, 200, 112, 193);
 RT_INTERFACE!{interface IPnpObject(IPnpObjectVtbl): IInspectable(IInspectableVtbl) [IID_IPnpObject] {
     fn get_Type(&self, out: *mut PnpObjectType) -> HRESULT,
@@ -9920,7 +9920,7 @@ RT_CLASS!{class PnpObjectWatcher: IPnpObjectWatcher}
 } // Windows.Devices.Enumeration.Pnp
 } // Windows.Devices.Enumeration
 pub mod geolocation { // Windows.Devices.Geolocation
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AltitudeReferenceSystem: i32 {
     Unspecified = 0, Terrain = 1, Ellipsoid = 2, Geoid = 3, Surface = 4,
 }}
@@ -10725,7 +10725,7 @@ RT_ENUM! { enum VisitStateChange: i32 {
     TrackingLost = 0, Arrived = 1, Departed = 2, OtherMovement = 3,
 }}
 pub mod geofencing { // Windows.Devices.Geolocation.Geofencing
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IGeofence, 2617837603, 60856, 18400, 130, 69, 91, 246, 29, 50, 31, 45);
 RT_INTERFACE!{interface IGeofence(IGeofenceVtbl): IInspectable(IInspectableVtbl) [IID_IGeofence] {
     fn get_StartTime(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -10934,7 +10934,7 @@ RT_ENUM! { enum MonitoredGeofenceStates: u32 {
 } // Windows.Devices.Geolocation.Geofencing
 } // Windows.Devices.Geolocation
 pub mod gpio { // Windows.Devices.Gpio
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct GpioChangeCount {
     Count: u64, RelativeTime: foundation::TimeSpan,
 }}
@@ -11288,7 +11288,7 @@ RT_ENUM! { enum GpioSharingMode: i32 {
     Exclusive = 0, SharedReadOnly = 1,
 }}
 pub mod provider { // Windows.Devices.Gpio.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IGpioControllerProvider, 2903625415, 6634, 19233, 135, 79, 185, 26, 237, 74, 37, 219);
 RT_INTERFACE!{interface IGpioControllerProvider(IGpioControllerProviderVtbl): IInspectable(IInspectableVtbl) [IID_IGpioControllerProvider] {
     fn get_PinCount(&self, out: *mut i32) -> HRESULT,
@@ -11429,7 +11429,7 @@ RT_ENUM! { enum ProviderGpioSharingMode: i32 {
 } // Windows.Devices.Gpio.Provider
 } // Windows.Devices.Gpio
 pub mod haptics { // Windows.Devices.Haptics
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class KnownSimpleHapticsControllerWaveforms}
 impl RtActivatable<IKnownSimpleHapticsControllerWaveformsStatics> for KnownSimpleHapticsControllerWaveforms {}
 impl KnownSimpleHapticsControllerWaveforms {
@@ -11647,7 +11647,7 @@ impl IVibrationDeviceStatics {
 }
 } // Windows.Devices.Haptics
 pub mod humaninterfacedevice { // Windows.Devices.HumanInterfaceDevice
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IHidBooleanControl, 1380840586, 13973, 16524, 187, 162, 226, 235, 90, 191, 188, 32);
 RT_INTERFACE!{interface IHidBooleanControl(IHidBooleanControlVtbl): IInspectable(IInspectableVtbl) [IID_IHidBooleanControl] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -12260,7 +12260,7 @@ RT_ENUM! { enum HidReportType: i32 {
 }}
 } // Windows.Devices.HumanInterfaceDevice
 pub mod i2c { // Windows.Devices.I2c
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum I2cBusSpeed: i32 {
     StandardMode = 0, FastMode = 1,
 }}
@@ -12457,7 +12457,7 @@ RT_ENUM! { enum I2cTransferStatus: i32 {
     FullTransfer = 0, PartialTransfer = 1, SlaveAddressNotAcknowledged = 2, ClockStretchTimeout = 3, UnknownError = 4,
 }}
 pub mod provider { // Windows.Devices.I2c.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_II2cControllerProvider, 1640151938, 17680, 16739, 168, 124, 78, 21, 169, 85, 137, 128);
 RT_INTERFACE!{interface II2cControllerProvider(II2cControllerProviderVtbl): IInspectable(IInspectableVtbl) [IID_II2cControllerProvider] {
     fn GetDeviceProvider(&self, settings: *mut ProviderI2cConnectionSettings, out: *mut *mut II2cDeviceProvider) -> HRESULT
@@ -12578,7 +12578,7 @@ RT_ENUM! { enum ProviderI2cTransferStatus: i32 {
 } // Windows.Devices.I2c.Provider
 } // Windows.Devices.I2c
 pub mod input { // Windows.Devices.Input
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IKeyboardCapabilities, 977247062, 26520, 19388, 131, 62, 15, 52, 177, 124, 101, 255);
 RT_INTERFACE!{interface IKeyboardCapabilities(IKeyboardCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IKeyboardCapabilities] {
     fn get_KeyboardPresent(&self, out: *mut i32) -> HRESULT
@@ -12788,7 +12788,7 @@ RT_CLASS!{class TouchCapabilities: ITouchCapabilities}
 impl RtActivatable<IActivationFactory> for TouchCapabilities {}
 DEFINE_CLSID!(TouchCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,84,111,117,99,104,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_TouchCapabilities]);
 pub mod preview { // Windows.Devices.Input.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum GazeDeviceConfigurationStatePreview: i32 {
     Unknown = 0, Ready = 1, Configuring = 2, ScreenSetupNeeded = 3, UserCalibrationNeeded = 4,
 }}
@@ -13116,7 +13116,7 @@ RT_CLASS!{class GazePointPreview: IGazePointPreview}
 } // Windows.Devices.Input.Preview
 } // Windows.Devices.Input
 pub mod lights { // Windows.Devices.Lights
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ILamp, 75324314, 59973, 19243, 177, 162, 20, 223, 240, 11, 222, 123);
 RT_INTERFACE!{interface ILamp(ILampVtbl): IInspectable(IInspectableVtbl) [IID_ILamp] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -13492,7 +13492,7 @@ impl ILampStatics {
     }}
 }
 pub mod effects { // Windows.Devices.Lights.Effects
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ILampArrayBitmapEffect, 842588261, 55415, 17959, 137, 229, 42, 136, 247, 5, 47, 166);
 RT_INTERFACE!{interface ILampArrayBitmapEffect(ILampArrayBitmapEffectVtbl): IInspectable(IInspectableVtbl) [IID_ILampArrayBitmapEffect] {
     fn get_Duration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -13570,7 +13570,7 @@ impl ILampArrayBitmapEffectFactory {
 DEFINE_IID!(IID_ILampArrayBitmapRequestedEventArgs, 3367284638, 65123, 19793, 186, 189, 97, 157, 239, 180, 84, 186);
 RT_INTERFACE!{interface ILampArrayBitmapRequestedEventArgs(ILampArrayBitmapRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILampArrayBitmapRequestedEventArgs] {
     fn get_SinceStarted(&self, out: *mut foundation::TimeSpan) -> HRESULT,
-    #[cfg(feature="windows-graphics")] fn UpdateBitmap(&self, bitmap: *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn UpdateBitmap(&self, bitmap: *mut crate::windows::graphics::imaging::SoftwareBitmap) -> HRESULT
 }}
 impl ILampArrayBitmapRequestedEventArgs {
     #[inline] pub fn get_since_started(&self) -> Result<foundation::TimeSpan> { unsafe { 
@@ -13578,7 +13578,7 @@ impl ILampArrayBitmapRequestedEventArgs {
         let hr = ((*self.lpVtbl).get_SinceStarted)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn update_bitmap(&self, bitmap: &::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn update_bitmap(&self, bitmap: &crate::windows::graphics::imaging::SoftwareBitmap) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).UpdateBitmap)(self as *const _ as *mut _, bitmap as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -13587,9 +13587,9 @@ RT_CLASS!{class LampArrayBitmapRequestedEventArgs: ILampArrayBitmapRequestedEven
 DEFINE_IID!(IID_ILampArrayBlinkEffect, 3955176950, 12229, 19379, 179, 195, 98, 33, 167, 104, 13, 19);
 RT_INTERFACE!{interface ILampArrayBlinkEffect(ILampArrayBlinkEffectVtbl): IInspectable(IInspectableVtbl) [IID_ILampArrayBlinkEffect] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut crate::windows::ui::Color) -> HRESULT,
     #[cfg(not(feature="windows-ui"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-ui")] fn put_Color(&self, value: ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn put_Color(&self, value: crate::windows::ui::Color) -> HRESULT,
     fn get_AttackDuration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
     fn put_AttackDuration(&self, value: foundation::TimeSpan) -> HRESULT,
     fn get_SustainDuration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -13606,12 +13606,12 @@ RT_INTERFACE!{interface ILampArrayBlinkEffect(ILampArrayBlinkEffectVtbl): IInspe
     fn put_RepetitionMode(&self, value: LampArrayRepetitionMode) -> HRESULT
 }}
 impl ILampArrayBlinkEffect {
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_color(&self) -> Result<::rt::gen::windows::ui::Color> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_color(&self) -> Result<crate::windows::ui::Color> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Color)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, value: ::rt::gen::windows::ui::Color) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, value: crate::windows::ui::Color) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Color)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -13701,9 +13701,9 @@ impl ILampArrayBlinkEffectFactory {
 DEFINE_IID!(IID_ILampArrayColorRampEffect, 721437751, 16551, 17198, 160, 185, 13, 87, 12, 33, 83, 255);
 RT_INTERFACE!{interface ILampArrayColorRampEffect(ILampArrayColorRampEffectVtbl): IInspectable(IInspectableVtbl) [IID_ILampArrayColorRampEffect] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut crate::windows::ui::Color) -> HRESULT,
     #[cfg(not(feature="windows-ui"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-ui")] fn put_Color(&self, value: ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn put_Color(&self, value: crate::windows::ui::Color) -> HRESULT,
     fn get_RampDuration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
     fn put_RampDuration(&self, value: foundation::TimeSpan) -> HRESULT,
     fn get_StartDelay(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -13712,12 +13712,12 @@ RT_INTERFACE!{interface ILampArrayColorRampEffect(ILampArrayColorRampEffectVtbl)
     fn put_CompletionBehavior(&self, value: LampArrayEffectCompletionBehavior) -> HRESULT
 }}
 impl ILampArrayColorRampEffect {
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_color(&self) -> Result<::rt::gen::windows::ui::Color> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_color(&self) -> Result<crate::windows::ui::Color> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Color)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, value: ::rt::gen::windows::ui::Color) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, value: crate::windows::ui::Color) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Color)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -13951,9 +13951,9 @@ RT_ENUM! { enum LampArrayRepetitionMode: i32 {
 DEFINE_IID!(IID_ILampArraySolidEffect, 1142915603, 17356, 19251, 128, 235, 198, 221, 222, 125, 200, 237);
 RT_INTERFACE!{interface ILampArraySolidEffect(ILampArraySolidEffectVtbl): IInspectable(IInspectableVtbl) [IID_ILampArraySolidEffect] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_Color(&self, out: *mut crate::windows::ui::Color) -> HRESULT,
     #[cfg(not(feature="windows-ui"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-ui")] fn put_Color(&self, value: ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn put_Color(&self, value: crate::windows::ui::Color) -> HRESULT,
     fn get_Duration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
     fn put_Duration(&self, value: foundation::TimeSpan) -> HRESULT,
     fn get_StartDelay(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -13962,12 +13962,12 @@ RT_INTERFACE!{interface ILampArraySolidEffect(ILampArraySolidEffectVtbl): IInspe
     fn put_CompletionBehavior(&self, value: LampArrayEffectCompletionBehavior) -> HRESULT
 }}
 impl ILampArraySolidEffect {
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_color(&self) -> Result<::rt::gen::windows::ui::Color> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_color(&self) -> Result<crate::windows::ui::Color> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Color)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, value: ::rt::gen::windows::ui::Color) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, value: crate::windows::ui::Color) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Color)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -14021,10 +14021,10 @@ impl ILampArraySolidEffectFactory {
 DEFINE_IID!(IID_ILampArrayUpdateRequestedEventArgs, 1935019370, 22378, 18607, 133, 57, 103, 255, 160, 171, 53, 22);
 RT_INTERFACE!{interface ILampArrayUpdateRequestedEventArgs(ILampArrayUpdateRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILampArrayUpdateRequestedEventArgs] {
     fn get_SinceStarted(&self, out: *mut foundation::TimeSpan) -> HRESULT,
-    #[cfg(feature="windows-ui")] fn SetColor(&self, desiredColor: ::rt::gen::windows::ui::Color) -> HRESULT,
-    #[cfg(feature="windows-ui")] fn SetColorForIndex(&self, lampIndex: i32, desiredColor: ::rt::gen::windows::ui::Color) -> HRESULT,
-    #[cfg(feature="windows-ui")] fn SetSingleColorForIndices(&self, desiredColor: ::rt::gen::windows::ui::Color, lampIndexesSize: u32, lampIndexes: *mut i32) -> HRESULT,
-    #[cfg(feature="windows-ui")] fn SetColorsForIndices(&self, desiredColorsSize: u32, desiredColors: *mut ::rt::gen::windows::ui::Color, lampIndexesSize: u32, lampIndexes: *mut i32) -> HRESULT
+    #[cfg(feature="windows-ui")] fn SetColor(&self, desiredColor: crate::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn SetColorForIndex(&self, lampIndex: i32, desiredColor: crate::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn SetSingleColorForIndices(&self, desiredColor: crate::windows::ui::Color, lampIndexesSize: u32, lampIndexes: *mut i32) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn SetColorsForIndices(&self, desiredColorsSize: u32, desiredColors: *mut crate::windows::ui::Color, lampIndexesSize: u32, lampIndexes: *mut i32) -> HRESULT
 }}
 impl ILampArrayUpdateRequestedEventArgs {
     #[inline] pub fn get_since_started(&self) -> Result<foundation::TimeSpan> { unsafe { 
@@ -14032,19 +14032,19 @@ impl ILampArrayUpdateRequestedEventArgs {
         let hr = ((*self.lpVtbl).get_SinceStarted)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, desiredColor: ::rt::gen::windows::ui::Color) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_color(&self, desiredColor: crate::windows::ui::Color) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetColor)(self as *const _ as *mut _, desiredColor);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_color_for_index(&self, lampIndex: i32, desiredColor: ::rt::gen::windows::ui::Color) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_color_for_index(&self, lampIndex: i32, desiredColor: crate::windows::ui::Color) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetColorForIndex)(self as *const _ as *mut _, lampIndex, desiredColor);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_single_color_for_indices(&self, desiredColor: ::rt::gen::windows::ui::Color, lampIndexes: &[i32]) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_single_color_for_indices(&self, desiredColor: crate::windows::ui::Color, lampIndexes: &[i32]) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetSingleColorForIndices)(self as *const _ as *mut _, desiredColor, lampIndexes.len() as u32, lampIndexes.as_ptr() as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn set_colors_for_indices(&self, desiredColors: &[::rt::gen::windows::ui::Color], lampIndexes: &[i32]) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn set_colors_for_indices(&self, desiredColors: &[crate::windows::ui::Color], lampIndexes: &[i32]) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).SetColorsForIndices)(self as *const _ as *mut _, desiredColors.len() as u32, desiredColors.as_ptr() as *mut _, lampIndexes.len() as u32, lampIndexes.as_ptr() as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -14053,7 +14053,7 @@ RT_CLASS!{class LampArrayUpdateRequestedEventArgs: ILampArrayUpdateRequestedEven
 } // Windows.Devices.Lights.Effects
 } // Windows.Devices.Lights
 pub mod midi { // Windows.Devices.Midi
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{class MidiActiveSensingMessage: IMidiMessage}
 impl RtActivatable<IActivationFactory> for MidiActiveSensingMessage {}
 DEFINE_CLSID!(MidiActiveSensingMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,65,99,116,105,118,101,83,101,110,115,105,110,103,77,101,115,115,97,103,101,0]) [CLSID_MidiActiveSensingMessage]);
@@ -14666,7 +14666,7 @@ impl RtActivatable<IActivationFactory> for MidiTuneRequestMessage {}
 DEFINE_CLSID!(MidiTuneRequestMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,84,117,110,101,82,101,113,117,101,115,116,77,101,115,115,97,103,101,0]) [CLSID_MidiTuneRequestMessage]);
 } // Windows.Devices.Midi
 pub mod perception { // Windows.Devices.Perception
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class KnownCameraIntrinsicsProperties}
 impl RtActivatable<IKnownCameraIntrinsicsPropertiesStatics> for KnownCameraIntrinsicsProperties {}
 impl KnownCameraIntrinsicsProperties {
@@ -16375,7 +16375,7 @@ impl IPerceptionVideoProfile {
 }
 RT_CLASS!{class PerceptionVideoProfile: IPerceptionVideoProfile}
 pub mod provider { // Windows.Devices.Perception.Provider
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class KnownPerceptionFrameKind}
 impl RtActivatable<IKnownPerceptionFrameKindStatics> for KnownPerceptionFrameKind {}
 impl KnownPerceptionFrameKind {
@@ -16835,7 +16835,7 @@ impl PerceptionStopFaceAuthenticationHandler {
 DEFINE_IID!(IID_IPerceptionVideoFrameAllocator, 1278781402, 64984, 20180, 160, 57, 42, 111, 155, 35, 80, 56);
 RT_INTERFACE!{interface IPerceptionVideoFrameAllocator(IPerceptionVideoFrameAllocatorVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionVideoFrameAllocator] {
     fn AllocateFrame(&self, out: *mut *mut PerceptionFrame) -> HRESULT,
-    #[cfg(feature="windows-media")] fn CopyFromVideoFrame(&self, frame: *mut ::rt::gen::windows::media::VideoFrame, out: *mut *mut PerceptionFrame) -> HRESULT
+    #[cfg(feature="windows-media")] fn CopyFromVideoFrame(&self, frame: *mut crate::windows::media::VideoFrame, out: *mut *mut PerceptionFrame) -> HRESULT
 }}
 impl IPerceptionVideoFrameAllocator {
     #[inline] pub fn allocate_frame(&self) -> Result<Option<ComPtr<PerceptionFrame>>> { unsafe { 
@@ -16843,7 +16843,7 @@ impl IPerceptionVideoFrameAllocator {
         let hr = ((*self.lpVtbl).AllocateFrame)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-media")] #[inline] pub fn copy_from_video_frame(&self, frame: &::rt::gen::windows::media::VideoFrame) -> Result<Option<ComPtr<PerceptionFrame>>> { unsafe { 
+    #[cfg(feature="windows-media")] #[inline] pub fn copy_from_video_frame(&self, frame: &crate::windows::media::VideoFrame) -> Result<Option<ComPtr<PerceptionFrame>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CopyFromVideoFrame)(self as *const _ as *mut _, frame as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -16852,17 +16852,17 @@ impl IPerceptionVideoFrameAllocator {
 RT_CLASS!{class PerceptionVideoFrameAllocator: IPerceptionVideoFrameAllocator}
 impl RtActivatable<IPerceptionVideoFrameAllocatorFactory> for PerceptionVideoFrameAllocator {}
 impl PerceptionVideoFrameAllocator {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create(maxOutstandingFrameCountForWrite: u32, format: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: ::rt::gen::windows::graphics::imaging::BitmapAlphaMode) -> Result<ComPtr<PerceptionVideoFrameAllocator>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create(maxOutstandingFrameCountForWrite: u32, format: crate::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: crate::windows::graphics::imaging::BitmapAlphaMode) -> Result<ComPtr<PerceptionVideoFrameAllocator>> {
         <Self as RtActivatable<IPerceptionVideoFrameAllocatorFactory>>::get_activation_factory().create(maxOutstandingFrameCountForWrite, format, resolution, alpha)
     }
 }
 DEFINE_CLSID!(PerceptionVideoFrameAllocator(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,86,105,100,101,111,70,114,97,109,101,65,108,108,111,99,97,116,111,114,0]) [CLSID_PerceptionVideoFrameAllocator]);
 DEFINE_IID!(IID_IPerceptionVideoFrameAllocatorFactory, 442020065, 59674, 18462, 184, 118, 168, 158, 43, 188, 107, 51);
 RT_INTERFACE!{static interface IPerceptionVideoFrameAllocatorFactory(IPerceptionVideoFrameAllocatorFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionVideoFrameAllocatorFactory] {
-    #[cfg(feature="windows-graphics")] fn Create(&self, maxOutstandingFrameCountForWrite: u32, format: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: ::rt::gen::windows::graphics::imaging::BitmapAlphaMode, out: *mut *mut PerceptionVideoFrameAllocator) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn Create(&self, maxOutstandingFrameCountForWrite: u32, format: crate::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: crate::windows::graphics::imaging::BitmapAlphaMode, out: *mut *mut PerceptionVideoFrameAllocator) -> HRESULT
 }}
 impl IPerceptionVideoFrameAllocatorFactory {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create(&self, maxOutstandingFrameCountForWrite: u32, format: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: ::rt::gen::windows::graphics::imaging::BitmapAlphaMode) -> Result<ComPtr<PerceptionVideoFrameAllocator>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create(&self, maxOutstandingFrameCountForWrite: u32, format: crate::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: crate::windows::graphics::imaging::BitmapAlphaMode) -> Result<ComPtr<PerceptionVideoFrameAllocator>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Create)(self as *const _ as *mut _, maxOutstandingFrameCountForWrite, format, resolution, alpha, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -16871,7 +16871,7 @@ impl IPerceptionVideoFrameAllocatorFactory {
 } // Windows.Devices.Perception.Provider
 } // Windows.Devices.Perception
 pub mod pointofservice { // Windows.Devices.PointOfService
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBarcodeScanner, 3198369286, 45668, 20227, 169, 193, 69, 178, 15, 1, 19, 79);
 RT_INTERFACE!{interface IBarcodeScanner(IBarcodeScannerVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScanner] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -21591,7 +21591,7 @@ RT_ENUM! { enum UnifiedPosPowerReportingType: i32 {
     UnknownPowerReportingType = 0, Standard = 1, Advanced = 2,
 }}
 pub mod provider { // Windows.Devices.PointOfService.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBarcodeScannerDisableScannerRequest, 2297231296, 14265, 17013, 142, 119, 200, 229, 42, 229, 169, 200);
 RT_INTERFACE!{interface IBarcodeScannerDisableScannerRequest(IBarcodeScannerDisableScannerRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerDisableScannerRequest] {
     fn ReportCompletedAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22040,8 +22040,8 @@ RT_CLASS!{class BarcodeScannerProviderConnection: IBarcodeScannerProviderConnect
 DEFINE_IID!(IID_IBarcodeScannerProviderConnection2, 3197850573, 4404, 16780, 160, 107, 4, 66, 58, 115, 243, 215);
 RT_INTERFACE!{interface IBarcodeScannerProviderConnection2(IBarcodeScannerProviderConnection2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerProviderConnection2] {
     fn CreateFrameReaderAsync(&self, out: *mut *mut foundation::IAsyncOperation<BarcodeScannerFrameReader>) -> HRESULT,
-    #[cfg(feature="windows-graphics")] fn CreateFrameReaderWithFormatAsync(&self, preferredFormat: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, out: *mut *mut foundation::IAsyncOperation<BarcodeScannerFrameReader>) -> HRESULT,
-    #[cfg(feature="windows-graphics")] fn CreateFrameReaderWithFormatAndSizeAsync(&self, preferredFormat: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, preferredSize: ::rt::gen::windows::graphics::imaging::BitmapSize, out: *mut *mut foundation::IAsyncOperation<BarcodeScannerFrameReader>) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn CreateFrameReaderWithFormatAsync(&self, preferredFormat: crate::windows::graphics::imaging::BitmapPixelFormat, out: *mut *mut foundation::IAsyncOperation<BarcodeScannerFrameReader>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn CreateFrameReaderWithFormatAndSizeAsync(&self, preferredFormat: crate::windows::graphics::imaging::BitmapPixelFormat, preferredSize: crate::windows::graphics::imaging::BitmapSize, out: *mut *mut foundation::IAsyncOperation<BarcodeScannerFrameReader>) -> HRESULT
 }}
 impl IBarcodeScannerProviderConnection2 {
     #[inline] pub fn create_frame_reader_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<BarcodeScannerFrameReader>>> { unsafe { 
@@ -22049,12 +22049,12 @@ impl IBarcodeScannerProviderConnection2 {
         let hr = ((*self.lpVtbl).CreateFrameReaderAsync)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create_frame_reader_with_format_async(&self, preferredFormat: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat) -> Result<ComPtr<foundation::IAsyncOperation<BarcodeScannerFrameReader>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create_frame_reader_with_format_async(&self, preferredFormat: crate::windows::graphics::imaging::BitmapPixelFormat) -> Result<ComPtr<foundation::IAsyncOperation<BarcodeScannerFrameReader>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateFrameReaderWithFormatAsync)(self as *const _ as *mut _, preferredFormat, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn create_frame_reader_with_format_and_size_async(&self, preferredFormat: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, preferredSize: ::rt::gen::windows::graphics::imaging::BitmapSize) -> Result<ComPtr<foundation::IAsyncOperation<BarcodeScannerFrameReader>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn create_frame_reader_with_format_and_size_async(&self, preferredFormat: crate::windows::graphics::imaging::BitmapPixelFormat, preferredSize: crate::windows::graphics::imaging::BitmapSize) -> Result<ComPtr<foundation::IAsyncOperation<BarcodeScannerFrameReader>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateFrameReaderWithFormatAndSizeAsync)(self as *const _ as *mut _, preferredFormat, preferredSize, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -22308,13 +22308,13 @@ RT_ENUM! { enum BarcodeScannerTriggerState: i32 {
 DEFINE_IID!(IID_IBarcodeScannerVideoFrame, 2119717448, 40439, 16673, 161, 117, 128, 29, 128, 0, 17, 46);
 RT_INTERFACE!{interface IBarcodeScannerVideoFrame(IBarcodeScannerVideoFrameVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerVideoFrame] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_Format(&self, out: *mut ::rt::gen::windows::graphics::imaging::BitmapPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_Format(&self, out: *mut crate::windows::graphics::imaging::BitmapPixelFormat) -> HRESULT,
     fn get_Width(&self, out: *mut u32) -> HRESULT,
     fn get_Height(&self, out: *mut u32) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_PixelData(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_PixelData(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IBarcodeScannerVideoFrame {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_format(&self) -> Result<::rt::gen::windows::graphics::imaging::BitmapPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_format(&self) -> Result<crate::windows::graphics::imaging::BitmapPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Format)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -22329,7 +22329,7 @@ impl IBarcodeScannerVideoFrame {
         let hr = ((*self.lpVtbl).get_Height)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_pixel_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_pixel_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_PixelData)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -22386,7 +22386,7 @@ DEFINE_CLSID!(BarcodeSymbologyAttributesBuilder(&[87,105,110,100,111,119,115,46,
 } // Windows.Devices.PointOfService.Provider
 } // Windows.Devices.PointOfService
 pub mod portable { // Windows.Devices.Portable
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class ServiceDevice}
 impl RtActivatable<IServiceDeviceStatics> for ServiceDevice {}
 impl ServiceDevice {
@@ -22449,7 +22449,7 @@ impl IStorageDeviceStatics {
 }
 } // Windows.Devices.Portable
 pub mod power { // Windows.Devices.Power
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBattery, 3163115462, 114, 18376, 139, 93, 97, 74, 170, 122, 67, 126);
 RT_INTERFACE!{interface IBattery(IBatteryVtbl): IInspectable(IInspectableVtbl) [IID_IBattery] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -22553,7 +22553,7 @@ impl IBatteryStatics {
 }
 } // Windows.Devices.Power
 pub mod printers { // Windows.Devices.Printers
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPrint3DDevice, 68959513, 38675, 17058, 152, 19, 125, 195, 51, 116, 40, 211);
 RT_INTERFACE!{interface IPrint3DDevice(IPrint3DDeviceVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DDevice] {
     fn get_PrintSchema(&self, out: *mut *mut PrintSchema) -> HRESULT
@@ -22618,7 +22618,7 @@ impl IPrintSchema {
 }
 RT_CLASS!{class PrintSchema: IPrintSchema}
 pub mod extensions { // Windows.Devices.Printers.Extensions
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPrint3DWorkflow, 3312415933, 13929, 19046, 171, 66, 200, 21, 25, 48, 205, 52);
 RT_INTERFACE!{interface IPrint3DWorkflow(IPrint3DWorkflowVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DWorkflow] {
     fn get_DeviceID(&self, out: *mut HSTRING) -> HRESULT,
@@ -22839,7 +22839,7 @@ RT_CLASS!{class PrintTaskConfigurationSaveRequestedEventArgs: IPrintTaskConfigur
 } // Windows.Devices.Printers.Extensions
 } // Windows.Devices.Printers
 pub mod pwm { // Windows.Devices.Pwm
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPwmController, 3294583941, 53992, 17103, 155, 214, 207, 94, 208, 41, 230, 167);
 RT_INTERFACE!{interface IPwmController(IPwmControllerVtbl): IInspectable(IInspectableVtbl) [IID_IPwmController] {
     fn get_PinCount(&self, out: *mut i32) -> HRESULT,
@@ -23002,7 +23002,7 @@ RT_ENUM! { enum PwmPulsePolarity: i32 {
     ActiveHigh = 0, ActiveLow = 1,
 }}
 pub mod provider { // Windows.Devices.Pwm.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPwmControllerProvider, 318789947, 58083, 16548, 183, 217, 72, 223, 240, 55, 122, 82);
 RT_INTERFACE!{interface IPwmControllerProvider(IPwmControllerProviderVtbl): IInspectable(IInspectableVtbl) [IID_IPwmControllerProvider] {
     fn get_PinCount(&self, out: *mut i32) -> HRESULT,
@@ -23077,7 +23077,7 @@ impl IPwmProvider {
 } // Windows.Devices.Pwm.Provider
 } // Windows.Devices.Pwm
 pub mod radios { // Windows.Devices.Radios
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IRadio, 622926047, 45886, 16746, 135, 95, 28, 243, 138, 226, 216, 62);
 RT_INTERFACE!{interface IRadio(IRadioVtbl): IInspectable(IInspectableVtbl) [IID_IRadio] {
     fn SetStateAsync(&self, value: RadioState, out: *mut *mut foundation::IAsyncOperation<RadioAccessStatus>) -> HRESULT,
@@ -23175,7 +23175,7 @@ impl IRadioStatics {
 }
 } // Windows.Devices.Radios
 pub mod scanners { // Windows.Devices.Scanners
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IImageScanner, 1403555704, 21144, 18592, 141, 163, 128, 135, 81, 150, 101, 224);
 RT_INTERFACE!{interface IImageScanner(IImageScannerVtbl): IInspectable(IInspectableVtbl) [IID_IImageScanner] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -23620,7 +23620,7 @@ impl IImageScannerStatics {
 }
 } // Windows.Devices.Scanners
 pub mod sensors { // Windows.Devices.Sensors
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAccelerometer, 3742909768, 10001, 19879, 128, 152, 75, 130, 32, 93, 60, 125);
 RT_INTERFACE!{interface IAccelerometer(IAccelerometerVtbl): IInspectable(IInspectableVtbl) [IID_IAccelerometer] {
     fn GetCurrentReading(&self, out: *mut *mut AccelerometerReading) -> HRESULT,
@@ -26259,7 +26259,7 @@ impl ISimpleOrientationSensorStatics2 {
     }}
 }
 pub mod custom { // Windows.Devices.Sensors.Custom
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICustomSensor, 2704734637, 16436, 19277, 153, 221, 83, 26, 172, 100, 156, 9);
 RT_INTERFACE!{interface ICustomSensor(ICustomSensorVtbl): IInspectable(IInspectableVtbl) [IID_ICustomSensor] {
     fn GetCurrentReading(&self, out: *mut *mut CustomSensorReading) -> HRESULT,
@@ -26399,7 +26399,7 @@ impl ICustomSensorStatics {
 } // Windows.Devices.Sensors.Custom
 } // Windows.Devices.Sensors
 pub mod serialcommunication { // Windows.Devices.SerialCommunication
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IErrorReceivedEventArgs, 4240883545, 4739, 19850, 191, 223, 86, 107, 51, 221, 178, 143);
 RT_INTERFACE!{interface IErrorReceivedEventArgs(IErrorReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IErrorReceivedEventArgs] {
     fn get_Error(&self, out: *mut SerialError) -> HRESULT
@@ -26680,7 +26680,7 @@ RT_ENUM! { enum SerialStopBitCount: i32 {
 }}
 } // Windows.Devices.SerialCommunication
 pub mod smartcards { // Windows.Devices.SmartCards
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICardAddedEventArgs, 414969752, 61835, 19923, 177, 24, 223, 178, 200, 226, 60, 198);
 RT_INTERFACE!{interface ICardAddedEventArgs(ICardAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICardAddedEventArgs] {
     fn get_SmartCard(&self, out: *mut *mut SmartCard) -> HRESULT
@@ -28352,7 +28352,7 @@ RT_ENUM! { enum SmartCardUnlockPromptingBehavior: i32 {
 }}
 } // Windows.Devices.SmartCards
 pub mod sms { // Windows.Devices.Sms
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CellularClass: i32 {
     None = 0, Gsm = 1, Cdma = 2,
 }}
@@ -29651,7 +29651,7 @@ impl ISmsWapMessage {
 RT_CLASS!{class SmsWapMessage: ISmsWapMessage}
 } // Windows.Devices.Sms
 pub mod spi { // Windows.Devices.Spi
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISpiBusInfo, 2569618506, 21746, 18630, 185, 82, 156, 50, 252, 2, 198, 105);
 RT_INTERFACE!{interface ISpiBusInfo(ISpiBusInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISpiBusInfo] {
     fn get_ChipSelectLineCount(&self, out: *mut i32) -> HRESULT,
@@ -29890,7 +29890,7 @@ RT_ENUM! { enum SpiSharingMode: i32 {
     Exclusive = 0, Shared = 1,
 }}
 pub mod provider { // Windows.Devices.Spi.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IProviderSpiConnectionSettings, 4127409488, 42306, 20160, 150, 1, 164, 221, 104, 248, 105, 123);
 RT_INTERFACE!{interface IProviderSpiConnectionSettings(IProviderSpiConnectionSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IProviderSpiConnectionSettings] {
     fn get_ChipSelectLine(&self, out: *mut i32) -> HRESULT,
@@ -30038,7 +30038,7 @@ impl ISpiProvider {
 } // Windows.Devices.Spi.Provider
 } // Windows.Devices.Spi
 pub mod usb { // Windows.Devices.Usb
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUsbBulkInEndpointDescriptor, 1013860422, 1743, 17065, 157, 194, 151, 28, 27, 20, 182, 227);
 RT_INTERFACE!{interface IUsbBulkInEndpointDescriptor(IUsbBulkInEndpointDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IUsbBulkInEndpointDescriptor] {
     fn get_MaxPacketSize(&self, out: *mut u32) -> HRESULT,
@@ -31083,7 +31083,7 @@ RT_ENUM! { enum UsbWriteOptions: u32 {
 }}
 } // Windows.Devices.Usb
 pub mod wifi { // Windows.Devices.WiFi
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum WiFiAccessStatus: i32 {
     Unspecified = 0, Allowed = 1, DeniedByUser = 2, DeniedBySystem = 3,
 }}
@@ -31354,7 +31354,7 @@ RT_ENUM! { enum WiFiWpsKind: i32 {
 }}
 } // Windows.Devices.WiFi
 pub mod wifidirect { // Windows.Devices.WiFiDirect
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IWiFiDirectAdvertisement, 2874219053, 10758, 18849, 165, 132, 97, 67, 92, 121, 5, 166);
 RT_INTERFACE!{interface IWiFiDirectAdvertisement(IWiFiDirectAdvertisementVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectAdvertisement] {
     fn get_InformationElements(&self, out: *mut *mut foundation::collections::IVector<WiFiDirectInformationElement>) -> HRESULT,
@@ -31786,18 +31786,18 @@ RT_ENUM! { enum WiFiDirectPairingProcedure: i32 {
     GroupOwnerNegotiation = 0, Invitation = 1,
 }}
 pub mod services { // Windows.Devices.WiFiDirect.Services
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IWiFiDirectService, 1353366456, 24433, 17900, 132, 241, 161, 228, 252, 120, 121, 163);
 RT_INTERFACE!{interface IWiFiDirectService(IWiFiDirectServiceVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectService] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_RemoteServiceInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_RemoteServiceInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_SupportedConfigurationMethods(&self, out: *mut *mut foundation::collections::IVectorView<WiFiDirectServiceConfigurationMethod>) -> HRESULT,
     fn get_PreferGroupOwnerMode(&self, out: *mut bool) -> HRESULT,
     fn put_PreferGroupOwnerMode(&self, value: bool) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_SessionInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_SessionInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_SessionInfo(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_SessionInfo(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_ServiceError(&self, out: *mut WiFiDirectServiceError) -> HRESULT,
     fn add_SessionDeferred(&self, handler: *mut foundation::TypedEventHandler<WiFiDirectService, WiFiDirectServiceSessionDeferredEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_SessionDeferred(&self, token: foundation::EventRegistrationToken) -> HRESULT,
@@ -31806,7 +31806,7 @@ RT_INTERFACE!{interface IWiFiDirectService(IWiFiDirectServiceVtbl): IInspectable
     fn ConnectAsyncWithPin(&self, pin: HSTRING, out: *mut *mut foundation::IAsyncOperation<WiFiDirectServiceSession>) -> HRESULT
 }}
 impl IWiFiDirectService {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_remote_service_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_remote_service_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_RemoteServiceInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -31825,12 +31825,12 @@ impl IWiFiDirectService {
         let hr = ((*self.lpVtbl).put_PreferGroupOwnerMode)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SessionInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_session_info(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_session_info(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_SessionInfo)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -31870,7 +31870,7 @@ impl WiFiDirectService {
     #[inline] pub fn get_selector(serviceName: &HStringArg) -> Result<HString> {
         <Self as RtActivatable<IWiFiDirectServiceStatics>>::get_activation_factory().get_selector(serviceName)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_selector_with_filter(serviceName: &HStringArg, serviceInfoFilter: &::rt::gen::windows::storage::streams::IBuffer) -> Result<HString> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_selector_with_filter(serviceName: &HStringArg, serviceInfoFilter: &crate::windows::storage::streams::IBuffer) -> Result<HString> {
         <Self as RtActivatable<IWiFiDirectServiceStatics>>::get_activation_factory().get_selector_with_filter(serviceName, serviceInfoFilter)
     }
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<WiFiDirectService>>> {
@@ -31886,9 +31886,9 @@ RT_INTERFACE!{interface IWiFiDirectServiceAdvertiser(IWiFiDirectServiceAdvertise
     fn get_ServiceName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_ServiceNamePrefixes(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_ServiceInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_ServiceInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_ServiceInfo(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_ServiceInfo(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_AutoAcceptSession(&self, out: *mut bool) -> HRESULT,
     fn put_AutoAcceptSession(&self, value: bool) -> HRESULT,
     fn get_PreferGroupOwnerMode(&self, out: *mut bool) -> HRESULT,
@@ -31899,9 +31899,9 @@ RT_INTERFACE!{interface IWiFiDirectServiceAdvertiser(IWiFiDirectServiceAdvertise
     fn get_CustomServiceStatusCode(&self, out: *mut u32) -> HRESULT,
     fn put_CustomServiceStatusCode(&self, value: u32) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy13(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_DeferredSessionInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_DeferredSessionInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy14(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_DeferredSessionInfo(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_DeferredSessionInfo(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_AdvertisementStatus(&self, out: *mut WiFiDirectServiceAdvertisementStatus) -> HRESULT,
     fn get_ServiceError(&self, out: *mut WiFiDirectServiceError) -> HRESULT,
     fn add_SessionRequested(&self, handler: *mut foundation::TypedEventHandler<WiFiDirectServiceAdvertiser, WiFiDirectServiceSessionRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -31926,12 +31926,12 @@ impl IWiFiDirectServiceAdvertiser {
         let hr = ((*self.lpVtbl).get_ServiceNamePrefixes)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_service_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_service_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServiceInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_service_info(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_service_info(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ServiceInfo)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -31976,12 +31976,12 @@ impl IWiFiDirectServiceAdvertiser {
         let hr = ((*self.lpVtbl).put_CustomServiceStatusCode)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_deferred_session_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_deferred_session_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DeferredSessionInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_deferred_session_info(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_deferred_session_info(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_DeferredSessionInfo)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -32063,7 +32063,7 @@ impl IWiFiDirectServiceAdvertiserFactory {
 DEFINE_IID!(IID_IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs, 3705266206, 33759, 17381, 143, 67, 203, 232, 71, 158, 132, 235);
 RT_INTERFACE!{interface IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs(IWiFiDirectServiceAutoAcceptSessionConnectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs] {
     fn get_Session(&self, out: *mut *mut WiFiDirectServiceSession) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_SessionInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_SessionInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
     #[inline] pub fn get_session(&self) -> Result<Option<ComPtr<WiFiDirectServiceSession>>> { unsafe { 
@@ -32071,7 +32071,7 @@ impl IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
         let hr = ((*self.lpVtbl).get_Session)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SessionInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -32108,11 +32108,11 @@ RT_CLASS!{class WiFiDirectServiceProvisioningInfo: IWiFiDirectServiceProvisionin
 DEFINE_IID!(IID_IWiFiDirectServiceRemotePortAddedEventArgs, 3570318017, 16339, 20238, 183, 189, 120, 41, 6, 244, 68, 17);
 RT_INTERFACE!{interface IWiFiDirectServiceRemotePortAddedEventArgs(IWiFiDirectServiceRemotePortAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceRemotePortAddedEventArgs] {
     #[cfg(not(feature="windows-networking"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_EndpointPairs(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::networking::EndpointPair>) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn get_EndpointPairs(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::networking::EndpointPair>) -> HRESULT,
     fn get_Protocol(&self, out: *mut WiFiDirectServiceIPProtocol) -> HRESULT
 }}
 impl IWiFiDirectServiceRemotePortAddedEventArgs {
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_endpoint_pairs(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::networking::EndpointPair>>>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_endpoint_pairs(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::networking::EndpointPair>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_EndpointPairs)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -32134,13 +32134,13 @@ RT_INTERFACE!{interface IWiFiDirectServiceSession(IWiFiDirectServiceSessionVtbl)
     fn get_ServiceAddress(&self, out: *mut HSTRING) -> HRESULT,
     fn get_SessionAddress(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy7(&self) -> (),
-    #[cfg(feature="windows-networking")] fn GetConnectionEndpointPairs(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::networking::EndpointPair>) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn GetConnectionEndpointPairs(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::networking::EndpointPair>) -> HRESULT,
     fn add_SessionStatusChanged(&self, handler: *mut foundation::TypedEventHandler<WiFiDirectServiceSession, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_SessionStatusChanged(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy10(&self) -> (),
-    #[cfg(feature="windows-networking")] fn AddStreamSocketListenerAsync(&self, value: *mut ::rt::gen::windows::networking::sockets::StreamSocketListener, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn AddStreamSocketListenerAsync(&self, value: *mut crate::windows::networking::sockets::StreamSocketListener, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy11(&self) -> (),
-    #[cfg(feature="windows-networking")] fn AddDatagramSocketAsync(&self, value: *mut ::rt::gen::windows::networking::sockets::DatagramSocket, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn AddDatagramSocketAsync(&self, value: *mut crate::windows::networking::sockets::DatagramSocket, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn add_RemotePortAdded(&self, handler: *mut foundation::TypedEventHandler<WiFiDirectServiceSession, WiFiDirectServiceRemotePortAddedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_RemotePortAdded(&self, token: foundation::EventRegistrationToken) -> HRESULT
 }}
@@ -32180,7 +32180,7 @@ impl IWiFiDirectServiceSession {
         let hr = ((*self.lpVtbl).get_SessionAddress)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_connection_endpoint_pairs(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::networking::EndpointPair>>>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_connection_endpoint_pairs(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::networking::EndpointPair>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetConnectionEndpointPairs)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -32194,12 +32194,12 @@ impl IWiFiDirectServiceSession {
         let hr = ((*self.lpVtbl).remove_SessionStatusChanged)(self as *const _ as *mut _, token);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn add_stream_socket_listener_async(&self, value: &::rt::gen::windows::networking::sockets::StreamSocketListener) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn add_stream_socket_listener_async(&self, value: &crate::windows::networking::sockets::StreamSocketListener) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).AddStreamSocketListenerAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn add_datagram_socket_async(&self, value: &::rt::gen::windows::networking::sockets::DatagramSocket) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn add_datagram_socket_async(&self, value: &crate::windows::networking::sockets::DatagramSocket) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).AddDatagramSocketAsync)(self as *const _ as *mut _, value as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -32217,10 +32217,10 @@ impl IWiFiDirectServiceSession {
 RT_CLASS!{class WiFiDirectServiceSession: IWiFiDirectServiceSession}
 DEFINE_IID!(IID_IWiFiDirectServiceSessionDeferredEventArgs, 2382109055, 4609, 20255, 182, 244, 93, 241, 183, 185, 251, 46);
 RT_INTERFACE!{interface IWiFiDirectServiceSessionDeferredEventArgs(IWiFiDirectServiceSessionDeferredEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceSessionDeferredEventArgs] {
-    #[cfg(feature="windows-storage")] fn get_DeferredSessionInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_DeferredSessionInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IWiFiDirectServiceSessionDeferredEventArgs {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_deferred_session_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_deferred_session_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DeferredSessionInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -32234,7 +32234,7 @@ DEFINE_IID!(IID_IWiFiDirectServiceSessionRequest, 2699197579, 20683, 19032, 155,
 RT_INTERFACE!{interface IWiFiDirectServiceSessionRequest(IWiFiDirectServiceSessionRequestVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceSessionRequest] {
     fn get_DeviceInformation(&self, out: *mut *mut super::super::enumeration::DeviceInformation) -> HRESULT,
     fn get_ProvisioningInfo(&self, out: *mut *mut WiFiDirectServiceProvisioningInfo) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_SessionInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_SessionInfo(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IWiFiDirectServiceSessionRequest {
     #[inline] pub fn get_device_information(&self) -> Result<Option<ComPtr<super::super::enumeration::DeviceInformation>>> { unsafe { 
@@ -32247,7 +32247,7 @@ impl IWiFiDirectServiceSessionRequest {
         let hr = ((*self.lpVtbl).get_ProvisioningInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_info(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SessionInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -32273,7 +32273,7 @@ DEFINE_IID!(IID_IWiFiDirectServiceStatics, 2108948549, 64884, 18056, 183, 37, 93
 RT_INTERFACE!{static interface IWiFiDirectServiceStatics(IWiFiDirectServiceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceStatics] {
     fn GetSelector(&self, serviceName: HSTRING, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn GetSelectorWithFilter(&self, serviceName: HSTRING, serviceInfoFilter: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut HSTRING) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetSelectorWithFilter(&self, serviceName: HSTRING, serviceInfoFilter: *mut crate::windows::storage::streams::IBuffer, out: *mut HSTRING) -> HRESULT,
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncOperation<WiFiDirectService>) -> HRESULT
 }}
 impl IWiFiDirectServiceStatics {
@@ -32282,7 +32282,7 @@ impl IWiFiDirectServiceStatics {
         let hr = ((*self.lpVtbl).GetSelector)(self as *const _ as *mut _, serviceName.get(), &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_selector_with_filter(&self, serviceName: &HStringArg, serviceInfoFilter: &::rt::gen::windows::storage::streams::IBuffer) -> Result<HString> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_selector_with_filter(&self, serviceName: &HStringArg, serviceInfoFilter: &crate::windows::storage::streams::IBuffer) -> Result<HString> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetSelectorWithFilter)(self as *const _ as *mut _, serviceName.get(), serviceInfoFilter as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }

--- a/src/rt/gen/windows/foundation.rs
+++ b/src/rt/gen/windows/foundation.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAsyncAction, 1516535814, 33850, 19881, 134, 91, 157, 38, 229, 223, 173, 123);
 RT_INTERFACE!{interface IAsyncAction(IAsyncActionVtbl): IInspectable(IInspectableVtbl) [IID_IAsyncAction] {
     fn put_Completed(&self, handler: *mut AsyncActionCompletedHandler) -> HRESULT,
@@ -3407,7 +3407,7 @@ RT_PINTERFACE!{ for TypedEventHandler<IMemoryBufferReference, IInspectable> => [
 #[cfg(feature="windows-web")] RT_PINTERFACE!{ for TypedEventHandler<super::web::ui::IWebViewControl, super::web::ui::WebViewControlUnviewableContentIdentifiedEventArgs> => [0x571626e3,0x9780,0x5b37,0xbe,0x8a,0xab,0x8e,0x4e,0x78,0x98,0xcf] as IID_TypedEventHandler_2_Windows_Web_UI_IWebViewControl_Windows_Web_UI_WebViewControlUnviewableContentIdentifiedEventArgs }
 #[cfg(feature="windows-web")] RT_PINTERFACE!{ for TypedEventHandler<super::web::ui::IWebViewControl, super::web::ui::WebViewControlWebResourceRequestedEventArgs> => [0x3a6ed2bc,0x032b,0x5ec7,0xa2,0x0a,0xc1,0xef,0x49,0x25,0x0c,0x3c] as IID_TypedEventHandler_2_Windows_Web_UI_IWebViewControl_Windows_Web_UI_WebViewControlWebResourceRequestedEventArgs }
 pub mod collections { // Windows.Foundation.Collections
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CollectionChange: i32 {
     Reset = 0, ItemInserted = 1, ItemRemoved = 2, ItemChanged = 3,
 }}
@@ -5677,7 +5677,7 @@ RT_PINTERFACE!{ for VectorChangedEventHandler<IInspectable> => [0xb423a801,0xd35
 #[cfg(feature="windows-ui-xaml")] RT_PINTERFACE!{ for VectorChangedEventHandler<super::super::ui::xaml::DependencyObject> => [0xb62dec93,0xa7a5,0x5ff5,0xb2,0xd2,0x6b,0xd2,0x0c,0xa0,0xbd,0x4d] as IID_VectorChangedEventHandler_1_Windows_UI_Xaml_DependencyObject }
 } // Windows.Foundation.Collections
 pub mod diagnostics { // Windows.Foundation.Diagnostics
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class AsyncCausalityTracer}
 impl RtActivatable<IAsyncCausalityTracerStatics> for AsyncCausalityTracer {}
 impl AsyncCausalityTracer {
@@ -6933,7 +6933,7 @@ impl ITracingStatusChangedEventArgs {
 RT_CLASS!{class TracingStatusChangedEventArgs: ITracingStatusChangedEventArgs}
 } // Windows.Foundation.Diagnostics
 pub mod metadata { // Windows.Foundation.Metadata
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class ApiInformation}
 impl RtActivatable<IApiInformationStatics> for ApiInformation {}
 impl ApiInformation {
@@ -7060,7 +7060,7 @@ RT_ENUM! { enum ThreadingModel: i32 {
 }}
 } // Windows.Foundation.Metadata
 pub mod numerics { // Windows.Foundation.Numerics
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct Matrix3x2 {
     M11: f32, M12: f32, M21: f32, M22: f32, M31: f32, M32: f32,
 }}

--- a/src/rt/gen/windows/gaming.rs
+++ b/src/rt/gen/windows/gaming.rs
@@ -1,5 +1,5 @@
 pub mod input { // Windows.Gaming.Input
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IArcadeStick, 2974438301, 48891, 19585, 128, 81, 21, 236, 243, 177, 48, 54);
 RT_INTERFACE!{interface IArcadeStick(IArcadeStickVtbl): IInspectable(IInspectableVtbl) [IID_IArcadeStick] {
     fn GetButtonLabel(&self, button: ArcadeStickButtons, out: *mut GameControllerButtonLabel) -> HRESULT,
@@ -759,7 +759,7 @@ RT_STRUCT! { struct UINavigationReading {
     Timestamp: u64, RequiredButtons: RequiredUINavigationButtons, OptionalButtons: OptionalUINavigationButtons,
 }}
 pub mod custom { // Windows.Gaming.Input.Custom
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICustomGameControllerFactory, 1772138078, 30094, 19646, 172, 230, 98, 21, 95, 233, 18, 111);
 RT_INTERFACE!{interface ICustomGameControllerFactory(ICustomGameControllerFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICustomGameControllerFactory] {
     fn CreateGameController(&self, provider: *mut IGameControllerProvider, out: *mut *mut IInspectable) -> HRESULT,
@@ -932,7 +932,7 @@ DEFINE_IID!(IID_IGipGameControllerProvider, 3687783961, 6901, 17832, 191, 2, 160
 RT_INTERFACE!{interface IGipGameControllerProvider(IGipGameControllerProviderVtbl): IInspectable(IInspectableVtbl) [IID_IGipGameControllerProvider] {
     fn SendMessage(&self, messageClass: GipMessageClass, messageId: u8, messageBufferSize: u32, messageBuffer: *mut u8) -> HRESULT,
     fn SendReceiveMessage(&self, messageClass: GipMessageClass, messageId: u8, requestMessageBufferSize: u32, requestMessageBuffer: *mut u8, responseMessageBufferSize: u32, responseMessageBuffer: *mut u8) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn UpdateFirmwareAsync(&self, firmwareImage: *mut ::rt::gen::windows::storage::streams::IInputStream, out: *mut *mut foundation::IAsyncOperationWithProgress<GipFirmwareUpdateResult, GipFirmwareUpdateProgress>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn UpdateFirmwareAsync(&self, firmwareImage: *mut crate::windows::storage::streams::IInputStream, out: *mut *mut foundation::IAsyncOperationWithProgress<GipFirmwareUpdateResult, GipFirmwareUpdateProgress>) -> HRESULT
 }}
 impl IGipGameControllerProvider {
     #[inline] pub fn send_message(&self, messageClass: GipMessageClass, messageId: u8, messageBuffer: &[u8]) -> Result<()> { unsafe { 
@@ -943,7 +943,7 @@ impl IGipGameControllerProvider {
         let hr = ((*self.lpVtbl).SendReceiveMessage)(self as *const _ as *mut _, messageClass, messageId, requestMessageBuffer.len() as u32, requestMessageBuffer.as_ptr() as *mut _, responseMessageBuffer.len() as u32, responseMessageBuffer.as_mut_ptr() as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn update_firmware_async(&self, firmwareImage: &::rt::gen::windows::storage::streams::IInputStream) -> Result<ComPtr<foundation::IAsyncOperationWithProgress<GipFirmwareUpdateResult, GipFirmwareUpdateProgress>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn update_firmware_async(&self, firmwareImage: &crate::windows::storage::streams::IInputStream) -> Result<ComPtr<foundation::IAsyncOperationWithProgress<GipFirmwareUpdateResult, GipFirmwareUpdateProgress>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).UpdateFirmwareAsync)(self as *const _ as *mut _, firmwareImage as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1025,7 +1025,7 @@ impl IXusbGameControllerProvider {
 RT_CLASS!{class XusbGameControllerProvider: IXusbGameControllerProvider}
 } // Windows.Gaming.Input.Custom
 pub mod forcefeedback { // Windows.Gaming.Input.ForceFeedback
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IConditionForceEffect, 852617832, 13973, 20073, 133, 192, 205, 25, 68, 24, 145, 64);
 RT_INTERFACE!{interface IConditionForceEffect(IConditionForceEffectVtbl): IInspectable(IInspectableVtbl) [IID_IConditionForceEffect] {
     fn get_Kind(&self, out: *mut ConditionForceEffectKind) -> HRESULT,
@@ -1266,7 +1266,7 @@ impl RtActivatable<IActivationFactory> for RampForceEffect {}
 DEFINE_CLSID!(RampForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,82,97,109,112,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_RampForceEffect]);
 } // Windows.Gaming.Input.ForceFeedback
 pub mod preview { // Windows.Gaming.Input.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class GameControllerProviderInfo}
 impl RtActivatable<IGameControllerProviderInfoStatics> for GameControllerProviderInfo {}
 impl GameControllerProviderInfo {
@@ -1299,7 +1299,7 @@ impl IGameControllerProviderInfoStatics {
 } // Windows.Gaming.Input
 pub mod preview { // Windows.Gaming.Preview
 pub mod gamesenumeration { // Windows.Gaming.Preview.GamesEnumeration
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class GameList}
 impl RtActivatable<IGameListStatics> for GameList {}
 impl RtActivatable<IGameListStatics2> for GameList {}
@@ -1352,14 +1352,14 @@ impl GameListChangedEventHandler {
 DEFINE_IID!(IID_IGameListEntry, 1935221971, 33055, 17556, 182, 156, 198, 65, 160, 198, 21, 67);
 RT_INTERFACE!{interface IGameListEntry(IGameListEntryVtbl): IInspectable(IInspectableVtbl) [IID_IGameListEntry] {
     #[cfg(not(feature="windows-applicationmodel"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-applicationmodel")] fn get_DisplayInfo(&self, out: *mut *mut ::rt::gen::windows::applicationmodel::AppDisplayInfo) -> HRESULT,
+    #[cfg(feature="windows-applicationmodel")] fn get_DisplayInfo(&self, out: *mut *mut crate::windows::applicationmodel::AppDisplayInfo) -> HRESULT,
     fn LaunchAsync(&self, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
     fn get_Category(&self, out: *mut GameListCategory) -> HRESULT,
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMapView<HString, IInspectable>) -> HRESULT,
     fn SetCategoryAsync(&self, value: GameListCategory, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl IGameListEntry {
-    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_display_info(&self) -> Result<Option<ComPtr<::rt::gen::windows::applicationmodel::AppDisplayInfo>>> { unsafe { 
+    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_display_info(&self) -> Result<Option<ComPtr<crate::windows::applicationmodel::AppDisplayInfo>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DisplayInfo)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1390,12 +1390,12 @@ DEFINE_IID!(IID_IGameListEntry2, 3628765067, 34633, 18981, 144, 211, 246, 197, 1
 RT_INTERFACE!{interface IGameListEntry2(IGameListEntry2Vtbl): IInspectable(IInspectableVtbl) [IID_IGameListEntry2] {
     fn get_LaunchableState(&self, out: *mut GameListEntryLaunchableState) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_LauncherExecutable(&self, out: *mut *mut ::rt::gen::windows::storage::IStorageFile) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_LauncherExecutable(&self, out: *mut *mut crate::windows::storage::IStorageFile) -> HRESULT,
     fn get_LaunchParameters(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SetLauncherExecutableFileAsync(&self, executableFile: *mut ::rt::gen::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SetLauncherExecutableFileAsync(&self, executableFile: *mut crate::windows::storage::IStorageFile, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SetLauncherExecutableFileWithParamsAsync(&self, executableFile: *mut ::rt::gen::windows::storage::IStorageFile, launchParams: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SetLauncherExecutableFileWithParamsAsync(&self, executableFile: *mut crate::windows::storage::IStorageFile, launchParams: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn get_TitleId(&self, out: *mut HSTRING) -> HRESULT,
     fn SetTitleIdAsync(&self, id: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn get_GameModeConfiguration(&self, out: *mut *mut GameModeConfiguration) -> HRESULT
@@ -1406,7 +1406,7 @@ impl IGameListEntry2 {
         let hr = ((*self.lpVtbl).get_LaunchableState)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_launcher_executable(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::IStorageFile>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_launcher_executable(&self) -> Result<Option<ComPtr<crate::windows::storage::IStorageFile>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_LauncherExecutable)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1416,12 +1416,12 @@ impl IGameListEntry2 {
         let hr = ((*self.lpVtbl).get_LaunchParameters)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_launcher_executable_file_async(&self, executableFile: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_launcher_executable_file_async(&self, executableFile: &crate::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SetLauncherExecutableFileAsync)(self as *const _ as *mut _, executableFile as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_launcher_executable_file_with_params_async(&self, executableFile: &::rt::gen::windows::storage::IStorageFile, launchParams: &HStringArg) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_launcher_executable_file_with_params_async(&self, executableFile: &crate::windows::storage::IStorageFile, launchParams: &HStringArg) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SetLauncherExecutableFileWithParamsAsync)(self as *const _ as *mut _, executableFile as *const _ as *mut _, launchParams.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1667,7 +1667,7 @@ impl IGameModeUserConfigurationStatics {
 } // Windows.Gaming.Preview.GamesEnumeration
 } // Windows.Gaming.Preview
 pub mod ui { // Windows.Gaming.UI
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class GameBar}
 impl RtActivatable<IGameBarStatics> for GameBar {}
 impl GameBar {
@@ -1856,11 +1856,11 @@ RT_CLASS!{class GameUIProviderActivatedEventArgs: IGameUIProviderActivatedEventA
 } // Windows.Gaming.UI
 pub mod xboxlive { // Windows.Gaming.XboxLive
 pub mod storage { // Windows.Gaming.XboxLive.Storage
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IGameSaveBlobGetResult, 2440200672, 29185, 18771, 170, 44, 64, 8, 240, 58, 239, 69);
 RT_INTERFACE!{interface IGameSaveBlobGetResult(IGameSaveBlobGetResultVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveBlobGetResult] {
     fn get_Status(&self, out: *mut GameSaveErrorStatus) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut foundation::collections::IMapView<HString, ::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Value(&self, out: *mut *mut foundation::collections::IMapView<HString, crate::windows::storage::streams::IBuffer>) -> HRESULT
 }}
 impl IGameSaveBlobGetResult {
     #[inline] pub fn get_status(&self) -> Result<GameSaveErrorStatus> { unsafe { 
@@ -1868,7 +1868,7 @@ impl IGameSaveBlobGetResult {
         let hr = ((*self.lpVtbl).get_Status)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<foundation::collections::IMapView<HString, ::rt::gen::windows::storage::streams::IBuffer>>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value(&self) -> Result<Option<ComPtr<foundation::collections::IMapView<HString, crate::windows::storage::streams::IBuffer>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Value)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1940,9 +1940,9 @@ RT_INTERFACE!{interface IGameSaveContainer(IGameSaveContainerVtbl): IInspectable
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_Provider(&self, out: *mut *mut GameSaveProvider) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SubmitUpdatesAsync(&self, blobsToWrite: *mut foundation::collections::IMapView<HString, ::rt::gen::windows::storage::streams::IBuffer>, blobsToDelete: *mut foundation::collections::IIterable<HString>, displayName: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveOperationResult>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SubmitUpdatesAsync(&self, blobsToWrite: *mut foundation::collections::IMapView<HString, crate::windows::storage::streams::IBuffer>, blobsToDelete: *mut foundation::collections::IIterable<HString>, displayName: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveOperationResult>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn ReadAsync(&self, blobsToRead: *mut foundation::collections::IMapView<HString, ::rt::gen::windows::storage::streams::IBuffer>, out: *mut *mut foundation::IAsyncOperation<GameSaveOperationResult>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ReadAsync(&self, blobsToRead: *mut foundation::collections::IMapView<HString, crate::windows::storage::streams::IBuffer>, out: *mut *mut foundation::IAsyncOperation<GameSaveOperationResult>) -> HRESULT,
     fn GetAsync(&self, blobsToRead: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncOperation<GameSaveBlobGetResult>) -> HRESULT,
     fn SubmitPropertySetUpdatesAsync(&self, blobsToWrite: *mut foundation::collections::IPropertySet, blobsToDelete: *mut foundation::collections::IIterable<HString>, displayName: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveOperationResult>) -> HRESULT,
     fn CreateBlobInfoQuery(&self, blobNamePrefix: HSTRING, out: *mut *mut GameSaveBlobInfoQuery) -> HRESULT
@@ -1958,12 +1958,12 @@ impl IGameSaveContainer {
         let hr = ((*self.lpVtbl).get_Provider)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn submit_updates_async(&self, blobsToWrite: &foundation::collections::IMapView<HString, ::rt::gen::windows::storage::streams::IBuffer>, blobsToDelete: &foundation::collections::IIterable<HString>, displayName: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveOperationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn submit_updates_async(&self, blobsToWrite: &foundation::collections::IMapView<HString, crate::windows::storage::streams::IBuffer>, blobsToDelete: &foundation::collections::IIterable<HString>, displayName: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveOperationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SubmitUpdatesAsync)(self as *const _ as *mut _, blobsToWrite as *const _ as *mut _, blobsToDelete as *const _ as *mut _, displayName.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn read_async(&self, blobsToRead: &foundation::collections::IMapView<HString, ::rt::gen::windows::storage::streams::IBuffer>) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveOperationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn read_async(&self, blobsToRead: &foundation::collections::IMapView<HString, crate::windows::storage::streams::IBuffer>) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveOperationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ReadAsync)(self as *const _ as *mut _, blobsToRead as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -2081,7 +2081,7 @@ RT_CLASS!{class GameSaveOperationResult: IGameSaveOperationResult}
 DEFINE_IID!(IID_IGameSaveProvider, 2426798996, 33022, 16913, 151, 248, 165, 222, 20, 221, 149, 210);
 RT_INTERFACE!{interface IGameSaveProvider(IGameSaveProviderVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveProvider] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut ::rt::gen::windows::system::User) -> HRESULT,
+    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut crate::windows::system::User) -> HRESULT,
     fn CreateContainer(&self, name: HSTRING, out: *mut *mut GameSaveContainer) -> HRESULT,
     fn DeleteContainerAsync(&self, name: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveOperationResult>) -> HRESULT,
     fn CreateContainerInfoQuery(&self, out: *mut *mut GameSaveContainerInfoQuery) -> HRESULT,
@@ -2090,7 +2090,7 @@ RT_INTERFACE!{interface IGameSaveProvider(IGameSaveProviderVtbl): IInspectable(I
     fn get_ContainersChangedSinceLastSync(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT
 }}
 impl IGameSaveProvider {
-    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<::rt::gen::windows::system::User>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<crate::windows::system::User>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_User)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2129,10 +2129,10 @@ impl IGameSaveProvider {
 RT_CLASS!{class GameSaveProvider: IGameSaveProvider}
 impl RtActivatable<IGameSaveProviderStatics> for GameSaveProvider {}
 impl GameSaveProvider {
-    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user_async(user: &::rt::gen::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user_async(user: &crate::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> {
         <Self as RtActivatable<IGameSaveProviderStatics>>::get_activation_factory().get_for_user_async(user, serviceConfigId)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn get_sync_on_demand_for_user_async(user: &::rt::gen::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn get_sync_on_demand_for_user_async(user: &crate::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> {
         <Self as RtActivatable<IGameSaveProviderStatics>>::get_activation_factory().get_sync_on_demand_for_user_async(user, serviceConfigId)
     }
 }
@@ -2157,16 +2157,16 @@ impl IGameSaveProviderGetResult {
 RT_CLASS!{class GameSaveProviderGetResult: IGameSaveProviderGetResult}
 DEFINE_IID!(IID_IGameSaveProviderStatics, 3491577552, 31491, 17565, 140, 189, 52, 2, 132, 42, 16, 72);
 RT_INTERFACE!{static interface IGameSaveProviderStatics(IGameSaveProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveProviderStatics] {
-    #[cfg(feature="windows-system")] fn GetForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, serviceConfigId: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveProviderGetResult>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn GetSyncOnDemandForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, serviceConfigId: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveProviderGetResult>) -> HRESULT
+    #[cfg(feature="windows-system")] fn GetForUserAsync(&self, user: *mut crate::windows::system::User, serviceConfigId: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveProviderGetResult>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn GetSyncOnDemandForUserAsync(&self, user: *mut crate::windows::system::User, serviceConfigId: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveProviderGetResult>) -> HRESULT
 }}
 impl IGameSaveProviderStatics {
-    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user_async(&self, user: &::rt::gen::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user_async(&self, user: &crate::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, serviceConfigId.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_sync_on_demand_for_user_async(&self, user: &::rt::gen::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_sync_on_demand_for_user_async(&self, user: &crate::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetSyncOnDemandForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, serviceConfigId.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }

--- a/src/rt/gen/windows/globalization.rs
+++ b/src/rt/gen/windows/globalization.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class ApplicationLanguages}
 impl RtActivatable<IApplicationLanguagesStatics> for ApplicationLanguages {}
 impl RtActivatable<IApplicationLanguagesStatics2> for ApplicationLanguages {}
@@ -3060,7 +3060,7 @@ impl ITimeZoneOnCalendar {
     }}
 }
 pub mod collation { // Windows.Globalization.Collation
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICharacterGrouping, 4209467835, 32861, 19376, 149, 187, 193, 247, 195, 232, 235, 142);
 RT_INTERFACE!{interface ICharacterGrouping(ICharacterGroupingVtbl): IInspectable(IInspectableVtbl) [IID_ICharacterGrouping] {
     fn get_First(&self, out: *mut HSTRING) -> HRESULT,
@@ -3112,7 +3112,7 @@ impl ICharacterGroupingsFactory {
 }
 } // Windows.Globalization.Collation
 pub mod datetimeformatting { // Windows.Globalization.DateTimeFormatting
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDateTimeFormatter, 2515454480, 29664, 20043, 161, 131, 61, 106, 208, 186, 53, 236);
 RT_INTERFACE!{interface IDateTimeFormatter(IDateTimeFormatterVtbl): IInspectable(IInspectableVtbl) [IID_IDateTimeFormatter] {
     fn get_Languages(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -3374,7 +3374,7 @@ RT_ENUM! { enum YearFormat: i32 {
 }}
 } // Windows.Globalization.DateTimeFormatting
 pub mod fonts { // Windows.Globalization.Fonts
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ILanguageFont, 2972605498, 46957, 17819, 190, 235, 144, 17, 81, 205, 119, 209);
 RT_INTERFACE!{interface ILanguageFont(ILanguageFontVtbl): IInspectable(IInspectableVtbl) [IID_ILanguageFont] {
     fn get_FontFamily(&self, out: *mut HSTRING) -> HRESULT,
@@ -3506,7 +3506,7 @@ impl ILanguageFontGroupFactory {
 }
 } // Windows.Globalization.Fonts
 pub mod numberformatting { // Windows.Globalization.NumberFormatting
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICurrencyFormatter, 292752549, 19200, 16818, 179, 50, 115, 177, 42, 73, 125, 84);
 RT_INTERFACE!{interface ICurrencyFormatter(ICurrencyFormatterVtbl): IInspectable(IInspectableVtbl) [IID_ICurrencyFormatter] {
     fn get_Currency(&self, out: *mut HSTRING) -> HRESULT,
@@ -3996,7 +3996,7 @@ impl ISignificantDigitsOption {
 }
 } // Windows.Globalization.NumberFormatting
 pub mod phonenumberformatting { // Windows.Globalization.PhoneNumberFormatting
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum PhoneNumberFormat: i32 {
     E164 = 0, International = 1, National = 2, Rfc3966 = 3,
 }}

--- a/src/rt/gen/windows/graphics.rs
+++ b/src/rt/gen/windows/graphics.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct DisplayAdapterId {
     LowPart: u32, HighPart: i32,
 }}
@@ -16,7 +16,7 @@ RT_STRUCT! { struct SizeInt32 {
     Width: i32, Height: i32,
 }}
 pub mod capture { // Windows.Graphics.Capture
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDirect3D11CaptureFrame, 4199597603, 14554, 19250, 172, 243, 250, 151, 52, 173, 128, 14);
 RT_INTERFACE!{interface IDirect3D11CaptureFrame(IDirect3D11CaptureFrameVtbl): IInspectable(IInspectableVtbl) [IID_IDirect3D11CaptureFrame] {
     fn get_Surface(&self, out: *mut *mut super::directx::direct3d11::IDirect3DSurface) -> HRESULT,
@@ -206,7 +206,7 @@ impl IGraphicsCaptureSessionStatics {
 }
 } // Windows.Graphics.Capture
 pub mod directx { // Windows.Graphics.DirectX
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum DirectXAlphaMode: i32 {
     Unspecified = 0, Premultiplied = 1, Straight = 2, Ignore = 3,
 }}
@@ -217,7 +217,7 @@ RT_ENUM! { enum DirectXPixelFormat: i32 {
     Unknown = 0, R32G32B32A32Typeless = 1, R32G32B32A32Float = 2, R32G32B32A32UInt = 3, R32G32B32A32Int = 4, R32G32B32Typeless = 5, R32G32B32Float = 6, R32G32B32UInt = 7, R32G32B32Int = 8, R16G16B16A16Typeless = 9, R16G16B16A16Float = 10, R16G16B16A16UIntNormalized = 11, R16G16B16A16UInt = 12, R16G16B16A16IntNormalized = 13, R16G16B16A16Int = 14, R32G32Typeless = 15, R32G32Float = 16, R32G32UInt = 17, R32G32Int = 18, R32G8X24Typeless = 19, D32FloatS8X24UInt = 20, R32FloatX8X24Typeless = 21, X32TypelessG8X24UInt = 22, R10G10B10A2Typeless = 23, R10G10B10A2UIntNormalized = 24, R10G10B10A2UInt = 25, R11G11B10Float = 26, R8G8B8A8Typeless = 27, R8G8B8A8UIntNormalized = 28, R8G8B8A8UIntNormalizedSrgb = 29, R8G8B8A8UInt = 30, R8G8B8A8IntNormalized = 31, R8G8B8A8Int = 32, R16G16Typeless = 33, R16G16Float = 34, R16G16UIntNormalized = 35, R16G16UInt = 36, R16G16IntNormalized = 37, R16G16Int = 38, R32Typeless = 39, D32Float = 40, R32Float = 41, R32UInt = 42, R32Int = 43, R24G8Typeless = 44, D24UIntNormalizedS8UInt = 45, R24UIntNormalizedX8Typeless = 46, X24TypelessG8UInt = 47, R8G8Typeless = 48, R8G8UIntNormalized = 49, R8G8UInt = 50, R8G8IntNormalized = 51, R8G8Int = 52, R16Typeless = 53, R16Float = 54, D16UIntNormalized = 55, R16UIntNormalized = 56, R16UInt = 57, R16IntNormalized = 58, R16Int = 59, R8Typeless = 60, R8UIntNormalized = 61, R8UInt = 62, R8IntNormalized = 63, R8Int = 64, A8UIntNormalized = 65, R1UIntNormalized = 66, R9G9B9E5SharedExponent = 67, R8G8B8G8UIntNormalized = 68, G8R8G8B8UIntNormalized = 69, BC1Typeless = 70, BC1UIntNormalized = 71, BC1UIntNormalizedSrgb = 72, BC2Typeless = 73, BC2UIntNormalized = 74, BC2UIntNormalizedSrgb = 75, BC3Typeless = 76, BC3UIntNormalized = 77, BC3UIntNormalizedSrgb = 78, BC4Typeless = 79, BC4UIntNormalized = 80, BC4IntNormalized = 81, BC5Typeless = 82, BC5UIntNormalized = 83, BC5IntNormalized = 84, B5G6R5UIntNormalized = 85, B5G5R5A1UIntNormalized = 86, B8G8R8A8UIntNormalized = 87, B8G8R8X8UIntNormalized = 88, R10G10B10XRBiasA2UIntNormalized = 89, B8G8R8A8Typeless = 90, B8G8R8A8UIntNormalizedSrgb = 91, B8G8R8X8Typeless = 92, B8G8R8X8UIntNormalizedSrgb = 93, BC6HTypeless = 94, BC6H16UnsignedFloat = 95, BC6H16Float = 96, BC7Typeless = 97, BC7UIntNormalized = 98, BC7UIntNormalizedSrgb = 99, Ayuv = 100, Y410 = 101, Y416 = 102, NV12 = 103, P010 = 104, P016 = 105, Opaque420 = 106, Yuy2 = 107, Y210 = 108, Y216 = 109, NV11 = 110, AI44 = 111, IA44 = 112, P8 = 113, A8P8 = 114, B4G4R4A4UIntNormalized = 115, P208 = 130, V208 = 131, V408 = 132,
 }}
 pub mod direct3d11 { // Windows.Graphics.DirectX.Direct3D11
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum Direct3DBindings: u32 {
     VertexBuffer = 1, IndexBuffer = 2, ConstantBuffer = 4, ShaderResource = 8, StreamOutput = 16, RenderTarget = 32, DepthStencil = 64, UnorderedAccess = 128, Decoder = 512, VideoEncoder = 1024,
 }}
@@ -254,7 +254,7 @@ RT_ENUM! { enum Direct3DUsage: i32 {
 } // Windows.Graphics.DirectX.Direct3D11
 } // Windows.Graphics.DirectX
 pub mod display { // Windows.Graphics.Display
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdvancedColorInfo, 2274876667, 45609, 16513, 174, 154, 44, 200, 94, 52, 173, 106);
 RT_INTERFACE!{interface IAdvancedColorInfo(IAdvancedColorInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAdvancedColorInfo] {
     fn get_CurrentAdvancedColorKind(&self, out: *mut AdvancedColorKind) -> HRESULT,
@@ -1090,7 +1090,7 @@ RT_ENUM! { enum ResolutionScale: i32 {
     Invalid = 0, Scale100Percent = 100, Scale120Percent = 120, Scale125Percent = 125, Scale140Percent = 140, Scale150Percent = 150, Scale160Percent = 160, Scale175Percent = 175, Scale180Percent = 180, Scale200Percent = 200, Scale225Percent = 225, Scale250Percent = 250, Scale300Percent = 300, Scale350Percent = 350, Scale400Percent = 400, Scale450Percent = 450, Scale500Percent = 500,
 }}
 pub mod core { // Windows.Graphics.Display.Core
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum HdmiDisplayColorSpace: i32 {
     RgbLimited = 0, RgbFull = 1, BT2020 = 2, BT709 = 3,
 }}
@@ -1260,7 +1260,7 @@ RT_ENUM! { enum HdmiDisplayPixelEncoding: i32 {
 } // Windows.Graphics.Display.Core
 } // Windows.Graphics.Display
 pub mod effects { // Windows.Graphics.Effects
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IGraphicsEffect, 3411132622, 36838, 17974, 178, 2, 134, 31, 170, 7, 216, 243);
 RT_INTERFACE!{interface IGraphicsEffect(IGraphicsEffectVtbl): IInspectable(IInspectableVtbl) [IID_IGraphicsEffect] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -1283,7 +1283,7 @@ RT_INTERFACE!{interface IGraphicsEffectSource(IGraphicsEffectSourceVtbl): IInspe
 }}
 } // Windows.Graphics.Effects
 pub mod holographic { // Windows.Graphics.Holographic
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct HolographicAdapterId {
     LowPart: u32, HighPart: i32,
 }}
@@ -2095,7 +2095,7 @@ RT_STRUCT! { struct HolographicStereoTransform {
 }}
 } // Windows.Graphics.Holographic
 pub mod imaging { // Windows.Graphics.Imaging
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum BitmapAlphaMode: i32 {
     Premultiplied = 0, Straight = 1, Ignore = 2,
 }}
@@ -3006,7 +3006,7 @@ RT_ENUM! { enum TiffCompressionMode: i32 {
 }}
 } // Windows.Graphics.Imaging
 pub mod printing { // Windows.Graphics.Printing
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum PrintBinding: i32 {
     Default = 0, NotAvailable = 1, PrinterCustom = 2, None = 3, Bale = 4, BindBottom = 5, BindLeft = 6, BindRight = 7, BindTop = 8, Booklet = 9, EdgeStitchBottom = 10, EdgeStitchLeft = 11, EdgeStitchRight = 12, EdgeStitchTop = 13, Fold = 14, JogOffset = 15, Trim = 16,
 }}
@@ -3841,7 +3841,7 @@ impl IStandardPrintTaskOptionsStatic3 {
     }}
 }
 pub mod optiondetails { // Windows.Graphics.Printing.OptionDetails
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPrintBindingOptionDetails, 3287600280, 38244, 20246, 160, 85, 169, 139, 154, 73, 233, 211);
 RT_INTERFACE!{interface IPrintBindingOptionDetails(IPrintBindingOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintBindingOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4018,10 +4018,10 @@ impl IPrintCustomItemListOptionDetails {
 RT_CLASS!{class PrintCustomItemListOptionDetails: IPrintOptionDetails}
 DEFINE_IID!(IID_IPrintCustomItemListOptionDetails2, 3386258749, 25884, 19001, 144, 110, 16, 145, 161, 128, 27, 241);
 RT_INTERFACE!{interface IPrintCustomItemListOptionDetails2(IPrintCustomItemListOptionDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrintCustomItemListOptionDetails2] {
-    #[cfg(feature="windows-storage")] fn AddItem(&self, itemId: HSTRING, displayName: HSTRING, description: HSTRING, icon: *mut ::rt::gen::windows::storage::streams::IRandomAccessStreamWithContentType) -> HRESULT
+    #[cfg(feature="windows-storage")] fn AddItem(&self, itemId: HSTRING, displayName: HSTRING, description: HSTRING, icon: *mut crate::windows::storage::streams::IRandomAccessStreamWithContentType) -> HRESULT
 }}
 impl IPrintCustomItemListOptionDetails2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn add_item(&self, itemId: &HStringArg, displayName: &HStringArg, description: &HStringArg, icon: &::rt::gen::windows::storage::streams::IRandomAccessStreamWithContentType) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn add_item(&self, itemId: &HStringArg, displayName: &HStringArg, description: &HStringArg, icon: &crate::windows::storage::streams::IRandomAccessStreamWithContentType) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).AddItem)(self as *const _ as *mut _, itemId.get(), displayName.get(), description.get(), icon as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -4550,13 +4550,13 @@ impl IPrintTextOptionDetails {
 }
 } // Windows.Graphics.Printing.OptionDetails
 pub mod printticket { // Windows.Graphics.Printing.PrintTicket
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPrintTicketCapabilities, 2353352843, 48092, 16982, 161, 66, 47, 214, 21, 236, 180, 22);
 RT_INTERFACE!{interface IPrintTicketCapabilities(IPrintTicketCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTicketCapabilities] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_XmlNamespace(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn get_DocumentBindingFeature(&self, out: *mut *mut PrintTicketFeature) -> HRESULT,
     fn get_DocumentCollateFeature(&self, out: *mut *mut PrintTicketFeature) -> HRESULT,
     fn get_DocumentDuplexFeature(&self, out: *mut *mut PrintTicketFeature) -> HRESULT,
@@ -4586,7 +4586,7 @@ impl IPrintTicketCapabilities {
         let hr = ((*self.lpVtbl).get_XmlNamespace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_XmlNode)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4683,7 +4683,7 @@ RT_INTERFACE!{interface IPrintTicketFeature(IPrintTicketFeatureVtbl): IInspectab
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_XmlNamespace(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
     fn GetOption(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut PrintTicketOption) -> HRESULT,
     fn get_Options(&self, out: *mut *mut foundation::collections::IVectorView<PrintTicketOption>) -> HRESULT,
@@ -4702,7 +4702,7 @@ impl IPrintTicketFeature {
         let hr = ((*self.lpVtbl).get_XmlNamespace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_XmlNode)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4746,12 +4746,12 @@ RT_INTERFACE!{interface IPrintTicketOption(IPrintTicketOptionVtbl): IInspectable
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_XmlNamespace(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-data")] fn GetPropertyNode(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn GetPropertyNode(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-data")] fn GetScoredPropertyNode(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn GetScoredPropertyNode(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn GetPropertyValue(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut PrintTicketValue) -> HRESULT,
     fn GetScoredPropertyValue(&self, name: HSTRING, xmlNamespace: HSTRING, out: *mut *mut PrintTicketValue) -> HRESULT
 }}
@@ -4766,7 +4766,7 @@ impl IPrintTicketOption {
         let hr = ((*self.lpVtbl).get_XmlNamespace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_XmlNode)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4776,12 +4776,12 @@ impl IPrintTicketOption {
         let hr = ((*self.lpVtbl).get_DisplayName)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_property_node(&self, name: &HStringArg, xmlNamespace: &HStringArg) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_property_node(&self, name: &HStringArg, xmlNamespace: &HStringArg) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetPropertyNode)(self as *const _ as *mut _, name.get(), xmlNamespace.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_scored_property_node(&self, name: &HStringArg, xmlNamespace: &HStringArg) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_scored_property_node(&self, name: &HStringArg, xmlNamespace: &HStringArg) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetScoredPropertyNode)(self as *const _ as *mut _, name.get(), xmlNamespace.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4806,7 +4806,7 @@ RT_INTERFACE!{interface IPrintTicketParameterDefinition(IPrintTicketParameterDef
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_XmlNamespace(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn get_DataType(&self, out: *mut PrintTicketParameterDataType) -> HRESULT,
     fn get_UnitType(&self, out: *mut HSTRING) -> HRESULT,
     fn get_RangeMin(&self, out: *mut i32) -> HRESULT,
@@ -4823,7 +4823,7 @@ impl IPrintTicketParameterDefinition {
         let hr = ((*self.lpVtbl).get_XmlNamespace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_XmlNode)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4855,7 +4855,7 @@ RT_INTERFACE!{interface IPrintTicketParameterInitializer(IPrintTicketParameterIn
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_XmlNamespace(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn put_Value(&self, value: *mut PrintTicketValue) -> HRESULT,
     fn get_Value(&self, out: *mut *mut PrintTicketValue) -> HRESULT
 }}
@@ -4870,7 +4870,7 @@ impl IPrintTicketParameterInitializer {
         let hr = ((*self.lpVtbl).get_XmlNamespace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_XmlNode)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4918,7 +4918,7 @@ RT_INTERFACE!{interface IWorkflowPrintTicket(IWorkflowPrintTicketVtbl): IInspect
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
     fn get_XmlNamespace(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-data"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut ::rt::gen::windows::data::xml::dom::IXmlNode) -> HRESULT,
+    #[cfg(feature="windows-data")] fn get_XmlNode(&self, out: *mut *mut crate::windows::data::xml::dom::IXmlNode) -> HRESULT,
     fn GetCapabilities(&self, out: *mut *mut PrintTicketCapabilities) -> HRESULT,
     fn get_DocumentBindingFeature(&self, out: *mut *mut PrintTicketFeature) -> HRESULT,
     fn get_DocumentCollateFeature(&self, out: *mut *mut PrintTicketFeature) -> HRESULT,
@@ -4954,7 +4954,7 @@ impl IWorkflowPrintTicket {
         let hr = ((*self.lpVtbl).get_XmlNamespace)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<::rt::gen::windows::data::xml::dom::IXmlNode>>> { unsafe { 
+    #[cfg(feature="windows-data")] #[inline] pub fn get_xml_node(&self) -> Result<Option<ComPtr<crate::windows::data::xml::dom::IXmlNode>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_XmlNode)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5096,7 +5096,7 @@ impl IWorkflowPrintTicketValidationResult {
 RT_CLASS!{class WorkflowPrintTicketValidationResult: IWorkflowPrintTicketValidationResult}
 } // Windows.Graphics.Printing.PrintTicket
 pub mod workflow { // Windows.Graphics.Printing.Workflow
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPrintWorkflowBackgroundSession, 1534661562, 3166, 21130, 116, 88, 134, 164, 108, 189, 220, 69);
 RT_INTERFACE!{interface IPrintWorkflowBackgroundSession(IPrintWorkflowBackgroundSessionVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowBackgroundSession] {
     fn add_SetupRequested(&self, setupEventHandler: *mut foundation::TypedEventHandler<PrintWorkflowBackgroundSession, PrintWorkflowBackgroundSetupRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5291,10 +5291,10 @@ impl IPrintWorkflowSourceContent {
 RT_CLASS!{class PrintWorkflowSourceContent: IPrintWorkflowSourceContent}
 DEFINE_IID!(IID_IPrintWorkflowSpoolStreamContent, 1927634638, 58374, 19316, 132, 225, 63, 243, 253, 205, 175, 112);
 RT_INTERFACE!{interface IPrintWorkflowSpoolStreamContent(IPrintWorkflowSpoolStreamContentVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowSpoolStreamContent] {
-    #[cfg(feature="windows-storage")] fn GetInputStream(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IInputStream) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetInputStream(&self, out: *mut *mut crate::windows::storage::streams::IInputStream) -> HRESULT
 }}
 impl IPrintWorkflowSpoolStreamContent {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_input_stream(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IInputStream>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_input_stream(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IInputStream>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetInputStream)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5303,10 +5303,10 @@ impl IPrintWorkflowSpoolStreamContent {
 RT_CLASS!{class PrintWorkflowSpoolStreamContent: IPrintWorkflowSpoolStreamContent}
 DEFINE_IID!(IID_IPrintWorkflowStreamTarget, 2990258820, 34149, 18571, 152, 57, 28, 158, 124, 122, 169, 22);
 RT_INTERFACE!{interface IPrintWorkflowStreamTarget(IPrintWorkflowStreamTargetVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowStreamTarget] {
-    #[cfg(feature="windows-storage")] fn GetOutputStream(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IOutputStream) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetOutputStream(&self, out: *mut *mut crate::windows::storage::streams::IOutputStream) -> HRESULT
 }}
 impl IPrintWorkflowStreamTarget {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_output_stream(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IOutputStream>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_output_stream(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IOutputStream>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetOutputStream)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5426,7 +5426,7 @@ RT_CLASS!{class PrintWorkflowXpsDataAvailableEventArgs: IPrintWorkflowXpsDataAva
 } // Windows.Graphics.Printing.Workflow
 } // Windows.Graphics.Printing
 pub mod printing3d { // Windows.Graphics.Printing3D
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPrint3DManager, 1294977802, 29542, 18801, 139, 213, 23, 196, 227, 232, 198, 192);
 RT_INTERFACE!{interface IPrint3DManager(IPrint3DManagerVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DManager] {
     fn add_TaskRequested(&self, eventHandler: *mut foundation::TypedEventHandler<Print3DManager, Print3DTaskRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,

--- a/src/rt/gen/windows/management.rs
+++ b/src/rt/gen/windows/management.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IMdmAlert, 2969289511, 10433, 19282, 165, 72, 197, 128, 124, 175, 112, 182);
 RT_INTERFACE!{interface IMdmAlert(IMdmAlertVtbl): IInspectable(IInspectableVtbl) [IID_IMdmAlert] {
     fn get_Data(&self, out: *mut HSTRING) -> HRESULT,
@@ -187,7 +187,7 @@ RT_ENUM! { enum MdmSessionState: i32 {
     NotStarted = 0, Starting = 1, Connecting = 2, Communicating = 3, AlertStatusAvailable = 4, Retrying = 5, Completed = 6,
 }}
 pub mod core { // Windows.Management.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IApplicationDataManager, 1959855154, 11929, 16384, 154, 58, 100, 48, 126, 133, 129, 41);
 RT_INTERFACE!{interface IApplicationDataManager(IApplicationDataManagerVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationDataManager] {
     
@@ -213,7 +213,7 @@ impl IApplicationDataManagerStatics {
 }
 } // Windows.Management.Core
 pub mod deployment { // Windows.Management.Deployment
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AddPackageByAppInstallerOptions: u32 {
     None = 0, InstallAllResources = 32, ForceTargetAppShutdown = 64, RequiredContentGroupOnly = 256,
 }}
@@ -831,7 +831,7 @@ RT_ENUM! { enum RemovalOptions: u32 {
     None = 0, PreserveApplicationData = 4096, RemoveForAllUsers = 524288,
 }}
 pub mod preview { // Windows.Management.Deployment.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class ClassicAppManager}
 impl RtActivatable<IClassicAppManagerStatics> for ClassicAppManager {}
 impl ClassicAppManager {
@@ -872,7 +872,7 @@ RT_CLASS!{class InstalledClassicAppInfo: IInstalledClassicAppInfo}
 } // Windows.Management.Deployment.Preview
 } // Windows.Management.Deployment
 pub mod policies { // Windows.Management.Policies
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class NamedPolicy}
 impl RtActivatable<INamedPolicyStatics> for NamedPolicy {}
 impl NamedPolicy {
@@ -991,7 +991,7 @@ impl INamedPolicyStatics {
 }
 } // Windows.Management.Policies
 pub mod update { // Windows.Management.Update
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPreviewBuildsManager, 4194819425, 32335, 23031, 124, 159, 222, 249, 5, 28, 95, 98);
 RT_INTERFACE!{interface IPreviewBuildsManager(IPreviewBuildsManagerVtbl): IInspectable(IInspectableVtbl) [IID_IPreviewBuildsManager] {
     fn get_ArePreviewBuildsAllowed(&self, out: *mut bool) -> HRESULT,
@@ -1062,7 +1062,7 @@ impl IPreviewBuildsState {
 RT_CLASS!{class PreviewBuildsState: IPreviewBuildsState}
 } // Windows.Management.Update
 pub mod workplace { // Windows.Management.Workplace
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IMdmAllowPolicyStatics, 3281455591, 29724, 16882, 164, 182, 49, 76, 49, 80, 37, 134);
 RT_INTERFACE!{static interface IMdmAllowPolicyStatics(IMdmAllowPolicyStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMdmAllowPolicyStatics] {
     fn IsBrowserAllowed(&self, out: *mut bool) -> HRESULT,

--- a/src/rt/gen/windows/media.rs
+++ b/src/rt/gen/windows/media.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAudioBuffer, 890722343, 29259, 19562, 177, 48, 246, 83, 127, 154, 224, 208);
 RT_INTERFACE!{interface IAudioBuffer(IAudioBufferVtbl): IInspectable(IInspectableVtbl) [IID_IAudioBuffer] {
     fn get_Capacity(&self, out: *mut u32) -> HRESULT,
@@ -1494,7 +1494,7 @@ impl IVideoFrameStatics {
     }}
 }
 pub mod appbroadcasting { // Windows.Media.AppBroadcasting
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppBroadcastingMonitor, 16341608, 35079, 18592, 184, 239, 36, 210, 8, 19, 117, 66);
 RT_INTERFACE!{interface IAppBroadcastingMonitor(IAppBroadcastingMonitorVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastingMonitor] {
     fn get_IsCurrentAppBroadcasting(&self, out: *mut bool) -> HRESULT,
@@ -1638,7 +1638,7 @@ impl IAppBroadcastingUIStatics {
 }
 } // Windows.Media.AppBroadcasting
 pub mod apprecording { // Windows.Media.AppRecording
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppRecordingManager, 3890372726, 41028, 18658, 165, 18, 48, 148, 213, 116, 199, 204);
 RT_INTERFACE!{interface IAppRecordingManager(IAppRecordingManagerVtbl): IInspectable(IInspectableVtbl) [IID_IAppRecordingManager] {
     fn GetStatus(&self, out: *mut *mut AppRecordingStatus) -> HRESULT,
@@ -1861,7 +1861,7 @@ impl IAppRecordingStatusDetails {
 RT_CLASS!{class AppRecordingStatusDetails: IAppRecordingStatusDetails}
 } // Windows.Media.AppRecording
 pub mod audio { // Windows.Media.Audio
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAudioDeviceInputNode, 2954587105, 28494, 18914, 172, 1, 85, 157, 98, 190, 179, 169);
 RT_INTERFACE!{interface IAudioDeviceInputNode(IAudioDeviceInputNodeVtbl): IInspectable(IInspectableVtbl) [IID_IAudioDeviceInputNode] {
     #[cfg(feature="windows-devices")] fn get_Device(&self, out: *mut *mut super::super::devices::enumeration::DeviceInformation) -> HRESULT
@@ -3958,7 +3958,7 @@ RT_ENUM! { enum SpatialAudioModel: i32 {
 }}
 } // Windows.Media.Audio
 pub mod capture { // Windows.Media.Capture
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdvancedCapturedPhoto, 4034032267, 45714, 17553, 157, 65, 153, 128, 122, 85, 11, 191);
 RT_INTERFACE!{interface IAdvancedCapturedPhoto(IAdvancedCapturedPhotoVtbl): IInspectable(IInspectableVtbl) [IID_IAdvancedCapturedPhoto] {
     fn get_Frame(&self, out: *mut *mut CapturedFrame) -> HRESULT,
@@ -8166,7 +8166,7 @@ RT_STRUCT! { struct WhiteBalanceGain {
     R: f64, G: f64, B: f64,
 }}
 pub mod core { // Windows.Media.Capture.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IVariablePhotoCapturedEventArgs, 3521858652, 6995, 20042, 139, 92, 219, 120, 135, 172, 148, 155);
 RT_INTERFACE!{interface IVariablePhotoCapturedEventArgs(IVariablePhotoCapturedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVariablePhotoCapturedEventArgs] {
     fn get_Frame(&self, out: *mut *mut super::CapturedFrame) -> HRESULT,
@@ -8256,7 +8256,7 @@ impl IVariablePhotoSequenceCapture2 {
 }
 } // Windows.Media.Capture.Core
 pub mod frames { // Windows.Media.Capture.Frames
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAudioMediaFrame, 2745827071, 32801, 17435, 154, 70, 231, 240, 19, 123, 121, 129);
 RT_INTERFACE!{interface IAudioMediaFrame(IAudioMediaFrameVtbl): IInspectable(IInspectableVtbl) [IID_IAudioMediaFrame] {
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
@@ -8284,7 +8284,7 @@ RT_CLASS!{class AudioMediaFrame: IAudioMediaFrame}
 DEFINE_IID!(IID_IBufferMediaFrame, 3048297415, 39812, 16482, 183, 156, 163, 101, 178, 89, 104, 84);
 RT_INTERFACE!{interface IBufferMediaFrame(IBufferMediaFrameVtbl): IInspectable(IInspectableVtbl) [IID_IBufferMediaFrame] {
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Buffer(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Buffer(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IBufferMediaFrame {
     #[inline] pub fn get_frame_reference(&self) -> Result<Option<ComPtr<MediaFrameReference>>> { unsafe { 
@@ -8292,7 +8292,7 @@ impl IBufferMediaFrame {
         let hr = ((*self.lpVtbl).get_FrameReference)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_buffer(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_buffer(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Buffer)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8304,7 +8304,7 @@ RT_INTERFACE!{interface IDepthMediaFrame(IDepthMediaFrameVtbl): IInspectable(IIn
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
     fn get_VideoMediaFrame(&self, out: *mut *mut VideoMediaFrame) -> HRESULT,
     fn get_DepthFormat(&self, out: *mut *mut DepthMediaFrameFormat) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryCreateCoordinateMapper(&self, cameraIntrinsics: *mut super::super::devices::core::CameraIntrinsics, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut super::super::devices::core::DepthCorrelatedCoordinateMapper) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryCreateCoordinateMapper(&self, cameraIntrinsics: *mut super::super::devices::core::CameraIntrinsics, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut super::super::devices::core::DepthCorrelatedCoordinateMapper) -> HRESULT
 }}
 impl IDepthMediaFrame {
     #[inline] pub fn get_frame_reference(&self) -> Result<Option<ComPtr<MediaFrameReference>>> { unsafe { 
@@ -8322,7 +8322,7 @@ impl IDepthMediaFrame {
         let hr = ((*self.lpVtbl).get_DepthFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_create_coordinate_mapper(&self, cameraIntrinsics: &super::super::devices::core::CameraIntrinsics, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<super::super::devices::core::DepthCorrelatedCoordinateMapper>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_create_coordinate_mapper(&self, cameraIntrinsics: &super::super::devices::core::CameraIntrinsics, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<super::super::devices::core::DepthCorrelatedCoordinateMapper>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryCreateCoordinateMapper)(self as *const _ as *mut _, cameraIntrinsics as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8506,7 +8506,7 @@ RT_INTERFACE!{interface IMediaFrameReference(IMediaFrameReferenceVtbl): IInspect
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMapView<Guid, IInspectable>) -> HRESULT,
     fn get_BufferMediaFrame(&self, out: *mut *mut BufferMediaFrame) -> HRESULT,
     fn get_VideoMediaFrame(&self, out: *mut *mut VideoMediaFrame) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn get_CoordinateSystem(&self, out: *mut *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> HRESULT
+    #[cfg(feature="windows-perception")] fn get_CoordinateSystem(&self, out: *mut *mut crate::windows::perception::spatial::SpatialCoordinateSystem) -> HRESULT
 }}
 impl IMediaFrameReference {
     #[inline] pub fn get_source_kind(&self) -> Result<MediaFrameSourceKind> { unsafe { 
@@ -8544,7 +8544,7 @@ impl IMediaFrameReference {
         let hr = ((*self.lpVtbl).get_VideoMediaFrame)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn get_coordinate_system(&self) -> Result<Option<ComPtr<::rt::gen::windows::perception::spatial::SpatialCoordinateSystem>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn get_coordinate_system(&self) -> Result<Option<ComPtr<crate::windows::perception::spatial::SpatialCoordinateSystem>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_CoordinateSystem)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8755,9 +8755,9 @@ RT_INTERFACE!{interface IMediaFrameSourceInfo(IMediaFrameSourceInfoVtbl): IInspe
     fn get_SourceKind(&self, out: *mut MediaFrameSourceKind) -> HRESULT,
     fn get_SourceGroup(&self, out: *mut *mut MediaFrameSourceGroup) -> HRESULT,
     #[cfg(not(feature="windows-devices"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_DeviceInformation(&self, out: *mut *mut ::rt::gen::windows::devices::enumeration::DeviceInformation) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_DeviceInformation(&self, out: *mut *mut crate::windows::devices::enumeration::DeviceInformation) -> HRESULT,
     fn get_Properties(&self, out: *mut *mut foundation::collections::IMapView<Guid, IInspectable>) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn get_CoordinateSystem(&self, out: *mut *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> HRESULT
+    #[cfg(feature="windows-perception")] fn get_CoordinateSystem(&self, out: *mut *mut crate::windows::perception::spatial::SpatialCoordinateSystem) -> HRESULT
 }}
 impl IMediaFrameSourceInfo {
     #[inline] pub fn get_id(&self) -> Result<HString> { unsafe { 
@@ -8780,7 +8780,7 @@ impl IMediaFrameSourceInfo {
         let hr = ((*self.lpVtbl).get_SourceGroup)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_device_information(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::enumeration::DeviceInformation>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_device_information(&self) -> Result<Option<ComPtr<crate::windows::devices::enumeration::DeviceInformation>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DeviceInformation)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8790,7 +8790,7 @@ impl IMediaFrameSourceInfo {
         let hr = ((*self.lpVtbl).get_Properties)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn get_coordinate_system(&self) -> Result<Option<ComPtr<::rt::gen::windows::perception::spatial::SpatialCoordinateSystem>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn get_coordinate_system(&self) -> Result<Option<ComPtr<crate::windows::perception::spatial::SpatialCoordinateSystem>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_CoordinateSystem)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8896,9 +8896,9 @@ RT_INTERFACE!{interface IVideoMediaFrame(IVideoMediaFrameVtbl): IInspectable(IIn
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
     fn get_VideoFormat(&self, out: *mut *mut VideoMediaFrameFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_SoftwareBitmap(&self, out: *mut *mut ::rt::gen::windows::graphics::imaging::SoftwareBitmap) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SoftwareBitmap(&self, out: *mut *mut crate::windows::graphics::imaging::SoftwareBitmap) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_Direct3DSurface(&self, out: *mut *mut ::rt::gen::windows::graphics::directx::direct3d11::IDirect3DSurface) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_Direct3DSurface(&self, out: *mut *mut crate::windows::graphics::directx::direct3d11::IDirect3DSurface) -> HRESULT,
     fn get_CameraIntrinsics(&self, out: *mut *mut super::super::devices::core::CameraIntrinsics) -> HRESULT,
     fn get_InfraredMediaFrame(&self, out: *mut *mut InfraredMediaFrame) -> HRESULT,
     fn get_DepthMediaFrame(&self, out: *mut *mut DepthMediaFrame) -> HRESULT,
@@ -8915,12 +8915,12 @@ impl IVideoMediaFrame {
         let hr = ((*self.lpVtbl).get_VideoFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_software_bitmap(&self) -> Result<Option<ComPtr<::rt::gen::windows::graphics::imaging::SoftwareBitmap>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_software_bitmap(&self) -> Result<Option<ComPtr<crate::windows::graphics::imaging::SoftwareBitmap>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SoftwareBitmap)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_direct3d_surface(&self) -> Result<Option<ComPtr<::rt::gen::windows::graphics::directx::direct3d11::IDirect3DSurface>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_direct3d_surface(&self) -> Result<Option<ComPtr<crate::windows::graphics::directx::direct3d11::IDirect3DSurface>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Direct3DSurface)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -8980,7 +8980,7 @@ RT_CLASS!{class VideoMediaFrameFormat: IVideoMediaFrameFormat}
 } // Windows.Media.Capture.Frames
 } // Windows.Media.Capture
 pub mod casting { // Windows.Media.Casting
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICastingConnection, 3449099859, 49905, 17560, 139, 120, 95, 180, 205, 54, 64, 221);
 RT_INTERFACE!{interface ICastingConnection(ICastingConnectionVtbl): IInspectable(IInspectableVtbl) [IID_ICastingConnection] {
     fn get_State(&self, out: *mut CastingConnectionState) -> HRESULT,
@@ -9288,7 +9288,7 @@ impl ICastingSource {
 RT_CLASS!{class CastingSource: ICastingSource}
 } // Windows.Media.Casting
 pub mod closedcaptioning { // Windows.Media.ClosedCaptioning
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum ClosedCaptionColor: i32 {
     Default = 0, White = 1, Black = 2, Red = 3, Green = 4, Blue = 5, Yellow = 6, Magenta = 7, Cyan = 8,
 }}
@@ -9427,7 +9427,7 @@ RT_ENUM! { enum ClosedCaptionStyle: i32 {
 }}
 } // Windows.Media.ClosedCaptioning
 pub mod contentrestrictions { // Windows.Media.ContentRestrictions
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum ContentAccessRestrictionLevel: i32 {
     Allow = 0, Warn = 1, Block = 2, Hide = 3,
 }}
@@ -9595,7 +9595,7 @@ impl IRatedContentRestrictionsFactory {
 }
 } // Windows.Media.ContentRestrictions
 pub mod control { // Windows.Media.Control
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICurrentSessionChangedEventArgs, 1768540985, 3066, 24544, 141, 115, 9, 204, 94, 84, 8, 225);
 RT_INTERFACE!{interface ICurrentSessionChangedEventArgs(ICurrentSessionChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICurrentSessionChangedEventArgs] {
     
@@ -10083,7 +10083,7 @@ RT_INTERFACE!{interface ITimelinePropertiesChangedEventArgs(ITimelinePropertiesC
 RT_CLASS!{class TimelinePropertiesChangedEventArgs: ITimelinePropertiesChangedEventArgs}
 } // Windows.Media.Control
 pub mod core { // Windows.Media.Core
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AudioDecoderDegradation: i32 {
     None = 0, DownmixTo2Channels = 1, DownmixTo6Channels = 2, DownmixTo8Channels = 3,
 }}
@@ -13663,7 +13663,7 @@ impl IVideoTrackSupportInfo {
 }
 RT_CLASS!{class VideoTrackSupportInfo: IVideoTrackSupportInfo}
 pub mod preview { // Windows.Media.Core.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class SoundLevelBroker}
 impl RtActivatable<ISoundLevelBrokerStatics> for SoundLevelBroker {}
 impl SoundLevelBroker {
@@ -13703,7 +13703,7 @@ impl ISoundLevelBrokerStatics {
 } // Windows.Media.Core.Preview
 } // Windows.Media.Core
 pub mod devices { // Windows.Media.Devices
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdvancedPhotoCaptureSettings, 150177338, 24, 17499, 147, 210, 100, 109, 28, 94, 208, 92);
 RT_INTERFACE!{interface IAdvancedPhotoCaptureSettings(IAdvancedPhotoCaptureSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IAdvancedPhotoCaptureSettings] {
     fn get_Mode(&self, out: *mut AdvancedPhotoMode) -> HRESULT,
@@ -15820,7 +15820,7 @@ RT_ENUM! { enum ZoomTransitionMode: i32 {
     Auto = 0, Direct = 1, Smooth = 2,
 }}
 pub mod core { // Windows.Media.Devices.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICameraIntrinsics, 178711858, 25993, 18906, 175, 222, 89, 66, 112, 202, 10, 172);
 RT_INTERFACE!{interface ICameraIntrinsics(ICameraIntrinsicsVtbl): IInspectable(IInspectableVtbl) [IID_ICameraIntrinsics] {
     fn get_FocalLength(&self, out: *mut foundation::numerics::Vector2) -> HRESULT,
@@ -15938,27 +15938,27 @@ impl ICameraIntrinsicsFactory {
 }
 DEFINE_IID!(IID_IDepthCorrelatedCoordinateMapper, 4183656955, 35568, 19632, 146, 109, 105, 104, 102, 229, 4, 106);
 RT_INTERFACE!{interface IDepthCorrelatedCoordinateMapper(IDepthCorrelatedCoordinateMapperVtbl): IInspectable(IInspectableVtbl) [IID_IDepthCorrelatedCoordinateMapper] {
-    #[cfg(feature="windows-perception")] fn UnprojectPoint(&self, sourcePoint: foundation::Point, targetCoordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut foundation::numerics::Vector3) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn UnprojectPoints(&self, sourcePointsSize: u32, sourcePoints: *mut foundation::Point, targetCoordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, resultsSize: u32, results: *mut foundation::numerics::Vector3) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn MapPoint(&self, sourcePoint: foundation::Point, targetCoordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: *mut CameraIntrinsics, out: *mut foundation::Point) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn MapPoints(&self, sourcePointsSize: u32, sourcePoints: *mut foundation::Point, targetCoordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: *mut CameraIntrinsics, resultsSize: u32, results: *mut foundation::Point) -> HRESULT
+    #[cfg(feature="windows-perception")] fn UnprojectPoint(&self, sourcePoint: foundation::Point, targetCoordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut foundation::numerics::Vector3) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn UnprojectPoints(&self, sourcePointsSize: u32, sourcePoints: *mut foundation::Point, targetCoordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, resultsSize: u32, results: *mut foundation::numerics::Vector3) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn MapPoint(&self, sourcePoint: foundation::Point, targetCoordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: *mut CameraIntrinsics, out: *mut foundation::Point) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn MapPoints(&self, sourcePointsSize: u32, sourcePoints: *mut foundation::Point, targetCoordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: *mut CameraIntrinsics, resultsSize: u32, results: *mut foundation::Point) -> HRESULT
 }}
 impl IDepthCorrelatedCoordinateMapper {
-    #[cfg(feature="windows-perception")] #[inline] pub fn unproject_point(&self, sourcePoint: foundation::Point, targetCoordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<foundation::numerics::Vector3> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn unproject_point(&self, sourcePoint: foundation::Point, targetCoordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<foundation::numerics::Vector3> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).UnprojectPoint)(self as *const _ as *mut _, sourcePoint, targetCoordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn unproject_points(&self, sourcePoints: &[foundation::Point], targetCoordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, results: &mut [foundation::numerics::Vector3]) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn unproject_points(&self, sourcePoints: &[foundation::Point], targetCoordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem, results: &mut [foundation::numerics::Vector3]) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).UnprojectPoints)(self as *const _ as *mut _, sourcePoints.len() as u32, sourcePoints.as_ptr() as *mut _, targetCoordinateSystem as *const _ as *mut _, results.len() as u32, results.as_mut_ptr() as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn map_point(&self, sourcePoint: foundation::Point, targetCoordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: &CameraIntrinsics) -> Result<foundation::Point> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn map_point(&self, sourcePoint: foundation::Point, targetCoordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: &CameraIntrinsics) -> Result<foundation::Point> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).MapPoint)(self as *const _ as *mut _, sourcePoint, targetCoordinateSystem as *const _ as *mut _, targetCameraIntrinsics as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn map_points(&self, sourcePoints: &[foundation::Point], targetCoordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: &CameraIntrinsics, results: &mut [foundation::Point]) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn map_points(&self, sourcePoints: &[foundation::Point], targetCoordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem, targetCameraIntrinsics: &CameraIntrinsics, results: &mut [foundation::Point]) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).MapPoints)(self as *const _ as *mut _, sourcePoints.len() as u32, sourcePoints.as_ptr() as *mut _, targetCoordinateSystem as *const _ as *mut _, targetCameraIntrinsics as *const _ as *mut _, results.len() as u32, results.as_mut_ptr() as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -16408,7 +16408,7 @@ RT_CLASS!{class VariablePhotoSequenceController: IVariablePhotoSequenceControlle
 } // Windows.Media.Devices.Core
 } // Windows.Media.Devices
 pub mod dialprotocol { // Windows.Media.DialProtocol
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDialApp, 1432353747, 17847, 18931, 187, 215, 48, 45, 182, 8, 70, 70);
 RT_INTERFACE!{interface IDialApp(IDialAppVtbl): IInspectable(IInspectableVtbl) [IID_IDialApp] {
     fn get_AppName(&self, out: *mut HSTRING) -> HRESULT,
@@ -16713,7 +16713,7 @@ impl IDialReceiverAppStatics {
 }
 } // Windows.Media.DialProtocol
 pub mod editing { // Windows.Media.Editing
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBackgroundAudioTrack, 1267839933, 40481, 16998, 169, 194, 103, 221, 1, 26, 35, 87);
 RT_INTERFACE!{interface IBackgroundAudioTrack(IBackgroundAudioTrackVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundAudioTrack] {
     fn get_TrimTimeFromStart(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -17273,7 +17273,7 @@ RT_ENUM! { enum VideoFramePrecision: i32 {
 }}
 } // Windows.Media.Editing
 pub mod effects { // Windows.Media.Effects
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAudioCaptureEffectsManager, 2407907953, 909, 17299, 130, 152, 84, 1, 16, 96, 142, 239);
 RT_INTERFACE!{interface IAudioCaptureEffectsManager(IAudioCaptureEffectsManagerVtbl): IInspectable(IInspectableVtbl) [IID_IAudioCaptureEffectsManager] {
     fn add_AudioCaptureEffectsChanged(&self, handler: *mut foundation::TypedEventHandler<AudioCaptureEffectsManager, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -17880,7 +17880,7 @@ impl IVideoTransformSphericalProjection {
 RT_CLASS!{class VideoTransformSphericalProjection: IVideoTransformSphericalProjection}
 } // Windows.Media.Effects
 pub mod faceanalysis { // Windows.Media.FaceAnalysis
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDetectedFace, 2181092436, 26300, 13535, 148, 16, 232, 148, 0, 25, 84, 20);
 RT_INTERFACE!{interface IDetectedFace(IDetectedFaceVtbl): IInspectable(IInspectableVtbl) [IID_IDetectedFace] {
     #[cfg(feature="windows-graphics")] fn get_FaceBox(&self, out: *mut super::super::graphics::imaging::BitmapBounds) -> HRESULT
@@ -18063,7 +18063,7 @@ impl IFaceTrackerStatics {
 }
 } // Windows.Media.FaceAnalysis
 pub mod import { // Windows.Media.Import
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum PhotoImportAccessMode: i32 {
     ReadWrite = 0, ReadOnly = 1, ReadAndDelete = 2,
 }}
@@ -19026,7 +19026,7 @@ impl IPhotoImportVideoSegment {
 RT_CLASS!{class PhotoImportVideoSegment: IPhotoImportVideoSegment}
 } // Windows.Media.Import
 pub mod mediaproperties { // Windows.Media.MediaProperties
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAudioEncodingProperties, 1656519190, 92, 19259, 138, 11, 10, 9, 14, 150, 135, 243);
 RT_INTERFACE!{interface IAudioEncodingProperties(IAudioEncodingPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IAudioEncodingProperties] {
     fn put_Bitrate(&self, value: u32) -> HRESULT,
@@ -20433,7 +20433,7 @@ RT_ENUM! { enum VideoEncodingQuality: i32 {
 }}
 } // Windows.Media.MediaProperties
 pub mod ocr { // Windows.Media.Ocr
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IOcrEngine, 1511308353, 23414, 12608, 182, 128, 136, 37, 86, 38, 131, 172);
 RT_INTERFACE!{interface IOcrEngine(IOcrEngineVtbl): IInspectable(IInspectableVtbl) [IID_IOcrEngine] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -20572,7 +20572,7 @@ impl IOcrWord {
 RT_CLASS!{class OcrWord: IOcrWord}
 } // Windows.Media.Ocr
 pub mod playto { // Windows.Media.PlayTo
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICurrentTimeChangeRequestedEventArgs, 2574324516, 60871, 19445, 145, 246, 60, 134, 39, 219, 89, 229);
 RT_INTERFACE!{interface ICurrentTimeChangeRequestedEventArgs(ICurrentTimeChangeRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICurrentTimeChangeRequestedEventArgs] {
     fn get_Time(&self, out: *mut foundation::TimeSpan) -> HRESULT
@@ -21222,7 +21222,7 @@ impl IVolumeChangeRequestedEventArgs {
 RT_CLASS!{class VolumeChangeRequestedEventArgs: IVolumeChangeRequestedEventArgs}
 } // Windows.Media.PlayTo
 pub mod playback { // Windows.Media.Playback
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AutoLoadedDisplayPropertyKind: i32 {
     None = 0, MusicOrVideo = 1, Music = 2, Video = 3,
 }}
@@ -23803,7 +23803,7 @@ RT_ENUM! { enum TimedMetadataTrackPresentationMode: i32 {
 }}
 } // Windows.Media.Playback
 pub mod playlists { // Windows.Media.Playlists
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPlaylist, 2151102197, 53060, 19863, 131, 179, 122, 8, 158, 154, 182, 99);
 RT_INTERFACE!{interface IPlaylist(IPlaylistVtbl): IInspectable(IInspectableVtbl) [IID_IPlaylist] {
     #[cfg(feature="windows-storage")] fn get_Files(&self, out: *mut *mut foundation::collections::IVector<super::super::storage::StorageFile>) -> HRESULT,
@@ -23858,7 +23858,7 @@ impl IPlaylistStatics {
 }
 } // Windows.Media.Playlists
 pub mod protection { // Windows.Media.Protection
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IComponentLoadFailedEventArgs, 2509713043, 30534, 16766, 132, 149, 240, 49, 187, 197, 134, 44);
 RT_INTERFACE!{interface IComponentLoadFailedEventArgs(IComponentLoadFailedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IComponentLoadFailedEventArgs] {
     fn get_Information(&self, out: *mut *mut RevocationAndRenewalInformation) -> HRESULT,
@@ -24178,7 +24178,7 @@ impl ServiceRequestedEventHandler {
     }}
 }
 pub mod playready { // Windows.Media.Protection.PlayReady
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum NDCertificateFeature: i32 {
     Transmitter = 1, Receiver = 2, SharedCertificate = 3, SecureClock = 4, AntiRollBackClock = 5, CRLS = 9, PlayReady3Features = 13,
 }}
@@ -24617,10 +24617,10 @@ impl INDStartResult {
 }
 DEFINE_IID!(IID_INDStorageFileHelper, 3639656184, 37330, 19783, 163, 249, 234, 255, 78, 219, 114, 159);
 RT_INTERFACE!{interface INDStorageFileHelper(INDStorageFileHelperVtbl): IInspectable(IInspectableVtbl) [IID_INDStorageFileHelper] {
-    #[cfg(feature="windows-storage")] fn GetFileURLs(&self, file: *mut ::rt::gen::windows::storage::IStorageFile, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetFileURLs(&self, file: *mut crate::windows::storage::IStorageFile, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT
 }}
 impl INDStorageFileHelper {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_file_urls(&self, file: &::rt::gen::windows::storage::IStorageFile) -> Result<Option<ComPtr<foundation::collections::IVector<HString>>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_file_urls(&self, file: &crate::windows::storage::IStorageFile) -> Result<Option<ComPtr<foundation::collections::IVector<HString>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetFileURLs)(self as *const _ as *mut _, file as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -25677,13 +25677,13 @@ impl IPlayReadyStatics5 {
 } // Windows.Media.Protection.PlayReady
 } // Windows.Media.Protection
 pub mod render { // Windows.Media.Render
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AudioRenderCategory: i32 {
     Other = 0, ForegroundOnlyMedia = 1, BackgroundCapableMedia = 2, Communications = 3, Alerts = 4, SoundEffects = 5, GameEffects = 6, GameMedia = 7, GameChat = 8, Speech = 9, Movie = 10, Media = 11,
 }}
 } // Windows.Media.Render
 pub mod speechrecognition { // Windows.Media.SpeechRecognition
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISpeechContinuousRecognitionCompletedEventArgs, 3822086587, 58124, 24088, 66, 75, 127, 190, 129, 248, 251, 208);
 RT_INTERFACE!{interface ISpeechContinuousRecognitionCompletedEventArgs(ISpeechContinuousRecognitionCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechContinuousRecognitionCompletedEventArgs] {
     fn get_Status(&self, out: *mut SpeechRecognitionResultStatus) -> HRESULT
@@ -26384,7 +26384,7 @@ impl ISpeechRecognizerUIOptions {
 RT_CLASS!{class SpeechRecognizerUIOptions: ISpeechRecognizerUIOptions}
 } // Windows.Media.SpeechRecognition
 pub mod speechsynthesis { // Windows.Media.SpeechSynthesis
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IInstalledVoicesStatic, 2102554316, 30003, 19519, 133, 190, 136, 140, 43, 174, 235, 220);
 RT_INTERFACE!{static interface IInstalledVoicesStatic(IInstalledVoicesStaticVtbl): IInspectable(IInspectableVtbl) [IID_IInstalledVoicesStatic] {
     fn get_AllVoices(&self, out: *mut *mut foundation::collections::IVectorView<VoiceInformation>) -> HRESULT,
@@ -26621,7 +26621,7 @@ RT_CLASS!{class VoiceInformation: IVoiceInformation}
 } // Windows.Media.SpeechSynthesis
 pub mod streaming { // Windows.Media.Streaming
 pub mod adaptive { // Windows.Media.Streaming.Adaptive
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdaptiveMediaSource, 1282618095, 54175, 17302, 180, 217, 4, 57, 87, 167, 201, 100);
 RT_INTERFACE!{interface IAdaptiveMediaSource(IAdaptiveMediaSourceVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSource] {
     fn get_IsLive(&self, out: *mut bool) -> HRESULT,
@@ -26782,13 +26782,13 @@ impl AdaptiveMediaSource {
     #[inline] pub fn create_from_uri_async(uri: &foundation::Uri) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
         <Self as RtActivatable<IAdaptiveMediaSourceStatics>>::get_activation_factory().create_from_uri_async(uri)
     }
-    #[cfg(feature="windows-web")] #[inline] pub fn create_from_uri_with_downloader_async(uri: &foundation::Uri, httpClient: &::rt::gen::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
+    #[cfg(feature="windows-web")] #[inline] pub fn create_from_uri_with_downloader_async(uri: &foundation::Uri, httpClient: &crate::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
         <Self as RtActivatable<IAdaptiveMediaSourceStatics>>::get_activation_factory().create_from_uri_with_downloader_async(uri, httpClient)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_from_stream_async(stream: &::rt::gen::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_from_stream_async(stream: &crate::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
         <Self as RtActivatable<IAdaptiveMediaSourceStatics>>::get_activation_factory().create_from_stream_async(stream, uri, contentType)
     }
-    #[cfg(all(feature="windows-storage",feature="windows-web"))] #[inline] pub fn create_from_stream_with_downloader_async(stream: &::rt::gen::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg, httpClient: &::rt::gen::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
+    #[cfg(all(feature="windows-storage",feature="windows-web"))] #[inline] pub fn create_from_stream_with_downloader_async(stream: &crate::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg, httpClient: &crate::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> {
         <Self as RtActivatable<IAdaptiveMediaSourceStatics>>::get_activation_factory().create_from_stream_with_downloader_async(stream, uri, contentType, httpClient)
     }
 }
@@ -26911,7 +26911,7 @@ DEFINE_IID!(IID_IAdaptiveMediaSourceCreationResult, 1183233714, 32783, 20017, 14
 RT_INTERFACE!{interface IAdaptiveMediaSourceCreationResult(IAdaptiveMediaSourceCreationResultVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceCreationResult] {
     fn get_Status(&self, out: *mut AdaptiveMediaSourceCreationStatus) -> HRESULT,
     fn get_MediaSource(&self, out: *mut *mut AdaptiveMediaSource) -> HRESULT,
-    #[cfg(feature="windows-web")] fn get_HttpResponseMessage(&self, out: *mut *mut ::rt::gen::windows::web::http::HttpResponseMessage) -> HRESULT
+    #[cfg(feature="windows-web")] fn get_HttpResponseMessage(&self, out: *mut *mut crate::windows::web::http::HttpResponseMessage) -> HRESULT
 }}
 impl IAdaptiveMediaSourceCreationResult {
     #[inline] pub fn get_status(&self) -> Result<AdaptiveMediaSourceCreationStatus> { unsafe { 
@@ -26924,7 +26924,7 @@ impl IAdaptiveMediaSourceCreationResult {
         let hr = ((*self.lpVtbl).get_MediaSource)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn get_http_response_message(&self) -> Result<Option<ComPtr<::rt::gen::windows::web::http::HttpResponseMessage>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn get_http_response_message(&self) -> Result<Option<ComPtr<crate::windows::web::http::HttpResponseMessage>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_HttpResponseMessage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -27091,7 +27091,7 @@ RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadCompletedEventArgs(IAdaptive
     fn get_ResourceUri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
     fn get_ResourceByteRangeOffset(&self, out: *mut *mut foundation::IReference<u64>) -> HRESULT,
     fn get_ResourceByteRangeLength(&self, out: *mut *mut foundation::IReference<u64>) -> HRESULT,
-    #[cfg(feature="windows-web")] fn get_HttpResponseMessage(&self, out: *mut *mut ::rt::gen::windows::web::http::HttpResponseMessage) -> HRESULT
+    #[cfg(feature="windows-web")] fn get_HttpResponseMessage(&self, out: *mut *mut crate::windows::web::http::HttpResponseMessage) -> HRESULT
 }}
 impl IAdaptiveMediaSourceDownloadCompletedEventArgs {
     #[inline] pub fn get_resource_type(&self) -> Result<AdaptiveMediaSourceResourceType> { unsafe { 
@@ -27114,7 +27114,7 @@ impl IAdaptiveMediaSourceDownloadCompletedEventArgs {
         let hr = ((*self.lpVtbl).get_ResourceByteRangeLength)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn get_http_response_message(&self) -> Result<Option<ComPtr<::rt::gen::windows::web::http::HttpResponseMessage>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn get_http_response_message(&self) -> Result<Option<ComPtr<crate::windows::web::http::HttpResponseMessage>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_HttpResponseMessage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -27167,7 +27167,7 @@ RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadFailedEventArgs(IAdaptiveMed
     fn get_ResourceUri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
     fn get_ResourceByteRangeOffset(&self, out: *mut *mut foundation::IReference<u64>) -> HRESULT,
     fn get_ResourceByteRangeLength(&self, out: *mut *mut foundation::IReference<u64>) -> HRESULT,
-    #[cfg(feature="windows-web")] fn get_HttpResponseMessage(&self, out: *mut *mut ::rt::gen::windows::web::http::HttpResponseMessage) -> HRESULT
+    #[cfg(feature="windows-web")] fn get_HttpResponseMessage(&self, out: *mut *mut crate::windows::web::http::HttpResponseMessage) -> HRESULT
 }}
 impl IAdaptiveMediaSourceDownloadFailedEventArgs {
     #[inline] pub fn get_resource_type(&self) -> Result<AdaptiveMediaSourceResourceType> { unsafe { 
@@ -27190,7 +27190,7 @@ impl IAdaptiveMediaSourceDownloadFailedEventArgs {
         let hr = ((*self.lpVtbl).get_ResourceByteRangeLength)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn get_http_response_message(&self) -> Result<Option<ComPtr<::rt::gen::windows::web::http::HttpResponseMessage>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn get_http_response_message(&self) -> Result<Option<ComPtr<crate::windows::web::http::HttpResponseMessage>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_HttpResponseMessage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -27335,13 +27335,13 @@ RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadResult(IAdaptiveMediaSourceD
     fn get_ResourceUri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
     fn put_ResourceUri(&self, value: *mut foundation::Uri) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_InputStream(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IInputStream) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_InputStream(&self, out: *mut *mut crate::windows::storage::streams::IInputStream) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_InputStream(&self, value: *mut ::rt::gen::windows::storage::streams::IInputStream) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_InputStream(&self, value: *mut crate::windows::storage::streams::IInputStream) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_Buffer(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_Buffer(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_Buffer(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_Buffer(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_ContentType(&self, out: *mut HSTRING) -> HRESULT,
     fn put_ContentType(&self, value: HSTRING) -> HRESULT,
     fn get_ExtendedStatus(&self, out: *mut u32) -> HRESULT,
@@ -27357,21 +27357,21 @@ impl IAdaptiveMediaSourceDownloadResult {
         let hr = ((*self.lpVtbl).put_ResourceUri)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_input_stream(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IInputStream>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_input_stream(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IInputStream>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_InputStream)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_input_stream(&self, value: &::rt::gen::windows::storage::streams::IInputStream) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_input_stream(&self, value: &crate::windows::storage::streams::IInputStream) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_InputStream)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_buffer(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_buffer(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Buffer)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_buffer(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_buffer(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Buffer)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -27484,10 +27484,10 @@ RT_INTERFACE!{static interface IAdaptiveMediaSourceStatics(IAdaptiveMediaSourceS
     fn IsContentTypeSupported(&self, contentType: HSTRING, out: *mut bool) -> HRESULT,
     fn CreateFromUriAsync(&self, uri: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT,
     #[cfg(not(feature="windows-web"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-web")] fn CreateFromUriWithDownloaderAsync(&self, uri: *mut foundation::Uri, httpClient: *mut ::rt::gen::windows::web::http::HttpClient, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT,
+    #[cfg(feature="windows-web")] fn CreateFromUriWithDownloaderAsync(&self, uri: *mut foundation::Uri, httpClient: *mut crate::windows::web::http::HttpClient, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn CreateFromStreamAsync(&self, stream: *mut ::rt::gen::windows::storage::streams::IInputStream, uri: *mut foundation::Uri, contentType: HSTRING, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT,
-    #[cfg(all(feature="windows-storage",feature="windows-web"))] fn CreateFromStreamWithDownloaderAsync(&self, stream: *mut ::rt::gen::windows::storage::streams::IInputStream, uri: *mut foundation::Uri, contentType: HSTRING, httpClient: *mut ::rt::gen::windows::web::http::HttpClient, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateFromStreamAsync(&self, stream: *mut crate::windows::storage::streams::IInputStream, uri: *mut foundation::Uri, contentType: HSTRING, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT,
+    #[cfg(all(feature="windows-storage",feature="windows-web"))] fn CreateFromStreamWithDownloaderAsync(&self, stream: *mut crate::windows::storage::streams::IInputStream, uri: *mut foundation::Uri, contentType: HSTRING, httpClient: *mut crate::windows::web::http::HttpClient, out: *mut *mut foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>) -> HRESULT
 }}
 impl IAdaptiveMediaSourceStatics {
     #[inline] pub fn is_content_type_supported(&self, contentType: &HStringArg) -> Result<bool> { unsafe { 
@@ -27500,17 +27500,17 @@ impl IAdaptiveMediaSourceStatics {
         let hr = ((*self.lpVtbl).CreateFromUriAsync)(self as *const _ as *mut _, uri as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn create_from_uri_with_downloader_async(&self, uri: &foundation::Uri, httpClient: &::rt::gen::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn create_from_uri_with_downloader_async(&self, uri: &foundation::Uri, httpClient: &crate::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateFromUriWithDownloaderAsync)(self as *const _ as *mut _, uri as *const _ as *mut _, httpClient as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_from_stream_async(&self, stream: &::rt::gen::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_from_stream_async(&self, stream: &crate::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateFromStreamAsync)(self as *const _ as *mut _, stream as *const _ as *mut _, uri as *const _ as *mut _, contentType.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-storage",feature="windows-web"))] #[inline] pub fn create_from_stream_with_downloader_async(&self, stream: &::rt::gen::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg, httpClient: &::rt::gen::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> { unsafe { 
+    #[cfg(all(feature="windows-storage",feature="windows-web"))] #[inline] pub fn create_from_stream_with_downloader_async(&self, stream: &crate::windows::storage::streams::IInputStream, uri: &foundation::Uri, contentType: &HStringArg, httpClient: &crate::windows::web::http::HttpClient) -> Result<ComPtr<foundation::IAsyncOperation<AdaptiveMediaSourceCreationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateFromStreamWithDownloaderAsync)(self as *const _ as *mut _, stream as *const _ as *mut _, uri as *const _ as *mut _, contentType.get(), httpClient as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -27519,7 +27519,7 @@ impl IAdaptiveMediaSourceStatics {
 } // Windows.Media.Streaming.Adaptive
 } // Windows.Media.Streaming
 pub mod transcoding { // Windows.Media.Transcoding
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IMediaTranscoder, 420256210, 41130, 19764, 134, 188, 238, 209, 177, 44, 47, 91);
 RT_INTERFACE!{interface IMediaTranscoder(IMediaTranscoderVtbl): IInspectable(IInspectableVtbl) [IID_IMediaTranscoder] {
     fn put_TrimStartTime(&self, value: foundation::TimeSpan) -> HRESULT,

--- a/src/rt/gen/windows/networking.rs
+++ b/src/rt/gen/windows/networking.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum DomainNameType: i32 {
     Suffix = 0, FullyQualified = 1,
 }}
@@ -152,7 +152,7 @@ RT_ENUM! { enum HostNameType: i32 {
     DomainName = 0, Ipv4 = 1, Ipv6 = 2, Bluetooth = 3,
 }}
 pub mod backgroundtransfer { // Windows.Networking.BackgroundTransfer
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBackgroundDownloader, 3251082035, 26185, 19229, 168, 38, 164, 179, 221, 35, 77, 11);
 RT_INTERFACE!{interface IBackgroundDownloader(IBackgroundDownloaderVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundDownloader] {
     #[cfg(feature="windows-storage")] fn CreateDownload(&self, uri: *mut foundation::Uri, resultFile: *mut super::super::storage::IStorageFile, out: *mut *mut DownloadOperation) -> HRESULT,
@@ -1105,7 +1105,7 @@ impl IUploadOperation3 {
 }
 } // Windows.Networking.BackgroundTransfer
 pub mod connectivity { // Windows.Networking.Connectivity
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAttributedNetworkUsage, 4150898745, 60578, 17899, 173, 225, 176, 54, 139, 117, 108, 73);
 RT_INTERFACE!{interface IAttributedNetworkUsage(IAttributedNetworkUsageVtbl): IInspectable(IInspectableVtbl) [IID_IAttributedNetworkUsage] {
     fn get_BytesSent(&self, out: *mut u64) -> HRESULT,
@@ -2214,7 +2214,7 @@ RT_ENUM! { enum WwanNetworkRegistrationState: i32 {
 }}
 } // Windows.Networking.Connectivity
 pub mod networkoperators { // Windows.Networking.NetworkOperators
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum DataClasses: u32 {
     None = 0, Gprs = 1, Edge = 2, Umts = 4, Hsdpa = 8, Hsupa = 16, LteAdvanced = 32, Cdma1xRtt = 65536, Cdma1xEvdo = 131072, Cdma1xEvdoRevA = 262144, Cdma1xEvdv = 524288, Cdma3xRtt = 1048576, Cdma1xEvdoRevB = 2097152, CdmaUmb = 4194304, Custom = 2147483648,
 }}
@@ -5221,7 +5221,7 @@ impl IUssdSessionStatics {
 }
 } // Windows.Networking.NetworkOperators
 pub mod proximity { // Windows.Networking.Proximity
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IConnectionRequestedEventArgs, 3949498798, 20254, 19558, 189, 13, 70, 146, 74, 148, 46, 8);
 RT_INTERFACE!{interface IConnectionRequestedEventArgs(IConnectionRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IConnectionRequestedEventArgs] {
     fn get_PeerInformation(&self, out: *mut *mut PeerInformation) -> HRESULT
@@ -5825,7 +5825,7 @@ RT_ENUM! { enum TriggeredConnectState: i32 {
 }}
 } // Windows.Networking.Proximity
 pub mod pushnotifications { // Windows.Networking.PushNotifications
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPushNotificationChannel, 724045870, 61195, 20281, 155, 138, 163, 193, 148, 222, 112, 129);
 RT_INTERFACE!{interface IPushNotificationChannel(IPushNotificationChannelVtbl): IInspectable(IInspectableVtbl) [IID_IPushNotificationChannel] {
     fn get_Uri(&self, out: *mut HSTRING) -> HRESULT,
@@ -6059,7 +6059,7 @@ impl IRawNotification2 {
 } // Windows.Networking.PushNotifications
 pub mod servicediscovery { // Windows.Networking.ServiceDiscovery
 pub mod dnssd { // Windows.Networking.ServiceDiscovery.Dnssd
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDnssdRegistrationResult, 1031301842, 58886, 21328, 115, 234, 126, 151, 240, 102, 22, 47);
 RT_INTERFACE!{interface IDnssdRegistrationResult(IDnssdRegistrationResultVtbl): IInspectable(IInspectableVtbl) [IID_IDnssdRegistrationResult] {
     fn get_Status(&self, out: *mut DnssdRegistrationStatus) -> HRESULT,
@@ -6260,7 +6260,7 @@ RT_ENUM! { enum DnssdServiceWatcherStatus: i32 {
 } // Windows.Networking.ServiceDiscovery.Dnssd
 } // Windows.Networking.ServiceDiscovery
 pub mod sockets { // Windows.Networking.Sockets
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct BandwidthStatistics {
     OutboundBitsPerSecond: u64, InboundBitsPerSecond: u64, OutboundBitsPerSecondInstability: u64, InboundBitsPerSecondInstability: u64, OutboundBandwidthPeaked: bool, InboundBandwidthPeaked: bool,
 }}
@@ -8058,7 +8058,7 @@ impl IWebSocketServerCustomValidationRequestedEventArgs {
 RT_CLASS!{class WebSocketServerCustomValidationRequestedEventArgs: IWebSocketServerCustomValidationRequestedEventArgs}
 } // Windows.Networking.Sockets
 pub mod vpn { // Windows.Networking.Vpn
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IVpnAppId, 2064033333, 23640, 16857, 148, 167, 191, 188, 241, 216, 202, 84);
 RT_INTERFACE!{interface IVpnAppId(IVpnAppIdVtbl): IInspectable(IInspectableVtbl) [IID_IVpnAppId] {
     fn get_Type(&self, out: *mut VpnAppIdType) -> HRESULT,
@@ -9685,7 +9685,7 @@ impl IVpnTrafficFilterFactory {
 }
 } // Windows.Networking.Vpn
 pub mod xboxlive { // Windows.Networking.XboxLive
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IXboxLiveDeviceAddress, 4122727033, 15494, 19287, 163, 26, 185, 70, 36, 8, 253, 1);
 RT_INTERFACE!{interface IXboxLiveDeviceAddress(IXboxLiveDeviceAddressVtbl): IInspectable(IInspectableVtbl) [IID_IXboxLiveDeviceAddress] {
     fn add_SnapshotChanged(&self, handler: *mut foundation::TypedEventHandler<XboxLiveDeviceAddress, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,

--- a/src/rt/gen/windows/perception.rs
+++ b/src/rt/gen/windows/perception.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPerceptionTimestamp, 2277656580, 41518, 19163, 186, 38, 215, 142, 246, 57, 188, 244);
 RT_INTERFACE!{interface IPerceptionTimestamp(IPerceptionTimestampVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionTimestamp] {
     fn get_TargetTime(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -64,7 +64,7 @@ impl IPerceptionTimestampHelperStatics2 {
 }
 pub mod automation { // Windows.Perception.Automation
 pub mod core { // Windows.Perception.Automation.Core
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class CorePerceptionAutomation}
 impl RtActivatable<ICorePerceptionAutomationStatics> for CorePerceptionAutomation {}
 impl CorePerceptionAutomation {
@@ -86,7 +86,7 @@ impl ICorePerceptionAutomationStatics {
 } // Windows.Perception.Automation.Core
 } // Windows.Perception.Automation
 pub mod people { // Windows.Perception.People
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IHeadPose, 2136655269, 18907, 14239, 148, 41, 50, 162, 250, 243, 79, 166);
 RT_INTERFACE!{interface IHeadPose(IHeadPoseVtbl): IInspectable(IInspectableVtbl) [IID_IHeadPose] {
     fn get_Position(&self, out: *mut foundation::numerics::Vector3) -> HRESULT,
@@ -113,7 +113,7 @@ impl IHeadPose {
 RT_CLASS!{class HeadPose: IHeadPose}
 } // Windows.Perception.People
 pub mod spatial { // Windows.Perception.Spatial
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISpatialAnchor, 86631886, 7476, 14082, 188, 236, 234, 191, 245, 120, 168, 105);
 RT_INTERFACE!{interface ISpatialAnchor(ISpatialAnchorVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialAnchor] {
     fn get_CoordinateSystem(&self, out: *mut *mut SpatialCoordinateSystem) -> HRESULT,
@@ -973,7 +973,7 @@ impl ISpatialStationaryFrameOfReference {
 }
 RT_CLASS!{class SpatialStationaryFrameOfReference: ISpatialStationaryFrameOfReference}
 pub mod preview { // Windows.Perception.Spatial.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class SpatialGraphInteropPreview}
 impl RtActivatable<ISpatialGraphInteropPreviewStatics> for SpatialGraphInteropPreview {}
 impl SpatialGraphInteropPreview {
@@ -1022,7 +1022,7 @@ impl ISpatialGraphInteropPreviewStatics {
 }
 } // Windows.Perception.Spatial.Preview
 pub mod surfaces { // Windows.Perception.Spatial.Surfaces
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISpatialSurfaceInfo, 4176079847, 14775, 14690, 187, 3, 87, 245, 110, 31, 176, 161);
 RT_INTERFACE!{interface ISpatialSurfaceInfo(ISpatialSurfaceInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceInfo] {
     fn get_Id(&self, out: *mut Guid) -> HRESULT,
@@ -1104,13 +1104,13 @@ RT_CLASS!{class SpatialSurfaceMesh: ISpatialSurfaceMesh}
 DEFINE_IID!(IID_ISpatialSurfaceMeshBuffer, 2479839712, 34591, 13304, 152, 178, 3, 209, 1, 69, 143, 111);
 RT_INTERFACE!{interface ISpatialSurfaceMeshBuffer(ISpatialSurfaceMeshBufferVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMeshBuffer] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_Format(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_Format(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     fn get_Stride(&self, out: *mut u32) -> HRESULT,
     fn get_ElementCount(&self, out: *mut u32) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl ISpatialSurfaceMeshBuffer {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Format)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -1125,7 +1125,7 @@ impl ISpatialSurfaceMeshBuffer {
         let hr = ((*self.lpVtbl).get_ElementCount)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Data)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1135,45 +1135,45 @@ RT_CLASS!{class SpatialSurfaceMeshBuffer: ISpatialSurfaceMeshBuffer}
 DEFINE_IID!(IID_ISpatialSurfaceMeshOptions, 3530923913, 13682, 15661, 161, 13, 95, 238, 147, 148, 170, 55);
 RT_INTERFACE!{interface ISpatialSurfaceMeshOptions(ISpatialSurfaceMeshOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMeshOptions] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_VertexPositionFormat(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_VertexPositionFormat(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_VertexPositionFormat(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_VertexPositionFormat(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_TriangleIndexFormat(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_TriangleIndexFormat(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_TriangleIndexFormat(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_TriangleIndexFormat(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_VertexNormalFormat(&self, out: *mut ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_VertexNormalFormat(&self, out: *mut crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_VertexNormalFormat(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_VertexNormalFormat(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> HRESULT,
     fn get_IncludeVertexNormals(&self, out: *mut bool) -> HRESULT,
     fn put_IncludeVertexNormals(&self, value: bool) -> HRESULT
 }}
 impl ISpatialSurfaceMeshOptions {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_vertex_position_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_vertex_position_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_VertexPositionFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_vertex_position_format(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_vertex_position_format(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_VertexPositionFormat)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_triangle_index_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_triangle_index_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_TriangleIndexFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_triangle_index_format(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_triangle_index_format(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_TriangleIndexFormat)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_vertex_normal_format(&self) -> Result<::rt::gen::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_vertex_normal_format(&self) -> Result<crate::windows::graphics::directx::DirectXPixelFormat> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_VertexNormalFormat)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_vertex_normal_format(&self, value: ::rt::gen::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_vertex_normal_format(&self, value: crate::windows::graphics::directx::DirectXPixelFormat) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_VertexNormalFormat)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -1191,35 +1191,35 @@ RT_CLASS!{class SpatialSurfaceMeshOptions: ISpatialSurfaceMeshOptions}
 impl RtActivatable<ISpatialSurfaceMeshOptionsStatics> for SpatialSurfaceMeshOptions {}
 impl RtActivatable<IActivationFactory> for SpatialSurfaceMeshOptions {}
 impl SpatialSurfaceMeshOptions {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_position_formats() -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>>>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_position_formats() -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>>>> {
         <Self as RtActivatable<ISpatialSurfaceMeshOptionsStatics>>::get_activation_factory().get_supported_vertex_position_formats()
     }
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_triangle_index_formats() -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>>>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_triangle_index_formats() -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>>>> {
         <Self as RtActivatable<ISpatialSurfaceMeshOptionsStatics>>::get_activation_factory().get_supported_triangle_index_formats()
     }
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_normal_formats() -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>>>> {
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_normal_formats() -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>>>> {
         <Self as RtActivatable<ISpatialSurfaceMeshOptionsStatics>>::get_activation_factory().get_supported_vertex_normal_formats()
     }
 }
 DEFINE_CLSID!(SpatialSurfaceMeshOptions(&[87,105,110,100,111,119,115,46,80,101,114,99,101,112,116,105,111,110,46,83,112,97,116,105,97,108,46,83,117,114,102,97,99,101,115,46,83,112,97,116,105,97,108,83,117,114,102,97,99,101,77,101,115,104,79,112,116,105,111,110,115,0]) [CLSID_SpatialSurfaceMeshOptions]);
 DEFINE_IID!(IID_ISpatialSurfaceMeshOptionsStatics, 2603879103, 38785, 17669, 137, 53, 1, 53, 117, 202, 174, 94);
 RT_INTERFACE!{static interface ISpatialSurfaceMeshOptionsStatics(ISpatialSurfaceMeshOptionsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMeshOptionsStatics] {
-    #[cfg(feature="windows-graphics")] fn get_SupportedVertexPositionFormats(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT,
-    #[cfg(feature="windows-graphics")] fn get_SupportedTriangleIndexFormats(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT,
-    #[cfg(feature="windows-graphics")] fn get_SupportedVertexNormalFormats(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT
+    #[cfg(feature="windows-graphics")] fn get_SupportedVertexPositionFormats(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SupportedTriangleIndexFormats(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_SupportedVertexNormalFormats(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>) -> HRESULT
 }}
 impl ISpatialSurfaceMeshOptionsStatics {
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_position_formats(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_position_formats(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SupportedVertexPositionFormats)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_triangle_index_formats(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_triangle_index_formats(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SupportedTriangleIndexFormats)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_normal_formats(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::graphics::directx::DirectXPixelFormat>>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_supported_vertex_normal_formats(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::graphics::directx::DirectXPixelFormat>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SupportedVertexNormalFormats)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }

--- a/src/rt/gen/windows/security.rs
+++ b/src/rt/gen/windows/security.rs
@@ -1,6 +1,6 @@
 pub mod authentication { // Windows.Security.Authentication
 pub mod identity { // Windows.Security.Authentication.Identity
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IEnterpriseKeyCredentialRegistrationInfo, 942807756, 26411, 18467, 182, 3, 107, 60, 117, 61, 175, 151);
 RT_INTERFACE!{interface IEnterpriseKeyCredentialRegistrationInfo(IEnterpriseKeyCredentialRegistrationInfoVtbl): IInspectable(IInspectableVtbl) [IID_IEnterpriseKeyCredentialRegistrationInfo] {
     fn get_TenantId(&self, out: *mut HSTRING) -> HRESULT,
@@ -68,7 +68,7 @@ impl IEnterpriseKeyCredentialRegistrationManagerStatics {
     }}
 }
 pub mod core { // Windows.Security.Authentication.Identity.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IMicrosoftAccountMultiFactorAuthenticationManager, 265502885, 62836, 17184, 160, 142, 10, 25, 168, 35, 34, 170);
 RT_INTERFACE!{interface IMicrosoftAccountMultiFactorAuthenticationManager(IMicrosoftAccountMultiFactorAuthenticationManagerVtbl): IInspectable(IInspectableVtbl) [IID_IMicrosoftAccountMultiFactorAuthenticationManager] {
     fn GetOneTimePassCodeAsync(&self, userAccountId: HSTRING, codeLength: u32, out: *mut *mut foundation::IAsyncOperation<MicrosoftAccountMultiFactorOneTimeCodedInfo>) -> HRESULT,
@@ -287,43 +287,43 @@ impl IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
 RT_CLASS!{class MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo: IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo}
 } // Windows.Security.Authentication.Identity.Core
 pub mod provider { // Windows.Security.Authentication.Identity.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthentication, 34215653, 27173, 16547, 140, 0, 80, 160, 35, 246, 25, 209);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorAuthentication(ISecondaryAuthenticationFactorAuthenticationVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorAuthentication] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_ServiceAuthenticationHmac(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_ServiceAuthenticationHmac(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_SessionNonce(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_SessionNonce(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_DeviceNonce(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_DeviceNonce(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_DeviceConfigurationData(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_DeviceConfigurationData(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-storage")] fn FinishAuthenticationAsync(&self, deviceHmac: *mut ::rt::gen::windows::storage::streams::IBuffer, sessionHmac: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorFinishAuthenticationStatus>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn FinishAuthenticationAsync(&self, deviceHmac: *mut crate::windows::storage::streams::IBuffer, sessionHmac: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorFinishAuthenticationStatus>) -> HRESULT,
     fn AbortAuthenticationAsync(&self, errorLogMessage: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl ISecondaryAuthenticationFactorAuthentication {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_service_authentication_hmac(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_service_authentication_hmac(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServiceAuthenticationHmac)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_nonce(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_session_nonce(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SessionNonce)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_device_nonce(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_device_nonce(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DeviceNonce)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_device_configuration_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_device_configuration_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DeviceConfigurationData)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn finish_authentication_async(&self, deviceHmac: &::rt::gen::windows::storage::streams::IBuffer, sessionHmac: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorFinishAuthenticationStatus>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn finish_authentication_async(&self, deviceHmac: &crate::windows::storage::streams::IBuffer, sessionHmac: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorFinishAuthenticationStatus>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FinishAuthenticationAsync)(self as *const _ as *mut _, deviceHmac as *const _ as *mut _, sessionHmac as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -340,7 +340,7 @@ impl SecondaryAuthenticationFactorAuthentication {
     #[inline] pub fn show_notification_message_async(deviceName: &HStringArg, message: SecondaryAuthenticationFactorAuthenticationMessage) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorAuthenticationStatics>>::get_activation_factory().show_notification_message_async(deviceName, message)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn start_authentication_async(deviceId: &HStringArg, serviceAuthenticationNonce: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationResult>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn start_authentication_async(deviceId: &HStringArg, serviceAuthenticationNonce: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationResult>>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorAuthenticationStatics>>::get_activation_factory().start_authentication_async(deviceId, serviceAuthenticationNonce)
     }
     #[inline] pub fn add_authentication_stage_changed(handler: &foundation::EventHandler<SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs>) -> Result<foundation::EventRegistrationToken> {
@@ -421,7 +421,7 @@ DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationStatics, 1062741590,
 RT_INTERFACE!{static interface ISecondaryAuthenticationFactorAuthenticationStatics(ISecondaryAuthenticationFactorAuthenticationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorAuthenticationStatics] {
     fn ShowNotificationMessageAsync(&self, deviceName: HSTRING, message: SecondaryAuthenticationFactorAuthenticationMessage, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn StartAuthenticationAsync(&self, deviceId: HSTRING, serviceAuthenticationNonce: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationResult>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn StartAuthenticationAsync(&self, deviceId: HSTRING, serviceAuthenticationNonce: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationResult>) -> HRESULT,
     fn add_AuthenticationStageChanged(&self, handler: *mut foundation::EventHandler<SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_AuthenticationStageChanged(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     fn GetAuthenticationStageInfoAsync(&self, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationStageInfo>) -> HRESULT
@@ -432,7 +432,7 @@ impl ISecondaryAuthenticationFactorAuthenticationStatics {
         let hr = ((*self.lpVtbl).ShowNotificationMessageAsync)(self as *const _ as *mut _, deviceName.get(), message, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn start_authentication_async(&self, deviceId: &HStringArg, serviceAuthenticationNonce: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn start_authentication_async(&self, deviceId: &HStringArg, serviceAuthenticationNonce: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorAuthenticationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).StartAuthenticationAsync)(self as *const _ as *mut _, deviceId.get(), serviceAuthenticationNonce as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -471,7 +471,7 @@ DEFINE_IID!(IID_ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrati
 RT_INTERFACE!{static interface ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics(ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics] {
     fn RegisterDevicePresenceMonitoringAsync(&self, deviceId: HSTRING, deviceInstancePath: HSTRING, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn RegisterDevicePresenceMonitoringWithNewDeviceAsync(&self, deviceId: HSTRING, deviceInstancePath: HSTRING, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, deviceFriendlyName: HSTRING, deviceModelNumber: HSTRING, deviceConfigurationData: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn RegisterDevicePresenceMonitoringWithNewDeviceAsync(&self, deviceId: HSTRING, deviceInstancePath: HSTRING, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, deviceFriendlyName: HSTRING, deviceModelNumber: HSTRING, deviceConfigurationData: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>) -> HRESULT,
     fn UnregisterDevicePresenceMonitoringAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn IsDevicePresenceMonitoringSupported(&self, out: *mut bool) -> HRESULT
 }}
@@ -481,7 +481,7 @@ impl ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics {
         let hr = ((*self.lpVtbl).RegisterDevicePresenceMonitoringAsync)(self as *const _ as *mut _, deviceId.get(), deviceInstancePath.get(), monitoringMode, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn register_device_presence_monitoring_with_new_device_async(&self, deviceId: &HStringArg, deviceInstancePath: &HStringArg, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceConfigurationData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn register_device_presence_monitoring_with_new_device_async(&self, deviceId: &HStringArg, deviceInstancePath: &HStringArg, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceConfigurationData: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).RegisterDevicePresenceMonitoringWithNewDeviceAsync)(self as *const _ as *mut _, deviceId.get(), deviceInstancePath.get(), monitoringMode, deviceFriendlyName.get(), deviceModelNumber.get(), deviceConfigurationData as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -508,7 +508,7 @@ RT_INTERFACE!{interface ISecondaryAuthenticationFactorInfo(ISecondaryAuthenticat
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
     fn get_DeviceFriendlyName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_DeviceModelNumber(&self, out: *mut HSTRING) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_DeviceConfigurationData(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_DeviceConfigurationData(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl ISecondaryAuthenticationFactorInfo {
     #[inline] pub fn get_device_id(&self) -> Result<HString> { unsafe { 
@@ -526,7 +526,7 @@ impl ISecondaryAuthenticationFactorInfo {
         let hr = ((*self.lpVtbl).get_DeviceModelNumber)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_device_configuration_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_device_configuration_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DeviceConfigurationData)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -559,11 +559,11 @@ impl ISecondaryAuthenticationFactorInfo2 {
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorRegistration, 2672606132, 36026, 18608, 132, 13, 219, 178, 42, 84, 198, 120);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorRegistration(ISecondaryAuthenticationFactorRegistrationVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorRegistration] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn FinishRegisteringDeviceAsync(&self, deviceConfigurationData: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn FinishRegisteringDeviceAsync(&self, deviceConfigurationData: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn AbortRegisteringDeviceAsync(&self, errorLogMessage: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl ISecondaryAuthenticationFactorRegistration {
-    #[cfg(feature="windows-storage")] #[inline] pub fn finish_registering_device_async(&self, deviceConfigurationData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn finish_registering_device_async(&self, deviceConfigurationData: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FinishRegisteringDeviceAsync)(self as *const _ as *mut _, deviceConfigurationData as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -581,7 +581,7 @@ impl SecondaryAuthenticationFactorRegistration {
     #[inline] pub fn register_device_presence_monitoring_async(deviceId: &HStringArg, deviceInstancePath: &HStringArg, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics>>::get_activation_factory().register_device_presence_monitoring_async(deviceId, deviceInstancePath, monitoringMode)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn register_device_presence_monitoring_with_new_device_async(deviceId: &HStringArg, deviceInstancePath: &HStringArg, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceConfigurationData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn register_device_presence_monitoring_with_new_device_async(deviceId: &HStringArg, deviceInstancePath: &HStringArg, monitoringMode: SecondaryAuthenticationFactorDevicePresenceMonitoringMode, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceConfigurationData: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus>>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics>>::get_activation_factory().register_device_presence_monitoring_with_new_device_async(deviceId, deviceInstancePath, monitoringMode, deviceFriendlyName, deviceModelNumber, deviceConfigurationData)
     }
     #[inline] pub fn unregister_device_presence_monitoring_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncAction>> {
@@ -590,7 +590,7 @@ impl SecondaryAuthenticationFactorRegistration {
     #[inline] pub fn is_device_presence_monitoring_supported() -> Result<bool> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics>>::get_activation_factory().is_device_presence_monitoring_supported()
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn request_start_registering_device_async(deviceId: &HStringArg, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceKey: &::rt::gen::windows::storage::streams::IBuffer, mutualAuthenticationKey: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn request_start_registering_device_async(deviceId: &HStringArg, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceKey: &crate::windows::storage::streams::IBuffer, mutualAuthenticationKey: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorRegistrationStatics>>::get_activation_factory().request_start_registering_device_async(deviceId, capabilities, deviceFriendlyName, deviceModelNumber, deviceKey, mutualAuthenticationKey)
     }
     #[inline] pub fn find_all_registered_device_info_async(queryType: SecondaryAuthenticationFactorDeviceFindScope) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<SecondaryAuthenticationFactorInfo>>>> {
@@ -599,7 +599,7 @@ impl SecondaryAuthenticationFactorRegistration {
     #[inline] pub fn unregister_device_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorRegistrationStatics>>::get_activation_factory().unregister_device_async(deviceId)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn update_device_configuration_data_async(deviceId: &HStringArg, deviceConfigurationData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn update_device_configuration_data_async(deviceId: &HStringArg, deviceConfigurationData: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<ISecondaryAuthenticationFactorRegistrationStatics>>::get_activation_factory().update_device_configuration_data_async(deviceId, deviceConfigurationData)
     }
 }
@@ -624,13 +624,13 @@ impl ISecondaryAuthenticationFactorRegistrationResult {
 RT_CLASS!{class SecondaryAuthenticationFactorRegistrationResult: ISecondaryAuthenticationFactorRegistrationResult}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorRegistrationStatics, 450826085, 58295, 16725, 153, 127, 183, 86, 239, 101, 190, 186);
 RT_INTERFACE!{static interface ISecondaryAuthenticationFactorRegistrationStatics(ISecondaryAuthenticationFactorRegistrationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorRegistrationStatics] {
-    #[cfg(feature="windows-storage")] fn RequestStartRegisteringDeviceAsync(&self, deviceId: HSTRING, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: HSTRING, deviceModelNumber: HSTRING, deviceKey: *mut ::rt::gen::windows::storage::streams::IBuffer, mutualAuthenticationKey: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn RequestStartRegisteringDeviceAsync(&self, deviceId: HSTRING, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: HSTRING, deviceModelNumber: HSTRING, deviceKey: *mut crate::windows::storage::streams::IBuffer, mutualAuthenticationKey: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>) -> HRESULT,
     fn FindAllRegisteredDeviceInfoAsync(&self, queryType: SecondaryAuthenticationFactorDeviceFindScope, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<SecondaryAuthenticationFactorInfo>>) -> HRESULT,
     fn UnregisterDeviceAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn UpdateDeviceConfigurationDataAsync(&self, deviceId: HSTRING, deviceConfigurationData: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT
+    #[cfg(feature="windows-storage")] fn UpdateDeviceConfigurationDataAsync(&self, deviceId: HSTRING, deviceConfigurationData: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl ISecondaryAuthenticationFactorRegistrationStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn request_start_registering_device_async(&self, deviceId: &HStringArg, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceKey: &::rt::gen::windows::storage::streams::IBuffer, mutualAuthenticationKey: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn request_start_registering_device_async(&self, deviceId: &HStringArg, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: &HStringArg, deviceModelNumber: &HStringArg, deviceKey: &crate::windows::storage::streams::IBuffer, mutualAuthenticationKey: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).RequestStartRegisteringDeviceAsync)(self as *const _ as *mut _, deviceId.get(), capabilities, deviceFriendlyName.get(), deviceModelNumber.get(), deviceKey as *const _ as *mut _, mutualAuthenticationKey as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -645,7 +645,7 @@ impl ISecondaryAuthenticationFactorRegistrationStatics {
         let hr = ((*self.lpVtbl).UnregisterDeviceAsync)(self as *const _ as *mut _, deviceId.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn update_device_configuration_data_async(&self, deviceId: &HStringArg, deviceConfigurationData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn update_device_configuration_data_async(&self, deviceId: &HStringArg, deviceConfigurationData: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).UpdateDeviceConfigurationDataAsync)(self as *const _ as *mut _, deviceId.get(), deviceConfigurationData as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -657,7 +657,7 @@ RT_ENUM! { enum SecondaryAuthenticationFactorRegistrationStatus: i32 {
 } // Windows.Security.Authentication.Identity.Provider
 } // Windows.Security.Authentication.Identity
 pub mod onlineid { // Windows.Security.Authentication.OnlineId
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CredentialPromptType: i32 {
     PromptIfNeeded = 0, RetypeCredentials = 1, DoNotPrompt = 2,
 }}
@@ -785,7 +785,7 @@ impl OnlineIdSystemAuthenticator {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<OnlineIdSystemAuthenticatorForUser>>> {
         <Self as RtActivatable<IOnlineIdSystemAuthenticatorStatics>>::get_activation_factory().get_default()
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user(user: &::rt::gen::windows::system::User) -> Result<Option<ComPtr<OnlineIdSystemAuthenticatorForUser>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user(user: &crate::windows::system::User) -> Result<Option<ComPtr<OnlineIdSystemAuthenticatorForUser>>> {
         <Self as RtActivatable<IOnlineIdSystemAuthenticatorStatics>>::get_activation_factory().get_for_user(user)
     }
 }
@@ -795,7 +795,7 @@ RT_INTERFACE!{interface IOnlineIdSystemAuthenticatorForUser(IOnlineIdSystemAuthe
     fn GetTicketAsync(&self, request: *mut OnlineIdServiceTicketRequest, out: *mut *mut foundation::IAsyncOperation<OnlineIdSystemTicketResult>) -> HRESULT,
     fn put_ApplicationId(&self, value: Guid) -> HRESULT,
     fn get_ApplicationId(&self, out: *mut Guid) -> HRESULT,
-    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut ::rt::gen::windows::system::User) -> HRESULT
+    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut crate::windows::system::User) -> HRESULT
 }}
 impl IOnlineIdSystemAuthenticatorForUser {
     #[inline] pub fn get_ticket_async(&self, request: &OnlineIdServiceTicketRequest) -> Result<ComPtr<foundation::IAsyncOperation<OnlineIdSystemTicketResult>>> { unsafe { 
@@ -812,7 +812,7 @@ impl IOnlineIdSystemAuthenticatorForUser {
         let hr = ((*self.lpVtbl).get_ApplicationId)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<::rt::gen::windows::system::User>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<crate::windows::system::User>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_User)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -822,7 +822,7 @@ RT_CLASS!{class OnlineIdSystemAuthenticatorForUser: IOnlineIdSystemAuthenticator
 DEFINE_IID!(IID_IOnlineIdSystemAuthenticatorStatics, 2231662482, 63028, 16867, 150, 164, 81, 100, 233, 2, 199, 64);
 RT_INTERFACE!{static interface IOnlineIdSystemAuthenticatorStatics(IOnlineIdSystemAuthenticatorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdSystemAuthenticatorStatics] {
     fn get_Default(&self, out: *mut *mut OnlineIdSystemAuthenticatorForUser) -> HRESULT,
-    #[cfg(feature="windows-system")] fn GetForUser(&self, user: *mut ::rt::gen::windows::system::User, out: *mut *mut OnlineIdSystemAuthenticatorForUser) -> HRESULT
+    #[cfg(feature="windows-system")] fn GetForUser(&self, user: *mut crate::windows::system::User, out: *mut *mut OnlineIdSystemAuthenticatorForUser) -> HRESULT
 }}
 impl IOnlineIdSystemAuthenticatorStatics {
     #[inline] pub fn get_default(&self) -> Result<Option<ComPtr<OnlineIdSystemAuthenticatorForUser>>> { unsafe { 
@@ -830,7 +830,7 @@ impl IOnlineIdSystemAuthenticatorStatics {
         let hr = ((*self.lpVtbl).get_Default)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user(&self, user: &::rt::gen::windows::system::User) -> Result<Option<ComPtr<OnlineIdSystemAuthenticatorForUser>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_for_user(&self, user: &crate::windows::system::User) -> Result<Option<ComPtr<OnlineIdSystemAuthenticatorForUser>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetForUser)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -939,7 +939,7 @@ impl IUserIdentity {
 RT_CLASS!{class UserIdentity: IUserIdentity}
 } // Windows.Security.Authentication.OnlineId
 pub mod web { // Windows.Security.Authentication.Web
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum TokenBindingKeyType: i32 {
     Rsa2048 = 0, EcdsaP256 = 1, AnyExisting = 2,
 }}
@@ -1059,7 +1059,7 @@ RT_ENUM! { enum WebAuthenticationStatus: i32 {
     Success = 0, UserCancel = 1, ErrorHttp = 2,
 }}
 pub mod core { // Windows.Security.Authentication.Web.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IFindAllAccountsResult, 2776705885, 46894, 16908, 134, 171, 170, 192, 215, 183, 38, 31);
 RT_INTERFACE!{interface IFindAllAccountsResult(IFindAllAccountsResultVtbl): IInspectable(IInspectableVtbl) [IID_IFindAllAccountsResult] {
     fn get_Accounts(&self, out: *mut *mut foundation::collections::IVectorView<super::super::super::credentials::WebAccount>) -> HRESULT,
@@ -1165,7 +1165,7 @@ impl WebAuthenticationCoreManager {
     #[inline] pub fn find_account_provider_with_authority_async(webAccountProviderId: &HStringArg, authority: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> {
         <Self as RtActivatable<IWebAuthenticationCoreManagerStatics>>::get_activation_factory().find_account_provider_with_authority_async(webAccountProviderId, authority)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn find_account_provider_with_authority_for_user_async(webAccountProviderId: &HStringArg, authority: &HStringArg, user: &::rt::gen::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn find_account_provider_with_authority_for_user_async(webAccountProviderId: &HStringArg, authority: &HStringArg, user: &crate::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> {
         <Self as RtActivatable<IWebAuthenticationCoreManagerStatics2>>::get_activation_factory().find_account_provider_with_authority_for_user_async(webAccountProviderId, authority, user)
     }
     #[inline] pub fn create_web_account_monitor(webAccounts: &foundation::collections::IIterable<super::super::super::credentials::WebAccount>) -> Result<Option<ComPtr<WebAccountMonitor>>> {
@@ -1183,7 +1183,7 @@ impl WebAuthenticationCoreManager {
     #[inline] pub fn find_system_account_provider_with_authority_async(webAccountProviderId: &HStringArg, authority: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> {
         <Self as RtActivatable<IWebAuthenticationCoreManagerStatics4>>::get_activation_factory().find_system_account_provider_with_authority_async(webAccountProviderId, authority)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn find_system_account_provider_with_authority_for_user_async(webAccountProviderId: &HStringArg, authority: &HStringArg, user: &::rt::gen::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn find_system_account_provider_with_authority_for_user_async(webAccountProviderId: &HStringArg, authority: &HStringArg, user: &crate::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> {
         <Self as RtActivatable<IWebAuthenticationCoreManagerStatics4>>::get_activation_factory().find_system_account_provider_with_authority_for_user_async(webAccountProviderId, authority, user)
     }
 }
@@ -1237,10 +1237,10 @@ impl IWebAuthenticationCoreManagerStatics {
 }
 DEFINE_IID!(IID_IWebAuthenticationCoreManagerStatics2, 4119074890, 35671, 18464, 182, 164, 112, 165, 182, 252, 244, 74);
 RT_INTERFACE!{static interface IWebAuthenticationCoreManagerStatics2(IWebAuthenticationCoreManagerStatics2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebAuthenticationCoreManagerStatics2] {
-    #[cfg(feature="windows-system")] fn FindAccountProviderWithAuthorityForUserAsync(&self, webAccountProviderId: HSTRING, authority: HSTRING, user: *mut ::rt::gen::windows::system::User, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>) -> HRESULT
+    #[cfg(feature="windows-system")] fn FindAccountProviderWithAuthorityForUserAsync(&self, webAccountProviderId: HSTRING, authority: HSTRING, user: *mut crate::windows::system::User, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>) -> HRESULT
 }}
 impl IWebAuthenticationCoreManagerStatics2 {
-    #[cfg(feature="windows-system")] #[inline] pub fn find_account_provider_with_authority_for_user_async(&self, webAccountProviderId: &HStringArg, authority: &HStringArg, user: &::rt::gen::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn find_account_provider_with_authority_for_user_async(&self, webAccountProviderId: &HStringArg, authority: &HStringArg, user: &crate::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindAccountProviderWithAuthorityForUserAsync)(self as *const _ as *mut _, webAccountProviderId.get(), authority.get(), user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1263,7 +1263,7 @@ RT_INTERFACE!{static interface IWebAuthenticationCoreManagerStatics4(IWebAuthent
     fn FindAllAccountsWithClientIdAsync(&self, provider: *mut super::super::super::credentials::WebAccountProvider, clientId: HSTRING, out: *mut *mut foundation::IAsyncOperation<FindAllAccountsResult>) -> HRESULT,
     fn FindSystemAccountProviderAsync(&self, webAccountProviderId: HSTRING, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>) -> HRESULT,
     fn FindSystemAccountProviderWithAuthorityAsync(&self, webAccountProviderId: HSTRING, authority: HSTRING, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn FindSystemAccountProviderWithAuthorityForUserAsync(&self, webAccountProviderId: HSTRING, authority: HSTRING, user: *mut ::rt::gen::windows::system::User, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>) -> HRESULT
+    #[cfg(feature="windows-system")] fn FindSystemAccountProviderWithAuthorityForUserAsync(&self, webAccountProviderId: HSTRING, authority: HSTRING, user: *mut crate::windows::system::User, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>) -> HRESULT
 }}
 impl IWebAuthenticationCoreManagerStatics4 {
     #[inline] pub fn find_all_accounts_async(&self, provider: &super::super::super::credentials::WebAccountProvider) -> Result<ComPtr<foundation::IAsyncOperation<FindAllAccountsResult>>> { unsafe { 
@@ -1286,7 +1286,7 @@ impl IWebAuthenticationCoreManagerStatics4 {
         let hr = ((*self.lpVtbl).FindSystemAccountProviderWithAuthorityAsync)(self as *const _ as *mut _, webAccountProviderId.get(), authority.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn find_system_account_provider_with_authority_for_user_async(&self, webAccountProviderId: &HStringArg, authority: &HStringArg, user: &::rt::gen::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn find_system_account_provider_with_authority_for_user_async(&self, webAccountProviderId: &HStringArg, authority: &HStringArg, user: &crate::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccountProvider>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindSystemAccountProviderWithAuthorityForUserAsync)(self as *const _ as *mut _, webAccountProviderId.get(), authority.get(), user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1547,7 +1547,7 @@ impl IWebTokenResponseFactory {
 }
 } // Windows.Security.Authentication.Web.Core
 pub mod provider { // Windows.Security.Authentication.Web.Provider
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IWebAccountClientView, 3887949498, 3015, 19558, 191, 212, 101, 211, 8, 44, 188, 168);
 RT_INTERFACE!{interface IWebAccountClientView(IWebAccountClientViewVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountClientView] {
     fn get_ApplicationCallbackUri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -1622,7 +1622,7 @@ impl WebAccountManager {
     #[inline] pub fn find_all_provider_web_accounts_async() -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>>> {
         <Self as RtActivatable<IWebAccountManagerStatics>>::get_activation_factory().find_all_provider_web_accounts_async()
     }
-    #[cfg(feature="windows-web")] #[inline] pub fn push_cookies_async(uri: &foundation::Uri, cookies: &foundation::collections::IVectorView<::rt::gen::windows::web::http::HttpCookie>) -> Result<ComPtr<foundation::IAsyncAction>> {
+    #[cfg(feature="windows-web")] #[inline] pub fn push_cookies_async(uri: &foundation::Uri, cookies: &foundation::collections::IVectorView<crate::windows::web::http::HttpCookie>) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<IWebAccountManagerStatics>>::get_activation_factory().push_cookies_async(uri, cookies)
     }
     #[inline] pub fn set_view_async(webAccount: &super::super::super::credentials::WebAccount, view: &WebAccountClientView) -> Result<ComPtr<foundation::IAsyncAction>> {
@@ -1634,7 +1634,7 @@ impl WebAccountManager {
     #[inline] pub fn get_views_async(webAccount: &super::super::super::credentials::WebAccount) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<WebAccountClientView>>>> {
         <Self as RtActivatable<IWebAccountManagerStatics>>::get_activation_factory().get_views_async(webAccount)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_web_account_picture_async(webAccount: &super::super::super::credentials::WebAccount, webAccountPicture: &::rt::gen::windows::storage::streams::IRandomAccessStream) -> Result<ComPtr<foundation::IAsyncAction>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_web_account_picture_async(webAccount: &super::super::super::credentials::WebAccount, webAccountPicture: &crate::windows::storage::streams::IRandomAccessStream) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<IWebAccountManagerStatics>>::get_activation_factory().set_web_account_picture_async(webAccount, webAccountPicture)
     }
     #[inline] pub fn clear_web_account_picture_async(webAccount: &super::super::super::credentials::WebAccount) -> Result<ComPtr<foundation::IAsyncAction>> {
@@ -1643,16 +1643,16 @@ impl WebAccountManager {
     #[inline] pub fn pull_cookies_async(uriString: &HStringArg, callerPFN: &HStringArg) -> Result<ComPtr<foundation::IAsyncAction>> {
         <Self as RtActivatable<IWebAccountManagerStatics2>>::get_activation_factory().pull_cookies_async(uriString, callerPFN)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn find_all_provider_web_accounts_for_user_async(user: &::rt::gen::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn find_all_provider_web_accounts_for_user_async(user: &crate::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>>> {
         <Self as RtActivatable<IWebAccountManagerStatics3>>::get_activation_factory().find_all_provider_web_accounts_for_user_async(user)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_for_user_async(user: &::rt::gen::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_for_user_async(user: &crate::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> {
         <Self as RtActivatable<IWebAccountManagerStatics3>>::get_activation_factory().add_web_account_for_user_async(user, webAccountId, webAccountUserName, props)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_for_user_async(user: &::rt::gen::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_for_user_async(user: &crate::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> {
         <Self as RtActivatable<IWebAccountManagerStatics3>>::get_activation_factory().add_web_account_with_scope_for_user_async(user, webAccountId, webAccountUserName, props, scope)
     }
-    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_and_map_for_user_async(user: &::rt::gen::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, perUserWebAccountId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_and_map_for_user_async(user: &crate::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, perUserWebAccountId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> {
         <Self as RtActivatable<IWebAccountManagerStatics3>>::get_activation_factory().add_web_account_with_scope_and_map_for_user_async(user, webAccountId, webAccountUserName, props, scope, perUserWebAccountId)
     }
     #[inline] pub fn invalidate_app_cache_for_all_accounts_async() -> Result<ComPtr<foundation::IAsyncAction>> {
@@ -1691,12 +1691,12 @@ RT_INTERFACE!{static interface IWebAccountManagerStatics(IWebAccountManagerStati
     fn DeleteWebAccountAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn FindAllProviderWebAccountsAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>) -> HRESULT,
     #[cfg(not(feature="windows-web"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-web")] fn PushCookiesAsync(&self, uri: *mut foundation::Uri, cookies: *mut foundation::collections::IVectorView<::rt::gen::windows::web::http::HttpCookie>, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-web")] fn PushCookiesAsync(&self, uri: *mut foundation::Uri, cookies: *mut foundation::collections::IVectorView<crate::windows::web::http::HttpCookie>, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn SetViewAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, view: *mut WebAccountClientView, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn ClearViewAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, applicationCallbackUri: *mut foundation::Uri, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn GetViewsAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<WebAccountClientView>>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy8(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SetWebAccountPictureAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, webAccountPicture: *mut ::rt::gen::windows::storage::streams::IRandomAccessStream, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SetWebAccountPictureAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, webAccountPicture: *mut crate::windows::storage::streams::IRandomAccessStream, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
     fn ClearWebAccountPictureAsync(&self, webAccount: *mut super::super::super::credentials::WebAccount, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl IWebAccountManagerStatics {
@@ -1720,7 +1720,7 @@ impl IWebAccountManagerStatics {
         let hr = ((*self.lpVtbl).FindAllProviderWebAccountsAsync)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn push_cookies_async(&self, uri: &foundation::Uri, cookies: &foundation::collections::IVectorView<::rt::gen::windows::web::http::HttpCookie>) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn push_cookies_async(&self, uri: &foundation::Uri, cookies: &foundation::collections::IVectorView<crate::windows::web::http::HttpCookie>) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).PushCookiesAsync)(self as *const _ as *mut _, uri as *const _ as *mut _, cookies as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1740,7 +1740,7 @@ impl IWebAccountManagerStatics {
         let hr = ((*self.lpVtbl).GetViewsAsync)(self as *const _ as *mut _, webAccount as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_web_account_picture_async(&self, webAccount: &super::super::super::credentials::WebAccount, webAccountPicture: &::rt::gen::windows::storage::streams::IRandomAccessStream) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_web_account_picture_async(&self, webAccount: &super::super::super::credentials::WebAccount, webAccountPicture: &crate::windows::storage::streams::IRandomAccessStream) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SetWebAccountPictureAsync)(self as *const _ as *mut _, webAccount as *const _ as *mut _, webAccountPicture as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1764,28 +1764,28 @@ impl IWebAccountManagerStatics2 {
 }
 DEFINE_IID!(IID_IWebAccountManagerStatics3, 3712295846, 35407, 19106, 177, 94, 3, 245, 80, 175, 19, 89);
 RT_INTERFACE!{static interface IWebAccountManagerStatics3(IWebAccountManagerStatics3Vtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountManagerStatics3] {
-    #[cfg(feature="windows-system")] fn FindAllProviderWebAccountsForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn AddWebAccountForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, webAccountId: HSTRING, webAccountUserName: HSTRING, props: *mut foundation::collections::IMapView<HString, HString>, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccount>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn AddWebAccountWithScopeForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, webAccountId: HSTRING, webAccountUserName: HSTRING, props: *mut foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccount>) -> HRESULT,
-    #[cfg(feature="windows-system")] fn AddWebAccountWithScopeAndMapForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, webAccountId: HSTRING, webAccountUserName: HSTRING, props: *mut foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, perUserWebAccountId: HSTRING, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccount>) -> HRESULT
+    #[cfg(feature="windows-system")] fn FindAllProviderWebAccountsForUserAsync(&self, user: *mut crate::windows::system::User, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn AddWebAccountForUserAsync(&self, user: *mut crate::windows::system::User, webAccountId: HSTRING, webAccountUserName: HSTRING, props: *mut foundation::collections::IMapView<HString, HString>, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccount>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn AddWebAccountWithScopeForUserAsync(&self, user: *mut crate::windows::system::User, webAccountId: HSTRING, webAccountUserName: HSTRING, props: *mut foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccount>) -> HRESULT,
+    #[cfg(feature="windows-system")] fn AddWebAccountWithScopeAndMapForUserAsync(&self, user: *mut crate::windows::system::User, webAccountId: HSTRING, webAccountUserName: HSTRING, props: *mut foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, perUserWebAccountId: HSTRING, out: *mut *mut foundation::IAsyncOperation<super::super::super::credentials::WebAccount>) -> HRESULT
 }}
 impl IWebAccountManagerStatics3 {
-    #[cfg(feature="windows-system")] #[inline] pub fn find_all_provider_web_accounts_for_user_async(&self, user: &::rt::gen::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn find_all_provider_web_accounts_for_user_async(&self, user: &crate::windows::system::User) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<super::super::super::credentials::WebAccount>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindAllProviderWebAccountsForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_for_user_async(&self, user: &::rt::gen::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_for_user_async(&self, user: &crate::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).AddWebAccountForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, webAccountId.get(), webAccountUserName.get(), props as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_for_user_async(&self, user: &::rt::gen::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_for_user_async(&self, user: &crate::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).AddWebAccountWithScopeForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, webAccountId.get(), webAccountUserName.get(), props as *const _ as *mut _, scope, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_and_map_for_user_async(&self, user: &::rt::gen::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, perUserWebAccountId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn add_web_account_with_scope_and_map_for_user_async(&self, user: &crate::windows::system::User, webAccountId: &HStringArg, webAccountUserName: &HStringArg, props: &foundation::collections::IMapView<HString, HString>, scope: WebAccountScope, perUserWebAccountId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<super::super::super::credentials::WebAccount>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).AddWebAccountWithScopeAndMapForUserAsync)(self as *const _ as *mut _, user as *const _ as *mut _, webAccountId.get(), webAccountUserName.get(), props as *const _ as *mut _, scope, perUserWebAccountId.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -1912,7 +1912,7 @@ DEFINE_IID!(IID_IWebAccountProviderRetrieveCookiesOperation, 1510212673, 4003, 1
 RT_INTERFACE!{interface IWebAccountProviderRetrieveCookiesOperation(IWebAccountProviderRetrieveCookiesOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderRetrieveCookiesOperation] {
     fn get_Context(&self, out: *mut *mut foundation::Uri) -> HRESULT,
     #[cfg(not(feature="windows-web"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-web")] fn get_Cookies(&self, out: *mut *mut foundation::collections::IVector<::rt::gen::windows::web::http::HttpCookie>) -> HRESULT,
+    #[cfg(feature="windows-web")] fn get_Cookies(&self, out: *mut *mut foundation::collections::IVector<crate::windows::web::http::HttpCookie>) -> HRESULT,
     fn put_Uri(&self, uri: *mut foundation::Uri) -> HRESULT,
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
     fn get_ApplicationCallbackUri(&self, out: *mut *mut foundation::Uri) -> HRESULT
@@ -1923,7 +1923,7 @@ impl IWebAccountProviderRetrieveCookiesOperation {
         let hr = ((*self.lpVtbl).get_Context)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn get_cookies(&self) -> Result<Option<ComPtr<foundation::collections::IVector<::rt::gen::windows::web::http::HttpCookie>>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn get_cookies(&self) -> Result<Option<ComPtr<foundation::collections::IVector<crate::windows::web::http::HttpCookie>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Cookies)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1996,10 +1996,10 @@ impl IWebAccountProviderTokenObjects {
 }
 DEFINE_IID!(IID_IWebAccountProviderTokenObjects2, 270579859, 23717, 20479, 149, 251, 184, 32, 39, 63, 195, 149);
 RT_INTERFACE!{interface IWebAccountProviderTokenObjects2(IWebAccountProviderTokenObjects2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderTokenObjects2] {
-    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut ::rt::gen::windows::system::User) -> HRESULT
+    #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut crate::windows::system::User) -> HRESULT
 }}
 impl IWebAccountProviderTokenObjects2 {
-    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<::rt::gen::windows::system::User>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_user(&self) -> Result<Option<ComPtr<crate::windows::system::User>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_User)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2111,10 +2111,10 @@ impl IWebProviderTokenRequest {
 RT_CLASS!{class WebProviderTokenRequest: IWebProviderTokenRequest}
 DEFINE_IID!(IID_IWebProviderTokenRequest2, 3050778188, 4273, 19110, 136, 177, 11, 108, 158, 12, 30, 70);
 RT_INTERFACE!{interface IWebProviderTokenRequest2(IWebProviderTokenRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebProviderTokenRequest2] {
-    #[cfg(feature="windows-storage")] fn GetApplicationTokenBindingKeyIdAsync(&self, keyType: super::TokenBindingKeyType, target: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GetApplicationTokenBindingKeyIdAsync(&self, keyType: super::TokenBindingKeyType, target: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT
 }}
 impl IWebProviderTokenRequest2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_application_token_binding_key_id_async(&self, keyType: super::TokenBindingKeyType, target: &foundation::Uri) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_application_token_binding_key_id_async(&self, keyType: super::TokenBindingKeyType, target: &foundation::Uri) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetApplicationTokenBindingKeyIdAsync)(self as *const _ as *mut _, keyType, target as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -2177,7 +2177,7 @@ impl IWebProviderTokenResponseFactory {
 } // Windows.Security.Authentication.Web
 } // Windows.Security.Authentication
 pub mod credentials { // Windows.Security.Credentials
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICredentialFactory, 1424954273, 48934, 18357, 151, 221, 222, 119, 155, 124, 173, 88);
 RT_INTERFACE!{static interface ICredentialFactory(ICredentialFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICredentialFactory] {
     fn CreatePasswordCredential(&self, resource: HSTRING, userName: HSTRING, password: HSTRING, out: *mut *mut PasswordCredential) -> HRESULT
@@ -2624,7 +2624,7 @@ RT_ENUM! { enum WebAccountState: i32 {
     None = 0, Connected = 1, Error = 2,
 }}
 pub mod ui { // Windows.Security.Credentials.UI
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AuthenticationProtocol: i32 {
     Basic = 0, Digest = 1, Ntlm = 2, Kerberos = 3, Negotiate = 4, CredSsp = 5, Custom = 6,
 }}
@@ -2657,9 +2657,9 @@ RT_INTERFACE!{interface ICredentialPickerOptions(ICredentialPickerOptionsVtbl): 
     fn put_CustomAuthenticationProtocol(&self, value: HSTRING) -> HRESULT,
     fn get_CustomAuthenticationProtocol(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy12(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_PreviousCredential(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_PreviousCredential(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy13(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_PreviousCredential(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_PreviousCredential(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn put_AlwaysDisplayDialog(&self, value: bool) -> HRESULT,
     fn get_AlwaysDisplayDialog(&self, out: *mut bool) -> HRESULT,
     fn put_CallerSavesCredential(&self, value: bool) -> HRESULT,
@@ -2722,11 +2722,11 @@ impl ICredentialPickerOptions {
         let hr = ((*self.lpVtbl).get_CustomAuthenticationProtocol)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_previous_credential(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_previous_credential(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_PreviousCredential)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_previous_credential(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_previous_credential(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_PreviousCredential)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2768,7 +2768,7 @@ RT_INTERFACE!{interface ICredentialPickerResults(ICredentialPickerResultsVtbl): 
     fn get_CredentialSaveOption(&self, out: *mut CredentialSaveOption) -> HRESULT,
     fn get_CredentialSaved(&self, out: *mut bool) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_Credential(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_Credential(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_CredentialDomainName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_CredentialUserName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_CredentialPassword(&self, out: *mut HSTRING) -> HRESULT
@@ -2789,7 +2789,7 @@ impl ICredentialPickerResults {
         let hr = ((*self.lpVtbl).get_CredentialSaved)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_credential(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_credential(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Credential)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2874,7 +2874,7 @@ impl IUserConsentVerifierStatics {
 } // Windows.Security.Credentials.UI
 } // Windows.Security.Credentials
 pub mod cryptography { // Windows.Security.Cryptography
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum BinaryStringEncoding: i32 {
     Utf8 = 0, Utf16LE = 1, Utf16BE = 2,
 }}
@@ -2988,7 +2988,7 @@ impl ICryptographicBufferStatics {
     }}
 }
 pub mod certificates { // Windows.Security.Cryptography.Certificates
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICertificate, 859796492, 1240, 17331, 178, 120, 140, 95, 204, 155, 229, 160);
 RT_INTERFACE!{interface ICertificate(ICertificateVtbl): IInspectable(IInspectableVtbl) [IID_ICertificate] {
     fn BuildChainAsync(&self, certificates: *mut foundation::collections::IIterable<Certificate>, out: *mut *mut foundation::IAsyncOperation<CertificateChain>) -> HRESULT,
@@ -2997,7 +2997,7 @@ RT_INTERFACE!{interface ICertificate(ICertificateVtbl): IInspectable(IInspectabl
     fn GetHashValue(&self, outSize: *mut u32, out: *mut *mut u8) -> HRESULT,
     fn GetHashValueWithAlgorithm(&self, hashAlgorithmName: HSTRING, outSize: *mut u32, out: *mut *mut u8) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-storage")] fn GetCertificateBlob(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetCertificateBlob(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_Subject(&self, out: *mut HSTRING) -> HRESULT,
     fn get_Issuer(&self, out: *mut HSTRING) -> HRESULT,
     fn get_HasPrivateKey(&self, out: *mut bool) -> HRESULT,
@@ -3034,7 +3034,7 @@ impl ICertificate {
         let hr = ((*self.lpVtbl).GetHashValueWithAlgorithm)(self as *const _ as *mut _, hashAlgorithmName.get(), &mut outSize, &mut out);
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_certificate_blob(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_certificate_blob(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetCertificateBlob)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -3087,7 +3087,7 @@ impl ICertificate {
 RT_CLASS!{class Certificate: ICertificate}
 impl RtActivatable<ICertificateFactory> for Certificate {}
 impl Certificate {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_certificate(certBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<Certificate>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_certificate(certBlob: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<Certificate>> {
         <Self as RtActivatable<ICertificateFactory>>::get_activation_factory().create_certificate(certBlob)
     }
 }
@@ -3307,10 +3307,10 @@ impl RtActivatable<IActivationFactory> for CertificateExtension {}
 DEFINE_CLSID!(CertificateExtension(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,69,120,116,101,110,115,105,111,110,0]) [CLSID_CertificateExtension]);
 DEFINE_IID!(IID_ICertificateFactory, 397681180, 19375, 17570, 150, 8, 4, 251, 98, 177, 105, 66);
 RT_INTERFACE!{static interface ICertificateFactory(ICertificateFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICertificateFactory] {
-    #[cfg(feature="windows-storage")] fn CreateCertificate(&self, certBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut Certificate) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateCertificate(&self, certBlob: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut Certificate) -> HRESULT
 }}
 impl ICertificateFactory {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_certificate(&self, certBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<Certificate>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_certificate(&self, certBlob: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<Certificate>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateCertificate)(self as *const _ as *mut _, certBlob as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -3912,8 +3912,8 @@ DEFINE_IID!(IID_IChainValidationParameters, 3295951690, 32432, 19286, 160, 64, 1
 RT_INTERFACE!{interface IChainValidationParameters(IChainValidationParametersVtbl): IInspectable(IInspectableVtbl) [IID_IChainValidationParameters] {
     fn get_CertificateChainPolicy(&self, out: *mut CertificateChainPolicy) -> HRESULT,
     fn put_CertificateChainPolicy(&self, value: CertificateChainPolicy) -> HRESULT,
-    #[cfg(feature="windows-networking")] fn get_ServerDnsName(&self, out: *mut *mut ::rt::gen::windows::networking::HostName) -> HRESULT,
-    #[cfg(feature="windows-networking")] fn put_ServerDnsName(&self, value: *mut ::rt::gen::windows::networking::HostName) -> HRESULT
+    #[cfg(feature="windows-networking")] fn get_ServerDnsName(&self, out: *mut *mut crate::windows::networking::HostName) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn put_ServerDnsName(&self, value: *mut crate::windows::networking::HostName) -> HRESULT
 }}
 impl IChainValidationParameters {
     #[inline] pub fn get_certificate_chain_policy(&self) -> Result<CertificateChainPolicy> { unsafe { 
@@ -3925,12 +3925,12 @@ impl IChainValidationParameters {
         let hr = ((*self.lpVtbl).put_CertificateChainPolicy)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_server_dns_name(&self) -> Result<Option<ComPtr<::rt::gen::windows::networking::HostName>>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_server_dns_name(&self) -> Result<Option<ComPtr<crate::windows::networking::HostName>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServerDnsName)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn set_server_dns_name(&self, value: &::rt::gen::windows::networking::HostName) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn set_server_dns_name(&self, value: &crate::windows::networking::HostName) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ServerDnsName)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3974,20 +3974,20 @@ RT_CLASS!{class CmsAttachedSignature: ICmsAttachedSignature}
 impl RtActivatable<ICmsAttachedSignatureFactory> for CmsAttachedSignature {}
 impl RtActivatable<ICmsAttachedSignatureStatics> for CmsAttachedSignature {}
 impl CmsAttachedSignature {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_attached_signature(inputBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsAttachedSignature>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_attached_signature(inputBlob: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsAttachedSignature>> {
         <Self as RtActivatable<ICmsAttachedSignatureFactory>>::get_activation_factory().create_cms_attached_signature(inputBlob)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(data: &::rt::gen::windows::storage::streams::IBuffer, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(data: &crate::windows::storage::streams::IBuffer, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICmsAttachedSignatureStatics>>::get_activation_factory().generate_signature_async(data, signers, certificates)
     }
 }
 DEFINE_CLSID!(CmsAttachedSignature(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,109,115,65,116,116,97,99,104,101,100,83,105,103,110,97,116,117,114,101,0]) [CLSID_CmsAttachedSignature]);
 DEFINE_IID!(IID_ICmsAttachedSignatureFactory, 3502832661, 63319, 19556, 163, 98, 82, 204, 28, 119, 207, 251);
 RT_INTERFACE!{static interface ICmsAttachedSignatureFactory(ICmsAttachedSignatureFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICmsAttachedSignatureFactory] {
-    #[cfg(feature="windows-storage")] fn CreateCmsAttachedSignature(&self, inputBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CmsAttachedSignature) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateCmsAttachedSignature(&self, inputBlob: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CmsAttachedSignature) -> HRESULT
 }}
 impl ICmsAttachedSignatureFactory {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_attached_signature(&self, inputBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsAttachedSignature>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_attached_signature(&self, inputBlob: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsAttachedSignature>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateCmsAttachedSignature)(self as *const _ as *mut _, inputBlob as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -3995,10 +3995,10 @@ impl ICmsAttachedSignatureFactory {
 }
 DEFINE_IID!(IID_ICmsAttachedSignatureStatics, 2274925710, 45229, 18829, 167, 245, 120, 181, 155, 206, 75, 54);
 RT_INTERFACE!{static interface ICmsAttachedSignatureStatics(ICmsAttachedSignatureStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICmsAttachedSignatureStatics] {
-    #[cfg(feature="windows-storage")] fn GenerateSignatureAsync(&self, data: *mut ::rt::gen::windows::storage::streams::IBuffer, signers: *mut foundation::collections::IIterable<CmsSignerInfo>, certificates: *mut foundation::collections::IIterable<Certificate>, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GenerateSignatureAsync(&self, data: *mut crate::windows::storage::streams::IBuffer, signers: *mut foundation::collections::IIterable<CmsSignerInfo>, certificates: *mut foundation::collections::IIterable<Certificate>, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT
 }}
 impl ICmsAttachedSignatureStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(&self, data: &::rt::gen::windows::storage::streams::IBuffer, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(&self, data: &crate::windows::storage::streams::IBuffer, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GenerateSignatureAsync)(self as *const _ as *mut _, data as *const _ as *mut _, signers as *const _ as *mut _, certificates as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -4008,7 +4008,7 @@ DEFINE_IID!(IID_ICmsDetachedSignature, 253686100, 63070, 17718, 131, 57, 89, 68,
 RT_INTERFACE!{interface ICmsDetachedSignature(ICmsDetachedSignatureVtbl): IInspectable(IInspectableVtbl) [IID_ICmsDetachedSignature] {
     fn get_Certificates(&self, out: *mut *mut foundation::collections::IVectorView<Certificate>) -> HRESULT,
     fn get_Signers(&self, out: *mut *mut foundation::collections::IVectorView<CmsSignerInfo>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn VerifySignatureAsync(&self, data: *mut ::rt::gen::windows::storage::streams::IInputStream, out: *mut *mut foundation::IAsyncOperation<SignatureValidationResult>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn VerifySignatureAsync(&self, data: *mut crate::windows::storage::streams::IInputStream, out: *mut *mut foundation::IAsyncOperation<SignatureValidationResult>) -> HRESULT
 }}
 impl ICmsDetachedSignature {
     #[inline] pub fn get_certificates(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<Certificate>>>> { unsafe { 
@@ -4021,7 +4021,7 @@ impl ICmsDetachedSignature {
         let hr = ((*self.lpVtbl).get_Signers)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature_async(&self, data: &::rt::gen::windows::storage::streams::IInputStream) -> Result<ComPtr<foundation::IAsyncOperation<SignatureValidationResult>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature_async(&self, data: &crate::windows::storage::streams::IInputStream) -> Result<ComPtr<foundation::IAsyncOperation<SignatureValidationResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).VerifySignatureAsync)(self as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -4031,20 +4031,20 @@ RT_CLASS!{class CmsDetachedSignature: ICmsDetachedSignature}
 impl RtActivatable<ICmsDetachedSignatureFactory> for CmsDetachedSignature {}
 impl RtActivatable<ICmsDetachedSignatureStatics> for CmsDetachedSignature {}
 impl CmsDetachedSignature {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_detached_signature(inputBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsDetachedSignature>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_detached_signature(inputBlob: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsDetachedSignature>> {
         <Self as RtActivatable<ICmsDetachedSignatureFactory>>::get_activation_factory().create_cms_detached_signature(inputBlob)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(data: &::rt::gen::windows::storage::streams::IInputStream, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(data: &crate::windows::storage::streams::IInputStream, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICmsDetachedSignatureStatics>>::get_activation_factory().generate_signature_async(data, signers, certificates)
     }
 }
 DEFINE_CLSID!(CmsDetachedSignature(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,109,115,68,101,116,97,99,104,101,100,83,105,103,110,97,116,117,114,101,0]) [CLSID_CmsDetachedSignature]);
 DEFINE_IID!(IID_ICmsDetachedSignatureFactory, 3299554563, 44671, 17287, 173, 25, 0, 241, 80, 228, 142, 187);
 RT_INTERFACE!{static interface ICmsDetachedSignatureFactory(ICmsDetachedSignatureFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICmsDetachedSignatureFactory] {
-    #[cfg(feature="windows-storage")] fn CreateCmsDetachedSignature(&self, inputBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CmsDetachedSignature) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateCmsDetachedSignature(&self, inputBlob: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CmsDetachedSignature) -> HRESULT
 }}
 impl ICmsDetachedSignatureFactory {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_detached_signature(&self, inputBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsDetachedSignature>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_cms_detached_signature(&self, inputBlob: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<CmsDetachedSignature>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateCmsDetachedSignature)(self as *const _ as *mut _, inputBlob as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -4052,10 +4052,10 @@ impl ICmsDetachedSignatureFactory {
 }
 DEFINE_IID!(IID_ICmsDetachedSignatureStatics, 1024543997, 49051, 18050, 155, 230, 145, 245, 124, 5, 56, 8);
 RT_INTERFACE!{static interface ICmsDetachedSignatureStatics(ICmsDetachedSignatureStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICmsDetachedSignatureStatics] {
-    #[cfg(feature="windows-storage")] fn GenerateSignatureAsync(&self, data: *mut ::rt::gen::windows::storage::streams::IInputStream, signers: *mut foundation::collections::IIterable<CmsSignerInfo>, certificates: *mut foundation::collections::IIterable<Certificate>, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn GenerateSignatureAsync(&self, data: *mut crate::windows::storage::streams::IInputStream, signers: *mut foundation::collections::IIterable<CmsSignerInfo>, certificates: *mut foundation::collections::IIterable<Certificate>, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT
 }}
 impl ICmsDetachedSignatureStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(&self, data: &::rt::gen::windows::storage::streams::IInputStream, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn generate_signature_async(&self, data: &crate::windows::storage::streams::IInputStream, signers: &foundation::collections::IIterable<CmsSignerInfo>, certificates: &foundation::collections::IIterable<Certificate>) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GenerateSignatureAsync)(self as *const _ as *mut _, data as *const _ as *mut _, signers as *const _ as *mut _, certificates as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -4620,7 +4620,7 @@ impl IUserCertificateStore {
 RT_CLASS!{class UserCertificateStore: IUserCertificateStore}
 } // Windows.Security.Cryptography.Certificates
 pub mod core { // Windows.Security.Cryptography.Core
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class AsymmetricAlgorithmNames}
 impl RtActivatable<IAsymmetricAlgorithmNamesStatics> for AsymmetricAlgorithmNames {}
 impl RtActivatable<IAsymmetricAlgorithmNamesStatics2> for AsymmetricAlgorithmNames {}
@@ -4830,10 +4830,10 @@ DEFINE_IID!(IID_IAsymmetricKeyAlgorithmProvider, 3906142007, 25177, 20104, 183, 
 RT_INTERFACE!{interface IAsymmetricKeyAlgorithmProvider(IAsymmetricKeyAlgorithmProviderVtbl): IInspectable(IInspectableVtbl) [IID_IAsymmetricKeyAlgorithmProvider] {
     fn get_AlgorithmName(&self, out: *mut HSTRING) -> HRESULT,
     fn CreateKeyPair(&self, keySize: u32, out: *mut *mut CryptographicKey) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ImportDefaultPrivateKeyBlob(&self, keyBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ImportKeyPairWithBlobType(&self, keyBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, blobType: CryptographicPrivateKeyBlobType, out: *mut *mut CryptographicKey) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ImportDefaultPublicKeyBlob(&self, keyBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ImportPublicKeyWithBlobType(&self, keyBlob: *mut ::rt::gen::windows::storage::streams::IBuffer, blobType: CryptographicPublicKeyBlobType, out: *mut *mut CryptographicKey) -> HRESULT
+    #[cfg(feature="windows-storage")] fn ImportDefaultPrivateKeyBlob(&self, keyBlob: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ImportKeyPairWithBlobType(&self, keyBlob: *mut crate::windows::storage::streams::IBuffer, blobType: CryptographicPrivateKeyBlobType, out: *mut *mut CryptographicKey) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ImportDefaultPublicKeyBlob(&self, keyBlob: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ImportPublicKeyWithBlobType(&self, keyBlob: *mut crate::windows::storage::streams::IBuffer, blobType: CryptographicPublicKeyBlobType, out: *mut *mut CryptographicKey) -> HRESULT
 }}
 impl IAsymmetricKeyAlgorithmProvider {
     #[inline] pub fn get_algorithm_name(&self) -> Result<HString> { unsafe { 
@@ -4846,22 +4846,22 @@ impl IAsymmetricKeyAlgorithmProvider {
         let hr = ((*self.lpVtbl).CreateKeyPair)(self as *const _ as *mut _, keySize, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn import_default_private_key_blob(&self, keyBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn import_default_private_key_blob(&self, keyBlob: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ImportDefaultPrivateKeyBlob)(self as *const _ as *mut _, keyBlob as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn import_key_pair_with_blob_type(&self, keyBlob: &::rt::gen::windows::storage::streams::IBuffer, blobType: CryptographicPrivateKeyBlobType) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn import_key_pair_with_blob_type(&self, keyBlob: &crate::windows::storage::streams::IBuffer, blobType: CryptographicPrivateKeyBlobType) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ImportKeyPairWithBlobType)(self as *const _ as *mut _, keyBlob as *const _ as *mut _, blobType, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn import_default_public_key_blob(&self, keyBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn import_default_public_key_blob(&self, keyBlob: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ImportDefaultPublicKeyBlob)(self as *const _ as *mut _, keyBlob as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn import_public_key_with_blob_type(&self, keyBlob: &::rt::gen::windows::storage::streams::IBuffer, blobType: CryptographicPublicKeyBlobType) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn import_public_key_with_blob_type(&self, keyBlob: &crate::windows::storage::streams::IBuffer, blobType: CryptographicPublicKeyBlobType) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ImportPublicKeyWithBlobType)(self as *const _ as *mut _, keyBlob as *const _ as *mut _, blobType, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4910,86 +4910,86 @@ RT_CLASS!{static class CryptographicEngine}
 impl RtActivatable<ICryptographicEngineStatics> for CryptographicEngine {}
 impl RtActivatable<ICryptographicEngineStatics2> for CryptographicEngine {}
 impl CryptographicEngine {
-    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, iv: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, iv: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().encrypt(key, data, iv)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, iv: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, iv: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().decrypt(key, data, iv)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt_and_authenticate(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, nonce: &::rt::gen::windows::storage::streams::IBuffer, authenticatedData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<EncryptedAndAuthenticatedData>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt_and_authenticate(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, nonce: &crate::windows::storage::streams::IBuffer, authenticatedData: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<EncryptedAndAuthenticatedData>>> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().encrypt_and_authenticate(key, data, nonce, authenticatedData)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_and_authenticate(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, nonce: &::rt::gen::windows::storage::streams::IBuffer, authenticationTag: &::rt::gen::windows::storage::streams::IBuffer, authenticatedData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_and_authenticate(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, nonce: &crate::windows::storage::streams::IBuffer, authenticationTag: &crate::windows::storage::streams::IBuffer, authenticatedData: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().decrypt_and_authenticate(key, data, nonce, authenticationTag, authenticatedData)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().sign(key, data)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, signature: &::rt::gen::windows::storage::streams::IBuffer) -> Result<bool> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, signature: &crate::windows::storage::streams::IBuffer) -> Result<bool> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().verify_signature(key, data, signature)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn derive_key_material(key: &CryptographicKey, parameters: &KeyDerivationParameters, desiredKeySize: u32) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn derive_key_material(key: &CryptographicKey, parameters: &KeyDerivationParameters, desiredKeySize: u32) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics>>::get_activation_factory().derive_key_material(key, parameters, desiredKeySize)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics2>>::get_activation_factory().sign_hashed_data(key, data)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature_with_hash_input(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, signature: &::rt::gen::windows::storage::streams::IBuffer) -> Result<bool> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature_with_hash_input(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, signature: &crate::windows::storage::streams::IBuffer) -> Result<bool> {
         <Self as RtActivatable<ICryptographicEngineStatics2>>::get_activation_factory().verify_signature_with_hash_input(key, data, signature)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_async(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, iv: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_async(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, iv: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics2>>::get_activation_factory().decrypt_async(key, data, iv)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign_async(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign_async(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics2>>::get_activation_factory().sign_async(key, data)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data_async(key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data_async(key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> {
         <Self as RtActivatable<ICryptographicEngineStatics2>>::get_activation_factory().sign_hashed_data_async(key, data)
     }
 }
 DEFINE_CLSID!(CryptographicEngine(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,67,114,121,112,116,111,103,114,97,112,104,105,99,69,110,103,105,110,101,0]) [CLSID_CryptographicEngine]);
 DEFINE_IID!(IID_ICryptographicEngineStatics, 2682914361, 28663, 19589, 160, 149, 149, 235, 49, 113, 94, 185);
 RT_INTERFACE!{static interface ICryptographicEngineStatics(ICryptographicEngineStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICryptographicEngineStatics] {
-    #[cfg(feature="windows-storage")] fn Encrypt(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, iv: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn Decrypt(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, iv: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn EncryptAndAuthenticate(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, nonce: *mut ::rt::gen::windows::storage::streams::IBuffer, authenticatedData: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut EncryptedAndAuthenticatedData) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn DecryptAndAuthenticate(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, nonce: *mut ::rt::gen::windows::storage::streams::IBuffer, authenticationTag: *mut ::rt::gen::windows::storage::streams::IBuffer, authenticatedData: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn Sign(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn VerifySignature(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, signature: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut bool) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn DeriveKeyMaterial(&self, key: *mut CryptographicKey, parameters: *mut KeyDerivationParameters, desiredKeySize: u32, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn Encrypt(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, iv: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn Decrypt(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, iv: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn EncryptAndAuthenticate(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, nonce: *mut crate::windows::storage::streams::IBuffer, authenticatedData: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut EncryptedAndAuthenticatedData) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn DecryptAndAuthenticate(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, nonce: *mut crate::windows::storage::streams::IBuffer, authenticationTag: *mut crate::windows::storage::streams::IBuffer, authenticatedData: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn Sign(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn VerifySignature(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, signature: *mut crate::windows::storage::streams::IBuffer, out: *mut bool) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn DeriveKeyMaterial(&self, key: *mut CryptographicKey, parameters: *mut KeyDerivationParameters, desiredKeySize: u32, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl ICryptographicEngineStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, iv: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, iv: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Encrypt)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, iv as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, iv: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, iv: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Decrypt)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, iv as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt_and_authenticate(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, nonce: &::rt::gen::windows::storage::streams::IBuffer, authenticatedData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<EncryptedAndAuthenticatedData>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn encrypt_and_authenticate(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, nonce: &crate::windows::storage::streams::IBuffer, authenticatedData: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<EncryptedAndAuthenticatedData>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).EncryptAndAuthenticate)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, nonce as *const _ as *mut _, authenticatedData as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_and_authenticate(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, nonce: &::rt::gen::windows::storage::streams::IBuffer, authenticationTag: &::rt::gen::windows::storage::streams::IBuffer, authenticatedData: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_and_authenticate(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, nonce: &crate::windows::storage::streams::IBuffer, authenticationTag: &crate::windows::storage::streams::IBuffer, authenticatedData: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).DecryptAndAuthenticate)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, nonce as *const _ as *mut _, authenticationTag as *const _ as *mut _, authenticatedData as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).Sign)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, signature: &::rt::gen::windows::storage::streams::IBuffer) -> Result<bool> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, signature: &crate::windows::storage::streams::IBuffer) -> Result<bool> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).VerifySignature)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, signature as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn derive_key_material(&self, key: &CryptographicKey, parameters: &KeyDerivationParameters, desiredKeySize: u32) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn derive_key_material(&self, key: &CryptographicKey, parameters: &KeyDerivationParameters, desiredKeySize: u32) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).DeriveKeyMaterial)(self as *const _ as *mut _, key as *const _ as *mut _, parameters as *const _ as *mut _, desiredKeySize, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -4997,34 +4997,34 @@ impl ICryptographicEngineStatics {
 }
 DEFINE_IID!(IID_ICryptographicEngineStatics2, 1733904638, 57247, 16785, 146, 199, 108, 230, 245, 132, 32, 224);
 RT_INTERFACE!{static interface ICryptographicEngineStatics2(ICryptographicEngineStatics2Vtbl): IInspectable(IInspectableVtbl) [IID_ICryptographicEngineStatics2] {
-    #[cfg(feature="windows-storage")] fn SignHashedData(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn VerifySignatureWithHashInput(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, signature: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut bool) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn DecryptAsync(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, iv: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn SignAsync(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn SignHashedDataAsync(&self, key: *mut CryptographicKey, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn SignHashedData(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn VerifySignatureWithHashInput(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, signature: *mut crate::windows::storage::streams::IBuffer, out: *mut bool) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn DecryptAsync(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, iv: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SignAsync(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SignHashedDataAsync(&self, key: *mut CryptographicKey, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT
 }}
 impl ICryptographicEngineStatics2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SignHashedData)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature_with_hash_input(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, signature: &::rt::gen::windows::storage::streams::IBuffer) -> Result<bool> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn verify_signature_with_hash_input(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, signature: &crate::windows::storage::streams::IBuffer) -> Result<bool> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).VerifySignatureWithHashInput)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, signature as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_async(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer, iv: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn decrypt_async(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer, iv: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).DecryptAsync)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, iv as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign_async(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign_async(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SignAsync)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data_async(&self, key: &CryptographicKey, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn sign_hashed_data_async(&self, key: &CryptographicKey, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SignHashedDataAsync)(self as *const _ as *mut _, key as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -5034,10 +5034,10 @@ RT_CLASS!{class CryptographicHash: IHashComputation}
 DEFINE_IID!(IID_ICryptographicKey, 3978967920, 36475, 16393, 132, 1, 255, 209, 166, 46, 235, 39);
 RT_INTERFACE!{interface ICryptographicKey(ICryptographicKeyVtbl): IInspectable(IInspectableVtbl) [IID_ICryptographicKey] {
     fn get_KeySize(&self, out: *mut u32) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ExportDefaultPrivateKeyBlobType(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ExportPrivateKeyWithBlobType(&self, blobType: CryptographicPrivateKeyBlobType, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ExportDefaultPublicKeyBlobType(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ExportPublicKeyWithBlobType(&self, blobType: CryptographicPublicKeyBlobType, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn ExportDefaultPrivateKeyBlobType(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ExportPrivateKeyWithBlobType(&self, blobType: CryptographicPrivateKeyBlobType, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ExportDefaultPublicKeyBlobType(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ExportPublicKeyWithBlobType(&self, blobType: CryptographicPublicKeyBlobType, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl ICryptographicKey {
     #[inline] pub fn get_key_size(&self) -> Result<u32> { unsafe { 
@@ -5045,22 +5045,22 @@ impl ICryptographicKey {
         let hr = ((*self.lpVtbl).get_KeySize)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn export_default_private_key_blob_type(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn export_default_private_key_blob_type(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ExportDefaultPrivateKeyBlobType)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn export_private_key_with_blob_type(&self, blobType: CryptographicPrivateKeyBlobType) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn export_private_key_with_blob_type(&self, blobType: CryptographicPrivateKeyBlobType) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ExportPrivateKeyWithBlobType)(self as *const _ as *mut _, blobType, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn export_default_public_key_blob_type(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn export_default_public_key_blob_type(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ExportDefaultPublicKeyBlobType)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn export_public_key_with_blob_type(&self, blobType: CryptographicPublicKeyBlobType) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn export_public_key_with_blob_type(&self, blobType: CryptographicPublicKeyBlobType) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ExportPublicKeyWithBlobType)(self as *const _ as *mut _, blobType, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5502,16 +5502,16 @@ impl IEccCurveNamesStatics {
 }
 DEFINE_IID!(IID_IEncryptedAndAuthenticatedData, 1873031143, 7883, 19200, 190, 165, 96, 184, 63, 134, 47, 23);
 RT_INTERFACE!{interface IEncryptedAndAuthenticatedData(IEncryptedAndAuthenticatedDataVtbl): IInspectable(IInspectableVtbl) [IID_IEncryptedAndAuthenticatedData] {
-    #[cfg(feature="windows-storage")] fn get_EncryptedData(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn get_AuthenticationTag(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn get_EncryptedData(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_AuthenticationTag(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IEncryptedAndAuthenticatedData {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_encrypted_data(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_encrypted_data(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_EncryptedData)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_authentication_tag(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_authentication_tag(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_AuthenticationTag)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5578,7 +5578,7 @@ RT_INTERFACE!{interface IHashAlgorithmProvider(IHashAlgorithmProviderVtbl): IIns
     fn get_AlgorithmName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_HashLength(&self, out: *mut u32) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-storage")] fn HashData(&self, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn HashData(&self, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn CreateHash(&self, out: *mut *mut CryptographicHash) -> HRESULT
 }}
 impl IHashAlgorithmProvider {
@@ -5592,7 +5592,7 @@ impl IHashAlgorithmProvider {
         let hr = ((*self.lpVtbl).get_HashLength)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn hash_data(&self, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn hash_data(&self, data: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).HashData)(self as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5624,15 +5624,15 @@ impl IHashAlgorithmProviderStatics {
 }
 DEFINE_IID!(IID_IHashComputation, 1493488054, 44337, 17923, 163, 164, 177, 189, 169, 142, 37, 98);
 RT_INTERFACE!{interface IHashComputation(IHashComputationVtbl): IInspectable(IInspectableVtbl) [IID_IHashComputation] {
-    #[cfg(feature="windows-storage")] fn Append(&self, data: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn GetValueAndReset(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
+    #[cfg(feature="windows-storage")] fn Append(&self, data: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn GetValueAndReset(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT
 }}
 impl IHashComputation {
-    #[cfg(feature="windows-storage")] #[inline] pub fn append(&self, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn append(&self, data: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).Append)(self as *const _ as *mut _, data as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_value_and_reset(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_value_and_reset(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetValueAndReset)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5837,7 +5837,7 @@ impl IKeyDerivationAlgorithmNamesStatics2 {
 DEFINE_IID!(IID_IKeyDerivationAlgorithmProvider, 3791366203, 18033, 17335, 145, 88, 118, 58, 170, 152, 182, 191);
 RT_INTERFACE!{interface IKeyDerivationAlgorithmProvider(IKeyDerivationAlgorithmProviderVtbl): IInspectable(IInspectableVtbl) [IID_IKeyDerivationAlgorithmProvider] {
     fn get_AlgorithmName(&self, out: *mut HSTRING) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn CreateKey(&self, keyMaterial: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateKey(&self, keyMaterial: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT
 }}
 impl IKeyDerivationAlgorithmProvider {
     #[inline] pub fn get_algorithm_name(&self) -> Result<HString> { unsafe { 
@@ -5845,7 +5845,7 @@ impl IKeyDerivationAlgorithmProvider {
         let hr = ((*self.lpVtbl).get_AlgorithmName)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_key(&self, keyMaterial: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_key(&self, keyMaterial: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateKey)(self as *const _ as *mut _, keyMaterial as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -5873,18 +5873,18 @@ impl IKeyDerivationAlgorithmProviderStatics {
 DEFINE_IID!(IID_IKeyDerivationParameters, 2079349095, 1147, 19084, 150, 74, 70, 159, 253, 85, 34, 226);
 RT_INTERFACE!{interface IKeyDerivationParameters(IKeyDerivationParametersVtbl): IInspectable(IInspectableVtbl) [IID_IKeyDerivationParameters] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_KdfGenericBinary(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_KdfGenericBinary(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_KdfGenericBinary(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_KdfGenericBinary(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_IterationCount(&self, out: *mut u32) -> HRESULT
 }}
 impl IKeyDerivationParameters {
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_kdf_generic_binary(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_kdf_generic_binary(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_KdfGenericBinary)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_kdf_generic_binary(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_kdf_generic_binary(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_KdfGenericBinary)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -5898,13 +5898,13 @@ RT_CLASS!{class KeyDerivationParameters: IKeyDerivationParameters}
 impl RtActivatable<IKeyDerivationParametersStatics> for KeyDerivationParameters {}
 impl RtActivatable<IKeyDerivationParametersStatics2> for KeyDerivationParameters {}
 impl KeyDerivationParameters {
-    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_pbkdf2(pbkdf2Salt: &::rt::gen::windows::storage::streams::IBuffer, iterationCount: u32) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_pbkdf2(pbkdf2Salt: &crate::windows::storage::streams::IBuffer, iterationCount: u32) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
         <Self as RtActivatable<IKeyDerivationParametersStatics>>::get_activation_factory().build_for_pbkdf2(pbkdf2Salt, iterationCount)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp800108(label: &::rt::gen::windows::storage::streams::IBuffer, context: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp800108(label: &crate::windows::storage::streams::IBuffer, context: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
         <Self as RtActivatable<IKeyDerivationParametersStatics>>::get_activation_factory().build_for_sp800108(label, context)
     }
-    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp80056a(algorithmId: &::rt::gen::windows::storage::streams::IBuffer, partyUInfo: &::rt::gen::windows::storage::streams::IBuffer, partyVInfo: &::rt::gen::windows::storage::streams::IBuffer, suppPubInfo: &::rt::gen::windows::storage::streams::IBuffer, suppPrivInfo: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
+    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp80056a(algorithmId: &crate::windows::storage::streams::IBuffer, partyUInfo: &crate::windows::storage::streams::IBuffer, partyVInfo: &crate::windows::storage::streams::IBuffer, suppPubInfo: &crate::windows::storage::streams::IBuffer, suppPrivInfo: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
         <Self as RtActivatable<IKeyDerivationParametersStatics>>::get_activation_factory().build_for_sp80056a(algorithmId, partyUInfo, partyVInfo, suppPubInfo, suppPrivInfo)
     }
     #[inline] pub fn build_for_capi1_kdf(capi1KdfTargetAlgorithm: Capi1KdfTargetAlgorithm) -> Result<Option<ComPtr<KeyDerivationParameters>>> {
@@ -5930,22 +5930,22 @@ impl IKeyDerivationParameters2 {
 }
 DEFINE_IID!(IID_IKeyDerivationParametersStatics, 3935707070, 62335, 16710, 157, 254, 164, 86, 241, 115, 95, 75);
 RT_INTERFACE!{static interface IKeyDerivationParametersStatics(IKeyDerivationParametersStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyDerivationParametersStatics] {
-    #[cfg(feature="windows-storage")] fn BuildForPbkdf2(&self, pbkdf2Salt: *mut ::rt::gen::windows::storage::streams::IBuffer, iterationCount: u32, out: *mut *mut KeyDerivationParameters) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn BuildForSP800108(&self, label: *mut ::rt::gen::windows::storage::streams::IBuffer, context: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut KeyDerivationParameters) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn BuildForSP80056a(&self, algorithmId: *mut ::rt::gen::windows::storage::streams::IBuffer, partyUInfo: *mut ::rt::gen::windows::storage::streams::IBuffer, partyVInfo: *mut ::rt::gen::windows::storage::streams::IBuffer, suppPubInfo: *mut ::rt::gen::windows::storage::streams::IBuffer, suppPrivInfo: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut KeyDerivationParameters) -> HRESULT
+    #[cfg(feature="windows-storage")] fn BuildForPbkdf2(&self, pbkdf2Salt: *mut crate::windows::storage::streams::IBuffer, iterationCount: u32, out: *mut *mut KeyDerivationParameters) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn BuildForSP800108(&self, label: *mut crate::windows::storage::streams::IBuffer, context: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut KeyDerivationParameters) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn BuildForSP80056a(&self, algorithmId: *mut crate::windows::storage::streams::IBuffer, partyUInfo: *mut crate::windows::storage::streams::IBuffer, partyVInfo: *mut crate::windows::storage::streams::IBuffer, suppPubInfo: *mut crate::windows::storage::streams::IBuffer, suppPrivInfo: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut KeyDerivationParameters) -> HRESULT
 }}
 impl IKeyDerivationParametersStatics {
-    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_pbkdf2(&self, pbkdf2Salt: &::rt::gen::windows::storage::streams::IBuffer, iterationCount: u32) -> Result<Option<ComPtr<KeyDerivationParameters>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_pbkdf2(&self, pbkdf2Salt: &crate::windows::storage::streams::IBuffer, iterationCount: u32) -> Result<Option<ComPtr<KeyDerivationParameters>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).BuildForPbkdf2)(self as *const _ as *mut _, pbkdf2Salt as *const _ as *mut _, iterationCount, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp800108(&self, label: &::rt::gen::windows::storage::streams::IBuffer, context: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp800108(&self, label: &crate::windows::storage::streams::IBuffer, context: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).BuildForSP800108)(self as *const _ as *mut _, label as *const _ as *mut _, context as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp80056a(&self, algorithmId: &::rt::gen::windows::storage::streams::IBuffer, partyUInfo: &::rt::gen::windows::storage::streams::IBuffer, partyVInfo: &::rt::gen::windows::storage::streams::IBuffer, suppPubInfo: &::rt::gen::windows::storage::streams::IBuffer, suppPrivInfo: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn build_for_sp80056a(&self, algorithmId: &crate::windows::storage::streams::IBuffer, partyUInfo: &crate::windows::storage::streams::IBuffer, partyVInfo: &crate::windows::storage::streams::IBuffer, suppPubInfo: &crate::windows::storage::streams::IBuffer, suppPrivInfo: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<KeyDerivationParameters>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).BuildForSP80056a)(self as *const _ as *mut _, algorithmId as *const _ as *mut _, partyUInfo as *const _ as *mut _, partyVInfo as *const _ as *mut _, suppPubInfo as *const _ as *mut _, suppPrivInfo as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6030,7 +6030,7 @@ DEFINE_IID!(IID_IMacAlgorithmProvider, 1245693379, 7357, 16846, 160, 146, 170, 1
 RT_INTERFACE!{interface IMacAlgorithmProvider(IMacAlgorithmProviderVtbl): IInspectable(IInspectableVtbl) [IID_IMacAlgorithmProvider] {
     fn get_AlgorithmName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_MacLength(&self, out: *mut u32) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn CreateKey(&self, keyMaterial: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateKey(&self, keyMaterial: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT
 }}
 impl IMacAlgorithmProvider {
     #[inline] pub fn get_algorithm_name(&self) -> Result<HString> { unsafe { 
@@ -6043,7 +6043,7 @@ impl IMacAlgorithmProvider {
         let hr = ((*self.lpVtbl).get_MacLength)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_key(&self, keyMaterial: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_key(&self, keyMaterial: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateKey)(self as *const _ as *mut _, keyMaterial as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6059,10 +6059,10 @@ impl MacAlgorithmProvider {
 DEFINE_CLSID!(MacAlgorithmProvider(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,111,114,101,46,77,97,99,65,108,103,111,114,105,116,104,109,80,114,111,118,105,100,101,114,0]) [CLSID_MacAlgorithmProvider]);
 DEFINE_IID!(IID_IMacAlgorithmProvider2, 1839409685, 55601, 17133, 142, 126, 195, 1, 202, 238, 17, 156);
 RT_INTERFACE!{interface IMacAlgorithmProvider2(IMacAlgorithmProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IMacAlgorithmProvider2] {
-    #[cfg(feature="windows-storage")] fn CreateHash(&self, keyMaterial: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicHash) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateHash(&self, keyMaterial: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CryptographicHash) -> HRESULT
 }}
 impl IMacAlgorithmProvider2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_hash(&self, keyMaterial: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicHash>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_hash(&self, keyMaterial: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicHash>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateHash)(self as *const _ as *mut _, keyMaterial as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6292,7 +6292,7 @@ DEFINE_IID!(IID_ISymmetricKeyAlgorithmProvider, 1031686707, 15312, 18690, 138, 2
 RT_INTERFACE!{interface ISymmetricKeyAlgorithmProvider(ISymmetricKeyAlgorithmProviderVtbl): IInspectable(IInspectableVtbl) [IID_ISymmetricKeyAlgorithmProvider] {
     fn get_AlgorithmName(&self, out: *mut HSTRING) -> HRESULT,
     fn get_BlockLength(&self, out: *mut u32) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn CreateSymmetricKey(&self, keyMaterial: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT
+    #[cfg(feature="windows-storage")] fn CreateSymmetricKey(&self, keyMaterial: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut CryptographicKey) -> HRESULT
 }}
 impl ISymmetricKeyAlgorithmProvider {
     #[inline] pub fn get_algorithm_name(&self) -> Result<HString> { unsafe { 
@@ -6305,7 +6305,7 @@ impl ISymmetricKeyAlgorithmProvider {
         let hr = ((*self.lpVtbl).get_BlockLength)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn create_symmetric_key(&self, keyMaterial: &::rt::gen::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn create_symmetric_key(&self, keyMaterial: &crate::windows::storage::streams::IBuffer) -> Result<Option<ComPtr<CryptographicKey>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateSymmetricKey)(self as *const _ as *mut _, keyMaterial as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -6332,31 +6332,31 @@ impl ISymmetricKeyAlgorithmProviderStatics {
 }
 } // Windows.Security.Cryptography.Core
 pub mod dataprotection { // Windows.Security.Cryptography.DataProtection
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDataProtectionProvider, 157522248, 60706, 17008, 189, 28, 109, 114, 192, 15, 135, 135);
 RT_INTERFACE!{interface IDataProtectionProvider(IDataProtectionProviderVtbl): IInspectable(IInspectableVtbl) [IID_IDataProtectionProvider] {
-    #[cfg(feature="windows-storage")] fn ProtectAsync(&self, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn UnprotectAsync(&self, data: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn ProtectStreamAsync(&self, src: *mut ::rt::gen::windows::storage::streams::IInputStream, dest: *mut ::rt::gen::windows::storage::streams::IOutputStream, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
-    #[cfg(feature="windows-storage")] fn UnprotectStreamAsync(&self, src: *mut ::rt::gen::windows::storage::streams::IInputStream, dest: *mut ::rt::gen::windows::storage::streams::IOutputStream, out: *mut *mut foundation::IAsyncAction) -> HRESULT
+    #[cfg(feature="windows-storage")] fn ProtectAsync(&self, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn UnprotectAsync(&self, data: *mut crate::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn ProtectStreamAsync(&self, src: *mut crate::windows::storage::streams::IInputStream, dest: *mut crate::windows::storage::streams::IOutputStream, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn UnprotectStreamAsync(&self, src: *mut crate::windows::storage::streams::IInputStream, dest: *mut crate::windows::storage::streams::IOutputStream, out: *mut *mut foundation::IAsyncAction) -> HRESULT
 }}
 impl IDataProtectionProvider {
-    #[cfg(feature="windows-storage")] #[inline] pub fn protect_async(&self, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn protect_async(&self, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ProtectAsync)(self as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn unprotect_async(&self, data: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn unprotect_async(&self, data: &crate::windows::storage::streams::IBuffer) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).UnprotectAsync)(self as *const _ as *mut _, data as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn protect_stream_async(&self, src: &::rt::gen::windows::storage::streams::IInputStream, dest: &::rt::gen::windows::storage::streams::IOutputStream) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn protect_stream_async(&self, src: &crate::windows::storage::streams::IInputStream, dest: &crate::windows::storage::streams::IOutputStream) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).ProtectStreamAsync)(self as *const _ as *mut _, src as *const _ as *mut _, dest as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn unprotect_stream_async(&self, src: &::rt::gen::windows::storage::streams::IInputStream, dest: &::rt::gen::windows::storage::streams::IOutputStream) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn unprotect_stream_async(&self, src: &crate::windows::storage::streams::IInputStream, dest: &crate::windows::storage::streams::IOutputStream) -> Result<ComPtr<foundation::IAsyncAction>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).UnprotectStreamAsync)(self as *const _ as *mut _, src as *const _ as *mut _, dest as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -6385,7 +6385,7 @@ impl IDataProtectionProviderFactory {
 } // Windows.Security.Cryptography.DataProtection
 } // Windows.Security.Cryptography
 pub mod enterprisedata { // Windows.Security.EnterpriseData
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBufferProtectUnprotectResult, 1201233628, 27884, 20026, 178, 81, 158, 116, 133, 215, 158, 122);
 RT_INTERFACE!{interface IBufferProtectUnprotectResult(IBufferProtectUnprotectResultVtbl): IInspectable(IInspectableVtbl) [IID_IBufferProtectUnprotectResult] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -7367,7 +7367,7 @@ RT_INTERFACE!{interface IThreadNetworkContext(IThreadNetworkContextVtbl): IInspe
 RT_CLASS!{class ThreadNetworkContext: IThreadNetworkContext}
 } // Windows.Security.EnterpriseData
 pub mod exchangeactivesyncprovisioning { // Windows.Security.ExchangeActiveSyncProvisioning
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IEasClientDeviceInformation, 1423956353, 6504, 19619, 185, 88, 229, 149, 209, 101, 5, 235);
 RT_INTERFACE!{interface IEasClientDeviceInformation(IEasClientDeviceInformationVtbl): IInspectable(IInspectableVtbl) [IID_IEasClientDeviceInformation] {
     fn get_Id(&self, out: *mut Guid) -> HRESULT,

--- a/src/rt/gen/windows/services.rs
+++ b/src/rt/gen/windows/services.rs
@@ -1,5 +1,5 @@
 pub mod cortana { // Windows.Services.Cortana
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICortanaActionableInsights, 2501822129, 64643, 22637, 139, 132, 36, 82, 200, 152, 22, 37);
 RT_INTERFACE!{interface ICortanaActionableInsights(ICortanaActionableInsightsVtbl): IInspectable(IInspectableVtbl) [IID_ICortanaActionableInsights] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -220,7 +220,7 @@ impl ICortanaSettingsStatics {
 }
 } // Windows.Services.Cortana
 pub mod maps { // Windows.Services.Maps
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IEnhancedWaypoint, 3978726516, 22803, 4582, 139, 119, 134, 243, 12, 168, 147, 211);
 RT_INTERFACE!{interface IEnhancedWaypoint(IEnhancedWaypointVtbl): IInspectable(IInspectableVtbl) [IID_IEnhancedWaypoint] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -1245,7 +1245,7 @@ RT_ENUM! { enum WaypointKind: i32 {
     Stop = 0, Via = 1,
 }}
 pub mod guidance { // Windows.Services.Maps.Guidance
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum GuidanceAudioMeasurementSystem: i32 {
     Meters = 0, MilesAndYards = 1, MilesAndFeet = 2,
 }}
@@ -1303,7 +1303,7 @@ RT_ENUM! { enum GuidanceLaneMarkers: u32 {
 DEFINE_IID!(IID_IGuidanceManeuver, 4228461164, 60617, 18728, 162, 161, 114, 50, 185, 155, 148, 161);
 RT_INTERFACE!{interface IGuidanceManeuver(IGuidanceManeuverVtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceManeuver] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_StartLocation(&self, out: *mut *mut ::rt::gen::windows::devices::geolocation::Geopoint) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_StartLocation(&self, out: *mut *mut crate::windows::devices::geolocation::Geopoint) -> HRESULT,
     fn get_DistanceFromRouteStart(&self, out: *mut i32) -> HRESULT,
     fn get_DistanceFromPreviousManeuver(&self, out: *mut i32) -> HRESULT,
     fn get_DepartureRoadName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1317,7 +1317,7 @@ RT_INTERFACE!{interface IGuidanceManeuver(IGuidanceManeuverVtbl): IInspectable(I
     fn get_InstructionText(&self, out: *mut HSTRING) -> HRESULT
 }}
 impl IGuidanceManeuver {
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_start_location(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::geolocation::Geopoint>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_start_location(&self) -> Result<Option<ComPtr<crate::windows::devices::geolocation::Geopoint>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_StartLocation)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1385,14 +1385,14 @@ RT_ENUM! { enum GuidanceManeuverKind: i32 {
 DEFINE_IID!(IID_IGuidanceMapMatchedCoordinate, 3081548136, 10514, 19097, 175, 241, 121, 134, 9, 185, 129, 254);
 RT_INTERFACE!{interface IGuidanceMapMatchedCoordinate(IGuidanceMapMatchedCoordinateVtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceMapMatchedCoordinate] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_Location(&self, out: *mut *mut ::rt::gen::windows::devices::geolocation::Geopoint) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_Location(&self, out: *mut *mut crate::windows::devices::geolocation::Geopoint) -> HRESULT,
     fn get_CurrentHeading(&self, out: *mut f64) -> HRESULT,
     fn get_CurrentSpeed(&self, out: *mut f64) -> HRESULT,
     fn get_IsOnStreet(&self, out: *mut bool) -> HRESULT,
     fn get_Road(&self, out: *mut *mut GuidanceRoadSegment) -> HRESULT
 }}
 impl IGuidanceMapMatchedCoordinate {
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_location(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::geolocation::Geopoint>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_location(&self) -> Result<Option<ComPtr<crate::windows::devices::geolocation::Geopoint>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Location)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1450,8 +1450,8 @@ RT_INTERFACE!{interface IGuidanceNavigator(IGuidanceNavigatorVtbl): IInspectable
     fn add_UserLocationRestored(&self, handler: *mut foundation::TypedEventHandler<GuidanceNavigator, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_UserLocationRestored(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     fn SetGuidanceVoice(&self, voiceId: i32, voiceFolder: HSTRING) -> HRESULT,
-    #[cfg(feature="windows-devices")] fn UpdateUserLocation(&self, userLocation: *mut ::rt::gen::windows::devices::geolocation::Geocoordinate) -> HRESULT,
-    #[cfg(feature="windows-devices")] fn UpdateUserLocationWithPositionOverride(&self, userLocation: *mut ::rt::gen::windows::devices::geolocation::Geocoordinate, positionOverride: ::rt::gen::windows::devices::geolocation::BasicGeoposition) -> HRESULT
+    #[cfg(feature="windows-devices")] fn UpdateUserLocation(&self, userLocation: *mut crate::windows::devices::geolocation::Geocoordinate) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn UpdateUserLocationWithPositionOverride(&self, userLocation: *mut crate::windows::devices::geolocation::Geocoordinate, positionOverride: crate::windows::devices::geolocation::BasicGeoposition) -> HRESULT
 }}
 impl IGuidanceNavigator {
     #[inline] pub fn start_navigating(&self, route: &GuidanceRoute) -> Result<()> { unsafe { 
@@ -1567,11 +1567,11 @@ impl IGuidanceNavigator {
         let hr = ((*self.lpVtbl).SetGuidanceVoice)(self as *const _ as *mut _, voiceId, voiceFolder.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn update_user_location(&self, userLocation: &::rt::gen::windows::devices::geolocation::Geocoordinate) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn update_user_location(&self, userLocation: &crate::windows::devices::geolocation::Geocoordinate) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).UpdateUserLocation)(self as *const _ as *mut _, userLocation as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn update_user_location_with_position_override(&self, userLocation: &::rt::gen::windows::devices::geolocation::Geocoordinate, positionOverride: ::rt::gen::windows::devices::geolocation::BasicGeoposition) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn update_user_location_with_position_override(&self, userLocation: &crate::windows::devices::geolocation::Geocoordinate, positionOverride: crate::windows::devices::geolocation::BasicGeoposition) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).UpdateUserLocationWithPositionOverride)(self as *const _ as *mut _, userLocation as *const _ as *mut _, positionOverride);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -1656,7 +1656,7 @@ RT_INTERFACE!{interface IGuidanceRoadSegment(IGuidanceRoadSegmentVtbl): IInspect
     fn get_SpeedLimit(&self, out: *mut f64) -> HRESULT,
     fn get_TravelTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
     #[cfg(not(feature="windows-devices"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_Path(&self, out: *mut *mut ::rt::gen::windows::devices::geolocation::Geopath) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_Path(&self, out: *mut *mut crate::windows::devices::geolocation::Geopath) -> HRESULT,
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
     fn get_IsHighway(&self, out: *mut bool) -> HRESULT,
     fn get_IsTunnel(&self, out: *mut bool) -> HRESULT,
@@ -1683,7 +1683,7 @@ impl IGuidanceRoadSegment {
         let hr = ((*self.lpVtbl).get_TravelTime)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_path(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::geolocation::Geopath>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_path(&self) -> Result<Option<ComPtr<crate::windows::devices::geolocation::Geopath>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Path)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1726,9 +1726,9 @@ RT_INTERFACE!{interface IGuidanceRoadSignpost(IGuidanceRoadSignpostVtbl): IInspe
     fn get_ExitNumber(&self, out: *mut HSTRING) -> HRESULT,
     fn get_Exit(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-ui"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_BackgroundColor(&self, out: *mut ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_BackgroundColor(&self, out: *mut crate::windows::ui::Color) -> HRESULT,
     #[cfg(not(feature="windows-ui"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_ForegroundColor(&self, out: *mut ::rt::gen::windows::ui::Color) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_ForegroundColor(&self, out: *mut crate::windows::ui::Color) -> HRESULT,
     fn get_ExitDirections(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT
 }}
 impl IGuidanceRoadSignpost {
@@ -1742,12 +1742,12 @@ impl IGuidanceRoadSignpost {
         let hr = ((*self.lpVtbl).get_Exit)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_background_color(&self) -> Result<::rt::gen::windows::ui::Color> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_background_color(&self) -> Result<crate::windows::ui::Color> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_BackgroundColor)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_foreground_color(&self) -> Result<::rt::gen::windows::ui::Color> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_foreground_color(&self) -> Result<crate::windows::ui::Color> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_ForegroundColor)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -1765,9 +1765,9 @@ RT_INTERFACE!{interface IGuidanceRoute(IGuidanceRouteVtbl): IInspectable(IInspec
     fn get_Distance(&self, out: *mut i32) -> HRESULT,
     fn get_Maneuvers(&self, out: *mut *mut foundation::collections::IVectorView<GuidanceManeuver>) -> HRESULT,
     #[cfg(not(feature="windows-devices"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_BoundingBox(&self, out: *mut *mut ::rt::gen::windows::devices::geolocation::GeoboundingBox) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_BoundingBox(&self, out: *mut *mut crate::windows::devices::geolocation::GeoboundingBox) -> HRESULT,
     #[cfg(not(feature="windows-devices"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_Path(&self, out: *mut *mut ::rt::gen::windows::devices::geolocation::Geopath) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_Path(&self, out: *mut *mut crate::windows::devices::geolocation::Geopath) -> HRESULT,
     fn get_RoadSegments(&self, out: *mut *mut foundation::collections::IVectorView<GuidanceRoadSegment>) -> HRESULT,
     fn ConvertToMapRoute(&self, out: *mut *mut super::MapRoute) -> HRESULT
 }}
@@ -1787,12 +1787,12 @@ impl IGuidanceRoute {
         let hr = ((*self.lpVtbl).get_Maneuvers)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_bounding_box(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::geolocation::GeoboundingBox>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_bounding_box(&self) -> Result<Option<ComPtr<crate::windows::devices::geolocation::GeoboundingBox>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_BoundingBox)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_path(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::geolocation::Geopath>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_path(&self) -> Result<Option<ComPtr<crate::windows::devices::geolocation::Geopath>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Path)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1990,7 +1990,7 @@ impl IGuidanceUpdatedEventArgs {
 RT_CLASS!{class GuidanceUpdatedEventArgs: IGuidanceUpdatedEventArgs}
 } // Windows.Services.Maps.Guidance
 pub mod localsearch { // Windows.Services.Maps.LocalSearch
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class LocalCategories}
 impl RtActivatable<ILocalCategoriesStatics> for LocalCategories {}
 impl LocalCategories {
@@ -2080,7 +2080,7 @@ RT_INTERFACE!{interface ILocalLocation(ILocalLocationVtbl): IInspectable(IInspec
     fn get_Description(&self, out: *mut HSTRING) -> HRESULT,
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-devices"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_Point(&self, out: *mut *mut ::rt::gen::windows::devices::geolocation::Geopoint) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_Point(&self, out: *mut *mut crate::windows::devices::geolocation::Geopoint) -> HRESULT,
     fn get_PhoneNumber(&self, out: *mut HSTRING) -> HRESULT,
     fn get_DataAttribution(&self, out: *mut HSTRING) -> HRESULT
 }}
@@ -2105,7 +2105,7 @@ impl ILocalLocation {
         let hr = ((*self.lpVtbl).get_DisplayName)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_point(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::geolocation::Geopoint>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_point(&self) -> Result<Option<ComPtr<crate::windows::devices::geolocation::Geopoint>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Point)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2148,7 +2148,7 @@ impl ILocalLocation2 {
 RT_CLASS!{static class LocalLocationFinder}
 impl RtActivatable<ILocalLocationFinderStatics> for LocalLocationFinder {}
 impl LocalLocationFinder {
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_local_locations_async(searchTerm: &HStringArg, searchArea: &::rt::gen::windows::devices::geolocation::Geocircle, localCategory: &HStringArg, maxResults: u32) -> Result<ComPtr<foundation::IAsyncOperation<LocalLocationFinderResult>>> {
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_local_locations_async(searchTerm: &HStringArg, searchArea: &crate::windows::devices::geolocation::Geocircle, localCategory: &HStringArg, maxResults: u32) -> Result<ComPtr<foundation::IAsyncOperation<LocalLocationFinderResult>>> {
         <Self as RtActivatable<ILocalLocationFinderStatics>>::get_activation_factory().find_local_locations_async(searchTerm, searchArea, localCategory, maxResults)
     }
 }
@@ -2173,10 +2173,10 @@ impl ILocalLocationFinderResult {
 RT_CLASS!{class LocalLocationFinderResult: ILocalLocationFinderResult}
 DEFINE_IID!(IID_ILocalLocationFinderStatics, 3538907972, 41182, 18634, 129, 168, 7, 199, 220, 253, 55, 171);
 RT_INTERFACE!{static interface ILocalLocationFinderStatics(ILocalLocationFinderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILocalLocationFinderStatics] {
-    #[cfg(feature="windows-devices")] fn FindLocalLocationsAsync(&self, searchTerm: HSTRING, searchArea: *mut ::rt::gen::windows::devices::geolocation::Geocircle, localCategory: HSTRING, maxResults: u32, out: *mut *mut foundation::IAsyncOperation<LocalLocationFinderResult>) -> HRESULT
+    #[cfg(feature="windows-devices")] fn FindLocalLocationsAsync(&self, searchTerm: HSTRING, searchArea: *mut crate::windows::devices::geolocation::Geocircle, localCategory: HSTRING, maxResults: u32, out: *mut *mut foundation::IAsyncOperation<LocalLocationFinderResult>) -> HRESULT
 }}
 impl ILocalLocationFinderStatics {
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_local_locations_async(&self, searchTerm: &HStringArg, searchArea: &::rt::gen::windows::devices::geolocation::Geocircle, localCategory: &HStringArg, maxResults: u32) -> Result<ComPtr<foundation::IAsyncOperation<LocalLocationFinderResult>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_local_locations_async(&self, searchTerm: &HStringArg, searchArea: &crate::windows::devices::geolocation::Geocircle, localCategory: &HStringArg, maxResults: u32) -> Result<ComPtr<foundation::IAsyncOperation<LocalLocationFinderResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindLocalLocationsAsync)(self as *const _ as *mut _, searchTerm.get(), searchArea as *const _ as *mut _, localCategory.get(), maxResults, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -2188,12 +2188,12 @@ RT_ENUM! { enum LocalLocationFinderStatus: i32 {
 DEFINE_IID!(IID_ILocalLocationHoursOfOperationItem, 592743538, 41415, 17393, 164, 240, 16, 145, 195, 158, 198, 64);
 RT_INTERFACE!{interface ILocalLocationHoursOfOperationItem(ILocalLocationHoursOfOperationItemVtbl): IInspectable(IInspectableVtbl) [IID_ILocalLocationHoursOfOperationItem] {
     #[cfg(not(feature="windows-globalization"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-globalization")] fn get_Day(&self, out: *mut ::rt::gen::windows::globalization::DayOfWeek) -> HRESULT,
+    #[cfg(feature="windows-globalization")] fn get_Day(&self, out: *mut crate::windows::globalization::DayOfWeek) -> HRESULT,
     fn get_Start(&self, out: *mut foundation::TimeSpan) -> HRESULT,
     fn get_Span(&self, out: *mut foundation::TimeSpan) -> HRESULT
 }}
 impl ILocalLocationHoursOfOperationItem {
-    #[cfg(feature="windows-globalization")] #[inline] pub fn get_day(&self) -> Result<::rt::gen::windows::globalization::DayOfWeek> { unsafe { 
+    #[cfg(feature="windows-globalization")] #[inline] pub fn get_day(&self) -> Result<crate::windows::globalization::DayOfWeek> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Day)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -2255,7 +2255,7 @@ impl IPlaceInfoHelperStatics {
 }
 } // Windows.Services.Maps.LocalSearch
 pub mod offlinemaps { // Windows.Services.Maps.OfflineMaps
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IOfflineMapPackage, 2811717435, 42421, 16708, 181, 37, 230, 140, 136, 98, 102, 75);
 RT_INTERFACE!{interface IOfflineMapPackage(IOfflineMapPackageVtbl): IInspectable(IInspectableVtbl) [IID_IOfflineMapPackage] {
     fn get_Status(&self, out: *mut OfflineMapPackageStatus) -> HRESULT,
@@ -2305,13 +2305,13 @@ impl IOfflineMapPackage {
 RT_CLASS!{class OfflineMapPackage: IOfflineMapPackage}
 impl RtActivatable<IOfflineMapPackageStatics> for OfflineMapPackage {}
 impl OfflineMapPackage {
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_async(queryPoint: &::rt::gen::windows::devices::geolocation::Geopoint) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_async(queryPoint: &crate::windows::devices::geolocation::Geopoint) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
         <Self as RtActivatable<IOfflineMapPackageStatics>>::get_activation_factory().find_packages_async(queryPoint)
     }
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_bounding_box_async(queryBoundingBox: &::rt::gen::windows::devices::geolocation::GeoboundingBox) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_bounding_box_async(queryBoundingBox: &crate::windows::devices::geolocation::GeoboundingBox) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
         <Self as RtActivatable<IOfflineMapPackageStatics>>::get_activation_factory().find_packages_in_bounding_box_async(queryBoundingBox)
     }
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_geocircle_async(queryCircle: &::rt::gen::windows::devices::geolocation::Geocircle) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_geocircle_async(queryCircle: &crate::windows::devices::geolocation::Geocircle) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
         <Self as RtActivatable<IOfflineMapPackageStatics>>::get_activation_factory().find_packages_in_geocircle_async(queryCircle)
     }
 }
@@ -2354,22 +2354,22 @@ RT_ENUM! { enum OfflineMapPackageStartDownloadStatus: i32 {
 }}
 DEFINE_IID!(IID_IOfflineMapPackageStatics, 408844578, 43057, 19120, 148, 31, 105, 152, 250, 146, 146, 133);
 RT_INTERFACE!{static interface IOfflineMapPackageStatics(IOfflineMapPackageStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IOfflineMapPackageStatics] {
-    #[cfg(feature="windows-devices")] fn FindPackagesAsync(&self, queryPoint: *mut ::rt::gen::windows::devices::geolocation::Geopoint, out: *mut *mut foundation::IAsyncOperation<OfflineMapPackageQueryResult>) -> HRESULT,
-    #[cfg(feature="windows-devices")] fn FindPackagesInBoundingBoxAsync(&self, queryBoundingBox: *mut ::rt::gen::windows::devices::geolocation::GeoboundingBox, out: *mut *mut foundation::IAsyncOperation<OfflineMapPackageQueryResult>) -> HRESULT,
-    #[cfg(feature="windows-devices")] fn FindPackagesInGeocircleAsync(&self, queryCircle: *mut ::rt::gen::windows::devices::geolocation::Geocircle, out: *mut *mut foundation::IAsyncOperation<OfflineMapPackageQueryResult>) -> HRESULT
+    #[cfg(feature="windows-devices")] fn FindPackagesAsync(&self, queryPoint: *mut crate::windows::devices::geolocation::Geopoint, out: *mut *mut foundation::IAsyncOperation<OfflineMapPackageQueryResult>) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn FindPackagesInBoundingBoxAsync(&self, queryBoundingBox: *mut crate::windows::devices::geolocation::GeoboundingBox, out: *mut *mut foundation::IAsyncOperation<OfflineMapPackageQueryResult>) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn FindPackagesInGeocircleAsync(&self, queryCircle: *mut crate::windows::devices::geolocation::Geocircle, out: *mut *mut foundation::IAsyncOperation<OfflineMapPackageQueryResult>) -> HRESULT
 }}
 impl IOfflineMapPackageStatics {
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_async(&self, queryPoint: &::rt::gen::windows::devices::geolocation::Geopoint) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_async(&self, queryPoint: &crate::windows::devices::geolocation::Geopoint) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindPackagesAsync)(self as *const _ as *mut _, queryPoint as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_bounding_box_async(&self, queryBoundingBox: &::rt::gen::windows::devices::geolocation::GeoboundingBox) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_bounding_box_async(&self, queryBoundingBox: &crate::windows::devices::geolocation::GeoboundingBox) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindPackagesInBoundingBoxAsync)(self as *const _ as *mut _, queryBoundingBox as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_geocircle_async(&self, queryCircle: &::rt::gen::windows::devices::geolocation::Geocircle) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_in_geocircle_async(&self, queryCircle: &crate::windows::devices::geolocation::Geocircle) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).FindPackagesInGeocircleAsync)(self as *const _ as *mut _, queryCircle as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -2381,7 +2381,7 @@ RT_ENUM! { enum OfflineMapPackageStatus: i32 {
 } // Windows.Services.Maps.OfflineMaps
 } // Windows.Services.Maps
 pub mod store { // Windows.Services.Store
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IStoreAcquireLicenseResult, 4225209453, 61504, 19635, 154, 57, 41, 188, 236, 219, 226, 45);
 RT_INTERFACE!{interface IStoreAcquireLicenseResult(IStoreAcquireLicenseResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreAcquireLicenseResult] {
     fn get_StorePackageLicense(&self, out: *mut *mut StorePackageLicense) -> HRESULT,
@@ -3822,7 +3822,7 @@ impl IStoreVideo {
 RT_CLASS!{class StoreVideo: IStoreVideo}
 } // Windows.Services.Store
 pub mod targetedcontent { // Windows.Services.TargetedContent
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ITargetedContentAction, 3613092126, 27862, 19616, 157, 143, 71, 40, 176, 183, 230, 182);
 RT_INTERFACE!{interface ITargetedContentAction(ITargetedContentActionVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentAction] {
     fn InvokeAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT

--- a/src/rt/gen/windows/storage.rs
+++ b/src/rt/gen/windows/storage.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppDataPaths, 1929500170, 31138, 18633, 158, 192, 63, 218, 9, 47, 121, 225);
 RT_INTERFACE!{interface IAppDataPaths(IAppDataPathsVtbl): IInspectable(IInspectableVtbl) [IID_IAppDataPaths] {
     fn get_Cookies(&self, out: *mut HSTRING) -> HRESULT,
@@ -2226,7 +2226,7 @@ impl IUserDataPathsStatics {
     }}
 }
 pub mod accesscache { // Windows.Storage.AccessCache
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AccessCacheOptions: u32 {
     None = 0, DisallowUserInput = 1, FastLocationsOnly = 2, UseReadOnlyCachedCopy = 4, SuppressAccessTimeUpdate = 8,
 }}
@@ -2410,7 +2410,7 @@ impl IStorageItemMostRecentlyUsedList2 {
 }
 } // Windows.Storage.AccessCache
 pub mod bulkaccess { // Windows.Storage.BulkAccess
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{class FileInformation: IStorageItemInformation}
 DEFINE_IID!(IID_IFileInformationFactory, 1075677374, 38415, 19821, 167, 208, 26, 56, 97, 231, 108, 131);
 RT_INTERFACE!{interface IFileInformationFactory(IFileInformationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IFileInformationFactory] {
@@ -2583,7 +2583,7 @@ impl IStorageItemInformation {
 }
 } // Windows.Storage.BulkAccess
 pub mod compression { // Windows.Storage.Compression
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CompressAlgorithm: i32 {
     InvalidAlgorithm = 0, NullAlgorithm = 1, Mszip = 2, Xpress = 3, XpressHuff = 4, Lzms = 5,
 }}
@@ -2664,7 +2664,7 @@ impl IDecompressorFactory {
 }
 } // Windows.Storage.Compression
 pub mod fileproperties { // Windows.Storage.FileProperties
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBasicProperties, 3495777755, 30814, 19046, 190, 2, 155, 238, 197, 138, 234, 129);
 RT_INTERFACE!{interface IBasicProperties(IBasicPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IBasicProperties] {
     fn get_Size(&self, out: *mut u64) -> HRESULT,
@@ -3246,7 +3246,7 @@ impl IVideoProperties {
 RT_CLASS!{class VideoProperties: IVideoProperties}
 } // Windows.Storage.FileProperties
 pub mod pickers { // Windows.Storage.Pickers
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{class FileExtensionVector: foundation::collections::IVector<HString>}
 DEFINE_IID!(IID_IFileOpenPicker, 749217674, 4805, 19551, 137, 119, 148, 84, 119, 147, 194, 65);
 RT_INTERFACE!{interface IFileOpenPicker(IFileOpenPickerVtbl): IInspectable(IInspectableVtbl) [IID_IFileOpenPicker] {
@@ -3574,7 +3574,7 @@ RT_ENUM! { enum PickerViewMode: i32 {
     List = 0, Thumbnail = 1,
 }}
 pub mod provider { // Windows.Storage.Pickers.Provider
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AddFileResult: i32 {
     Added = 0, AlreadyAdded = 1, NotAllowed = 2, Unavailable = 3,
 }}
@@ -3835,7 +3835,7 @@ RT_CLASS!{class TargetFileRequestedEventArgs: ITargetFileRequestedEventArgs}
 } // Windows.Storage.Pickers.Provider
 } // Windows.Storage.Pickers
 pub mod provider { // Windows.Storage.Provider
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CachedFileOptions: u32 {
     None = 0, RequireUpdateOnAccess = 1, UseCachedFileWhenOffline = 2, DenyAccessWhenOffline = 4,
 }}
@@ -4488,7 +4488,7 @@ RT_ENUM! { enum WriteActivationMode: i32 {
 }}
 } // Windows.Storage.Provider
 pub mod search { // Windows.Storage.Search
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CommonFileQuery: i32 {
     DefaultQuery = 0, OrderByName = 1, OrderByTitle = 2, OrderByMusicProperties = 3, OrderBySearchRank = 4, OrderByDate = 5,
 }}
@@ -5139,7 +5139,7 @@ impl RtActivatable<IActivationFactory> for ValueAndLanguage {}
 DEFINE_CLSID!(ValueAndLanguage(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,86,97,108,117,101,65,110,100,76,97,110,103,117,97,103,101,0]) [CLSID_ValueAndLanguage]);
 } // Windows.Storage.Search
 pub mod streams { // Windows.Storage.Streams
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IBuffer, 2421821408, 48211, 4575, 140, 73, 0, 30, 79, 198, 134, 218);
 RT_INTERFACE!{interface IBuffer(IBufferVtbl): IInspectable(IInspectableVtbl) [IID_IBuffer] {
     fn get_Capacity(&self, out: *mut u32) -> HRESULT,

--- a/src/rt/gen/windows/system.rs
+++ b/src/rt/gen/windows/system.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAppActivationResult, 1800571136, 62574, 20144, 170, 108, 56, 175, 85, 124, 249, 237);
 RT_INTERFACE!{interface IAppActivationResult(IAppActivationResultVtbl): IInspectable(IInspectableVtbl) [IID_IAppActivationResult] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT,
@@ -2321,7 +2321,7 @@ RT_ENUM! { enum VirtualKeyModifiers: u32 {
     None = 0, Control = 1, Menu = 2, Shift = 4, Windows = 8,
 }}
 pub mod diagnostics { // Windows.System.Diagnostics
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDiagnosticActionResult, 3261440662, 59195, 16535, 178, 143, 52, 66, 240, 61, 216, 49);
 RT_INTERFACE!{interface IDiagnosticActionResult(IDiagnosticActionResultVtbl): IInspectable(IInspectableVtbl) [IID_IDiagnosticActionResult] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT,
@@ -2792,7 +2792,7 @@ impl ISystemMemoryUsageReport {
 }
 RT_CLASS!{class SystemMemoryUsageReport: ISystemMemoryUsageReport}
 pub mod deviceportal { // Windows.System.Diagnostics.DevicePortal
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDevicePortalConnection, 256147281, 4504, 19873, 141, 84, 189, 239, 57, 62, 9, 182);
 RT_INTERFACE!{interface IDevicePortalConnection(IDevicePortalConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePortalConnection] {
     fn add_Closed(&self, handler: *mut foundation::TypedEventHandler<DevicePortalConnection, DevicePortalConnectionClosedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -2823,7 +2823,7 @@ impl IDevicePortalConnection {
 RT_CLASS!{class DevicePortalConnection: IDevicePortalConnection}
 impl RtActivatable<IDevicePortalConnectionStatics> for DevicePortalConnection {}
 impl DevicePortalConnection {
-    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_for_app_service_connection(appServiceConnection: &::rt::gen::windows::applicationmodel::appservice::AppServiceConnection) -> Result<Option<ComPtr<DevicePortalConnection>>> {
+    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_for_app_service_connection(appServiceConnection: &crate::windows::applicationmodel::appservice::AppServiceConnection) -> Result<Option<ComPtr<DevicePortalConnection>>> {
         <Self as RtActivatable<IDevicePortalConnectionStatics>>::get_activation_factory().get_for_app_service_connection(appServiceConnection)
     }
 }
@@ -2845,16 +2845,16 @@ RT_ENUM! { enum DevicePortalConnectionClosedReason: i32 {
 }}
 DEFINE_IID!(IID_IDevicePortalConnectionRequestReceivedEventArgs, 1692065861, 28634, 17497, 158, 189, 236, 206, 34, 227, 133, 89);
 RT_INTERFACE!{interface IDevicePortalConnectionRequestReceivedEventArgs(IDevicePortalConnectionRequestReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePortalConnectionRequestReceivedEventArgs] {
-    #[cfg(feature="windows-web")] fn get_RequestMessage(&self, out: *mut *mut ::rt::gen::windows::web::http::HttpRequestMessage) -> HRESULT,
-    #[cfg(feature="windows-web")] fn get_ResponseMessage(&self, out: *mut *mut ::rt::gen::windows::web::http::HttpResponseMessage) -> HRESULT
+    #[cfg(feature="windows-web")] fn get_RequestMessage(&self, out: *mut *mut crate::windows::web::http::HttpRequestMessage) -> HRESULT,
+    #[cfg(feature="windows-web")] fn get_ResponseMessage(&self, out: *mut *mut crate::windows::web::http::HttpResponseMessage) -> HRESULT
 }}
 impl IDevicePortalConnectionRequestReceivedEventArgs {
-    #[cfg(feature="windows-web")] #[inline] pub fn get_request_message(&self) -> Result<Option<ComPtr<::rt::gen::windows::web::http::HttpRequestMessage>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn get_request_message(&self) -> Result<Option<ComPtr<crate::windows::web::http::HttpRequestMessage>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_RequestMessage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-web")] #[inline] pub fn get_response_message(&self) -> Result<Option<ComPtr<::rt::gen::windows::web::http::HttpResponseMessage>>> { unsafe { 
+    #[cfg(feature="windows-web")] #[inline] pub fn get_response_message(&self) -> Result<Option<ComPtr<crate::windows::web::http::HttpResponseMessage>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ResponseMessage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2863,10 +2863,10 @@ impl IDevicePortalConnectionRequestReceivedEventArgs {
 RT_CLASS!{class DevicePortalConnectionRequestReceivedEventArgs: IDevicePortalConnectionRequestReceivedEventArgs}
 DEFINE_IID!(IID_IDevicePortalConnectionStatics, 1270755815, 59833, 17989, 143, 237, 165, 62, 234, 14, 219, 214);
 RT_INTERFACE!{static interface IDevicePortalConnectionStatics(IDevicePortalConnectionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePortalConnectionStatics] {
-    #[cfg(feature="windows-applicationmodel")] fn GetForAppServiceConnection(&self, appServiceConnection: *mut ::rt::gen::windows::applicationmodel::appservice::AppServiceConnection, out: *mut *mut DevicePortalConnection) -> HRESULT
+    #[cfg(feature="windows-applicationmodel")] fn GetForAppServiceConnection(&self, appServiceConnection: *mut crate::windows::applicationmodel::appservice::AppServiceConnection, out: *mut *mut DevicePortalConnection) -> HRESULT
 }}
 impl IDevicePortalConnectionStatics {
-    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_for_app_service_connection(&self, appServiceConnection: &::rt::gen::windows::applicationmodel::appservice::AppServiceConnection) -> Result<Option<ComPtr<DevicePortalConnection>>> { unsafe { 
+    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_for_app_service_connection(&self, appServiceConnection: &crate::windows::applicationmodel::appservice::AppServiceConnection) -> Result<Option<ComPtr<DevicePortalConnection>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetForAppServiceConnection)(self as *const _ as *mut _, appServiceConnection as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2874,34 +2874,34 @@ impl IDevicePortalConnectionStatics {
 }
 DEFINE_IID!(IID_IDevicePortalWebSocketConnection, 1734703392, 54874, 17136, 174, 244, 120, 120, 8, 9, 139, 123);
 RT_INTERFACE!{interface IDevicePortalWebSocketConnection(IDevicePortalWebSocketConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePortalWebSocketConnection] {
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerMessageWebSocketForRequest(&self, request: *mut ::rt::gen::windows::web::http::HttpRequestMessage, out: *mut *mut ::rt::gen::windows::networking::sockets::ServerMessageWebSocket) -> HRESULT,
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerMessageWebSocketForRequest2(&self, request: *mut ::rt::gen::windows::web::http::HttpRequestMessage, messageType: ::rt::gen::windows::networking::sockets::SocketMessageType, protocol: HSTRING, out: *mut *mut ::rt::gen::windows::networking::sockets::ServerMessageWebSocket) -> HRESULT,
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerMessageWebSocketForRequest3(&self, request: *mut ::rt::gen::windows::web::http::HttpRequestMessage, messageType: ::rt::gen::windows::networking::sockets::SocketMessageType, protocol: HSTRING, outboundBufferSizeInBytes: u32, maxMessageSize: u32, receiveMode: ::rt::gen::windows::networking::sockets::MessageWebSocketReceiveMode, out: *mut *mut ::rt::gen::windows::networking::sockets::ServerMessageWebSocket) -> HRESULT,
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerStreamWebSocketForRequest(&self, request: *mut ::rt::gen::windows::web::http::HttpRequestMessage, out: *mut *mut ::rt::gen::windows::networking::sockets::ServerStreamWebSocket) -> HRESULT,
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerStreamWebSocketForRequest2(&self, request: *mut ::rt::gen::windows::web::http::HttpRequestMessage, protocol: HSTRING, outboundBufferSizeInBytes: u32, noDelay: bool, out: *mut *mut ::rt::gen::windows::networking::sockets::ServerStreamWebSocket) -> HRESULT
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerMessageWebSocketForRequest(&self, request: *mut crate::windows::web::http::HttpRequestMessage, out: *mut *mut crate::windows::networking::sockets::ServerMessageWebSocket) -> HRESULT,
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerMessageWebSocketForRequest2(&self, request: *mut crate::windows::web::http::HttpRequestMessage, messageType: crate::windows::networking::sockets::SocketMessageType, protocol: HSTRING, out: *mut *mut crate::windows::networking::sockets::ServerMessageWebSocket) -> HRESULT,
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerMessageWebSocketForRequest3(&self, request: *mut crate::windows::web::http::HttpRequestMessage, messageType: crate::windows::networking::sockets::SocketMessageType, protocol: HSTRING, outboundBufferSizeInBytes: u32, maxMessageSize: u32, receiveMode: crate::windows::networking::sockets::MessageWebSocketReceiveMode, out: *mut *mut crate::windows::networking::sockets::ServerMessageWebSocket) -> HRESULT,
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerStreamWebSocketForRequest(&self, request: *mut crate::windows::web::http::HttpRequestMessage, out: *mut *mut crate::windows::networking::sockets::ServerStreamWebSocket) -> HRESULT,
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] fn GetServerStreamWebSocketForRequest2(&self, request: *mut crate::windows::web::http::HttpRequestMessage, protocol: HSTRING, outboundBufferSizeInBytes: u32, noDelay: bool, out: *mut *mut crate::windows::networking::sockets::ServerStreamWebSocket) -> HRESULT
 }}
 impl IDevicePortalWebSocketConnection {
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_message_web_socket_for_request(&self, request: &::rt::gen::windows::web::http::HttpRequestMessage) -> Result<Option<ComPtr<::rt::gen::windows::networking::sockets::ServerMessageWebSocket>>> { unsafe { 
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_message_web_socket_for_request(&self, request: &crate::windows::web::http::HttpRequestMessage) -> Result<Option<ComPtr<crate::windows::networking::sockets::ServerMessageWebSocket>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetServerMessageWebSocketForRequest)(self as *const _ as *mut _, request as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_message_web_socket_for_request2(&self, request: &::rt::gen::windows::web::http::HttpRequestMessage, messageType: ::rt::gen::windows::networking::sockets::SocketMessageType, protocol: &HStringArg) -> Result<Option<ComPtr<::rt::gen::windows::networking::sockets::ServerMessageWebSocket>>> { unsafe { 
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_message_web_socket_for_request2(&self, request: &crate::windows::web::http::HttpRequestMessage, messageType: crate::windows::networking::sockets::SocketMessageType, protocol: &HStringArg) -> Result<Option<ComPtr<crate::windows::networking::sockets::ServerMessageWebSocket>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetServerMessageWebSocketForRequest2)(self as *const _ as *mut _, request as *const _ as *mut _, messageType, protocol.get(), &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_message_web_socket_for_request3(&self, request: &::rt::gen::windows::web::http::HttpRequestMessage, messageType: ::rt::gen::windows::networking::sockets::SocketMessageType, protocol: &HStringArg, outboundBufferSizeInBytes: u32, maxMessageSize: u32, receiveMode: ::rt::gen::windows::networking::sockets::MessageWebSocketReceiveMode) -> Result<Option<ComPtr<::rt::gen::windows::networking::sockets::ServerMessageWebSocket>>> { unsafe { 
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_message_web_socket_for_request3(&self, request: &crate::windows::web::http::HttpRequestMessage, messageType: crate::windows::networking::sockets::SocketMessageType, protocol: &HStringArg, outboundBufferSizeInBytes: u32, maxMessageSize: u32, receiveMode: crate::windows::networking::sockets::MessageWebSocketReceiveMode) -> Result<Option<ComPtr<crate::windows::networking::sockets::ServerMessageWebSocket>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetServerMessageWebSocketForRequest3)(self as *const _ as *mut _, request as *const _ as *mut _, messageType, protocol.get(), outboundBufferSizeInBytes, maxMessageSize, receiveMode, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_stream_web_socket_for_request(&self, request: &::rt::gen::windows::web::http::HttpRequestMessage) -> Result<Option<ComPtr<::rt::gen::windows::networking::sockets::ServerStreamWebSocket>>> { unsafe { 
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_stream_web_socket_for_request(&self, request: &crate::windows::web::http::HttpRequestMessage) -> Result<Option<ComPtr<crate::windows::networking::sockets::ServerStreamWebSocket>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetServerStreamWebSocketForRequest)(self as *const _ as *mut _, request as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_stream_web_socket_for_request2(&self, request: &::rt::gen::windows::web::http::HttpRequestMessage, protocol: &HStringArg, outboundBufferSizeInBytes: u32, noDelay: bool) -> Result<Option<ComPtr<::rt::gen::windows::networking::sockets::ServerStreamWebSocket>>> { unsafe { 
+    #[cfg(all(feature="windows-networking",feature="windows-web"))] #[inline] pub fn get_server_stream_web_socket_for_request2(&self, request: &crate::windows::web::http::HttpRequestMessage, protocol: &HStringArg, outboundBufferSizeInBytes: u32, noDelay: bool) -> Result<Option<ComPtr<crate::windows::networking::sockets::ServerStreamWebSocket>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetServerStreamWebSocketForRequest2)(self as *const _ as *mut _, request as *const _ as *mut _, protocol.get(), outboundBufferSizeInBytes, noDelay, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -2932,7 +2932,7 @@ impl IDevicePortalWebSocketConnectionRequestReceivedEventArgs {
 }
 } // Windows.System.Diagnostics.DevicePortal
 pub mod telemetry { // Windows.System.Diagnostics.Telemetry
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class PlatformTelemetryClient}
 impl RtActivatable<IPlatformTelemetryClientStatics> for PlatformTelemetryClient {}
 impl PlatformTelemetryClient {
@@ -3008,7 +3008,7 @@ RT_ENUM! { enum PlatformTelemetryRegistrationStatus: i32 {
 }}
 } // Windows.System.Diagnostics.Telemetry
 pub mod tracereporting { // Windows.System.Diagnostics.TraceReporting
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class PlatformDiagnosticActions}
 impl RtActivatable<IPlatformDiagnosticActionsStatics> for PlatformDiagnosticActions {}
 impl PlatformDiagnosticActions {
@@ -3172,7 +3172,7 @@ RT_ENUM! { enum PlatformDiagnosticTraceSlotType: i32 {
 } // Windows.System.Diagnostics.TraceReporting
 } // Windows.System.Diagnostics
 pub mod display { // Windows.System.Display
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDisplayRequest, 3849527364, 62623, 19296, 141, 212, 94, 126, 58, 99, 42, 192);
 RT_INTERFACE!{interface IDisplayRequest(IDisplayRequestVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayRequest] {
     fn RequestActive(&self) -> HRESULT,
@@ -3193,7 +3193,7 @@ impl RtActivatable<IActivationFactory> for DisplayRequest {}
 DEFINE_CLSID!(DisplayRequest(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,115,112,108,97,121,46,68,105,115,112,108,97,121,82,101,113,117,101,115,116,0]) [CLSID_DisplayRequest]);
 } // Windows.System.Display
 pub mod inventory { // Windows.System.Inventory
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IInstalledDesktopApp, 1978317037, 49340, 21348, 76, 40, 22, 110, 5, 69, 22, 122);
 RT_INTERFACE!{interface IInstalledDesktopApp(IInstalledDesktopAppVtbl): IInspectable(IInspectableVtbl) [IID_IInstalledDesktopApp] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -3244,7 +3244,7 @@ impl IInstalledDesktopAppStatics {
 }
 } // Windows.System.Inventory
 pub mod power { // Windows.System.Power
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class BackgroundEnergyManager}
 impl RtActivatable<IBackgroundEnergyManagerStatics> for BackgroundEnergyManager {}
 impl BackgroundEnergyManager {
@@ -3609,7 +3609,7 @@ RT_ENUM! { enum PowerSupplyStatus: i32 {
     NotPresent = 0, Inadequate = 1, Adequate = 2,
 }}
 pub mod diagnostics { // Windows.System.Power.Diagnostics
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class BackgroundEnergyDiagnostics}
 impl RtActivatable<IBackgroundEnergyDiagnosticsStatics> for BackgroundEnergyDiagnostics {}
 impl BackgroundEnergyDiagnostics {
@@ -3685,7 +3685,7 @@ impl IForegroundEnergyDiagnosticsStatics {
 } // Windows.System.Power.Diagnostics
 } // Windows.System.Power
 pub mod preview { // Windows.System.Preview
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum HingeState: i32 {
     Unknown = 0, Closed = 1, Concave = 2, Flat = 3, Convex = 4, Full = 5,
 }}
@@ -3788,7 +3788,7 @@ impl ITwoPanelHingedDevicePosturePreviewStatics {
 }
 } // Windows.System.Preview
 pub mod profile { // Windows.System.Profile
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class AnalyticsInfo}
 impl RtActivatable<IAnalyticsInfoStatics> for AnalyticsInfo {}
 impl RtActivatable<IAnalyticsInfoStatics2> for AnalyticsInfo {}
@@ -4383,7 +4383,7 @@ impl IWindowsIntegrityPolicyStatics {
     }}
 }
 pub mod systemmanufacturers { // Windows.System.Profile.SystemManufacturers
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IOemSupportInfo, 2368646741, 34799, 16998, 134, 208, 196, 175, 190, 178, 155, 185);
 RT_INTERFACE!{interface IOemSupportInfo(IOemSupportInfoVtbl): IInspectable(IInspectableVtbl) [IID_IOemSupportInfo] {
     fn get_SupportLink(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -4521,7 +4521,7 @@ impl ISystemSupportInfoStatics2 {
 } // Windows.System.Profile.SystemManufacturers
 } // Windows.System.Profile
 pub mod remotedesktop { // Windows.System.RemoteDesktop
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class InteractiveSession}
 impl RtActivatable<IInteractiveSessionStatics> for InteractiveSession {}
 impl InteractiveSession {
@@ -4543,7 +4543,7 @@ impl IInteractiveSessionStatics {
 }
 } // Windows.System.RemoteDesktop
 pub mod remotesystems { // Windows.System.RemoteSystems
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class KnownRemoteSystemCapabilities}
 impl RtActivatable<IKnownRemoteSystemCapabilitiesStatics> for KnownRemoteSystemCapabilities {}
 impl KnownRemoteSystemCapabilities {
@@ -5898,7 +5898,7 @@ impl IRemoteSystemWebAccountFilterFactory {
 }
 } // Windows.System.RemoteSystems
 pub mod threading { // Windows.System.Threading
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{static class ThreadPool}
 impl RtActivatable<IThreadPoolStatics> for ThreadPool {}
 impl ThreadPool {
@@ -6041,7 +6041,7 @@ RT_ENUM! { enum WorkItemPriority: i32 {
     Low = -1, Normal = 0, High = 1,
 }}
 pub mod core { // Windows.System.Threading.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPreallocatedWorkItem, 3067783676, 48219, 16410, 168, 178, 110, 117, 77, 20, 218, 166);
 RT_INTERFACE!{interface IPreallocatedWorkItem(IPreallocatedWorkItemVtbl): IInspectable(IInspectableVtbl) [IID_IPreallocatedWorkItem] {
     fn RunAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT
@@ -6164,7 +6164,7 @@ impl ISignalNotifierStatics {
 } // Windows.System.Threading.Core
 } // Windows.System.Threading
 pub mod update { // Windows.System.Update
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum SystemUpdateAttentionRequiredReason: i32 {
     None = 0, NetworkRequired = 1, InsufficientDiskSpace = 2, InsufficientBattery = 3, UpdateBlocked = 4,
 }}
@@ -6479,7 +6479,7 @@ RT_ENUM! { enum SystemUpdateStartInstallAction: i32 {
 }}
 } // Windows.System.Update
 pub mod userprofile { // Windows.System.UserProfile
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum AccountPictureKind: i32 {
     SmallImage = 0, LargeImage = 1, Video = 2,
 }}

--- a/src/rt/gen/windows/ui/mod.rs
+++ b/src/rt/gen/windows/ui/mod.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct Color {
     A: u8, R: u8, G: u8, B: u8,
 }}
@@ -1324,7 +1324,7 @@ impl IColorsStatics {
     }}
 }
 pub mod accessibility { // Windows.UI.Accessibility
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IScreenReaderPositionChangedEventArgs, 1434367461, 21712, 23757, 159, 197, 237, 51, 53, 127, 138, 159);
 RT_INTERFACE!{interface IScreenReaderPositionChangedEventArgs(IScreenReaderPositionChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IScreenReaderPositionChangedEventArgs] {
     fn get_ScreenPositionInRawPixels(&self, out: *mut foundation::Rect) -> HRESULT,
@@ -1370,7 +1370,7 @@ impl RtActivatable<IActivationFactory> for ScreenReaderService {}
 DEFINE_CLSID!(ScreenReaderService(&[87,105,110,100,111,119,115,46,85,73,46,65,99,99,101,115,115,105,98,105,108,105,116,121,46,83,99,114,101,101,110,82,101,97,100,101,114,83,101,114,118,105,99,101,0]) [CLSID_ScreenReaderService]);
 } // Windows.UI.Accessibility
 pub mod applicationsettings { // Windows.UI.ApplicationSettings
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAccountsSettingsPane, 2179634220, 20233, 17414, 165, 56, 131, 141, 155, 20, 183, 230);
 RT_INTERFACE!{interface IAccountsSettingsPane(IAccountsSettingsPaneVtbl): IInspectable(IInspectableVtbl) [IID_IAccountsSettingsPane] {
     fn add_AccountCommandsRequested(&self, handler: *mut foundation::TypedEventHandler<AccountsSettingsPane, AccountsSettingsPaneCommandsRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -1820,7 +1820,7 @@ impl WebAccountProviderCommandInvokedHandler {
 }
 } // Windows.UI.ApplicationSettings
 pub mod composition { // Windows.UI.Composition
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAmbientLight, 2759930017, 47044, 18167, 185, 191, 218, 244, 58, 68, 230, 238);
 RT_INTERFACE!{interface IAmbientLight(IAmbientLightVtbl): IInspectable(IInspectableVtbl) [IID_IAmbientLight] {
     fn get_Color(&self, out: *mut super::Color) -> HRESULT,
@@ -6020,7 +6020,7 @@ impl IVisualUnorderedCollection {
 }
 RT_CLASS!{class VisualUnorderedCollection: IVisualUnorderedCollection}
 pub mod core { // Windows.UI.Composition.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICompositorController, 762704730, 28839, 17301, 186, 45, 206, 240, 177, 131, 153, 249);
 RT_INTERFACE!{interface ICompositorController(ICompositorControllerVtbl): IInspectable(IInspectableVtbl) [IID_ICompositorController] {
     fn get_Compositor(&self, out: *mut *mut super::Compositor) -> HRESULT,
@@ -6059,7 +6059,7 @@ impl RtActivatable<IActivationFactory> for CompositorController {}
 DEFINE_CLSID!(CompositorController(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,67,111,114,101,46,67,111,109,112,111,115,105,116,111,114,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_CompositorController]);
 } // Windows.UI.Composition.Core
 pub mod desktop { // Windows.UI.Composition.Desktop
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IDesktopWindowTarget, 1663686346, 13158, 18702, 157, 179, 37, 49, 41, 41, 172, 81);
 RT_INTERFACE!{interface IDesktopWindowTarget(IDesktopWindowTargetVtbl): IInspectable(IInspectableVtbl) [IID_IDesktopWindowTarget] {
     fn get_IsTopmost(&self, out: *mut bool) -> HRESULT
@@ -6074,7 +6074,7 @@ impl IDesktopWindowTarget {
 RT_CLASS!{class DesktopWindowTarget: IDesktopWindowTarget}
 } // Windows.UI.Composition.Desktop
 pub mod diagnostics { // Windows.UI.Composition.Diagnostics
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICompositionDebugHeatMaps, 3835465900, 12275, 22533, 113, 140, 183, 37, 238, 7, 101, 15);
 RT_INTERFACE!{interface ICompositionDebugHeatMaps(ICompositionDebugHeatMapsVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionDebugHeatMaps] {
     fn Hide(&self, subtree: *mut super::Visual) -> HRESULT,
@@ -6136,7 +6136,7 @@ impl ICompositionDebugSettingsStatics {
 }
 } // Windows.UI.Composition.Diagnostics
 pub mod effects { // Windows.UI.Composition.Effects
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISceneLightingEffect, 2444975698, 38353, 20363, 154, 90, 100, 8, 178, 75, 140, 106);
 RT_INTERFACE!{interface ISceneLightingEffect(ISceneLightingEffectVtbl): IInspectable(IInspectableVtbl) [IID_ISceneLightingEffect] {
     fn get_AmbientAmount(&self, out: *mut f32) -> HRESULT,
@@ -6144,9 +6144,9 @@ RT_INTERFACE!{interface ISceneLightingEffect(ISceneLightingEffectVtbl): IInspect
     fn get_DiffuseAmount(&self, out: *mut f32) -> HRESULT,
     fn put_DiffuseAmount(&self, value: f32) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn get_NormalMapSource(&self, out: *mut *mut ::rt::gen::windows::graphics::effects::IGraphicsEffectSource) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn get_NormalMapSource(&self, out: *mut *mut crate::windows::graphics::effects::IGraphicsEffectSource) -> HRESULT,
     #[cfg(not(feature="windows-graphics"))] fn __Dummy5(&self) -> (),
-    #[cfg(feature="windows-graphics")] fn put_NormalMapSource(&self, value: *mut ::rt::gen::windows::graphics::effects::IGraphicsEffectSource) -> HRESULT,
+    #[cfg(feature="windows-graphics")] fn put_NormalMapSource(&self, value: *mut crate::windows::graphics::effects::IGraphicsEffectSource) -> HRESULT,
     fn get_SpecularAmount(&self, out: *mut f32) -> HRESULT,
     fn put_SpecularAmount(&self, value: f32) -> HRESULT,
     fn get_SpecularShine(&self, out: *mut f32) -> HRESULT,
@@ -6171,12 +6171,12 @@ impl ISceneLightingEffect {
         let hr = ((*self.lpVtbl).put_DiffuseAmount)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn get_normal_map_source(&self) -> Result<Option<ComPtr<::rt::gen::windows::graphics::effects::IGraphicsEffectSource>>> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn get_normal_map_source(&self) -> Result<Option<ComPtr<crate::windows::graphics::effects::IGraphicsEffectSource>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_NormalMapSource)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-graphics")] #[inline] pub fn set_normal_map_source(&self, value: &::rt::gen::windows::graphics::effects::IGraphicsEffectSource) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-graphics")] #[inline] pub fn set_normal_map_source(&self, value: &crate::windows::graphics::effects::IGraphicsEffectSource) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_NormalMapSource)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -6223,7 +6223,7 @@ RT_ENUM! { enum SceneLightingEffectReflectanceModel: i32 {
 }}
 } // Windows.UI.Composition.Effects
 pub mod interactions { // Windows.UI.Composition.Interactions
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICompositionConditionalValue, 1126499640, 60275, 17761, 167, 29, 26, 67, 234, 235, 122, 155);
 RT_INTERFACE!{interface ICompositionConditionalValue(ICompositionConditionalValueVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionConditionalValue] {
     fn get_Condition(&self, out: *mut *mut super::ExpressionAnimation) -> HRESULT,
@@ -7209,7 +7209,7 @@ impl IVisualInteractionSourceStatics {
 } // Windows.UI.Composition.Interactions
 } // Windows.UI.Composition
 pub mod core { // Windows.UI.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAcceleratorKeyEventArgs, 4280044618, 37511, 18187, 131, 110, 144, 134, 227, 18, 106, 222);
 RT_INTERFACE!{interface IAcceleratorKeyEventArgs(IAcceleratorKeyEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAcceleratorKeyEventArgs] {
     fn get_EventType(&self, out: *mut CoreAcceleratorKeyEventType) -> HRESULT,
@@ -8747,7 +8747,7 @@ impl IWindowSizeChangedEventArgs {
 }
 RT_CLASS!{class WindowSizeChangedEventArgs: IWindowSizeChangedEventArgs}
 pub mod animationmetrics { // Windows.UI.Core.AnimationMetrics
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAnimationDescription, 2098308425, 48701, 16862, 176, 129, 5, 193, 73, 150, 47, 155);
 RT_INTERFACE!{interface IAnimationDescription(IAnimationDescriptionVtbl): IInspectable(IInspectableVtbl) [IID_IAnimationDescription] {
     fn get_Animations(&self, out: *mut *mut foundation::collections::IVectorView<IPropertyAnimation>) -> HRESULT,
@@ -8904,7 +8904,7 @@ RT_CLASS!{class ScaleAnimation: IScaleAnimation}
 RT_CLASS!{class TranslationAnimation: IPropertyAnimation}
 } // Windows.UI.Core.AnimationMetrics
 pub mod preview { // Windows.UI.Core.Preview
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISystemNavigationCloseRequestedPreviewEventArgs, 2211450337, 52197, 20273, 132, 20, 54, 29, 160, 70, 81, 143);
 RT_INTERFACE!{interface ISystemNavigationCloseRequestedPreviewEventArgs(ISystemNavigationCloseRequestedPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemNavigationCloseRequestedPreviewEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -8966,7 +8966,7 @@ impl ISystemNavigationManagerPreviewStatics {
 } // Windows.UI.Core.Preview
 } // Windows.UI.Core
 pub mod input { // Windows.UI.Input
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct CrossSlideThresholds {
     SelectionStart: f32, SpeedBumpStart: f32, SpeedBumpEnd: f32, RearrangeStart: f32,
 }}
@@ -10726,7 +10726,7 @@ impl ITappedEventArgs {
 }
 RT_CLASS!{class TappedEventArgs: ITappedEventArgs}
 pub mod core { // Windows.UI.Input.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IRadialControllerIndependentInputSource, 1029144310, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerIndependentInputSource(IRadialControllerIndependentInputSourceVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerIndependentInputSource] {
     fn get_Controller(&self, out: *mut *mut super::RadialController) -> HRESULT,
@@ -10747,17 +10747,17 @@ impl IRadialControllerIndependentInputSource {
 RT_CLASS!{class RadialControllerIndependentInputSource: IRadialControllerIndependentInputSource}
 impl RtActivatable<IRadialControllerIndependentInputSourceStatics> for RadialControllerIndependentInputSource {}
 impl RadialControllerIndependentInputSource {
-    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn create_for_view(view: &::rt::gen::windows::applicationmodel::core::CoreApplicationView) -> Result<Option<ComPtr<RadialControllerIndependentInputSource>>> {
+    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn create_for_view(view: &crate::windows::applicationmodel::core::CoreApplicationView) -> Result<Option<ComPtr<RadialControllerIndependentInputSource>>> {
         <Self as RtActivatable<IRadialControllerIndependentInputSourceStatics>>::get_activation_factory().create_for_view(view)
     }
 }
 DEFINE_CLSID!(RadialControllerIndependentInputSource(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,67,111,114,101,46,82,97,100,105,97,108,67,111,110,116,114,111,108,108,101,114,73,110,100,101,112,101,110,100,101,110,116,73,110,112,117,116,83,111,117,114,99,101,0]) [CLSID_RadialControllerIndependentInputSource]);
 DEFINE_IID!(IID_IRadialControllerIndependentInputSource2, 1886628568, 13811, 20203, 135, 81, 190, 77, 10, 102, 250, 244);
 RT_INTERFACE!{interface IRadialControllerIndependentInputSource2(IRadialControllerIndependentInputSource2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerIndependentInputSource2] {
-    #[cfg(feature="windows-system")] fn get_DispatcherQueue(&self, out: *mut *mut ::rt::gen::windows::system::DispatcherQueue) -> HRESULT
+    #[cfg(feature="windows-system")] fn get_DispatcherQueue(&self, out: *mut *mut crate::windows::system::DispatcherQueue) -> HRESULT
 }}
 impl IRadialControllerIndependentInputSource2 {
-    #[cfg(feature="windows-system")] #[inline] pub fn get_dispatcher_queue(&self) -> Result<Option<ComPtr<::rt::gen::windows::system::DispatcherQueue>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_dispatcher_queue(&self) -> Result<Option<ComPtr<crate::windows::system::DispatcherQueue>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_DispatcherQueue)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -10765,10 +10765,10 @@ impl IRadialControllerIndependentInputSource2 {
 }
 DEFINE_IID!(IID_IRadialControllerIndependentInputSourceStatics, 1029144309, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{static interface IRadialControllerIndependentInputSourceStatics(IRadialControllerIndependentInputSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerIndependentInputSourceStatics] {
-    #[cfg(feature="windows-applicationmodel")] fn CreateForView(&self, view: *mut ::rt::gen::windows::applicationmodel::core::CoreApplicationView, out: *mut *mut RadialControllerIndependentInputSource) -> HRESULT
+    #[cfg(feature="windows-applicationmodel")] fn CreateForView(&self, view: *mut crate::windows::applicationmodel::core::CoreApplicationView, out: *mut *mut RadialControllerIndependentInputSource) -> HRESULT
 }}
 impl IRadialControllerIndependentInputSourceStatics {
-    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn create_for_view(&self, view: &::rt::gen::windows::applicationmodel::core::CoreApplicationView) -> Result<Option<ComPtr<RadialControllerIndependentInputSource>>> { unsafe { 
+    #[cfg(feature="windows-applicationmodel")] #[inline] pub fn create_for_view(&self, view: &crate::windows::applicationmodel::core::CoreApplicationView) -> Result<Option<ComPtr<RadialControllerIndependentInputSource>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateForView)(self as *const _ as *mut _, view as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -10776,7 +10776,7 @@ impl IRadialControllerIndependentInputSourceStatics {
 }
 } // Windows.UI.Input.Core
 pub mod inking { // Windows.UI.Input.Inking
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum HandwritingLineHeight: i32 {
     Small = 0, Medium = 1, Large = 2,
 }}
@@ -11775,9 +11775,9 @@ RT_INTERFACE!{interface IInkStrokeContainer(IInkStrokeContainerVtbl): IInspectab
     fn PasteFromClipboard(&self, position: foundation::Point, out: *mut foundation::Rect) -> HRESULT,
     fn CanPasteFromClipboard(&self, out: *mut bool) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy9(&self) -> (),
-    #[cfg(feature="windows-storage")] fn LoadAsync(&self, inputStream: *mut ::rt::gen::windows::storage::streams::IInputStream, out: *mut *mut foundation::IAsyncActionWithProgress<u64>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn LoadAsync(&self, inputStream: *mut crate::windows::storage::streams::IInputStream, out: *mut *mut foundation::IAsyncActionWithProgress<u64>) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy10(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SaveAsync(&self, outputStream: *mut ::rt::gen::windows::storage::streams::IOutputStream, out: *mut *mut foundation::IAsyncOperationWithProgress<u32, u32>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SaveAsync(&self, outputStream: *mut crate::windows::storage::streams::IOutputStream, out: *mut *mut foundation::IAsyncOperationWithProgress<u32, u32>) -> HRESULT,
     fn UpdateRecognitionResults(&self, recognitionResults: *mut foundation::collections::IVectorView<InkRecognitionResult>) -> HRESULT,
     fn GetStrokes(&self, out: *mut *mut foundation::collections::IVectorView<InkStroke>) -> HRESULT,
     fn GetRecognitionResults(&self, out: *mut *mut foundation::collections::IVectorView<InkRecognitionResult>) -> HRESULT
@@ -11826,12 +11826,12 @@ impl IInkStrokeContainer {
         let hr = ((*self.lpVtbl).CanPasteFromClipboard)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn load_async(&self, inputStream: &::rt::gen::windows::storage::streams::IInputStream) -> Result<ComPtr<foundation::IAsyncActionWithProgress<u64>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn load_async(&self, inputStream: &crate::windows::storage::streams::IInputStream) -> Result<ComPtr<foundation::IAsyncActionWithProgress<u64>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).LoadAsync)(self as *const _ as *mut _, inputStream as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn save_async(&self, outputStream: &::rt::gen::windows::storage::streams::IOutputStream) -> Result<ComPtr<foundation::IAsyncOperationWithProgress<u32, u32>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn save_async(&self, outputStream: &crate::windows::storage::streams::IOutputStream) -> Result<ComPtr<foundation::IAsyncOperationWithProgress<u32, u32>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SaveAsync)(self as *const _ as *mut _, outputStream as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -11872,11 +11872,11 @@ impl IInkStrokeContainer2 {
 DEFINE_IID!(IID_IInkStrokeContainer3, 1023917733, 47850, 19586, 167, 25, 123, 131, 218, 16, 103, 210);
 RT_INTERFACE!{interface IInkStrokeContainer3(IInkStrokeContainer3Vtbl): IInspectable(IInspectableVtbl) [IID_IInkStrokeContainer3] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-storage")] fn SaveWithFormatAsync(&self, outputStream: *mut ::rt::gen::windows::storage::streams::IOutputStream, inkPersistenceFormat: InkPersistenceFormat, out: *mut *mut foundation::IAsyncOperationWithProgress<u32, u32>) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn SaveWithFormatAsync(&self, outputStream: *mut crate::windows::storage::streams::IOutputStream, inkPersistenceFormat: InkPersistenceFormat, out: *mut *mut foundation::IAsyncOperationWithProgress<u32, u32>) -> HRESULT,
     fn GetStrokeById(&self, id: u32, out: *mut *mut InkStroke) -> HRESULT
 }}
 impl IInkStrokeContainer3 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn save_with_format_async(&self, outputStream: &::rt::gen::windows::storage::streams::IOutputStream, inkPersistenceFormat: InkPersistenceFormat) -> Result<ComPtr<foundation::IAsyncOperationWithProgress<u32, u32>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn save_with_format_async(&self, outputStream: &crate::windows::storage::streams::IOutputStream, inkPersistenceFormat: InkPersistenceFormat) -> Result<ComPtr<foundation::IAsyncOperationWithProgress<u32, u32>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).SaveWithFormatAsync)(self as *const _ as *mut _, outputStream as *const _ as *mut _, inkPersistenceFormat, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -12188,7 +12188,7 @@ RT_ENUM! { enum PenTipShape: i32 {
     Circle = 0, Rectangle = 1,
 }}
 pub mod analysis { // Windows.UI.Input.Inking.Analysis
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum InkAnalysisDrawingKind: i32 {
     Drawing = 0, Circle = 1, Ellipse = 2, Triangle = 3, IsoscelesTriangle = 4, EquilateralTriangle = 5, RightTriangle = 6, Quadrilateral = 7, Rectangle = 8, Square = 9, Diamond = 10, Trapezoid = 11, Parallelogram = 12, Pentagon = 13, Hexagon = 14,
 }}
@@ -12461,7 +12461,7 @@ impl IInkAnalyzerFactory {
 }
 } // Windows.UI.Input.Inking.Analysis
 pub mod core { // Windows.UI.Input.Inking.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICoreIncrementalInkStroke, 4255126995, 40294, 20349, 165, 127, 204, 112, 185, 207, 170, 118);
 RT_INTERFACE!{interface ICoreIncrementalInkStroke(ICoreIncrementalInkStrokeVtbl): IInspectable(IInspectableVtbl) [IID_ICoreIncrementalInkStroke] {
     fn AppendInkPoints(&self, inkPoints: *mut foundation::collections::IIterable<super::InkPoint>, out: *mut foundation::Rect) -> HRESULT,
@@ -12518,24 +12518,24 @@ impl ICoreIncrementalInkStrokeFactory {
 }
 DEFINE_IID!(IID_ICoreInkIndependentInputSource, 968068521, 30265, 17561, 165, 181, 25, 29, 0, 227, 91, 22);
 RT_INTERFACE!{interface ICoreInkIndependentInputSource(ICoreInkIndependentInputSourceVtbl): IInspectable(IInspectableVtbl) [IID_ICoreInkIndependentInputSource] {
-    fn add_PointerEntering(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerEntering(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerEntering(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
-    fn add_PointerHovering(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerHovering(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerHovering(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
-    fn add_PointerExiting(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerExiting(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerExiting(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
-    fn add_PointerPressing(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerPressing(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerPressing(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
-    fn add_PointerMoving(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerMoving(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerMoving(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
-    fn add_PointerReleasing(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerReleasing(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerReleasing(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
-    fn add_PointerLost(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
+    fn add_PointerLost(&self, handler: *mut foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_PointerLost(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
     fn get_InkPresenter(&self, out: *mut *mut super::InkPresenter) -> HRESULT
 }}
 impl ICoreInkIndependentInputSource {
-    #[inline] pub fn add_pointer_entering(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_entering(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerEntering)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12544,7 +12544,7 @@ impl ICoreInkIndependentInputSource {
         let hr = ((*self.lpVtbl).remove_PointerEntering)(self as *const _ as *mut _, cookie);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[inline] pub fn add_pointer_hovering(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_hovering(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerHovering)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12553,7 +12553,7 @@ impl ICoreInkIndependentInputSource {
         let hr = ((*self.lpVtbl).remove_PointerHovering)(self as *const _ as *mut _, cookie);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[inline] pub fn add_pointer_exiting(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_exiting(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerExiting)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12562,7 +12562,7 @@ impl ICoreInkIndependentInputSource {
         let hr = ((*self.lpVtbl).remove_PointerExiting)(self as *const _ as *mut _, cookie);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[inline] pub fn add_pointer_pressing(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_pressing(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerPressing)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12571,7 +12571,7 @@ impl ICoreInkIndependentInputSource {
         let hr = ((*self.lpVtbl).remove_PointerPressing)(self as *const _ as *mut _, cookie);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[inline] pub fn add_pointer_moving(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_moving(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerMoving)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12580,7 +12580,7 @@ impl ICoreInkIndependentInputSource {
         let hr = ((*self.lpVtbl).remove_PointerMoving)(self as *const _ as *mut _, cookie);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[inline] pub fn add_pointer_releasing(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_releasing(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerReleasing)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12589,7 +12589,7 @@ impl ICoreInkIndependentInputSource {
         let hr = ((*self.lpVtbl).remove_PointerReleasing)(self as *const _ as *mut _, cookie);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[inline] pub fn add_pointer_lost(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, super::super::super::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
+    #[inline] pub fn add_pointer_lost(&self, handler: &foundation::TypedEventHandler<CoreInkIndependentInputSource, crate::windows::ui::core::PointerEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).add_PointerLost)(self as *const _ as *mut _, handler as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
@@ -12626,8 +12626,8 @@ impl ICoreInkIndependentInputSourceStatics {
 DEFINE_IID!(IID_ICoreInkPresenterHost, 963545574, 32085, 17943, 158, 88, 104, 199, 12, 145, 105, 185);
 RT_INTERFACE!{interface ICoreInkPresenterHost(ICoreInkPresenterHostVtbl): IInspectable(IInspectableVtbl) [IID_ICoreInkPresenterHost] {
     fn get_InkPresenter(&self, out: *mut *mut super::InkPresenter) -> HRESULT,
-    fn get_RootVisual(&self, out: *mut *mut super::super::super::composition::ContainerVisual) -> HRESULT,
-    fn put_RootVisual(&self, value: *mut super::super::super::composition::ContainerVisual) -> HRESULT
+    fn get_RootVisual(&self, out: *mut *mut crate::windows::ui::composition::ContainerVisual) -> HRESULT,
+    fn put_RootVisual(&self, value: *mut crate::windows::ui::composition::ContainerVisual) -> HRESULT
 }}
 impl ICoreInkPresenterHost {
     #[inline] pub fn get_ink_presenter(&self) -> Result<Option<ComPtr<super::InkPresenter>>> { unsafe { 
@@ -12635,12 +12635,12 @@ impl ICoreInkPresenterHost {
         let hr = ((*self.lpVtbl).get_InkPresenter)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[inline] pub fn get_root_visual(&self) -> Result<Option<ComPtr<super::super::super::composition::ContainerVisual>>> { unsafe { 
+    #[inline] pub fn get_root_visual(&self) -> Result<Option<ComPtr<crate::windows::ui::composition::ContainerVisual>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_RootVisual)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[inline] pub fn set_root_visual(&self, value: &super::super::super::composition::ContainerVisual) -> Result<()> { unsafe { 
+    #[inline] pub fn set_root_visual(&self, value: &crate::windows::ui::composition::ContainerVisual) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_RootVisual)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -12767,7 +12767,7 @@ impl ICoreWetStrokeUpdateSourceStatics {
 }
 } // Windows.UI.Input.Inking.Core
 pub mod preview { // Windows.UI.Input.Inking.Preview
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IPalmRejectionDelayZonePreview, 1656002251, 21405, 21315, 166, 95, 65, 245, 48, 14, 199, 12);
 RT_INTERFACE!{interface IPalmRejectionDelayZonePreview(IPalmRejectionDelayZonePreviewVtbl): IInspectable(IInspectableVtbl) [IID_IPalmRejectionDelayZonePreview] {
     
@@ -12775,26 +12775,26 @@ RT_INTERFACE!{interface IPalmRejectionDelayZonePreview(IPalmRejectionDelayZonePr
 RT_CLASS!{class PalmRejectionDelayZonePreview: IPalmRejectionDelayZonePreview}
 impl RtActivatable<IPalmRejectionDelayZonePreviewStatics> for PalmRejectionDelayZonePreview {}
 impl PalmRejectionDelayZonePreview {
-    #[inline] pub fn create_for_visual(inputPanelVisual: &super::super::super::composition::Visual, inputPanelRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> {
+    #[inline] pub fn create_for_visual(inputPanelVisual: &crate::windows::ui::composition::Visual, inputPanelRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> {
         <Self as RtActivatable<IPalmRejectionDelayZonePreviewStatics>>::get_activation_factory().create_for_visual(inputPanelVisual, inputPanelRect)
     }
-    #[inline] pub fn create_for_visual_with_viewport_clip(inputPanelVisual: &super::super::super::composition::Visual, inputPanelRect: foundation::Rect, viewportVisual: &super::super::super::composition::Visual, viewportRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> {
+    #[inline] pub fn create_for_visual_with_viewport_clip(inputPanelVisual: &crate::windows::ui::composition::Visual, inputPanelRect: foundation::Rect, viewportVisual: &crate::windows::ui::composition::Visual, viewportRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> {
         <Self as RtActivatable<IPalmRejectionDelayZonePreviewStatics>>::get_activation_factory().create_for_visual_with_viewport_clip(inputPanelVisual, inputPanelRect, viewportVisual, viewportRect)
     }
 }
 DEFINE_CLSID!(PalmRejectionDelayZonePreview(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,80,114,101,118,105,101,119,46,80,97,108,109,82,101,106,101,99,116,105,111,110,68,101,108,97,121,90,111,110,101,80,114,101,118,105,101,119,0]) [CLSID_PalmRejectionDelayZonePreview]);
 DEFINE_IID!(IID_IPalmRejectionDelayZonePreviewStatics, 3455016672, 37840, 21417, 143, 14, 154, 55, 159, 143, 117, 48);
 RT_INTERFACE!{static interface IPalmRejectionDelayZonePreviewStatics(IPalmRejectionDelayZonePreviewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPalmRejectionDelayZonePreviewStatics] {
-    fn CreateForVisual(&self, inputPanelVisual: *mut super::super::super::composition::Visual, inputPanelRect: foundation::Rect, out: *mut *mut PalmRejectionDelayZonePreview) -> HRESULT,
-    fn CreateForVisualWithViewportClip(&self, inputPanelVisual: *mut super::super::super::composition::Visual, inputPanelRect: foundation::Rect, viewportVisual: *mut super::super::super::composition::Visual, viewportRect: foundation::Rect, out: *mut *mut PalmRejectionDelayZonePreview) -> HRESULT
+    fn CreateForVisual(&self, inputPanelVisual: *mut crate::windows::ui::composition::Visual, inputPanelRect: foundation::Rect, out: *mut *mut PalmRejectionDelayZonePreview) -> HRESULT,
+    fn CreateForVisualWithViewportClip(&self, inputPanelVisual: *mut crate::windows::ui::composition::Visual, inputPanelRect: foundation::Rect, viewportVisual: *mut crate::windows::ui::composition::Visual, viewportRect: foundation::Rect, out: *mut *mut PalmRejectionDelayZonePreview) -> HRESULT
 }}
 impl IPalmRejectionDelayZonePreviewStatics {
-    #[inline] pub fn create_for_visual(&self, inputPanelVisual: &super::super::super::composition::Visual, inputPanelRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> { unsafe { 
+    #[inline] pub fn create_for_visual(&self, inputPanelVisual: &crate::windows::ui::composition::Visual, inputPanelRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateForVisual)(self as *const _ as *mut _, inputPanelVisual as *const _ as *mut _, inputPanelRect, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[inline] pub fn create_for_visual_with_viewport_clip(&self, inputPanelVisual: &super::super::super::composition::Visual, inputPanelRect: foundation::Rect, viewportVisual: &super::super::super::composition::Visual, viewportRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> { unsafe { 
+    #[inline] pub fn create_for_visual_with_viewport_clip(&self, inputPanelVisual: &crate::windows::ui::composition::Visual, inputPanelRect: foundation::Rect, viewportVisual: &crate::windows::ui::composition::Visual, viewportRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateForVisualWithViewportClip)(self as *const _ as *mut _, inputPanelVisual as *const _ as *mut _, inputPanelRect, viewportVisual as *const _ as *mut _, viewportRect, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -12804,16 +12804,16 @@ impl IPalmRejectionDelayZonePreviewStatics {
 } // Windows.UI.Input.Inking
 pub mod preview { // Windows.UI.Input.Preview
 pub mod injection { // Windows.UI.Input.Preview.Injection
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum InjectedInputButtonChangeKind: i32 {
     None = 0, FirstButtonDown = 1, FirstButtonUp = 2, SecondButtonDown = 3, SecondButtonUp = 4, ThirdButtonDown = 5, ThirdButtonUp = 6, FourthButtonDown = 7, FourthButtonUp = 8, FifthButtonDown = 9, FifthButtonUp = 10,
 }}
 DEFINE_IID!(IID_IInjectedInputGamepadInfo, 548313663, 57105, 17778, 169, 171, 215, 91, 138, 94, 72, 173);
 RT_INTERFACE!{interface IInjectedInputGamepadInfo(IInjectedInputGamepadInfoVtbl): IInspectable(IInspectableVtbl) [IID_IInjectedInputGamepadInfo] {
     #[cfg(not(feature="windows-gaming"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-gaming")] fn get_Buttons(&self, out: *mut ::rt::gen::windows::gaming::input::GamepadButtons) -> HRESULT,
+    #[cfg(feature="windows-gaming")] fn get_Buttons(&self, out: *mut crate::windows::gaming::input::GamepadButtons) -> HRESULT,
     #[cfg(not(feature="windows-gaming"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-gaming")] fn put_Buttons(&self, value: ::rt::gen::windows::gaming::input::GamepadButtons) -> HRESULT,
+    #[cfg(feature="windows-gaming")] fn put_Buttons(&self, value: crate::windows::gaming::input::GamepadButtons) -> HRESULT,
     fn get_LeftThumbstickX(&self, out: *mut f64) -> HRESULT,
     fn put_LeftThumbstickX(&self, value: f64) -> HRESULT,
     fn get_LeftThumbstickY(&self, out: *mut f64) -> HRESULT,
@@ -12828,12 +12828,12 @@ RT_INTERFACE!{interface IInjectedInputGamepadInfo(IInjectedInputGamepadInfoVtbl)
     fn put_RightTrigger(&self, value: f64) -> HRESULT
 }}
 impl IInjectedInputGamepadInfo {
-    #[cfg(feature="windows-gaming")] #[inline] pub fn get_buttons(&self) -> Result<::rt::gen::windows::gaming::input::GamepadButtons> { unsafe { 
+    #[cfg(feature="windows-gaming")] #[inline] pub fn get_buttons(&self) -> Result<crate::windows::gaming::input::GamepadButtons> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_Buttons)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-gaming")] #[inline] pub fn set_buttons(&self, value: ::rt::gen::windows::gaming::input::GamepadButtons) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-gaming")] #[inline] pub fn set_buttons(&self, value: crate::windows::gaming::input::GamepadButtons) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Buttons)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -12896,17 +12896,17 @@ RT_CLASS!{class InjectedInputGamepadInfo: IInjectedInputGamepadInfo}
 impl RtActivatable<IInjectedInputGamepadInfoFactory> for InjectedInputGamepadInfo {}
 impl RtActivatable<IActivationFactory> for InjectedInputGamepadInfo {}
 impl InjectedInputGamepadInfo {
-    #[cfg(feature="windows-gaming")] #[inline] pub fn create_instance_from_gamepad_reading(reading: ::rt::gen::windows::gaming::input::GamepadReading) -> Result<ComPtr<InjectedInputGamepadInfo>> {
+    #[cfg(feature="windows-gaming")] #[inline] pub fn create_instance_from_gamepad_reading(reading: crate::windows::gaming::input::GamepadReading) -> Result<ComPtr<InjectedInputGamepadInfo>> {
         <Self as RtActivatable<IInjectedInputGamepadInfoFactory>>::get_activation_factory().create_instance_from_gamepad_reading(reading)
     }
 }
 DEFINE_CLSID!(InjectedInputGamepadInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,71,97,109,101,112,97,100,73,110,102,111,0]) [CLSID_InjectedInputGamepadInfo]);
 DEFINE_IID!(IID_IInjectedInputGamepadInfoFactory, 1499031670, 27705, 20164, 139, 42, 41, 239, 125, 225, 138, 202);
 RT_INTERFACE!{static interface IInjectedInputGamepadInfoFactory(IInjectedInputGamepadInfoFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IInjectedInputGamepadInfoFactory] {
-    #[cfg(feature="windows-gaming")] fn CreateInstanceFromGamepadReading(&self, reading: ::rt::gen::windows::gaming::input::GamepadReading, out: *mut *mut InjectedInputGamepadInfo) -> HRESULT
+    #[cfg(feature="windows-gaming")] fn CreateInstanceFromGamepadReading(&self, reading: crate::windows::gaming::input::GamepadReading, out: *mut *mut InjectedInputGamepadInfo) -> HRESULT
 }}
 impl IInjectedInputGamepadInfoFactory {
-    #[cfg(feature="windows-gaming")] #[inline] pub fn create_instance_from_gamepad_reading(&self, reading: ::rt::gen::windows::gaming::input::GamepadReading) -> Result<ComPtr<InjectedInputGamepadInfo>> { unsafe { 
+    #[cfg(feature="windows-gaming")] #[inline] pub fn create_instance_from_gamepad_reading(&self, reading: crate::windows::gaming::input::GamepadReading) -> Result<ComPtr<InjectedInputGamepadInfo>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateInstanceFromGamepadReading)(self as *const _ as *mut _, reading, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -13304,7 +13304,7 @@ impl IInputInjectorStatics2 {
 } // Windows.UI.Input.Preview.Injection
 } // Windows.UI.Input.Preview
 pub mod spatial { // Windows.UI.Input.Spatial
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ISpatialGestureRecognizer, 1902140364, 3125, 18035, 173, 189, 204, 4, 202, 166, 239, 69);
 RT_INTERFACE!{interface ISpatialGestureRecognizer(ISpatialGestureRecognizerVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialGestureRecognizer] {
     fn add_RecognitionStarted(&self, handler: *mut foundation::TypedEventHandler<SpatialGestureRecognizer, SpatialRecognitionStartedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -13535,7 +13535,7 @@ RT_CLASS!{class SpatialHoldCompletedEventArgs: ISpatialHoldCompletedEventArgs}
 DEFINE_IID!(IID_ISpatialHoldStartedEventArgs, 2385788281, 44214, 16708, 134, 21, 44, 251, 168, 163, 203, 63);
 RT_INTERFACE!{interface ISpatialHoldStartedEventArgs(ISpatialHoldStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialHoldStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT
 }}
 impl ISpatialHoldStartedEventArgs {
     #[inline] pub fn get_interaction_source_kind(&self) -> Result<SpatialInteractionSourceKind> { unsafe { 
@@ -13543,7 +13543,7 @@ impl ISpatialHoldStartedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13567,7 +13567,7 @@ RT_INTERFACE!{interface ISpatialInteractionController(ISpatialInteractionControl
     fn get_HasTouchpad(&self, out: *mut bool) -> HRESULT,
     fn get_HasThumbstick(&self, out: *mut bool) -> HRESULT,
     #[cfg(not(feature="windows-devices"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-devices")] fn get_SimpleHapticsController(&self, out: *mut *mut ::rt::gen::windows::devices::haptics::SimpleHapticsController) -> HRESULT,
+    #[cfg(feature="windows-devices")] fn get_SimpleHapticsController(&self, out: *mut *mut crate::windows::devices::haptics::SimpleHapticsController) -> HRESULT,
     fn get_VendorId(&self, out: *mut u16) -> HRESULT,
     fn get_ProductId(&self, out: *mut u16) -> HRESULT,
     fn get_Version(&self, out: *mut u16) -> HRESULT
@@ -13583,7 +13583,7 @@ impl ISpatialInteractionController {
         let hr = ((*self.lpVtbl).get_HasThumbstick)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-devices")] #[inline] pub fn get_simple_haptics_controller(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::haptics::SimpleHapticsController>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn get_simple_haptics_controller(&self) -> Result<Option<ComPtr<crate::windows::devices::haptics::SimpleHapticsController>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_SimpleHapticsController)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13607,10 +13607,10 @@ impl ISpatialInteractionController {
 RT_CLASS!{class SpatialInteractionController: ISpatialInteractionController}
 DEFINE_IID!(IID_ISpatialInteractionController2, 901175588, 51106, 18871, 183, 46, 84, 54, 178, 251, 143, 156);
 RT_INTERFACE!{interface ISpatialInteractionController2(ISpatialInteractionController2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionController2] {
-    #[cfg(feature="windows-storage")] fn TryGetRenderableModelAsync(&self, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStreamWithContentType>) -> HRESULT
+    #[cfg(feature="windows-storage")] fn TryGetRenderableModelAsync(&self, out: *mut *mut foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStreamWithContentType>) -> HRESULT
 }}
 impl ISpatialInteractionController2 {
-    #[cfg(feature="windows-storage")] #[inline] pub fn try_get_renderable_model_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStreamWithContentType>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn try_get_renderable_model_async(&self) -> Result<ComPtr<foundation::IAsyncOperation<crate::windows::storage::streams::IRandomAccessStreamWithContentType>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetRenderableModelAsync)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
@@ -13618,10 +13618,10 @@ impl ISpatialInteractionController2 {
 }
 DEFINE_IID!(IID_ISpatialInteractionController3, 1652844192, 40337, 18955, 136, 141, 22, 94, 103, 10, 140, 213);
 RT_INTERFACE!{interface ISpatialInteractionController3(ISpatialInteractionController3Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionController3] {
-    #[cfg(feature="windows-devices")] fn TryGetBatteryReport(&self, out: *mut *mut ::rt::gen::windows::devices::power::BatteryReport) -> HRESULT
+    #[cfg(feature="windows-devices")] fn TryGetBatteryReport(&self, out: *mut *mut crate::windows::devices::power::BatteryReport) -> HRESULT
 }}
 impl ISpatialInteractionController3 {
-    #[cfg(feature="windows-devices")] #[inline] pub fn try_get_battery_report(&self) -> Result<Option<ComPtr<::rt::gen::windows::devices::power::BatteryReport>>> { unsafe { 
+    #[cfg(feature="windows-devices")] #[inline] pub fn try_get_battery_report(&self) -> Result<Option<ComPtr<crate::windows::devices::power::BatteryReport>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetBatteryReport)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13679,7 +13679,7 @@ DEFINE_IID!(IID_ISpatialInteractionDetectedEventArgs, 123238628, 22881, 15169, 1
 RT_INTERFACE!{interface ISpatialInteractionDetectedEventArgs(ISpatialInteractionDetectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionDetectedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
     #[cfg(not(feature="windows-perception"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
     fn get_Interaction(&self, out: *mut *mut SpatialInteraction) -> HRESULT
 }}
 impl ISpatialInteractionDetectedEventArgs {
@@ -13688,7 +13688,7 @@ impl ISpatialInteractionDetectedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13725,7 +13725,7 @@ RT_INTERFACE!{interface ISpatialInteractionManager(ISpatialInteractionManagerVtb
     fn remove_SourceReleased(&self, token: foundation::EventRegistrationToken) -> HRESULT,
     fn add_InteractionDetected(&self, handler: *mut foundation::TypedEventHandler<SpatialInteractionManager, SpatialInteractionDetectedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_InteractionDetected(&self, token: foundation::EventRegistrationToken) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn GetDetectedSourcesAtTimestamp(&self, timeStamp: *mut ::rt::gen::windows::perception::PerceptionTimestamp, out: *mut *mut foundation::collections::IVectorView<SpatialInteractionSourceState>) -> HRESULT
+    #[cfg(feature="windows-perception")] fn GetDetectedSourcesAtTimestamp(&self, timeStamp: *mut crate::windows::perception::PerceptionTimestamp, out: *mut *mut foundation::collections::IVectorView<SpatialInteractionSourceState>) -> HRESULT
 }}
 impl ISpatialInteractionManager {
     #[inline] pub fn add_source_detected(&self, handler: &foundation::TypedEventHandler<SpatialInteractionManager, SpatialInteractionSourceEventArgs>) -> Result<foundation::EventRegistrationToken> { unsafe { 
@@ -13782,7 +13782,7 @@ impl ISpatialInteractionManager {
         let hr = ((*self.lpVtbl).remove_InteractionDetected)(self as *const _ as *mut _, token);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn get_detected_sources_at_timestamp(&self, timeStamp: &::rt::gen::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<foundation::collections::IVectorView<SpatialInteractionSourceState>>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn get_detected_sources_at_timestamp(&self, timeStamp: &crate::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<foundation::collections::IVectorView<SpatialInteractionSourceState>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).GetDetectedSourcesAtTimestamp)(self as *const _ as *mut _, timeStamp as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13834,7 +13834,7 @@ RT_INTERFACE!{interface ISpatialInteractionSource2(ISpatialInteractionSource2Vtb
     fn get_IsMenuSupported(&self, out: *mut bool) -> HRESULT,
     fn get_IsGraspSupported(&self, out: *mut bool) -> HRESULT,
     fn get_Controller(&self, out: *mut *mut SpatialInteractionController) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetStateAtTimestamp(&self, timestamp: *mut ::rt::gen::windows::perception::PerceptionTimestamp, out: *mut *mut SpatialInteractionSourceState) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetStateAtTimestamp(&self, timestamp: *mut crate::windows::perception::PerceptionTimestamp, out: *mut *mut SpatialInteractionSourceState) -> HRESULT
 }}
 impl ISpatialInteractionSource2 {
     #[inline] pub fn get_is_pointing_supported(&self) -> Result<bool> { unsafe { 
@@ -13857,7 +13857,7 @@ impl ISpatialInteractionSource2 {
         let hr = ((*self.lpVtbl).get_Controller)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_state_at_timestamp(&self, timestamp: &::rt::gen::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialInteractionSourceState>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_state_at_timestamp(&self, timestamp: &crate::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialInteractionSourceState>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetStateAtTimestamp)(self as *const _ as *mut _, timestamp as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13960,12 +13960,12 @@ RT_ENUM! { enum SpatialInteractionSourcePositionAccuracy: i32 {
 }}
 DEFINE_IID!(IID_ISpatialInteractionSourceProperties, 90195266, 16119, 12834, 159, 83, 99, 201, 203, 126, 59, 199);
 RT_INTERFACE!{interface ISpatialInteractionSourceProperties(ISpatialInteractionSourcePropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionSourceProperties] {
-    #[cfg(feature="windows-perception")] fn TryGetSourceLossMitigationDirection(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut foundation::IReference<foundation::numerics::Vector3>) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn TryGetSourceLossMitigationDirection(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut foundation::IReference<foundation::numerics::Vector3>) -> HRESULT,
     fn get_SourceLossRisk(&self, out: *mut f64) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetLocation(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialInteractionSourceLocation) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetLocation(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialInteractionSourceLocation) -> HRESULT
 }}
 impl ISpatialInteractionSourceProperties {
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_source_loss_mitigation_direction(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<foundation::IReference<foundation::numerics::Vector3>>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_source_loss_mitigation_direction(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<foundation::IReference<foundation::numerics::Vector3>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetSourceLossMitigationDirection)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13975,7 +13975,7 @@ impl ISpatialInteractionSourceProperties {
         let hr = ((*self.lpVtbl).get_SourceLossRisk)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_location(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialInteractionSourceLocation>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_location(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialInteractionSourceLocation>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetLocation)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -13987,8 +13987,8 @@ RT_INTERFACE!{interface ISpatialInteractionSourceState(ISpatialInteractionSource
     fn get_Source(&self, out: *mut *mut SpatialInteractionSource) -> HRESULT,
     fn get_Properties(&self, out: *mut *mut SpatialInteractionSourceProperties) -> HRESULT,
     fn get_IsPressed(&self, out: *mut bool) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn get_Timestamp(&self, out: *mut *mut ::rt::gen::windows::perception::PerceptionTimestamp) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT
+    #[cfg(feature="windows-perception")] fn get_Timestamp(&self, out: *mut *mut crate::windows::perception::PerceptionTimestamp) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT
 }}
 impl ISpatialInteractionSourceState {
     #[inline] pub fn get_source(&self) -> Result<Option<ComPtr<SpatialInteractionSource>>> { unsafe { 
@@ -14006,12 +14006,12 @@ impl ISpatialInteractionSourceState {
         let hr = ((*self.lpVtbl).get_IsPressed)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn get_timestamp(&self) -> Result<Option<ComPtr<::rt::gen::windows::perception::PerceptionTimestamp>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn get_timestamp(&self) -> Result<Option<ComPtr<crate::windows::perception::PerceptionTimestamp>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Timestamp)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14068,7 +14068,7 @@ RT_CLASS!{class SpatialManipulationCanceledEventArgs: ISpatialManipulationCancel
 DEFINE_IID!(IID_ISpatialManipulationCompletedEventArgs, 84436994, 62209, 17219, 146, 80, 47, 186, 165, 248, 122, 55);
 RT_INTERFACE!{interface ISpatialManipulationCompletedEventArgs(ISpatialManipulationCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationCompletedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetCumulativeDelta(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialManipulationDelta) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetCumulativeDelta(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialManipulationDelta) -> HRESULT
 }}
 impl ISpatialManipulationCompletedEventArgs {
     #[inline] pub fn get_interaction_source_kind(&self) -> Result<SpatialInteractionSourceKind> { unsafe { 
@@ -14076,7 +14076,7 @@ impl ISpatialManipulationCompletedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_cumulative_delta(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialManipulationDelta>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_cumulative_delta(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialManipulationDelta>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetCumulativeDelta)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14098,7 +14098,7 @@ RT_CLASS!{class SpatialManipulationDelta: ISpatialManipulationDelta}
 DEFINE_IID!(IID_ISpatialManipulationStartedEventArgs, 2715204558, 17061, 14203, 173, 166, 210, 142, 61, 56, 71, 55);
 RT_INTERFACE!{interface ISpatialManipulationStartedEventArgs(ISpatialManipulationStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT
 }}
 impl ISpatialManipulationStartedEventArgs {
     #[inline] pub fn get_interaction_source_kind(&self) -> Result<SpatialInteractionSourceKind> { unsafe { 
@@ -14106,7 +14106,7 @@ impl ISpatialManipulationStartedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14116,7 +14116,7 @@ RT_CLASS!{class SpatialManipulationStartedEventArgs: ISpatialManipulationStarted
 DEFINE_IID!(IID_ISpatialManipulationUpdatedEventArgs, 1596132251, 24774, 19910, 189, 201, 159, 74, 111, 21, 254, 73);
 RT_INTERFACE!{interface ISpatialManipulationUpdatedEventArgs(ISpatialManipulationUpdatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationUpdatedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn TryGetCumulativeDelta(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialManipulationDelta) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetCumulativeDelta(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialManipulationDelta) -> HRESULT
 }}
 impl ISpatialManipulationUpdatedEventArgs {
     #[inline] pub fn get_interaction_source_kind(&self) -> Result<SpatialInteractionSourceKind> { unsafe { 
@@ -14124,7 +14124,7 @@ impl ISpatialManipulationUpdatedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_cumulative_delta(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialManipulationDelta>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_cumulative_delta(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialManipulationDelta>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetCumulativeDelta)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14165,7 +14165,7 @@ DEFINE_IID!(IID_ISpatialNavigationStartedEventArgs, 1967797386, 64356, 18006, 14
 RT_INTERFACE!{interface ISpatialNavigationStartedEventArgs(ISpatialNavigationStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialNavigationStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
     #[cfg(not(feature="windows-perception"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
     fn get_IsNavigatingX(&self, out: *mut bool) -> HRESULT,
     fn get_IsNavigatingY(&self, out: *mut bool) -> HRESULT,
     fn get_IsNavigatingZ(&self, out: *mut bool) -> HRESULT
@@ -14176,7 +14176,7 @@ impl ISpatialNavigationStartedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14259,16 +14259,16 @@ impl ISpatialPointerInteractionSourcePose2 {
 }
 DEFINE_IID!(IID_ISpatialPointerPose, 1767089198, 49534, 13693, 151, 161, 114, 105, 208, 237, 45, 16);
 RT_INTERFACE!{interface ISpatialPointerPose(ISpatialPointerPoseVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialPointerPose] {
-    #[cfg(feature="windows-perception")] fn get_Timestamp(&self, out: *mut *mut ::rt::gen::windows::perception::PerceptionTimestamp) -> HRESULT,
-    #[cfg(feature="windows-perception")] fn get_Head(&self, out: *mut *mut ::rt::gen::windows::perception::people::HeadPose) -> HRESULT
+    #[cfg(feature="windows-perception")] fn get_Timestamp(&self, out: *mut *mut crate::windows::perception::PerceptionTimestamp) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn get_Head(&self, out: *mut *mut crate::windows::perception::people::HeadPose) -> HRESULT
 }}
 impl ISpatialPointerPose {
-    #[cfg(feature="windows-perception")] #[inline] pub fn get_timestamp(&self) -> Result<Option<ComPtr<::rt::gen::windows::perception::PerceptionTimestamp>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn get_timestamp(&self) -> Result<Option<ComPtr<crate::windows::perception::PerceptionTimestamp>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Timestamp)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn get_head(&self) -> Result<Option<ComPtr<::rt::gen::windows::perception::people::HeadPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn get_head(&self) -> Result<Option<ComPtr<crate::windows::perception::people::HeadPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Head)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14277,7 +14277,7 @@ impl ISpatialPointerPose {
 RT_CLASS!{class SpatialPointerPose: ISpatialPointerPose}
 impl RtActivatable<ISpatialPointerPoseStatics> for SpatialPointerPose {}
 impl SpatialPointerPose {
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_at_timestamp(coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, timestamp: &::rt::gen::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialPointerPose>>> {
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_at_timestamp(coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem, timestamp: &crate::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialPointerPose>>> {
         <Self as RtActivatable<ISpatialPointerPoseStatics>>::get_activation_factory().try_get_at_timestamp(coordinateSystem, timestamp)
     }
 }
@@ -14295,10 +14295,10 @@ impl ISpatialPointerPose2 {
 }
 DEFINE_IID!(IID_ISpatialPointerPoseStatics, 2723516841, 44193, 16096, 152, 22, 120, 92, 251, 46, 63, 184);
 RT_INTERFACE!{static interface ISpatialPointerPoseStatics(ISpatialPointerPoseStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialPointerPoseStatics] {
-    #[cfg(feature="windows-perception")] fn TryGetAtTimestamp(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, timestamp: *mut ::rt::gen::windows::perception::PerceptionTimestamp, out: *mut *mut SpatialPointerPose) -> HRESULT
+    #[cfg(feature="windows-perception")] fn TryGetAtTimestamp(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, timestamp: *mut crate::windows::perception::PerceptionTimestamp, out: *mut *mut SpatialPointerPose) -> HRESULT
 }}
 impl ISpatialPointerPoseStatics {
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_at_timestamp(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, timestamp: &::rt::gen::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_at_timestamp(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem, timestamp: &crate::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetAtTimestamp)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, timestamp as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14320,7 +14320,7 @@ DEFINE_IID!(IID_ISpatialRecognitionStartedEventArgs, 618271375, 8, 19053, 170, 8
 RT_INTERFACE!{interface ISpatialRecognitionStartedEventArgs(ISpatialRecognitionStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialRecognitionStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
     #[cfg(not(feature="windows-perception"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
     fn IsGesturePossible(&self, gesture: SpatialGestureSettings, out: *mut bool) -> HRESULT
 }}
 impl ISpatialRecognitionStartedEventArgs {
@@ -14329,7 +14329,7 @@ impl ISpatialRecognitionStartedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14345,7 +14345,7 @@ DEFINE_IID!(IID_ISpatialTappedEventArgs, 695043038, 62532, 19105, 178, 191, 157,
 RT_INTERFACE!{interface ISpatialTappedEventArgs(ISpatialTappedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialTappedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
     #[cfg(not(feature="windows-perception"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut ::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
+    #[cfg(feature="windows-perception")] fn TryGetPointerPose(&self, coordinateSystem: *mut crate::windows::perception::spatial::SpatialCoordinateSystem, out: *mut *mut SpatialPointerPose) -> HRESULT,
     fn get_TapCount(&self, out: *mut u32) -> HRESULT
 }}
 impl ISpatialTappedEventArgs {
@@ -14354,7 +14354,7 @@ impl ISpatialTappedEventArgs {
         let hr = ((*self.lpVtbl).get_InteractionSourceKind)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
+    #[cfg(feature="windows-perception")] #[inline] pub fn try_get_pointer_pose(&self, coordinateSystem: &crate::windows::perception::spatial::SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialPointerPose>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).TryGetPointerPose)(self as *const _ as *mut _, coordinateSystem as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -14369,7 +14369,7 @@ RT_CLASS!{class SpatialTappedEventArgs: ISpatialTappedEventArgs}
 } // Windows.UI.Input.Spatial
 } // Windows.UI.Input
 pub mod notifications { // Windows.UI.Notifications
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdaptiveNotificationContent, 3943546470, 29768, 17549, 157, 184, 215, 138, 205, 42, 187, 169);
 RT_INTERFACE!{interface IAdaptiveNotificationContent(IAdaptiveNotificationContentVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveNotificationContent] {
     fn get_Kind(&self, out: *mut AdaptiveNotificationContentKind) -> HRESULT,
@@ -16340,7 +16340,7 @@ RT_ENUM! { enum UserNotificationChangedKind: i32 {
     Added = 0, Removed = 1,
 }}
 pub mod management { // Windows.UI.Notifications.Management
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUserNotificationListener, 1649753665, 35334, 19695, 130, 21, 96, 51, 165, 190, 75, 3);
 RT_INTERFACE!{interface IUserNotificationListener(IUserNotificationListenerVtbl): IInspectable(IInspectableVtbl) [IID_IUserNotificationListener] {
     fn RequestAccessAsync(&self, out: *mut *mut foundation::IAsyncOperation<UserNotificationListenerAccessStatus>) -> HRESULT,
@@ -16416,7 +16416,7 @@ impl IUserNotificationListenerStatics {
 } // Windows.UI.Notifications.Management
 } // Windows.UI.Notifications
 pub mod popups { // Windows.UI.Popups
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IMessageDialog, 871734017, 21285, 17323, 154, 179, 189, 174, 68, 14, 65, 33);
 RT_INTERFACE!{interface IMessageDialog(IMessageDialogVtbl): IInspectable(IInspectableVtbl) [IID_IMessageDialog] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -16646,7 +16646,7 @@ impl RtActivatable<IActivationFactory> for UICommandSeparator {}
 DEFINE_CLSID!(UICommandSeparator(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,85,73,67,111,109,109,97,110,100,83,101,112,97,114,97,116,111,114,0]) [CLSID_UICommandSeparator]);
 } // Windows.UI.Popups
 pub mod shell { // Windows.UI.Shell
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAdaptiveCard, 1926256268, 41588, 16845, 130, 168, 152, 157, 64, 185, 176, 94);
 RT_INTERFACE!{interface IAdaptiveCard(IAdaptiveCardVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveCard] {
     fn ToJson(&self, out: *mut HSTRING) -> HRESULT
@@ -16795,7 +16795,7 @@ impl ITaskbarManagerStatics {
 }
 } // Windows.UI.Shell
 pub mod startscreen { // Windows.UI.StartScreen
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum ForegroundText: i32 {
     Dark = 0, Light = 1,
 }}
@@ -17628,7 +17628,7 @@ impl IVisualElementsRequestedEventArgs {
 RT_CLASS!{class VisualElementsRequestedEventArgs: IVisualElementsRequestedEventArgs}
 } // Windows.UI.StartScreen
 pub mod text { // Windows.UI.Text
-use ::prelude::*;
+use crate::prelude::*;
 RT_ENUM! { enum CaretType: i32 {
     Normal = 0, Null = 1,
 }}
@@ -19095,7 +19095,7 @@ RT_ENUM! { enum VerticalCharacterAlignment: i32 {
     Top = 0, Baseline = 1, Bottom = 2,
 }}
 pub mod core { // Windows.UI.Text.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICoreTextCompositionCompletedEventArgs, 523561910, 47007, 16673, 165, 231, 253, 169, 184, 97, 110, 48);
 RT_INTERFACE!{interface ICoreTextCompositionCompletedEventArgs(ICoreTextCompositionCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextCompositionCompletedEventArgs] {
     fn get_IsCanceled(&self, out: *mut bool) -> HRESULT,
@@ -19597,13 +19597,13 @@ DEFINE_CLSID!(CoreTextServicesConstants(&[87,105,110,100,111,119,115,46,85,73,46
 DEFINE_IID!(IID_ICoreTextServicesManager, 3260054915, 28170, 19082, 189, 248, 25, 72, 135, 72, 84, 186);
 RT_INTERFACE!{interface ICoreTextServicesManager(ICoreTextServicesManagerVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextServicesManager] {
     #[cfg(not(feature="windows-globalization"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-globalization")] fn get_InputLanguage(&self, out: *mut *mut ::rt::gen::windows::globalization::Language) -> HRESULT,
+    #[cfg(feature="windows-globalization")] fn get_InputLanguage(&self, out: *mut *mut crate::windows::globalization::Language) -> HRESULT,
     fn add_InputLanguageChanged(&self, handler: *mut foundation::TypedEventHandler<CoreTextServicesManager, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
     fn remove_InputLanguageChanged(&self, cookie: foundation::EventRegistrationToken) -> HRESULT,
     fn CreateEditContext(&self, out: *mut *mut CoreTextEditContext) -> HRESULT
 }}
 impl ICoreTextServicesManager {
-    #[cfg(feature="windows-globalization")] #[inline] pub fn get_input_language(&self) -> Result<Option<ComPtr<::rt::gen::windows::globalization::Language>>> { unsafe { 
+    #[cfg(feature="windows-globalization")] #[inline] pub fn get_input_language(&self) -> Result<Option<ComPtr<crate::windows::globalization::Language>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_InputLanguage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -19706,7 +19706,7 @@ RT_INTERFACE!{interface ICoreTextTextUpdatingEventArgs(ICoreTextTextUpdatingEven
     fn get_Text(&self, out: *mut HSTRING) -> HRESULT,
     fn get_NewSelection(&self, out: *mut CoreTextRange) -> HRESULT,
     #[cfg(not(feature="windows-globalization"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-globalization")] fn get_InputLanguage(&self, out: *mut *mut ::rt::gen::windows::globalization::Language) -> HRESULT,
+    #[cfg(feature="windows-globalization")] fn get_InputLanguage(&self, out: *mut *mut crate::windows::globalization::Language) -> HRESULT,
     fn get_Result(&self, out: *mut CoreTextTextUpdatingResult) -> HRESULT,
     fn put_Result(&self, value: CoreTextTextUpdatingResult) -> HRESULT,
     fn get_IsCanceled(&self, out: *mut bool) -> HRESULT,
@@ -19728,7 +19728,7 @@ impl ICoreTextTextUpdatingEventArgs {
         let hr = ((*self.lpVtbl).get_NewSelection)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-globalization")] #[inline] pub fn get_input_language(&self) -> Result<Option<ComPtr<::rt::gen::windows::globalization::Language>>> { unsafe { 
+    #[cfg(feature="windows-globalization")] #[inline] pub fn get_input_language(&self) -> Result<Option<ComPtr<crate::windows::globalization::Language>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_InputLanguage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -19760,7 +19760,7 @@ RT_ENUM! { enum CoreTextTextUpdatingResult: i32 {
 } // Windows.UI.Text.Core
 } // Windows.UI.Text
 pub mod viewmanagement { // Windows.UI.ViewManagement
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAccessibilitySettings, 4262363463, 50368, 17762, 185, 98, 19, 39, 181, 42, 213, 185);
 RT_INTERFACE!{interface IAccessibilitySettings(IAccessibilitySettingsVtbl): IInspectable(IInspectableVtbl) [IID_IAccessibilitySettings] {
     fn get_HighContrast(&self, out: *mut bool) -> HRESULT,
@@ -20982,7 +20982,7 @@ RT_ENUM! { enum ViewSizePreference: i32 {
     Default = 0, UseLess = 1, UseHalf = 2, UseMore = 3, UseMinimum = 4, UseNone = 5, Custom = 6,
 }}
 pub mod core { // Windows.UI.ViewManagement.Core
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_ICoreInputView, 3346058618, 28673, 19506, 191, 148, 37, 193, 245, 84, 203, 241);
 RT_INTERFACE!{interface ICoreInputView(ICoreInputViewVtbl): IInspectable(IInspectableVtbl) [IID_ICoreInputView] {
     fn add_OcclusionsChanged(&self, handler: *mut foundation::TypedEventHandler<CoreInputView, CoreInputViewOcclusionsChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -21185,7 +21185,7 @@ RT_ENUM! { enum CoreInputViewXYFocusTransferDirection: i32 {
 } // Windows.UI.ViewManagement.Core
 } // Windows.UI.ViewManagement
 pub mod webui { // Windows.UI.WebUI
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IActivatedDeferral, 3283949944, 42033, 18904, 167, 106, 57, 90, 78, 3, 220, 243);
 RT_INTERFACE!{interface IActivatedDeferral(IActivatedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IActivatedDeferral] {
     fn Complete(&self) -> HRESULT

--- a/src/rt/gen/windows/web.rs
+++ b/src/rt/gen/windows/web.rs
@@ -1,4 +1,4 @@
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IUriToStreamResolver, 2964039786, 39659, 19770, 149, 144, 0, 62, 60, 167, 226, 144);
 RT_INTERFACE!{interface IUriToStreamResolver(IUriToStreamResolverVtbl): IInspectable(IInspectableVtbl) [IID_IUriToStreamResolver] {
     #[cfg(feature="windows-storage")] fn UriToStreamAsync(&self, uri: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperation<super::storage::streams::IInputStream>) -> HRESULT
@@ -33,7 +33,7 @@ RT_ENUM! { enum WebErrorStatus: i32 {
     Unknown = 0, CertificateCommonNameIsIncorrect = 1, CertificateExpired = 2, CertificateContainsErrors = 3, CertificateRevoked = 4, CertificateIsInvalid = 5, ServerUnreachable = 6, Timeout = 7, ErrorHttpInvalidServerResponse = 8, ConnectionAborted = 9, ConnectionReset = 10, Disconnected = 11, HttpToHttpsOnRedirection = 12, HttpsToHttpOnRedirection = 13, CannotConnect = 14, HostNameNotResolved = 15, OperationCanceled = 16, RedirectFailed = 17, UnexpectedStatusCode = 18, UnexpectedRedirection = 19, UnexpectedClientError = 20, UnexpectedServerError = 21, InsufficientRangeSupport = 22, MissingContentLengthSupport = 23, MultipleChoices = 300, MovedPermanently = 301, Found = 302, SeeOther = 303, NotModified = 304, UseProxy = 305, TemporaryRedirect = 307, BadRequest = 400, Unauthorized = 401, PaymentRequired = 402, Forbidden = 403, NotFound = 404, MethodNotAllowed = 405, NotAcceptable = 406, ProxyAuthenticationRequired = 407, RequestTimeout = 408, Conflict = 409, Gone = 410, LengthRequired = 411, PreconditionFailed = 412, RequestEntityTooLarge = 413, RequestUriTooLong = 414, UnsupportedMediaType = 415, RequestedRangeNotSatisfiable = 416, ExpectationFailed = 417, InternalServerError = 500, NotImplemented = 501, BadGateway = 502, ServiceUnavailable = 503, GatewayTimeout = 504, HttpVersionNotSupported = 505,
 }}
 pub mod atompub { // Windows.Web.AtomPub
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IAtomPubClient, 892939320, 52717, 19788, 150, 55, 5, 241, 92, 28, 148, 6);
 RT_INTERFACE!{interface IAtomPubClient(IAtomPubClientVtbl): IInspectable(IInspectableVtbl) [IID_IAtomPubClient] {
     fn RetrieveServiceDocumentAsync(&self, uri: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperationWithProgress<ServiceDocument, super::syndication::RetrievalProgress>) -> HRESULT,
@@ -189,7 +189,7 @@ impl IWorkspace {
 RT_CLASS!{class Workspace: IWorkspace}
 } // Windows.Web.AtomPub
 pub mod http { // Windows.Web.Http
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{class HttpBufferContent: IHttpContent}
 impl RtActivatable<IHttpBufferContentFactory> for HttpBufferContent {}
 impl HttpBufferContent {
@@ -962,7 +962,7 @@ RT_ENUM! { enum HttpVersion: i32 {
     None = 0, Http10 = 1, Http11 = 2, Http20 = 3,
 }}
 pub mod diagnostics { // Windows.Web.Http.Diagnostics
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IHttpDiagnosticProvider, 3179353345, 41046, 19769, 177, 116, 131, 59, 123, 3, 176, 44);
 RT_INTERFACE!{interface IHttpDiagnosticProvider(IHttpDiagnosticProviderVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProvider] {
     fn Start(&self) -> HRESULT,
@@ -1014,7 +1014,7 @@ impl IHttpDiagnosticProvider {
 RT_CLASS!{class HttpDiagnosticProvider: IHttpDiagnosticProvider}
 impl RtActivatable<IHttpDiagnosticProviderStatics> for HttpDiagnosticProvider {}
 impl HttpDiagnosticProvider {
-    #[cfg(feature="windows-system")] #[inline] pub fn create_from_process_diagnostic_info(processDiagnosticInfo: &::rt::gen::windows::system::diagnostics::ProcessDiagnosticInfo) -> Result<Option<ComPtr<HttpDiagnosticProvider>>> {
+    #[cfg(feature="windows-system")] #[inline] pub fn create_from_process_diagnostic_info(processDiagnosticInfo: &crate::windows::system::diagnostics::ProcessDiagnosticInfo) -> Result<Option<ComPtr<HttpDiagnosticProvider>>> {
         <Self as RtActivatable<IHttpDiagnosticProviderStatics>>::get_activation_factory().create_from_process_diagnostic_info(processDiagnosticInfo)
     }
 }
@@ -1201,10 +1201,10 @@ impl IHttpDiagnosticProviderResponseReceivedEventArgs {
 RT_CLASS!{class HttpDiagnosticProviderResponseReceivedEventArgs: IHttpDiagnosticProviderResponseReceivedEventArgs}
 DEFINE_IID!(IID_IHttpDiagnosticProviderStatics, 1535266497, 27244, 18380, 175, 236, 30, 134, 188, 38, 5, 59);
 RT_INTERFACE!{static interface IHttpDiagnosticProviderStatics(IHttpDiagnosticProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProviderStatics] {
-    #[cfg(feature="windows-system")] fn CreateFromProcessDiagnosticInfo(&self, processDiagnosticInfo: *mut ::rt::gen::windows::system::diagnostics::ProcessDiagnosticInfo, out: *mut *mut HttpDiagnosticProvider) -> HRESULT
+    #[cfg(feature="windows-system")] fn CreateFromProcessDiagnosticInfo(&self, processDiagnosticInfo: *mut crate::windows::system::diagnostics::ProcessDiagnosticInfo, out: *mut *mut HttpDiagnosticProvider) -> HRESULT
 }}
 impl IHttpDiagnosticProviderStatics {
-    #[cfg(feature="windows-system")] #[inline] pub fn create_from_process_diagnostic_info(&self, processDiagnosticInfo: &::rt::gen::windows::system::diagnostics::ProcessDiagnosticInfo) -> Result<Option<ComPtr<HttpDiagnosticProvider>>> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn create_from_process_diagnostic_info(&self, processDiagnosticInfo: &crate::windows::system::diagnostics::ProcessDiagnosticInfo) -> Result<Option<ComPtr<HttpDiagnosticProvider>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).CreateFromProcessDiagnosticInfo)(self as *const _ as *mut _, processDiagnosticInfo as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1239,7 +1239,7 @@ impl IHttpDiagnosticSourceLocation {
 RT_CLASS!{class HttpDiagnosticSourceLocation: IHttpDiagnosticSourceLocation}
 } // Windows.Web.Http.Diagnostics
 pub mod filters { // Windows.Web.Http.Filters
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IHttpBaseProtocolFilter, 1908972297, 57649, 19284, 165, 60, 235, 67, 255, 55, 233, 187);
 RT_INTERFACE!{interface IHttpBaseProtocolFilter(IHttpBaseProtocolFilterVtbl): IInspectable(IInspectableVtbl) [IID_IHttpBaseProtocolFilter] {
     fn get_AllowAutoRedirect(&self, out: *mut bool) -> HRESULT,
@@ -1251,21 +1251,21 @@ RT_INTERFACE!{interface IHttpBaseProtocolFilter(IHttpBaseProtocolFilterVtbl): II
     fn get_CacheControl(&self, out: *mut *mut HttpCacheControl) -> HRESULT,
     fn get_CookieManager(&self, out: *mut *mut super::HttpCookieManager) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy8(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_ClientCertificate(&self, out: *mut *mut ::rt::gen::windows::security::cryptography::certificates::Certificate) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_ClientCertificate(&self, out: *mut *mut crate::windows::security::cryptography::certificates::Certificate) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy9(&self) -> (),
-    #[cfg(feature="windows-security")] fn put_ClientCertificate(&self, value: *mut ::rt::gen::windows::security::cryptography::certificates::Certificate) -> HRESULT,
+    #[cfg(feature="windows-security")] fn put_ClientCertificate(&self, value: *mut crate::windows::security::cryptography::certificates::Certificate) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy10(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_IgnorableServerCertificateErrors(&self, out: *mut *mut foundation::collections::IVector<::rt::gen::windows::security::cryptography::certificates::ChainValidationResult>) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_IgnorableServerCertificateErrors(&self, out: *mut *mut foundation::collections::IVector<crate::windows::security::cryptography::certificates::ChainValidationResult>) -> HRESULT,
     fn get_MaxConnectionsPerServer(&self, out: *mut u32) -> HRESULT,
     fn put_MaxConnectionsPerServer(&self, value: u32) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy13(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_ProxyCredential(&self, out: *mut *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_ProxyCredential(&self, out: *mut *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy14(&self) -> (),
-    #[cfg(feature="windows-security")] fn put_ProxyCredential(&self, value: *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn put_ProxyCredential(&self, value: *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy15(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_ServerCredential(&self, out: *mut *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_ServerCredential(&self, out: *mut *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy16(&self) -> (),
-    #[cfg(feature="windows-security")] fn put_ServerCredential(&self, value: *mut ::rt::gen::windows::security::credentials::PasswordCredential) -> HRESULT,
+    #[cfg(feature="windows-security")] fn put_ServerCredential(&self, value: *mut crate::windows::security::credentials::PasswordCredential) -> HRESULT,
     fn get_UseProxy(&self, out: *mut bool) -> HRESULT,
     fn put_UseProxy(&self, value: bool) -> HRESULT
 }}
@@ -1307,16 +1307,16 @@ impl IHttpBaseProtocolFilter {
         let hr = ((*self.lpVtbl).get_CookieManager)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_client_certificate(&self) -> Result<Option<ComPtr<::rt::gen::windows::security::cryptography::certificates::Certificate>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_client_certificate(&self) -> Result<Option<ComPtr<crate::windows::security::cryptography::certificates::Certificate>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ClientCertificate)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn set_client_certificate(&self, value: &::rt::gen::windows::security::cryptography::certificates::Certificate) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn set_client_certificate(&self, value: &crate::windows::security::cryptography::certificates::Certificate) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ClientCertificate)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_ignorable_server_certificate_errors(&self) -> Result<Option<ComPtr<foundation::collections::IVector<::rt::gen::windows::security::cryptography::certificates::ChainValidationResult>>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_ignorable_server_certificate_errors(&self) -> Result<Option<ComPtr<foundation::collections::IVector<crate::windows::security::cryptography::certificates::ChainValidationResult>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_IgnorableServerCertificateErrors)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1330,21 +1330,21 @@ impl IHttpBaseProtocolFilter {
         let hr = ((*self.lpVtbl).put_MaxConnectionsPerServer)(self as *const _ as *mut _, value);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_proxy_credential(&self) -> Result<Option<ComPtr<::rt::gen::windows::security::credentials::PasswordCredential>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_proxy_credential(&self) -> Result<Option<ComPtr<crate::windows::security::credentials::PasswordCredential>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ProxyCredential)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn set_proxy_credential(&self, value: &::rt::gen::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn set_proxy_credential(&self, value: &crate::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ProxyCredential)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_server_credential(&self) -> Result<Option<ComPtr<::rt::gen::windows::security::credentials::PasswordCredential>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_server_credential(&self) -> Result<Option<ComPtr<crate::windows::security::credentials::PasswordCredential>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServerCredential)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn set_server_credential(&self, value: &::rt::gen::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn set_server_credential(&self, value: &crate::windows::security::credentials::PasswordCredential) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ServerCredential)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -1466,13 +1466,13 @@ DEFINE_IID!(IID_IHttpServerCustomValidationRequestedEventArgs, 828767794, 59357,
 RT_INTERFACE!{interface IHttpServerCustomValidationRequestedEventArgs(IHttpServerCustomValidationRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpServerCustomValidationRequestedEventArgs] {
     fn get_RequestMessage(&self, out: *mut *mut super::HttpRequestMessage) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_ServerCertificate(&self, out: *mut *mut ::rt::gen::windows::security::cryptography::certificates::Certificate) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_ServerCertificate(&self, out: *mut *mut crate::windows::security::cryptography::certificates::Certificate) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_ServerCertificateErrorSeverity(&self, out: *mut ::rt::gen::windows::networking::sockets::SocketSslErrorSeverity) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn get_ServerCertificateErrorSeverity(&self, out: *mut crate::windows::networking::sockets::SocketSslErrorSeverity) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy3(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_ServerCertificateErrors(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::security::cryptography::certificates::ChainValidationResult>) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_ServerCertificateErrors(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::security::cryptography::certificates::ChainValidationResult>) -> HRESULT,
     #[cfg(not(feature="windows-security"))] fn __Dummy4(&self) -> (),
-    #[cfg(feature="windows-security")] fn get_ServerIntermediateCertificates(&self, out: *mut *mut foundation::collections::IVectorView<::rt::gen::windows::security::cryptography::certificates::Certificate>) -> HRESULT,
+    #[cfg(feature="windows-security")] fn get_ServerIntermediateCertificates(&self, out: *mut *mut foundation::collections::IVectorView<crate::windows::security::cryptography::certificates::Certificate>) -> HRESULT,
     fn Reject(&self) -> HRESULT,
     fn GetDeferral(&self, out: *mut *mut foundation::Deferral) -> HRESULT
 }}
@@ -1482,22 +1482,22 @@ impl IHttpServerCustomValidationRequestedEventArgs {
         let hr = ((*self.lpVtbl).get_RequestMessage)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_server_certificate(&self) -> Result<Option<ComPtr<::rt::gen::windows::security::cryptography::certificates::Certificate>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_server_certificate(&self) -> Result<Option<ComPtr<crate::windows::security::cryptography::certificates::Certificate>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServerCertificate)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_server_certificate_error_severity(&self) -> Result<::rt::gen::windows::networking::sockets::SocketSslErrorSeverity> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_server_certificate_error_severity(&self) -> Result<crate::windows::networking::sockets::SocketSslErrorSeverity> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_ServerCertificateErrorSeverity)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_server_certificate_errors(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::security::cryptography::certificates::ChainValidationResult>>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_server_certificate_errors(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::security::cryptography::certificates::ChainValidationResult>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServerCertificateErrors)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-security")] #[inline] pub fn get_server_intermediate_certificates(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<::rt::gen::windows::security::cryptography::certificates::Certificate>>>> { unsafe { 
+    #[cfg(feature="windows-security")] #[inline] pub fn get_server_intermediate_certificates(&self) -> Result<Option<ComPtr<foundation::collections::IVectorView<crate::windows::security::cryptography::certificates::Certificate>>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ServerIntermediateCertificates)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
@@ -1515,7 +1515,7 @@ impl IHttpServerCustomValidationRequestedEventArgs {
 RT_CLASS!{class HttpServerCustomValidationRequestedEventArgs: IHttpServerCustomValidationRequestedEventArgs}
 } // Windows.Web.Http.Filters
 pub mod headers { // Windows.Web.Http.Headers
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IHttpCacheDirectiveHeaderValueCollection, 2589485961, 54736, 20414, 189, 157, 181, 179, 99, 104, 17, 180);
 RT_INTERFACE!{interface IHttpCacheDirectiveHeaderValueCollection(IHttpCacheDirectiveHeaderValueCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpCacheDirectiveHeaderValueCollection] {
     fn get_MaxAge(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -2017,9 +2017,9 @@ RT_INTERFACE!{interface IHttpContentHeaderCollection(IHttpContentHeaderCollectio
     fn get_ContentLocation(&self, out: *mut *mut foundation::Uri) -> HRESULT,
     fn put_ContentLocation(&self, value: *mut foundation::Uri) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy8(&self) -> (),
-    #[cfg(feature="windows-storage")] fn get_ContentMD5(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn get_ContentMD5(&self, out: *mut *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     #[cfg(not(feature="windows-storage"))] fn __Dummy9(&self) -> (),
-    #[cfg(feature="windows-storage")] fn put_ContentMD5(&self, value: *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT,
+    #[cfg(feature="windows-storage")] fn put_ContentMD5(&self, value: *mut crate::windows::storage::streams::IBuffer) -> HRESULT,
     fn get_ContentRange(&self, out: *mut *mut HttpContentRangeHeaderValue) -> HRESULT,
     fn put_ContentRange(&self, value: *mut HttpContentRangeHeaderValue) -> HRESULT,
     fn get_ContentType(&self, out: *mut *mut HttpMediaTypeHeaderValue) -> HRESULT,
@@ -2069,12 +2069,12 @@ impl IHttpContentHeaderCollection {
         let hr = ((*self.lpVtbl).put_ContentLocation)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn get_content_md5(&self) -> Result<Option<ComPtr<::rt::gen::windows::storage::streams::IBuffer>>> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn get_content_md5(&self) -> Result<Option<ComPtr<crate::windows::storage::streams::IBuffer>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_ContentMD5)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-storage")] #[inline] pub fn set_content_md5(&self, value: &::rt::gen::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-storage")] #[inline] pub fn set_content_md5(&self, value: &crate::windows::storage::streams::IBuffer) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_ContentMD5)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3084,9 +3084,9 @@ RT_INTERFACE!{interface IHttpRequestHeaderCollection(IHttpRequestHeaderCollectio
     fn get_From(&self, out: *mut HSTRING) -> HRESULT,
     fn put_From(&self, value: HSTRING) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy13(&self) -> (),
-    #[cfg(feature="windows-networking")] fn get_Host(&self, out: *mut *mut ::rt::gen::windows::networking::HostName) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn get_Host(&self, out: *mut *mut crate::windows::networking::HostName) -> HRESULT,
     #[cfg(not(feature="windows-networking"))] fn __Dummy14(&self) -> (),
-    #[cfg(feature="windows-networking")] fn put_Host(&self, value: *mut ::rt::gen::windows::networking::HostName) -> HRESULT,
+    #[cfg(feature="windows-networking")] fn put_Host(&self, value: *mut crate::windows::networking::HostName) -> HRESULT,
     fn get_IfModifiedSince(&self, out: *mut *mut foundation::IReference<foundation::DateTime>) -> HRESULT,
     fn put_IfModifiedSince(&self, value: *mut foundation::IReference<foundation::DateTime>) -> HRESULT,
     fn get_IfUnmodifiedSince(&self, out: *mut *mut foundation::IReference<foundation::DateTime>) -> HRESULT,
@@ -3165,12 +3165,12 @@ impl IHttpRequestHeaderCollection {
         let hr = ((*self.lpVtbl).put_From)(self as *const _ as *mut _, value.get());
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn get_host(&self) -> Result<Option<ComPtr<::rt::gen::windows::networking::HostName>>> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn get_host(&self) -> Result<Option<ComPtr<crate::windows::networking::HostName>>> { unsafe { 
         let mut out = null_mut();
         let hr = ((*self.lpVtbl).get_Host)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
-    #[cfg(feature="windows-networking")] #[inline] pub fn set_host(&self, value: &::rt::gen::windows::networking::HostName) -> Result<()> { unsafe { 
+    #[cfg(feature="windows-networking")] #[inline] pub fn set_host(&self, value: &crate::windows::networking::HostName) -> Result<()> { unsafe { 
         let hr = ((*self.lpVtbl).put_Host)(self as *const _ as *mut _, value as *const _ as *mut _);
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
@@ -3417,7 +3417,7 @@ impl IHttpTransferCodingHeaderValueStatics {
 } // Windows.Web.Http.Headers
 } // Windows.Web.Http
 pub mod syndication { // Windows.Web.Syndication
-use ::prelude::*;
+use crate::prelude::*;
 RT_STRUCT! { struct RetrievalProgress {
     BytesRetrieved: u32, TotalBytesToRetrieve: u32,
 }}
@@ -4474,7 +4474,7 @@ RT_STRUCT! { struct TransferProgress {
 }}
 } // Windows.Web.Syndication
 pub mod ui { // Windows.Web.UI
-use ::prelude::*;
+use crate::prelude::*;
 DEFINE_IID!(IID_IWebViewControl, 1066537750, 48240, 19418, 145, 54, 201, 67, 112, 137, 159, 171);
 RT_INTERFACE!{interface IWebViewControl(IWebViewControlVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControl] {
     fn get_Source(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -5185,32 +5185,32 @@ impl IWebViewControlWebResourceRequestedEventArgs {
 }
 RT_CLASS!{class WebViewControlWebResourceRequestedEventArgs: IWebViewControlWebResourceRequestedEventArgs}
 pub mod interop { // Windows.Web.UI.Interop
-use ::prelude::*;
+use crate::prelude::*;
 RT_CLASS!{class WebViewControl: super::IWebViewControl}
 DEFINE_IID!(IID_IWebViewControlAcceleratorKeyPressedEventArgs, 2007147838, 31860, 17277, 162, 144, 58, 192, 216, 205, 86, 85);
 RT_INTERFACE!{interface IWebViewControlAcceleratorKeyPressedEventArgs(IWebViewControlAcceleratorKeyPressedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlAcceleratorKeyPressedEventArgs] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_EventType(&self, out: *mut ::rt::gen::windows::ui::core::CoreAcceleratorKeyEventType) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_EventType(&self, out: *mut crate::windows::ui::core::CoreAcceleratorKeyEventType) -> HRESULT,
     #[cfg(not(feature="windows-system"))] fn __Dummy1(&self) -> (),
-    #[cfg(feature="windows-system")] fn get_VirtualKey(&self, out: *mut ::rt::gen::windows::system::VirtualKey) -> HRESULT,
+    #[cfg(feature="windows-system")] fn get_VirtualKey(&self, out: *mut crate::windows::system::VirtualKey) -> HRESULT,
     #[cfg(not(feature="windows-ui"))] fn __Dummy2(&self) -> (),
-    #[cfg(feature="windows-ui")] fn get_KeyStatus(&self, out: *mut ::rt::gen::windows::ui::core::CorePhysicalKeyStatus) -> HRESULT,
+    #[cfg(feature="windows-ui")] fn get_KeyStatus(&self, out: *mut crate::windows::ui::core::CorePhysicalKeyStatus) -> HRESULT,
     fn get_RoutingStage(&self, out: *mut WebViewControlAcceleratorKeyRoutingStage) -> HRESULT,
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
     fn put_Handled(&self, value: bool) -> HRESULT
 }}
 impl IWebViewControlAcceleratorKeyPressedEventArgs {
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_event_type(&self) -> Result<::rt::gen::windows::ui::core::CoreAcceleratorKeyEventType> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_event_type(&self) -> Result<crate::windows::ui::core::CoreAcceleratorKeyEventType> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_EventType)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-system")] #[inline] pub fn get_virtual_key(&self) -> Result<::rt::gen::windows::system::VirtualKey> { unsafe { 
+    #[cfg(feature="windows-system")] #[inline] pub fn get_virtual_key(&self) -> Result<crate::windows::system::VirtualKey> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_VirtualKey)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
-    #[cfg(feature="windows-ui")] #[inline] pub fn get_key_status(&self) -> Result<::rt::gen::windows::ui::core::CorePhysicalKeyStatus> { unsafe { 
+    #[cfg(feature="windows-ui")] #[inline] pub fn get_key_status(&self) -> Result<crate::windows::ui::core::CorePhysicalKeyStatus> { unsafe { 
         let mut out = zeroed();
         let hr = ((*self.lpVtbl).get_KeyStatus)(self as *const _ as *mut _, &mut out);
         if hr == S_OK { Ok(out) } else { err(hr) }

--- a/src/rt/handler.rs
+++ b/src/rt/handler.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic;
 
-use {IUnknown, IAgileObject, ComInterface, ComIid, ComPtr, Guid};
+use crate::{IUnknown, IAgileObject, ComInterface, ComIid, ComPtr, Guid};
 
 use w::shared::ntdef::{VOID, ULONG};
 use w::shared::winerror::S_OK;
@@ -8,7 +8,7 @@ use w::shared::winerror::E_NOINTERFACE;
 use w::shared::guiddef::REFIID;
 use w::um::unknwnbase::IUnknownVtbl;
 
-use result::HRESULT;
+use crate::result::HRESULT;
 
 #[repr(C)]
 pub struct ComRepr<T, Vtbl> {
@@ -54,7 +54,7 @@ pub unsafe extern "system" fn ComReprHandler_QueryInterface<T, I>(this_: *mut IU
 
     // IAgileObject is only supported for Send objects
     if guid != *IUnknown::iid() && guid != *IAgileObject::iid() && guid != *<I as ComIid>::iid() { 
-        *ppv = ::std::ptr::null_mut();
+        *ppv = std::ptr::null_mut();
         return E_NOINTERFACE;
     }
     *ppv = this_ as *mut _ as *mut VOID;
@@ -84,7 +84,7 @@ impl<T, Interface: ComInterface> IntoInterface<Interface> for T where T: ComClas
     fn into_interface(self) -> ComPtr<Interface> {
         let com = Box::new(ComRepr {
             vtbl: Box::new(Self::get_vtbl()),
-            refcount: ::std::sync::atomic::AtomicUsize::new(1),
+            refcount: std::sync::atomic::AtomicUsize::new(1),
             data: self
         });
         unsafe { ComPtr::wrap(Box::into_raw(com) as *mut Interface) }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 
 use super::{ComInterface, HString, HStringReference, HStringArg, ComPtr, ComArray, ComIid, Guid};
-use HRESULT;
+use crate::HRESULT;
 
 use w::shared::ntdef::{VOID, ULONG};
 use w::shared::winerror::{S_OK, S_FALSE, CO_E_NOTINITIALIZED, REGDB_E_CLASSNOTREG};
@@ -22,7 +22,7 @@ use self::gen::windows::foundation::collections::{
 /// Represents a single UTF-16 character. This is the standard character type in WinRT. 
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct Char(pub ::w::ctypes::wchar_t); // TODO: deref to u16
+pub struct Char(pub w::ctypes::wchar_t); // TODO: deref to u16
 
 /// Marker trait for all Windows Runtime interfaces. They must inherit from `IInspectable`.
 pub unsafe trait RtInterface: ComInterface {}
@@ -74,7 +74,7 @@ impl<'a> RtType for HString {
     }
     #[doc(hidden)] #[inline]
     unsafe fn uninitialized() -> Self::Abi {
-        ::std::ptr::null_mut()
+        std::ptr::null_mut()
     }
     #[doc(hidden)] #[inline]
     unsafe fn wrap(v: Self::Abi) -> Self::Out {
@@ -95,7 +95,7 @@ impl<T> RtType for T where T: RtValueType
     }
     #[doc(hidden)] #[inline]
     unsafe fn uninitialized() -> Self::Abi {
-        ::std::mem::zeroed()
+        std::mem::zeroed()
     }
     #[doc(hidden)] #[inline]
     unsafe fn wrap(v: Self::Abi) -> Self::Out {
@@ -150,7 +150,7 @@ impl<T> RtDefaultConstructible for T where T: RtActivatable<IActivationFactory> 
 pub struct IteratorAdaptor<'a, T: RtType + 'a> {
     iter: ComPtr<IIterator<T>>,
     called_next: bool,
-    phantom: ::std::marker::PhantomData<&'a IIterable<T>>
+    phantom: std::marker::PhantomData<&'a IIterable<T>>
 }
 
 impl<'a, T: RtType + 'a> IteratorAdaptor<'a, T> {
@@ -159,7 +159,7 @@ impl<'a, T: RtType + 'a> IteratorAdaptor<'a, T> {
         IteratorAdaptor {
             iter: iter,
             called_next: false,
-            phantom: ::std::marker::PhantomData
+            phantom: std::marker::PhantomData
         }
     }
 }
@@ -180,7 +180,7 @@ impl<'a, T> Iterator for IteratorAdaptor<'a, T> where T: RtType
             match self.iter.move_next() {
                 Ok(true) => Some(self.iter.get_current().expect("IIterator::get_current failed")),
                 Ok(false) => None,
-                Err(::Error::ChangedState) => panic!("the iterator was invalidated by an operation that changed the state of the container"),
+                Err(crate::Error::ChangedState) => panic!("the iterator was invalidated by an operation that changed the state of the container"),
                 Err(e) => panic!("IIterator::move_next failed: {:?}", e),
             }
         }
@@ -205,7 +205,7 @@ impl<'a, T> IntoIterator for &'a IVector<T> where T: RtType, IIterable<T>: ComIi
     type Item = <T as RtType>::Out;
     type IntoIter = IteratorAdaptor<'a, T>;
     #[inline] fn into_iter(self) -> Self::IntoIter {
-        IteratorAdaptor::new(::comptr::query_interface::<_, IIterable<T>>(self).unwrap().first().unwrap().unwrap())
+        IteratorAdaptor::new(crate::comptr::query_interface::<_, IIterable<T>>(self).unwrap().first().unwrap().unwrap())
     }
 }
 
@@ -214,7 +214,7 @@ impl<'a, T> IntoIterator for &'a IVectorView<T> where T: RtType, IIterable<T>: C
     type Item = <T as RtType>::Out;
     type IntoIter = IteratorAdaptor<'a, T>;
     #[inline] fn into_iter(self) -> Self::IntoIter {
-        IteratorAdaptor::new(::comptr::query_interface::<_, IIterable<T>>(self).unwrap().first().unwrap().unwrap())
+        IteratorAdaptor::new(crate::comptr::query_interface::<_, IIterable<T>>(self).unwrap().first().unwrap().unwrap())
     }
 }
 
@@ -223,7 +223,7 @@ impl<'a, T> IntoIterator for &'a IObservableVector<T> where T: RtType, IIterable
     type Item = <T as RtType>::Out;
     type IntoIter = IteratorAdaptor<'a, T>;
     #[inline] fn into_iter(self) -> Self::IntoIter {
-        IteratorAdaptor::new(::comptr::query_interface::<_, IIterable<T>>(self).unwrap().first().unwrap().unwrap())
+        IteratorAdaptor::new(crate::comptr::query_interface::<_, IIterable<T>>(self).unwrap().first().unwrap().unwrap())
     }
 }
 
@@ -245,35 +245,35 @@ impl<'a, T> IntoIterator for &'a ComPtr<T> where &'a T: IntoIterator
 macro_rules! RT_INTERFACE {
     ($(#[$attr:meta])* interface $interface:ident<$t1:ident, $t2:ident> $($rest:tt)*) => {
         RT_INTERFACE!($(#[$attr])* basic $interface<$t1,$t2> $($rest)*);
-        unsafe impl<$t1: RtType, $t2: RtType> ::RtInterface for $interface<$t1,$t2> {}
-        unsafe impl<$t1: RtType, $t2: RtType> ::RtClassInterface for $interface<$t1,$t2> {}
+        unsafe impl<$t1: RtType, $t2: RtType> crate::RtInterface for $interface<$t1,$t2> {}
+        unsafe impl<$t1: RtType, $t2: RtType> crate::RtClassInterface for $interface<$t1,$t2> {}
     };
 
     ($(#[$attr:meta])* interface $interface:ident<$t1:ident> $($rest:tt)*) => {
         RT_INTERFACE!($(#[$attr])* basic $interface<$t1> $($rest)*);
-        unsafe impl<$t1: RtType> ::RtInterface for $interface<$t1> {}
-        unsafe impl<$t1: RtType> ::RtClassInterface for $interface<$t1> {}
+        unsafe impl<$t1: RtType> crate::RtInterface for $interface<$t1> {}
+        unsafe impl<$t1: RtType> crate::RtClassInterface for $interface<$t1> {}
     };
 
     ($(#[$attr:meta])* interface $interface:ident $($rest:tt)*) => {
         RT_INTERFACE!($(#[$attr])* basic $interface $($rest)*);
-        unsafe impl ::RtInterface for $interface {}
-        unsafe impl ::RtClassInterface for $interface {}
+        unsafe impl crate::RtInterface for $interface {}
+        unsafe impl crate::RtClassInterface for $interface {}
     };
 
     ($(#[$attr:meta])* static interface $interface:ident<$t1:ident, $t2:ident> $($rest:tt)*) => {
         RT_INTERFACE!($(#[$attr])* basic $interface<$t1,$t2> $($rest)*);
-        unsafe impl<$t1: RtType, $t2: RtType> ::RtInterface for $interface<$t1,$t2> {}
+        unsafe impl<$t1: RtType, $t2: RtType> crate::RtInterface for $interface<$t1,$t2> {}
     };
 
     ($(#[$attr:meta])* static interface $interface:ident<$t1:ident> $($rest:tt)*) => {
         RT_INTERFACE!($(#[$attr])* basic $interface<$t1> $($rest)*);
-        unsafe impl<$t1: RtType> ::RtInterface for $interface<$t1> {}
+        unsafe impl<$t1: RtType> crate::RtInterface for $interface<$t1> {}
     };
 
     ($(#[$attr:meta])* static interface $interface:ident $($rest:tt)*) => {
         RT_INTERFACE!($(#[$attr])* basic $interface $($rest)*);
-        unsafe impl ::RtInterface for $interface {}
+        unsafe impl crate::RtInterface for $interface {}
     };
 
     // version with no methods
@@ -289,32 +289,32 @@ macro_rules! RT_INTERFACE {
             lpVtbl: *const $vtbl
         }
         impl ComIid for $interface {
-            #[inline] fn iid() -> &'static ::Guid { &$iid }
+            #[inline] fn iid() -> &'static crate::Guid { &$iid }
         }
         impl ComInterface for $interface {
             type Vtbl = $vtbl;
         }
-        impl ::RtType for $interface {
+        impl crate::RtType for $interface {
             type In = $interface;
             type Abi = *mut $interface;
             type Out = Option<Self::OutNonNull>;
             type OutNonNull = ComPtr<$interface>;
 
             #[doc(hidden)] #[inline] unsafe fn unwrap(v: &Self::In) -> Self::Abi { v as *const _ as *mut _ }
-            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { ::std::ptr::null_mut() }
+            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { std::ptr::null_mut() }
             #[doc(hidden)] #[inline] unsafe fn wrap(v: Self::Abi) -> Self::Out { ComPtr::wrap_optional(v) }
         }
-        impl ::std::ops::Deref for $interface {
+        impl std::ops::Deref for $interface {
             type Target = $crate::$pinterface;
             #[inline]
             fn deref(&self) -> &$crate::$pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
-        impl ::std::ops::DerefMut for $interface {
+        impl std::ops::DerefMut for $interface {
             #[inline]
             fn deref_mut(&mut self) -> &mut $crate::$pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
     };
@@ -338,32 +338,32 @@ macro_rules! RT_INTERFACE {
             lpVtbl: *const $vtbl
         }
         impl ComIid for $interface {
-            #[inline] fn iid() -> &'static ::Guid { &$iid }
+            #[inline] fn iid() -> &'static crate::Guid { &$iid }
         }
         impl ComInterface for $interface {
             type Vtbl = $vtbl;
         }
-        impl ::RtType for $interface {
+        impl crate::RtType for $interface {
             type In = $interface;
             type Abi = *mut $interface;
             type Out = Option<Self::OutNonNull>;
             type OutNonNull = ComPtr<$interface>;
 
             #[doc(hidden)] #[inline] unsafe fn unwrap(v: &Self::In) -> Self::Abi { v as *const _ as *mut _ }
-            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { ::std::ptr::null_mut() }
+            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { std::ptr::null_mut() }
             #[doc(hidden)] #[inline] unsafe fn wrap(v: Self::Abi) -> Self::Out { ComPtr::wrap_optional(v) }
         }
-        impl ::std::ops::Deref for $interface {
+        impl std::ops::Deref for $interface {
             type Target = $crate::$pinterface;
             #[inline]
             fn deref(&self) -> &$crate::$pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
-        impl ::std::ops::DerefMut for $interface {
+        impl std::ops::DerefMut for $interface {
             #[inline]
             fn deref_mut(&mut self) -> &mut $crate::$pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
     };
@@ -389,27 +389,27 @@ macro_rules! RT_INTERFACE {
         impl<$t1> ComInterface for $interface<$t1> where $t1: RtType {
             type Vtbl = $vtbl<$t1>;
         }
-        impl<$t1> ::RtType for $interface<$t1> where $t1: RtType{
+        impl<$t1> crate::RtType for $interface<$t1> where $t1: RtType{
             type In = $interface<$t1>;
             type Abi = *mut $interface<$t1>;
             type Out = Option<Self::OutNonNull>;
             type OutNonNull = ComPtr<$interface<$t1>>;
 
             #[doc(hidden)] #[inline] unsafe fn unwrap(v: &Self::In) -> Self::Abi { v as *const _ as *mut _ }
-            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { ::std::ptr::null_mut() }
+            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { std::ptr::null_mut() }
             #[doc(hidden)] #[inline] unsafe fn wrap(v: Self::Abi) -> Self::Out { ComPtr::wrap_optional(v) }
         }
-        impl<$t1> ::std::ops::Deref for $interface<$t1> where $t1: RtType {
+        impl<$t1> std::ops::Deref for $interface<$t1> where $t1: RtType {
             type Target = $pinterface;
             #[inline]
             fn deref(&self) -> &$pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
-        impl<$t1> ::std::ops::DerefMut for $interface<$t1> where $t1: RtType {
+        impl<$t1> std::ops::DerefMut for $interface<$t1> where $t1: RtType {
             #[inline]
             fn deref_mut(&mut self) -> &mut $pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
     };
@@ -434,27 +434,27 @@ macro_rules! RT_INTERFACE {
         impl<$t1, $t2> ComInterface for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
             type Vtbl = $vtbl<$t1, $t2>;
         }
-        impl<$t1, $t2> ::RtType for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
+        impl<$t1, $t2> crate::RtType for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
             type In = $interface<$t1, $t2>;
             type Abi = *mut $interface<$t1, $t2>;
             type Out = Option<Self::OutNonNull>;
             type OutNonNull = ComPtr<$interface<$t1, $t2>>;
 
             #[doc(hidden)] #[inline] unsafe fn unwrap(v: &Self::In) -> Self::Abi { v as *const _ as *mut _ }
-            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { ::std::ptr::null_mut() }
+            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { std::ptr::null_mut() }
             #[doc(hidden)] #[inline] unsafe fn wrap(v: Self::Abi) -> Self::Out { ComPtr::wrap_optional(v) }
         }
-        impl<$t1, $t2> ::std::ops::Deref for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
+        impl<$t1, $t2> std::ops::Deref for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
             type Target = $pinterface;
             #[inline]
             fn deref(&self) -> &$pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
-        impl<$t1, $t2> ::std::ops::DerefMut for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
+        impl<$t1, $t2> std::ops::DerefMut for $interface<$t1, $t2> where $t1: RtType, $t2: RtType {
             #[inline]
             fn deref_mut(&mut self) -> &mut $pinterface {
-                unsafe { ::std::mem::transmute(self) }
+                unsafe { std::mem::transmute(self) }
             }
         }
     };
@@ -495,22 +495,22 @@ macro_rules! RT_DELEGATE {
         }
 
         $(#[cfg($cond_attr)])*
-        impl<_F_> ::rt::handler::ComClass<$interface> for $imp<_F_>
+        impl<_F_> crate::rt::handler::ComClass<$interface> for $imp<_F_>
             where $interface: ComIid, _F_: 'static + Send + FnMut($($t),*) -> Result<()>
         {
             #[inline]
             fn get_vtbl() -> $vtbl {
                 $vtbl {
                     parent: IUnknownVtbl {
-                        QueryInterface: ::rt::handler::ComReprHandler_QueryInterface::<$imp<_F_>, _>,
-                        AddRef: ::rt::handler::ComRepr_AddRef::<$imp<_F_>>,
-                        Release: ::rt::handler::ComRepr_Release::<$imp<_F_>>,
+                        QueryInterface: crate::rt::handler::ComReprHandler_QueryInterface::<$imp<_F_>, _>,
+                        AddRef: crate::rt::handler::ComRepr_AddRef::<$imp<_F_>>,
+                        Release: crate::rt::handler::ComRepr_Release::<$imp<_F_>>,
                     },
                     Invoke: {
                         unsafe extern "system" fn Invoke<_F_>(this_: *mut $interface $(,$p : $t)*) -> HRESULT
                             where $interface: ComIid, _F_: 'static + Send + FnMut($($t),*) -> Result<()>
                         {
-                            let this: &mut $imp<_F_> = ::rt::handler::ComClass::from_interface(this_);
+                            let this: &mut $imp<_F_> = crate::rt::handler::ComClass::from_interface(this_);
                             match (this.invoke)($($p),*) {
                                 Ok(()) => S_OK,
                                 Err(err) => err.as_hresult()
@@ -548,7 +548,7 @@ macro_rules! RT_DELEGATE {
 
         struct $imp<$($ht: RtType),+ , _F_> where _F_: 'static + Send + FnMut($($t),*) -> Result<()> {
             invoke: _F_,
-            phantom: ::std::marker::PhantomData<($($ht),+)>
+            phantom: std::marker::PhantomData<($($ht),+)>
         }
 
         impl<$($ht: RtType + 'static),+ , _F_> $imp<$($ht),+ , _F_>
@@ -558,27 +558,27 @@ macro_rules! RT_DELEGATE {
             pub fn new(f: _F_) -> $imp<$($ht),+ , _F_> {
                 $imp {
                     invoke: f,
-                    phantom: ::std::marker::PhantomData
+                    phantom: std::marker::PhantomData
                 }
             }
         }
 
-        impl<$($ht: RtType + 'static),+ , _F_> ::rt::handler::ComClass<$interface<$($ht),+>> for $imp<$($ht),+ , _F_>
+        impl<$($ht: RtType + 'static),+ , _F_> crate::rt::handler::ComClass<$interface<$($ht),+>> for $imp<$($ht),+ , _F_>
             where $interface<$($ht),+>: ComIid, _F_: 'static + Send + FnMut($($t),*) -> Result<()>
         {
             #[inline]
             fn get_vtbl() -> $vtbl<$($ht),+> {
                 $vtbl::<$($ht),+> {
                     parent: IUnknownVtbl {
-                        QueryInterface: ::rt::handler::ComReprHandler_QueryInterface::<$imp<$($ht),+ , _F_>, _>,
-                        AddRef: ::rt::handler::ComRepr_AddRef::<$imp<$($ht),+ , _F_>>,
-                        Release: ::rt::handler::ComRepr_Release::<$imp<$($ht),+ , _F_>>,
+                        QueryInterface: crate::rt::handler::ComReprHandler_QueryInterface::<$imp<$($ht),+ , _F_>, _>,
+                        AddRef: crate::rt::handler::ComRepr_AddRef::<$imp<$($ht),+ , _F_>>,
+                        Release: crate::rt::handler::ComRepr_Release::<$imp<$($ht),+ , _F_>>,
                     },
                     Invoke: {
                         unsafe extern "system" fn Invoke<$($ht: RtType + 'static),+ , _F_>(this_: *mut $interface<$($ht),+> $(,$p : $t)*) -> HRESULT
                             where $interface<$($ht),+>: ComIid, _F_: 'static + Send + FnMut($($t),*) -> Result<()>
                         {
-                            let this: &mut $imp<$($ht),+ , _F_> = ::rt::handler::ComClass::from_interface(this_);
+                            let this: &mut $imp<$($ht),+ , _F_> = crate::rt::handler::ComClass::from_interface(this_);
                             match (this.invoke)($($p),*) {
                                 Ok(()) => S_OK,
                                 Err(err) => err.as_hresult()
@@ -607,32 +607,32 @@ macro_rules! RT_CLASS {
 
     {class $cls:ident : $interface:ty} => {
         pub struct $cls($interface);
-        unsafe impl ::RtInterface for $cls {}
-        unsafe impl ::RtClassInterface for $cls {}
+        unsafe impl crate::RtInterface for $cls {}
+        unsafe impl crate::RtClassInterface for $cls {}
         impl ComInterface for $cls {
             type Vtbl = <$interface as ComInterface>::Vtbl;
         }
         impl ComIid for $cls {
-            #[inline] fn iid() -> &'static ::Guid { <$interface as ComIid>::iid() }
+            #[inline] fn iid() -> &'static crate::Guid { <$interface as ComIid>::iid() }
         }
-        impl ::RtType for $cls {
+        impl crate::RtType for $cls {
             type In = $cls;
             type Abi = *mut $cls;
             type Out = Option<Self::OutNonNull>;
             type OutNonNull = ComPtr<$cls>;
             
             #[doc(hidden)] #[inline] unsafe fn unwrap(v: &Self::In) -> Self::Abi { v as *const _ as *mut _ }
-            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { ::std::ptr::null_mut() }
+            #[doc(hidden)] #[inline] unsafe fn uninitialized() -> Self::Abi { std::ptr::null_mut() }
             #[doc(hidden)] #[inline] unsafe fn wrap(v: Self::Abi) -> Self::Out { ComPtr::wrap_optional(v) }
         }
-        impl ::std::ops::Deref for $cls {
+        impl std::ops::Deref for $cls {
             type Target = $interface;
             #[inline]
             fn deref(&self) -> &$interface {
                 &self.0
             }
         }
-        impl ::std::ops::DerefMut for $cls {
+        impl std::ops::DerefMut for $cls {
             #[inline]
             fn deref_mut(&mut self) -> &mut $interface {
                 &mut self.0
@@ -644,7 +644,7 @@ macro_rules! RT_CLASS {
 macro_rules! DEFINE_CLSID {
     ($clsname:ident($id:expr) [$idname:ident]) => {
         const $idname: &'static [u16] = $id; // Full name of the class as null-terminated UTF16 string
-        impl ::RtNamedClass for $clsname {
+        impl crate::RtNamedClass for $clsname {
             #[inline]
             fn name() -> &'static [u16] { $idname } 
         }
@@ -661,7 +661,7 @@ macro_rules! RT_ENUM {
         impl $name {
             $(pub const $variant: $name = $name($value);)+
         }
-        unsafe impl ::RtValueType for $name {}
+        unsafe impl crate::RtValueType for $name {}
     };
 }
 
@@ -671,7 +671,7 @@ macro_rules! RT_STRUCT {
         pub struct $name {
             $(pub $field: $ftype,)*
         }
-        unsafe impl ::RtValueType for $name {}
+        unsafe impl crate::RtValueType for $name {}
     };
 }
 
@@ -682,14 +682,14 @@ macro_rules! RT_PINTERFACE {
     ) => {
         DEFINE_IID!($iid, $l,$w1,$w2,$b1,$b2,$b3,$b4,$b5,$b6,$b7,$b8);
         impl ComIid for $t {
-            #[inline] fn iid() -> &'static ::Guid { &$iid }
+            #[inline] fn iid() -> &'static crate::Guid { &$iid }
         }
     };
 }
 
-pub mod handler;
-pub mod async;
-pub mod gen; // import auto-generated definitions (has to come after macro definitions)
+pub(crate) mod handler;
+pub(crate) mod async_util;
+pub(crate) mod gen; // import auto-generated definitions (has to come after macro definitions)
 
 // FIXME: maybe better reexport from winapi?
 DEFINE_IID!(IID_IInspectable, 0xAF86E2E0, 0xB12D, 0x4c6a, 0x9C, 0x5A, 0xD7, 0xAA, 0x65, 0x10, 0x1E, 0x90);
@@ -698,34 +698,34 @@ RT_INTERFACE!{
 interface IInspectable(IInspectableVtbl): IUnknown(IUnknownVtbl) [IID_IInspectable]  {
     fn GetIids(&self, iidCount: *mut ULONG, iids: *mut *mut IID) -> HRESULT,
     fn GetRuntimeClassName(&self, className: *mut HSTRING) -> HRESULT,
-    fn GetTrustLevel(&self, trustLevel: *mut ::TrustLevel) -> HRESULT
+    fn GetTrustLevel(&self, trustLevel: *mut crate::TrustLevel) -> HRESULT
 }}
 impl IInspectable {
     /// Returns the interfaces that are implemented by the current Windows Runtime object.
     #[inline]
     pub fn get_iids(&self) -> ComArray<Guid> {
-        let mut result = ::std::ptr::null_mut();
+        let mut result = std::ptr::null_mut();
         let mut count = 0;
         let hr = unsafe { ((*self.lpVtbl).GetIids)(self as *const _ as *mut _, &mut count, &mut result) };
         assert_eq!(hr, S_OK);
-        let result = result as *mut Guid; // convert from ::w::GUID to (binary compatible) Guid
+        let result = result as *mut Guid; // convert from w::GUID to (binary compatible) Guid
         unsafe { ComArray::from_raw(count, result) }
     }
 
     /// Returns the trust level of the current Windows Runtime object.
     #[inline]
-    pub fn get_trust_level(&self) -> ::TrustLevel {
-        let mut result = unsafe { ::std::mem::zeroed() };
+    pub fn get_trust_level(&self) -> crate::TrustLevel {
+        let mut result = unsafe { std::mem::zeroed() };
         let hr = unsafe { ((*self.lpVtbl).GetTrustLevel)(self as *const _ as *mut _, &mut result) };
         assert_eq!(hr, S_OK);
         result
     }
 }
 
-impl ::comptr::HiddenGetRuntimeClassName for IInspectable {
+impl crate::comptr::HiddenGetRuntimeClassName for IInspectable {
     #[inline]
     fn get_runtime_class_name(&self) -> HString {
-        let mut result = ::std::ptr::null_mut();
+        let mut result = std::ptr::null_mut();
         let hr = unsafe { ((*self.lpVtbl).GetRuntimeClassName)(self as *const _ as *mut _, &mut result) };
         assert_eq!(hr, S_OK);
         unsafe { HString::wrap(result) }
@@ -744,7 +744,7 @@ interface IActivationFactory(IActivationFactoryVtbl): IInspectable(IInspectableV
 impl IActivationFactory {
     #[inline]
     pub fn activate_instance(&self) -> ComPtr<IInspectable> {
-        let mut result = ::std::ptr::null_mut();
+        let mut result = std::ptr::null_mut();
         let hr = unsafe { ((*self.lpVtbl).ActivateInstance)(self as *const _ as *mut _, &mut result) };
         assert_eq!(hr, S_OK);
         unsafe { ComPtr::wrap(result) }
@@ -771,14 +771,14 @@ impl IMemoryBufferByteAccess {
     /// An empty slice is returned if the underlying buffer has already been closed.
     #[inline]
     pub unsafe fn get_buffer(&self) -> &[u8] {
-        let mut ptr = ::std::ptr::null_mut();
+        let mut ptr = std::ptr::null_mut();
         let mut capacity: u32 = 0;
         let hr = ((*self.lpVtbl).GetBuffer)(self as *const _ as *mut _, &mut ptr, &mut capacity);
         assert_eq!(hr, S_OK);
         if capacity == 0 {
             ptr = 1 as *mut u8; // null pointer is not allowed
         }
-        ::std::slice::from_raw_parts(ptr, capacity as usize)
+        std::slice::from_raw_parts(ptr, capacity as usize)
     }
 }
 


### PR DESCRIPTION
There should be a 0.6 release before this is merged, so we have an improved version for those who have to use an older rustc.

After the 0.6 release we're going to drop support for older compilers.