### PR TITLE
Implement runtime IID calculation for parametric interfaces via const fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["Generator/**"]
 
 [dependencies]
 winapi = { version = "0.3", features = ["winnt", "combaseapi", "oleauto", "roapi", "roerrorapi", "hstring", "winstring", "winerror", "restrictederrorinfo"] }
+uuid = { version = "0.7", features = ["v5"] }
 
 [features]
 nightly = []

--- a/Generator/ParametricInterfaceManager.cs
+++ b/Generator/ParametricInterfaceManager.cs
@@ -10,8 +10,6 @@ namespace Generator
 {
     public class ParametricInterfaceManager
     {
-        private static Guid Namespace = new Guid("11F47AD5-7B73-42C0-ABAE-878B1E16ADEE");
-
         private static IEnumerable<Type> baseTypes = new List<Type>
         {
             //typeof(void),

--- a/Generator/Types/ClassDef.cs
+++ b/Generator/Types/ClassDef.cs
@@ -86,15 +86,16 @@ namespace Generator.Types
             {
                 var dependsOnAssemblies = new List<string>(ForeignAssemblyDependencies.GroupBy(t => t.Module.Assembly.Name.Name).Select(g => g.Key));
                 var features = new FeatureConditions(dependsOnAssemblies);
+                string fullname = '"' + Type.FullName + '"';
 
                 Module.Append($@"
-{ features.GetAttribute() }RT_CLASS!{{class { DefinitionName }: { aliasedType }}}");
+{ features.GetAttribute() }RT_CLASS!{{class { DefinitionName }: { aliasedType } [{ fullname }]}}");
                 if (!features.IsEmpty)
                 {
                     // if the aliased type is from a different assembly that is not included, just use IInspectable instead
                     // otherwise types depending on this class would transitively depend on the aliased type
                     Module.Append($@"
-{ features.GetInvertedAttribute() }RT_CLASS!{{class { DefinitionName }: IInspectable}}");
+{ features.GetInvertedAttribute() }RT_CLASS!{{class { DefinitionName }: IInspectable [{ fullname }]}}");
                 }
 
                 foreach (var factory in factories.OrderBy(f => f))

--- a/Generator/Types/EnumDef.cs
+++ b/Generator/Types/EnumDef.cs
@@ -31,8 +31,9 @@ namespace Generator.Types
 
         public override void Emit()
         {
+            string fullname = '"' + Type.FullName + '"';
             Module.Append($@"
-RT_ENUM! {{ enum { DefinitionName }: { UnderlyingTypeName } {{
+RT_ENUM! {{ enum { DefinitionName }: { UnderlyingTypeName } [{ fullname }] {{
     { String.Join(", ", Type.Fields.Where(f => f.Name != "value__").Select(f => $"{ NameHelpers.PreventKeywords(f.Name) } ({ Type.Name }_{ f.Name }) = { f.Constant }")) },
 }}}}");
         }

--- a/Generator/Types/StructDef.cs
+++ b/Generator/Types/StructDef.cs
@@ -35,9 +35,10 @@ namespace Generator.Types
 
         public override void Emit()
         {
+            string fullname = '"' + Type.FullName + '"';
             // TODO: derive(Eq) whenever possible?
             Module.Append($@"
-RT_STRUCT! {{ struct { DefinitionName } {{
+RT_STRUCT! {{ struct { DefinitionName } [{ fullname }] {{
     { string.Join(", ", fields) }{ (fields.Any() ? "," : "") }
 }}}}");
         }

--- a/src/cominterfaces.rs
+++ b/src/cominterfaces.rs
@@ -14,7 +14,7 @@ pub trait ComInterface {
 pub trait ComIid {
     // TODO: use associated constant once that is stable
     //const IID: REFIID;
-    fn iid() -> &'static Guid;
+    fn iid() -> Guid;
 }
 
 // extend some definitions from winapi (re-export existing types where possible!)
@@ -22,7 +22,7 @@ DEFINE_IID!(IID_IUnknown, 0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x
 
 /// Re-export from WinAPI crate
 pub type IUnknown = ::w::um::unknwnbase::IUnknown;
-impl ComIid for IUnknown { #[inline] fn iid() -> &'static Guid { &IID_IUnknown } }
+impl ComIid for IUnknown { #[inline] fn iid() -> Guid { *IID_IUnknown } }
 impl ComInterface for IUnknown { type Vtbl = IUnknownVtbl; }
 
 DEFINE_IID!(IID_IRestrictedErrorInfo, 0x82BA7092, 0x4C88, 0x427D, 0xA7, 0xBC, 0x16, 0xDD, 0x93, 0xFE, 0xB6, 0x7E);
@@ -30,7 +30,7 @@ DEFINE_IID!(IID_IRestrictedErrorInfo, 0x82BA7092, 0x4C88, 0x427D, 0xA7, 0xBC, 0x
 /// Re-export from WinAPI crate
 pub type IRestrictedErrorInfo = ::w::um::restrictederrorinfo::IRestrictedErrorInfo;
 pub type IRestrictedErrorInfoVtbl = ::w::um::restrictederrorinfo::IRestrictedErrorInfoVtbl;
-impl ComIid for IRestrictedErrorInfo { #[inline] fn iid() -> &'static Guid { &IID_IRestrictedErrorInfo } }
+impl ComIid for IRestrictedErrorInfo { #[inline] fn iid() -> Guid { *IID_IRestrictedErrorInfo } }
 impl ComInterface for IRestrictedErrorInfo { type Vtbl = IRestrictedErrorInfoVtbl; }
 
 DEFINE_IID!(IID_IAgileObject, 0x94EA2B94, 0xE9CC, 0x49E0, 0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90);
@@ -54,5 +54,5 @@ impl ::std::ops::DerefMut for IAgileObject {
         unsafe { ::std::mem::transmute(self) }
     }
 }
-impl ComIid for IAgileObject { #[inline] fn iid() -> &'static Guid { &IID_IAgileObject } }
+impl ComIid for IAgileObject { #[inline] fn iid() -> Guid { *IID_IAgileObject } }
 impl ComInterface for IAgileObject { type Vtbl = IUnknownVtbl; }

--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 use std::fmt;
 use std::ptr;
-use ::{ComIid, ComInterface, RtInterface, RtClassInterface, IInspectable, Guid};
+use ::{ComIid, ComInterface, RtInterface, RtClassInterface, IInspectable};
 
 use w::shared::ntdef::VOID;
 use w::shared::minwindef::LPVOID;
@@ -24,7 +24,7 @@ impl<T> fmt::Pointer for ComPtr<T> {
 // This is a helper method that is not exposed publically by the library
 #[inline]
 pub fn query_interface<T, Target>(interface: &T) -> Option<ComPtr<Target>> where Target: ComIid, T: ComInterface {
-    let iid: &'static Guid = Target::iid();
+    let iid = Target::iid();
     let as_unknown = unsafe { &mut *(interface  as *const T as *mut T as *mut IUnknown) };
     let mut res = ptr::null_mut();
     unsafe {

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -1,3 +1,5 @@
+extern crate uuid;
+
 use std::{fmt, cmp, mem};
 
 use w::shared::guiddef::GUID;
@@ -43,6 +45,21 @@ impl cmp::PartialEq<Guid> for Guid {
 }
 
 impl cmp::Eq for Guid {}
+
+pub(crate) fn format_for_iid_descriptor(buffer: &mut String, guid: &Guid) { // should be const fn
+    buffer.push_str(&format!("{:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            guid.Data1, guid.Data2, guid.Data3,
+            guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
+            guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]));
+}
+
+pub(crate) fn iid_from_descriptor(descriptor: &str) -> Guid {
+    use self::uuid::Uuid;
+    let namespace = Uuid::parse_str("11F47AD5-7B73-42C0-ABAE-878B1E16ADEE").expect("invalid IID namespace UUID");
+    let iid = Uuid::new_v5(&namespace, descriptor.as_bytes());
+    let (p1, p2, p3, p4) = iid.as_fields();
+    Guid { Data1: p1, Data2: p2, Data3: p3, Data4: *p4 }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use rt::{RtInterface, RtClassInterface, RtNamedClass, RtValueType, RtType, R
              RtDefaultConstructible, IInspectable, IInspectableVtbl, IActivationFactory,
              IMemoryBufferByteAccess, Char, RuntimeContext, IteratorAdaptor};
 pub use rt::async::{RtAsyncAction, RtAsyncOperation};
+pub(crate) use rt::RtIidDescriptor;
 
 mod result;
 pub use result::{Result, Error, HRESULT};

--- a/src/rt/gen/windows/ai.rs
+++ b/src/rt/gen/windows/ai.rs
@@ -31,7 +31,7 @@ impl IImageFeatureDescriptor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageFeatureDescriptor: IImageFeatureDescriptor}
+RT_CLASS!{class ImageFeatureDescriptor: IImageFeatureDescriptor ["Windows.AI.MachineLearning.ImageFeatureDescriptor"]}
 DEFINE_IID!(IID_IImageFeatureValue, 4030812121, 51626, 17413, 183, 251, 148, 248, 124, 138, 48, 55);
 RT_INTERFACE!{interface IImageFeatureValue(IImageFeatureValueVtbl): IInspectable(IInspectableVtbl) [IID_IImageFeatureValue] {
     #[cfg(feature="windows-media")] fn get_VideoFrame(&self, out: *mut *mut super::super::media::VideoFrame) -> HRESULT
@@ -43,7 +43,7 @@ impl IImageFeatureValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageFeatureValue: IImageFeatureValue}
+RT_CLASS!{class ImageFeatureValue: IImageFeatureValue ["Windows.AI.MachineLearning.ImageFeatureValue"]}
 impl RtActivatable<IImageFeatureValueStatics> for ImageFeatureValue {}
 impl ImageFeatureValue {
     #[cfg(feature="windows-media")] #[inline] pub fn create_from_video_frame(image: &super::super::media::VideoFrame) -> Result<Option<ComPtr<ImageFeatureValue>>> {
@@ -115,7 +115,7 @@ impl ILearningModel {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModel: ILearningModel}
+RT_CLASS!{class LearningModel: ILearningModel ["Windows.AI.MachineLearning.LearningModel"]}
 impl RtActivatable<ILearningModelStatics> for LearningModel {}
 impl LearningModel {
     #[cfg(feature="windows-storage")] #[inline] pub fn load_from_storage_file_async(modelFile: &super::super::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<LearningModel>>> {
@@ -164,7 +164,7 @@ impl ILearningModelBinding {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelBinding: ILearningModelBinding}
+RT_CLASS!{class LearningModelBinding: ILearningModelBinding ["Windows.AI.MachineLearning.LearningModelBinding"]}
 impl RtActivatable<ILearningModelBindingFactory> for LearningModelBinding {}
 impl LearningModelBinding {
     #[inline] pub fn create_from_session(session: &LearningModelSession) -> Result<ComPtr<LearningModelBinding>> {
@@ -200,7 +200,7 @@ impl ILearningModelDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelDevice: ILearningModelDevice}
+RT_CLASS!{class LearningModelDevice: ILearningModelDevice ["Windows.AI.MachineLearning.LearningModelDevice"]}
 impl RtActivatable<ILearningModelDeviceFactory> for LearningModelDevice {}
 impl RtActivatable<ILearningModelDeviceStatics> for LearningModelDevice {}
 impl LearningModelDevice {
@@ -223,7 +223,7 @@ impl ILearningModelDeviceFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LearningModelDeviceKind: i32 {
+RT_ENUM! { enum LearningModelDeviceKind: i32 ["Windows.AI.MachineLearning.LearningModelDeviceKind"] {
     Default (LearningModelDeviceKind_Default) = 0, Cpu (LearningModelDeviceKind_Cpu) = 1, DirectX (LearningModelDeviceKind_DirectX) = 2, DirectXHighPerformance (LearningModelDeviceKind_DirectXHighPerformance) = 3, DirectXMinPower (LearningModelDeviceKind_DirectXMinPower) = 4,
 }}
 DEFINE_IID!(IID_ILearningModelDeviceStatics, 1240670471, 43199, 17083, 146, 199, 16, 177, 45, 197, 210, 31);
@@ -266,7 +266,7 @@ impl ILearningModelEvaluationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelEvaluationResult: ILearningModelEvaluationResult}
+RT_CLASS!{class LearningModelEvaluationResult: ILearningModelEvaluationResult ["Windows.AI.MachineLearning.LearningModelEvaluationResult"]}
 DEFINE_IID!(IID_ILearningModelFeatureDescriptor, 3154694012, 28368, 16388, 151, 186, 185, 162, 238, 205, 43, 79);
 RT_INTERFACE!{interface ILearningModelFeatureDescriptor(ILearningModelFeatureDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_ILearningModelFeatureDescriptor] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -296,7 +296,7 @@ impl ILearningModelFeatureDescriptor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LearningModelFeatureKind: i32 {
+RT_ENUM! { enum LearningModelFeatureKind: i32 ["Windows.AI.MachineLearning.LearningModelFeatureKind"] {
     Tensor (LearningModelFeatureKind_Tensor) = 0, Sequence (LearningModelFeatureKind_Sequence) = 1, Map (LearningModelFeatureKind_Map) = 2, Image (LearningModelFeatureKind_Image) = 3,
 }}
 DEFINE_IID!(IID_ILearningModelFeatureValue, 4111467995, 16517, 19966, 159, 237, 149, 235, 12, 12, 247, 92);
@@ -361,7 +361,7 @@ impl ILearningModelSession {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelSession: ILearningModelSession}
+RT_CLASS!{class LearningModelSession: ILearningModelSession ["Windows.AI.MachineLearning.LearningModelSession"]}
 impl RtActivatable<ILearningModelSessionFactory> for LearningModelSession {}
 impl LearningModelSession {
     #[inline] pub fn create_from_model(model: &LearningModel) -> Result<ComPtr<LearningModelSession>> {
@@ -459,7 +459,7 @@ impl IMapFeatureDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapFeatureDescriptor: IMapFeatureDescriptor}
+RT_CLASS!{class MapFeatureDescriptor: IMapFeatureDescriptor ["Windows.AI.MachineLearning.MapFeatureDescriptor"]}
 DEFINE_IID!(IID_ISequenceFeatureDescriptor, 2230752346, 22059, 19810, 168, 81, 115, 154, 206, 217, 102, 104);
 RT_INTERFACE!{interface ISequenceFeatureDescriptor(ISequenceFeatureDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_ISequenceFeatureDescriptor] {
     fn get_ElementDescriptor(&self, out: *mut *mut ILearningModelFeatureDescriptor) -> HRESULT
@@ -471,7 +471,7 @@ impl ISequenceFeatureDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SequenceFeatureDescriptor: ISequenceFeatureDescriptor}
+RT_CLASS!{class SequenceFeatureDescriptor: ISequenceFeatureDescriptor ["Windows.AI.MachineLearning.SequenceFeatureDescriptor"]}
 DEFINE_IID!(IID_ITensor, 88642963, 41733, 18981, 173, 9, 68, 1, 25, 180, 183, 246);
 RT_INTERFACE!{interface ITensor(ITensorVtbl): IInspectable(IInspectableVtbl) [IID_ITensor] {
     fn get_TensorKind(&self, out: *mut TensorKind) -> HRESULT,
@@ -500,7 +500,7 @@ impl ITensorBoolean {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorBoolean: ITensorBoolean}
+RT_CLASS!{class TensorBoolean: ITensorBoolean ["Windows.AI.MachineLearning.TensorBoolean"]}
 impl RtActivatable<ITensorBooleanStatics> for TensorBoolean {}
 impl TensorBoolean {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorBoolean>>> {
@@ -557,7 +557,7 @@ impl ITensorDouble {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorDouble: ITensorDouble}
+RT_CLASS!{class TensorDouble: ITensorDouble ["Windows.AI.MachineLearning.TensorDouble"]}
 impl RtActivatable<ITensorDoubleStatics> for TensorDouble {}
 impl TensorDouble {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorDouble>>> {
@@ -620,7 +620,7 @@ impl ITensorFeatureDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorFeatureDescriptor: ITensorFeatureDescriptor}
+RT_CLASS!{class TensorFeatureDescriptor: ITensorFeatureDescriptor ["Windows.AI.MachineLearning.TensorFeatureDescriptor"]}
 DEFINE_IID!(IID_ITensorFloat, 4062719362, 43522, 17096, 160, 200, 223, 30, 252, 150, 118, 225);
 RT_INTERFACE!{interface ITensorFloat(ITensorFloatVtbl): IInspectable(IInspectableVtbl) [IID_ITensorFloat] {
     fn GetAsVectorView(&self, out: *mut *mut foundation::collections::IVectorView<f32>) -> HRESULT
@@ -632,7 +632,7 @@ impl ITensorFloat {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorFloat: ITensorFloat}
+RT_CLASS!{class TensorFloat: ITensorFloat ["Windows.AI.MachineLearning.TensorFloat"]}
 impl RtActivatable<ITensorFloatStatics> for TensorFloat {}
 impl TensorFloat {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorFloat>>> {
@@ -660,7 +660,7 @@ impl ITensorFloat16Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorFloat16Bit: ITensorFloat16Bit}
+RT_CLASS!{class TensorFloat16Bit: ITensorFloat16Bit ["Windows.AI.MachineLearning.TensorFloat16Bit"]}
 impl RtActivatable<ITensorFloat16BitStatics> for TensorFloat16Bit {}
 impl TensorFloat16Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorFloat16Bit>>> {
@@ -746,7 +746,7 @@ impl ITensorInt16Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorInt16Bit: ITensorInt16Bit}
+RT_CLASS!{class TensorInt16Bit: ITensorInt16Bit ["Windows.AI.MachineLearning.TensorInt16Bit"]}
 impl RtActivatable<ITensorInt16BitStatics> for TensorInt16Bit {}
 impl TensorInt16Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorInt16Bit>>> {
@@ -803,7 +803,7 @@ impl ITensorInt32Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorInt32Bit: ITensorInt32Bit}
+RT_CLASS!{class TensorInt32Bit: ITensorInt32Bit ["Windows.AI.MachineLearning.TensorInt32Bit"]}
 impl RtActivatable<ITensorInt32BitStatics> for TensorInt32Bit {}
 impl TensorInt32Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorInt32Bit>>> {
@@ -860,7 +860,7 @@ impl ITensorInt64Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorInt64Bit: ITensorInt64Bit}
+RT_CLASS!{class TensorInt64Bit: ITensorInt64Bit ["Windows.AI.MachineLearning.TensorInt64Bit"]}
 impl RtActivatable<ITensorInt64BitStatics> for TensorInt64Bit {}
 impl TensorInt64Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorInt64Bit>>> {
@@ -917,7 +917,7 @@ impl ITensorInt8Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorInt8Bit: ITensorInt8Bit}
+RT_CLASS!{class TensorInt8Bit: ITensorInt8Bit ["Windows.AI.MachineLearning.TensorInt8Bit"]}
 impl RtActivatable<ITensorInt8BitStatics> for TensorInt8Bit {}
 impl TensorInt8Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorInt8Bit>>> {
@@ -963,7 +963,7 @@ impl ITensorInt8BitStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TensorKind: i32 {
+RT_ENUM! { enum TensorKind: i32 ["Windows.AI.MachineLearning.TensorKind"] {
     Undefined (TensorKind_Undefined) = 0, Float (TensorKind_Float) = 1, UInt8 (TensorKind_UInt8) = 2, Int8 (TensorKind_Int8) = 3, UInt16 (TensorKind_UInt16) = 4, Int16 (TensorKind_Int16) = 5, Int32 (TensorKind_Int32) = 6, Int64 (TensorKind_Int64) = 7, String (TensorKind_String) = 8, Boolean (TensorKind_Boolean) = 9, Float16 (TensorKind_Float16) = 10, Double (TensorKind_Double) = 11, UInt32 (TensorKind_UInt32) = 12, UInt64 (TensorKind_UInt64) = 13, Complex64 (TensorKind_Complex64) = 14, Complex128 (TensorKind_Complex128) = 15,
 }}
 DEFINE_IID!(IID_ITensorString, 1478702536, 48561, 17936, 188, 117, 53, 233, 203, 240, 9, 183);
@@ -977,7 +977,7 @@ impl ITensorString {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorString: ITensorString}
+RT_CLASS!{class TensorString: ITensorString ["Windows.AI.MachineLearning.TensorString"]}
 impl RtActivatable<ITensorStringStatics> for TensorString {}
 impl TensorString {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorString>>> {
@@ -1034,7 +1034,7 @@ impl ITensorUInt16Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorUInt16Bit: ITensorUInt16Bit}
+RT_CLASS!{class TensorUInt16Bit: ITensorUInt16Bit ["Windows.AI.MachineLearning.TensorUInt16Bit"]}
 impl RtActivatable<ITensorUInt16BitStatics> for TensorUInt16Bit {}
 impl TensorUInt16Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorUInt16Bit>>> {
@@ -1091,7 +1091,7 @@ impl ITensorUInt32Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorUInt32Bit: ITensorUInt32Bit}
+RT_CLASS!{class TensorUInt32Bit: ITensorUInt32Bit ["Windows.AI.MachineLearning.TensorUInt32Bit"]}
 impl RtActivatable<ITensorUInt32BitStatics> for TensorUInt32Bit {}
 impl TensorUInt32Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorUInt32Bit>>> {
@@ -1148,7 +1148,7 @@ impl ITensorUInt64Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorUInt64Bit: ITensorUInt64Bit}
+RT_CLASS!{class TensorUInt64Bit: ITensorUInt64Bit ["Windows.AI.MachineLearning.TensorUInt64Bit"]}
 impl RtActivatable<ITensorUInt64BitStatics> for TensorUInt64Bit {}
 impl TensorUInt64Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorUInt64Bit>>> {
@@ -1205,7 +1205,7 @@ impl ITensorUInt8Bit {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorUInt8Bit: ITensorUInt8Bit}
+RT_CLASS!{class TensorUInt8Bit: ITensorUInt8Bit ["Windows.AI.MachineLearning.TensorUInt8Bit"]}
 impl RtActivatable<ITensorUInt8BitStatics> for TensorUInt8Bit {}
 impl TensorUInt8Bit {
     #[inline] pub fn create() -> Result<Option<ComPtr<TensorUInt8Bit>>> {
@@ -1253,7 +1253,7 @@ impl ITensorUInt8BitStatics {
 }
 pub mod preview { // Windows.AI.MachineLearning.Preview
 use ::prelude::*;
-RT_ENUM! { enum FeatureElementKindPreview: i32 {
+RT_ENUM! { enum FeatureElementKindPreview: i32 ["Windows.AI.MachineLearning.Preview.FeatureElementKindPreview"] {
     Undefined (FeatureElementKindPreview_Undefined) = 0, Float (FeatureElementKindPreview_Float) = 1, UInt8 (FeatureElementKindPreview_UInt8) = 2, Int8 (FeatureElementKindPreview_Int8) = 3, UInt16 (FeatureElementKindPreview_UInt16) = 4, Int16 (FeatureElementKindPreview_Int16) = 5, Int32 (FeatureElementKindPreview_Int32) = 6, Int64 (FeatureElementKindPreview_Int64) = 7, String (FeatureElementKindPreview_String) = 8, Boolean (FeatureElementKindPreview_Boolean) = 9, Float16 (FeatureElementKindPreview_Float16) = 10, Double (FeatureElementKindPreview_Double) = 11, UInt32 (FeatureElementKindPreview_UInt32) = 12, UInt64 (FeatureElementKindPreview_UInt64) = 13, Complex64 (FeatureElementKindPreview_Complex64) = 14, Complex128 (FeatureElementKindPreview_Complex128) = 15,
 }}
 DEFINE_IID!(IID_IImageVariableDescriptorPreview, 2061630066, 670, 19909, 162, 248, 95, 183, 99, 21, 65, 80);
@@ -1280,7 +1280,7 @@ impl IImageVariableDescriptorPreview {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageVariableDescriptorPreview: IImageVariableDescriptorPreview}
+RT_CLASS!{class ImageVariableDescriptorPreview: IImageVariableDescriptorPreview ["Windows.AI.MachineLearning.Preview.ImageVariableDescriptorPreview"]}
 DEFINE_IID!(IID_IInferencingOptionsPreview, 1203536389, 19766, 18345, 143, 104, 255, 203, 51, 157, 208, 252);
 RT_INTERFACE!{interface IInferencingOptionsPreview(IInferencingOptionsPreviewVtbl): IInspectable(IInspectableVtbl) [IID_IInferencingOptionsPreview] {
     fn get_PreferredDeviceKind(&self, out: *mut LearningModelDeviceKindPreview) -> HRESULT,
@@ -1341,7 +1341,7 @@ impl IInferencingOptionsPreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InferencingOptionsPreview: IInferencingOptionsPreview}
+RT_CLASS!{class InferencingOptionsPreview: IInferencingOptionsPreview ["Windows.AI.MachineLearning.Preview.InferencingOptionsPreview"]}
 DEFINE_IID!(IID_ILearningModelBindingPreview, 2479423976, 27768, 19279, 174, 193, 166, 187, 158, 105, 22, 36);
 RT_INTERFACE!{interface ILearningModelBindingPreview(ILearningModelBindingPreviewVtbl): IInspectable(IInspectableVtbl) [IID_ILearningModelBindingPreview] {
     fn Bind(&self, name: HSTRING, value: *mut IInspectable) -> HRESULT,
@@ -1362,7 +1362,7 @@ impl ILearningModelBindingPreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelBindingPreview: ILearningModelBindingPreview}
+RT_CLASS!{class LearningModelBindingPreview: ILearningModelBindingPreview ["Windows.AI.MachineLearning.Preview.LearningModelBindingPreview"]}
 impl RtActivatable<ILearningModelBindingPreviewFactory> for LearningModelBindingPreview {}
 impl LearningModelBindingPreview {
     #[inline] pub fn create_from_model(model: &LearningModelPreview) -> Result<ComPtr<LearningModelBindingPreview>> {
@@ -1434,8 +1434,8 @@ impl ILearningModelDescriptionPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelDescriptionPreview: ILearningModelDescriptionPreview}
-RT_ENUM! { enum LearningModelDeviceKindPreview: i32 {
+RT_CLASS!{class LearningModelDescriptionPreview: ILearningModelDescriptionPreview ["Windows.AI.MachineLearning.Preview.LearningModelDescriptionPreview"]}
+RT_ENUM! { enum LearningModelDeviceKindPreview: i32 ["Windows.AI.MachineLearning.Preview.LearningModelDeviceKindPreview"] {
     LearningDeviceAny (LearningModelDeviceKindPreview_LearningDeviceAny) = 0, LearningDeviceCpu (LearningModelDeviceKindPreview_LearningDeviceCpu) = 1, LearningDeviceGpu (LearningModelDeviceKindPreview_LearningDeviceGpu) = 2, LearningDeviceNpu (LearningModelDeviceKindPreview_LearningDeviceNpu) = 3, LearningDeviceDsp (LearningModelDeviceKindPreview_LearningDeviceDsp) = 4, LearningDeviceFpga (LearningModelDeviceKindPreview_LearningDeviceFpga) = 5,
 }}
 DEFINE_IID!(IID_ILearningModelEvaluationResultPreview, 3743804063, 39011, 16520, 132, 152, 135, 161, 244, 104, 111, 146);
@@ -1455,8 +1455,8 @@ impl ILearningModelEvaluationResultPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelEvaluationResultPreview: ILearningModelEvaluationResultPreview}
-RT_ENUM! { enum LearningModelFeatureKindPreview: i32 {
+RT_CLASS!{class LearningModelEvaluationResultPreview: ILearningModelEvaluationResultPreview ["Windows.AI.MachineLearning.Preview.LearningModelEvaluationResultPreview"]}
+RT_ENUM! { enum LearningModelFeatureKindPreview: i32 ["Windows.AI.MachineLearning.Preview.LearningModelFeatureKindPreview"] {
     Undefined (LearningModelFeatureKindPreview_Undefined) = 0, Tensor (LearningModelFeatureKindPreview_Tensor) = 1, Sequence (LearningModelFeatureKindPreview_Sequence) = 2, Map (LearningModelFeatureKindPreview_Map) = 3, Image (LearningModelFeatureKindPreview_Image) = 4,
 }}
 DEFINE_IID!(IID_ILearningModelPreview, 77342314, 37812, 18316, 174, 184, 112, 21, 123, 240, 255, 148);
@@ -1493,7 +1493,7 @@ impl ILearningModelPreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelPreview: ILearningModelPreview}
+RT_CLASS!{class LearningModelPreview: ILearningModelPreview ["Windows.AI.MachineLearning.Preview.LearningModelPreview"]}
 impl RtActivatable<ILearningModelPreviewStatics> for LearningModelPreview {}
 impl LearningModelPreview {
     #[cfg(feature="windows-storage")] #[inline] pub fn load_model_from_storage_file_async(modelFile: &::rt::gen::windows::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<LearningModelPreview>>> {
@@ -1550,7 +1550,7 @@ impl ILearningModelVariableDescriptorPreview {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LearningModelVariableDescriptorPreview: ILearningModelVariableDescriptorPreview}
+RT_CLASS!{class LearningModelVariableDescriptorPreview: ILearningModelVariableDescriptorPreview ["Windows.AI.MachineLearning.Preview.LearningModelVariableDescriptorPreview"]}
 DEFINE_IID!(IID_IMapVariableDescriptorPreview, 1018397552, 49195, 16950, 179, 232, 107, 220, 164, 156, 49, 41);
 RT_INTERFACE!{interface IMapVariableDescriptorPreview(IMapVariableDescriptorPreviewVtbl): IInspectable(IInspectableVtbl) [IID_IMapVariableDescriptorPreview] {
     fn get_KeyKind(&self, out: *mut FeatureElementKindPreview) -> HRESULT,
@@ -1580,7 +1580,7 @@ impl IMapVariableDescriptorPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapVariableDescriptorPreview: IMapVariableDescriptorPreview}
+RT_CLASS!{class MapVariableDescriptorPreview: IMapVariableDescriptorPreview ["Windows.AI.MachineLearning.Preview.MapVariableDescriptorPreview"]}
 DEFINE_IID!(IID_ISequenceVariableDescriptorPreview, 2631463570, 39090, 17712, 161, 182, 45, 237, 95, 236, 188, 38);
 RT_INTERFACE!{interface ISequenceVariableDescriptorPreview(ISequenceVariableDescriptorPreviewVtbl): IInspectable(IInspectableVtbl) [IID_ISequenceVariableDescriptorPreview] {
     fn get_ElementType(&self, out: *mut *mut ILearningModelVariableDescriptorPreview) -> HRESULT
@@ -1592,7 +1592,7 @@ impl ISequenceVariableDescriptorPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SequenceVariableDescriptorPreview: ISequenceVariableDescriptorPreview}
+RT_CLASS!{class SequenceVariableDescriptorPreview: ISequenceVariableDescriptorPreview ["Windows.AI.MachineLearning.Preview.SequenceVariableDescriptorPreview"]}
 DEFINE_IID!(IID_ITensorVariableDescriptorPreview, 2819575834, 39596, 16947, 151, 132, 172, 234, 249, 37, 16, 181);
 RT_INTERFACE!{interface ITensorVariableDescriptorPreview(ITensorVariableDescriptorPreviewVtbl): IInspectable(IInspectableVtbl) [IID_ITensorVariableDescriptorPreview] {
     fn get_DataType(&self, out: *mut FeatureElementKindPreview) -> HRESULT,
@@ -1610,6 +1610,6 @@ impl ITensorVariableDescriptorPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TensorVariableDescriptorPreview: ITensorVariableDescriptorPreview}
+RT_CLASS!{class TensorVariableDescriptorPreview: ITensorVariableDescriptorPreview ["Windows.AI.MachineLearning.Preview.TensorVariableDescriptorPreview"]}
 } // Windows.AI.MachineLearning.Preview
 } // Windows.AI.MachineLearning

--- a/src/rt/gen/windows/applicationmodel.rs
+++ b/src/rt/gen/windows/applicationmodel.rs
@@ -1,5 +1,5 @@
 use ::prelude::*;
-RT_ENUM! { enum AddResourcePackageOptions: u32 {
+RT_ENUM! { enum AddResourcePackageOptions: u32 ["Windows.ApplicationModel.AddResourcePackageOptions"] {
     None (AddResourcePackageOptions_None) = 0, ForceTargetAppShutdown (AddResourcePackageOptions_ForceTargetAppShutdown) = 1, ApplyUpdateIfAvailable (AddResourcePackageOptions_ApplyUpdateIfAvailable) = 2,
 }}
 DEFINE_IID!(IID_IAppDisplayInfo, 451612931, 58580, 16810, 164, 246, 196, 162, 118, 231, 158, 172);
@@ -25,7 +25,7 @@ impl IAppDisplayInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppDisplayInfo: IAppDisplayInfo}
+RT_CLASS!{class AppDisplayInfo: IAppDisplayInfo ["Windows.ApplicationModel.AppDisplayInfo"]}
 DEFINE_IID!(IID_IAppInfo, 3481229747, 27145, 19944, 166, 192, 87, 146, 213, 104, 128, 209);
 RT_INTERFACE!{interface IAppInfo(IAppInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAppInfo] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -55,7 +55,7 @@ impl IAppInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInfo: IAppInfo}
+RT_CLASS!{class AppInfo: IAppInfo ["Windows.ApplicationModel.AppInfo"]}
 DEFINE_IID!(IID_IAppInstallerInfo, 699083456, 54518, 17059, 173, 205, 214, 88, 60, 101, 149, 8);
 RT_INTERFACE!{interface IAppInstallerInfo(IAppInstallerInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallerInfo] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT
@@ -67,7 +67,7 @@ impl IAppInstallerInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstallerInfo: IAppInstallerInfo}
+RT_CLASS!{class AppInstallerInfo: IAppInstallerInfo ["Windows.ApplicationModel.AppInstallerInfo"]}
 DEFINE_IID!(IID_IAppInstance, 1734290247, 62047, 17714, 159, 214, 54, 51, 224, 99, 77, 1);
 RT_INTERFACE!{interface IAppInstance(IAppInstanceVtbl): IInspectable(IInspectableVtbl) [IID_IAppInstance] {
     fn get_Key(&self, out: *mut HSTRING) -> HRESULT,
@@ -90,7 +90,7 @@ impl IAppInstance {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstance: IAppInstance}
+RT_CLASS!{class AppInstance: IAppInstance ["Windows.ApplicationModel.AppInstance"]}
 impl RtActivatable<IAppInstanceStatics> for AppInstance {}
 impl AppInstance {
     #[inline] pub fn get_recommended_instance() -> Result<Option<ComPtr<AppInstance>>> {
@@ -189,7 +189,7 @@ impl IEnteredBackgroundEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EnteredBackgroundEventArgs: IEnteredBackgroundEventArgs}
+RT_CLASS!{class EnteredBackgroundEventArgs: IEnteredBackgroundEventArgs ["Windows.ApplicationModel.EnteredBackgroundEventArgs"]}
 RT_CLASS!{static class FullTrustProcessLauncher}
 impl RtActivatable<IFullTrustProcessLauncherStatics> for FullTrustProcessLauncher {}
 impl FullTrustProcessLauncher {
@@ -247,7 +247,7 @@ impl ILeavingBackgroundEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LeavingBackgroundEventArgs: ILeavingBackgroundEventArgs}
+RT_CLASS!{class LeavingBackgroundEventArgs: ILeavingBackgroundEventArgs ["Windows.ApplicationModel.LeavingBackgroundEventArgs"]}
 DEFINE_IID!(IID_ILimitedAccessFeatureRequestResult, 3562100390, 7716, 24029, 171, 180, 97, 136, 171, 164, 213, 191);
 RT_INTERFACE!{interface ILimitedAccessFeatureRequestResult(ILimitedAccessFeatureRequestResultVtbl): IInspectable(IInspectableVtbl) [IID_ILimitedAccessFeatureRequestResult] {
     fn get_FeatureId(&self, out: *mut HSTRING) -> HRESULT,
@@ -271,7 +271,7 @@ impl ILimitedAccessFeatureRequestResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LimitedAccessFeatureRequestResult: ILimitedAccessFeatureRequestResult}
+RT_CLASS!{class LimitedAccessFeatureRequestResult: ILimitedAccessFeatureRequestResult ["Windows.ApplicationModel.LimitedAccessFeatureRequestResult"]}
 RT_CLASS!{static class LimitedAccessFeatures}
 impl RtActivatable<ILimitedAccessFeaturesStatics> for LimitedAccessFeatures {}
 impl LimitedAccessFeatures {
@@ -291,7 +291,7 @@ impl ILimitedAccessFeaturesStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LimitedAccessFeatureStatus: i32 {
+RT_ENUM! { enum LimitedAccessFeatureStatus: i32 ["Windows.ApplicationModel.LimitedAccessFeatureStatus"] {
     Unavailable (LimitedAccessFeatureStatus_Unavailable) = 0, Available (LimitedAccessFeatureStatus_Available) = 1, AvailableWithoutToken (LimitedAccessFeatureStatus_AvailableWithoutToken) = 2, Unknown (LimitedAccessFeatureStatus_Unknown) = 3,
 }}
 DEFINE_IID!(IID_IPackage, 373061935, 48501, 16700, 191, 35, 177, 254, 123, 149, 216, 37);
@@ -324,7 +324,7 @@ impl IPackage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Package: IPackage}
+RT_CLASS!{class Package: IPackage ["Windows.ApplicationModel.Package"]}
 impl RtActivatable<IPackageStatics> for Package {}
 impl Package {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<Package>>> {
@@ -537,7 +537,7 @@ impl IPackageCatalog {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageCatalog: IPackageCatalog}
+RT_CLASS!{class PackageCatalog: IPackageCatalog ["Windows.ApplicationModel.PackageCatalog"]}
 impl RtActivatable<IPackageCatalogStatics> for PackageCatalog {}
 impl PackageCatalog {
     #[inline] pub fn open_for_current_package() -> Result<Option<ComPtr<PackageCatalog>>> {
@@ -615,7 +615,7 @@ impl IPackageCatalogAddOptionalPackageResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageCatalogAddOptionalPackageResult: IPackageCatalogAddOptionalPackageResult}
+RT_CLASS!{class PackageCatalogAddOptionalPackageResult: IPackageCatalogAddOptionalPackageResult ["Windows.ApplicationModel.PackageCatalogAddOptionalPackageResult"]}
 DEFINE_IID!(IID_IPackageCatalogAddResourcePackageResult, 2520174093, 15895, 18751, 170, 8, 204, 236, 111, 222, 246, 153);
 RT_INTERFACE!{interface IPackageCatalogAddResourcePackageResult(IPackageCatalogAddResourcePackageResultVtbl): IInspectable(IInspectableVtbl) [IID_IPackageCatalogAddResourcePackageResult] {
     fn get_Package(&self, out: *mut *mut Package) -> HRESULT,
@@ -639,7 +639,7 @@ impl IPackageCatalogAddResourcePackageResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageCatalogAddResourcePackageResult: IPackageCatalogAddResourcePackageResult}
+RT_CLASS!{class PackageCatalogAddResourcePackageResult: IPackageCatalogAddResourcePackageResult ["Windows.ApplicationModel.PackageCatalogAddResourcePackageResult"]}
 DEFINE_IID!(IID_IPackageCatalogRemoveOptionalPackagesResult, 701692283, 55668, 20068, 147, 89, 34, 202, 223, 215, 152, 40);
 RT_INTERFACE!{interface IPackageCatalogRemoveOptionalPackagesResult(IPackageCatalogRemoveOptionalPackagesResultVtbl): IInspectable(IInspectableVtbl) [IID_IPackageCatalogRemoveOptionalPackagesResult] {
     fn get_PackagesRemoved(&self, out: *mut *mut foundation::collections::IVectorView<Package>) -> HRESULT,
@@ -657,7 +657,7 @@ impl IPackageCatalogRemoveOptionalPackagesResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageCatalogRemoveOptionalPackagesResult: IPackageCatalogRemoveOptionalPackagesResult}
+RT_CLASS!{class PackageCatalogRemoveOptionalPackagesResult: IPackageCatalogRemoveOptionalPackagesResult ["Windows.ApplicationModel.PackageCatalogRemoveOptionalPackagesResult"]}
 DEFINE_IID!(IID_IPackageCatalogRemoveResourcePackagesResult, 2926679817, 6738, 17185, 135, 179, 229, 161, 161, 121, 129, 167);
 RT_INTERFACE!{interface IPackageCatalogRemoveResourcePackagesResult(IPackageCatalogRemoveResourcePackagesResultVtbl): IInspectable(IInspectableVtbl) [IID_IPackageCatalogRemoveResourcePackagesResult] {
     fn get_PackagesRemoved(&self, out: *mut *mut foundation::collections::IVectorView<Package>) -> HRESULT,
@@ -675,7 +675,7 @@ impl IPackageCatalogRemoveResourcePackagesResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageCatalogRemoveResourcePackagesResult: IPackageCatalogRemoveResourcePackagesResult}
+RT_CLASS!{class PackageCatalogRemoveResourcePackagesResult: IPackageCatalogRemoveResourcePackagesResult ["Windows.ApplicationModel.PackageCatalogRemoveResourcePackagesResult"]}
 DEFINE_IID!(IID_IPackageCatalogStatics, 2710345366, 58971, 17972, 186, 33, 94, 99, 235, 114, 68, 167);
 RT_INTERFACE!{static interface IPackageCatalogStatics(IPackageCatalogStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPackageCatalogStatics] {
     fn OpenForCurrentPackage(&self, out: *mut *mut PackageCatalog) -> HRESULT,
@@ -722,7 +722,7 @@ impl IPackageContentGroup {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageContentGroup: IPackageContentGroup}
+RT_CLASS!{class PackageContentGroup: IPackageContentGroup ["Windows.ApplicationModel.PackageContentGroup"]}
 impl RtActivatable<IPackageContentGroupStatics> for PackageContentGroup {}
 impl PackageContentGroup {
     #[inline] pub fn get_required_group_name() -> Result<HString> {
@@ -777,8 +777,8 @@ impl IPackageContentGroupStagingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageContentGroupStagingEventArgs: IPackageContentGroupStagingEventArgs}
-RT_ENUM! { enum PackageContentGroupState: i32 {
+RT_CLASS!{class PackageContentGroupStagingEventArgs: IPackageContentGroupStagingEventArgs ["Windows.ApplicationModel.PackageContentGroupStagingEventArgs"]}
+RT_ENUM! { enum PackageContentGroupState: i32 ["Windows.ApplicationModel.PackageContentGroupState"] {
     NotStaged (PackageContentGroupState_NotStaged) = 0, Queued (PackageContentGroupState_Queued) = 1, Staging (PackageContentGroupState_Staging) = 2, Staged (PackageContentGroupState_Staged) = 3,
 }}
 DEFINE_IID!(IID_IPackageContentGroupStatics, 1894675993, 24338, 19346, 185, 234, 108, 202, 218, 19, 188, 117);
@@ -846,7 +846,7 @@ impl IPackageId {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageId: IPackageId}
+RT_CLASS!{class PackageId: IPackageId ["Windows.ApplicationModel.PackageId"]}
 DEFINE_IID!(IID_IPackageIdWithMetadata, 1079474812, 3230, 17469, 144, 116, 133, 95, 92, 224, 160, 141);
 RT_INTERFACE!{interface IPackageIdWithMetadata(IPackageIdWithMetadataVtbl): IInspectable(IInspectableVtbl) [IID_IPackageIdWithMetadata] {
     fn get_ProductId(&self, out: *mut HSTRING) -> HRESULT,
@@ -899,11 +899,11 @@ impl IPackageInstallingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageInstallingEventArgs: IPackageInstallingEventArgs}
-RT_STRUCT! { struct PackageInstallProgress {
+RT_CLASS!{class PackageInstallingEventArgs: IPackageInstallingEventArgs ["Windows.ApplicationModel.PackageInstallingEventArgs"]}
+RT_STRUCT! { struct PackageInstallProgress ["Windows.ApplicationModel.PackageInstallProgress"] {
     PercentComplete: u32,
 }}
-RT_ENUM! { enum PackageSignatureKind: i32 {
+RT_ENUM! { enum PackageSignatureKind: i32 ["Windows.ApplicationModel.PackageSignatureKind"] {
     None (PackageSignatureKind_None) = 0, Developer (PackageSignatureKind_Developer) = 1, Enterprise (PackageSignatureKind_Enterprise) = 2, Store (PackageSignatureKind_Store) = 3, System (PackageSignatureKind_System) = 4,
 }}
 DEFINE_IID!(IID_IPackageStagingEventArgs, 272721965, 21730, 20305, 184, 40, 158, 247, 4, 108, 33, 15);
@@ -941,7 +941,7 @@ impl IPackageStagingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageStagingEventArgs: IPackageStagingEventArgs}
+RT_CLASS!{class PackageStagingEventArgs: IPackageStagingEventArgs ["Windows.ApplicationModel.PackageStagingEventArgs"]}
 DEFINE_IID!(IID_IPackageStatics, 1314081759, 10592, 18552, 151, 164, 150, 36, 222, 183, 47, 45);
 RT_INTERFACE!{static interface IPackageStatics(IPackageStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPackageStatics] {
     fn get_Current(&self, out: *mut *mut Package) -> HRESULT
@@ -1030,7 +1030,7 @@ impl IPackageStatus {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageStatus: IPackageStatus}
+RT_CLASS!{class PackageStatus: IPackageStatus ["Windows.ApplicationModel.PackageStatus"]}
 DEFINE_IID!(IID_IPackageStatus2, 4096326291, 31830, 18530, 172, 250, 171, 174, 220, 192, 105, 77);
 RT_INTERFACE!{interface IPackageStatus2(IPackageStatus2Vtbl): IInspectable(IInspectableVtbl) [IID_IPackageStatus2] {
     fn get_IsPartiallyStaged(&self, out: *mut bool) -> HRESULT
@@ -1053,7 +1053,7 @@ impl IPackageStatusChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageStatusChangedEventArgs: IPackageStatusChangedEventArgs}
+RT_CLASS!{class PackageStatusChangedEventArgs: IPackageStatusChangedEventArgs ["Windows.ApplicationModel.PackageStatusChangedEventArgs"]}
 DEFINE_IID!(IID_IPackageUninstallingEventArgs, 1145285202, 43810, 17613, 130, 187, 78, 201, 184, 39, 54, 122);
 RT_INTERFACE!{interface IPackageUninstallingEventArgs(IPackageUninstallingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPackageUninstallingEventArgs] {
     fn get_ActivityId(&self, out: *mut Guid) -> HRESULT,
@@ -1089,8 +1089,8 @@ impl IPackageUninstallingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageUninstallingEventArgs: IPackageUninstallingEventArgs}
-RT_ENUM! { enum PackageUpdateAvailability: i32 {
+RT_CLASS!{class PackageUninstallingEventArgs: IPackageUninstallingEventArgs ["Windows.ApplicationModel.PackageUninstallingEventArgs"]}
+RT_ENUM! { enum PackageUpdateAvailability: i32 ["Windows.ApplicationModel.PackageUpdateAvailability"] {
     Unknown (PackageUpdateAvailability_Unknown) = 0, NoUpdates (PackageUpdateAvailability_NoUpdates) = 1, Available (PackageUpdateAvailability_Available) = 2, Required (PackageUpdateAvailability_Required) = 3, Error (PackageUpdateAvailability_Error) = 4,
 }}
 DEFINE_IID!(IID_IPackageUpdateAvailabilityResult, 290344969, 6554, 18593, 160, 121, 49, 60, 69, 99, 74, 113);
@@ -1110,7 +1110,7 @@ impl IPackageUpdateAvailabilityResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageUpdateAvailabilityResult: IPackageUpdateAvailabilityResult}
+RT_CLASS!{class PackageUpdateAvailabilityResult: IPackageUpdateAvailabilityResult ["Windows.ApplicationModel.PackageUpdateAvailabilityResult"]}
 DEFINE_IID!(IID_IPackageUpdatingEventArgs, 3447407144, 64884, 17470, 177, 20, 35, 230, 119, 176, 232, 111);
 RT_INTERFACE!{interface IPackageUpdatingEventArgs(IPackageUpdatingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPackageUpdatingEventArgs] {
     fn get_ActivityId(&self, out: *mut Guid) -> HRESULT,
@@ -1152,8 +1152,8 @@ impl IPackageUpdatingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageUpdatingEventArgs: IPackageUpdatingEventArgs}
-RT_STRUCT! { struct PackageVersion {
+RT_CLASS!{class PackageUpdatingEventArgs: IPackageUpdatingEventArgs ["Windows.ApplicationModel.PackageUpdatingEventArgs"]}
+RT_STRUCT! { struct PackageVersion ["Windows.ApplicationModel.PackageVersion"] {
     Major: u16, Minor: u16, Build: u16, Revision: u16,
 }}
 DEFINE_IID!(IID_IPackageWithMetadata, 2509543296, 7657, 16626, 180, 82, 13, 233, 241, 145, 0, 18);
@@ -1206,7 +1206,7 @@ impl IStartupTask {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StartupTask: IStartupTask}
+RT_CLASS!{class StartupTask: IStartupTask ["Windows.ApplicationModel.StartupTask"]}
 impl RtActivatable<IStartupTaskStatics> for StartupTask {}
 impl StartupTask {
     #[inline] pub fn get_for_current_package_async() -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<StartupTask>>>> {
@@ -1217,7 +1217,7 @@ impl StartupTask {
     }
 }
 DEFINE_CLSID!(StartupTask(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,97,114,116,117,112,84,97,115,107,0]) [CLSID_StartupTask]);
-RT_ENUM! { enum StartupTaskState: i32 {
+RT_ENUM! { enum StartupTaskState: i32 ["Windows.ApplicationModel.StartupTaskState"] {
     Disabled (StartupTaskState_Disabled) = 0, DisabledByUser (StartupTaskState_DisabledByUser) = 1, Enabled (StartupTaskState_Enabled) = 2, DisabledByPolicy (StartupTaskState_DisabledByPolicy) = 3, EnabledByPolicy (StartupTaskState_EnabledByPolicy) = 4,
 }}
 DEFINE_IID!(IID_IStartupTaskStatics, 3998965949, 41288, 16807, 178, 110, 232, 184, 138, 30, 98, 248);
@@ -1247,7 +1247,7 @@ impl ISuspendingDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SuspendingDeferral: ISuspendingDeferral}
+RT_CLASS!{class SuspendingDeferral: ISuspendingDeferral ["Windows.ApplicationModel.SuspendingDeferral"]}
 DEFINE_IID!(IID_ISuspendingEventArgs, 2516982789, 11706, 19720, 176, 189, 43, 48, 161, 49, 198, 170);
 RT_INTERFACE!{interface ISuspendingEventArgs(ISuspendingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISuspendingEventArgs] {
     fn get_SuspendingOperation(&self, out: *mut *mut SuspendingOperation) -> HRESULT
@@ -1259,7 +1259,7 @@ impl ISuspendingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SuspendingEventArgs: ISuspendingEventArgs}
+RT_CLASS!{class SuspendingEventArgs: ISuspendingEventArgs ["Windows.ApplicationModel.SuspendingEventArgs"]}
 DEFINE_IID!(IID_ISuspendingOperation, 2644822593, 8417, 20123, 159, 101, 169, 244, 53, 52, 12, 58);
 RT_INTERFACE!{interface ISuspendingOperation(ISuspendingOperationVtbl): IInspectable(IInspectableVtbl) [IID_ISuspendingOperation] {
     fn GetDeferral(&self, out: *mut *mut SuspendingDeferral) -> HRESULT,
@@ -1277,7 +1277,7 @@ impl ISuspendingOperation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SuspendingOperation: ISuspendingOperation}
+RT_CLASS!{class SuspendingOperation: ISuspendingOperation ["Windows.ApplicationModel.SuspendingOperation"]}
 pub mod activation { // Windows.ApplicationModel.Activation
 use ::prelude::*;
 DEFINE_IID!(IID_IActivatedEventArgs, 3479508755, 52488, 20440, 182, 151, 162, 129, 182, 84, 78, 46);
@@ -1314,10 +1314,10 @@ impl IActivatedEventArgsWithUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ActivationKind: i32 {
+RT_ENUM! { enum ActivationKind: i32 ["Windows.ApplicationModel.Activation.ActivationKind"] {
     Launch (ActivationKind_Launch) = 0, Search (ActivationKind_Search) = 1, ShareTarget (ActivationKind_ShareTarget) = 2, File (ActivationKind_File) = 3, Protocol (ActivationKind_Protocol) = 4, FileOpenPicker (ActivationKind_FileOpenPicker) = 5, FileSavePicker (ActivationKind_FileSavePicker) = 6, CachedFileUpdater (ActivationKind_CachedFileUpdater) = 7, ContactPicker (ActivationKind_ContactPicker) = 8, Device (ActivationKind_Device) = 9, PrintTaskSettings (ActivationKind_PrintTaskSettings) = 10, CameraSettings (ActivationKind_CameraSettings) = 11, RestrictedLaunch (ActivationKind_RestrictedLaunch) = 12, AppointmentsProvider (ActivationKind_AppointmentsProvider) = 13, Contact (ActivationKind_Contact) = 14, LockScreenCall (ActivationKind_LockScreenCall) = 15, VoiceCommand (ActivationKind_VoiceCommand) = 16, LockScreen (ActivationKind_LockScreen) = 17, PickerReturned (ActivationKind_PickerReturned) = 1000, WalletAction (ActivationKind_WalletAction) = 1001, PickFileContinuation (ActivationKind_PickFileContinuation) = 1002, PickSaveFileContinuation (ActivationKind_PickSaveFileContinuation) = 1003, PickFolderContinuation (ActivationKind_PickFolderContinuation) = 1004, WebAuthenticationBrokerContinuation (ActivationKind_WebAuthenticationBrokerContinuation) = 1005, WebAccountProvider (ActivationKind_WebAccountProvider) = 1006, ComponentUI (ActivationKind_ComponentUI) = 1007, ProtocolForResults (ActivationKind_ProtocolForResults) = 1009, ToastNotification (ActivationKind_ToastNotification) = 1010, Print3DWorkflow (ActivationKind_Print3DWorkflow) = 1011, DialReceiver (ActivationKind_DialReceiver) = 1012, DevicePairing (ActivationKind_DevicePairing) = 1013, UserDataAccountsProvider (ActivationKind_UserDataAccountsProvider) = 1014, FilePickerExperience (ActivationKind_FilePickerExperience) = 1015, LockScreenComponent (ActivationKind_LockScreenComponent) = 1016, ContactPanel (ActivationKind_ContactPanel) = 1017, PrintWorkflowForegroundTask (ActivationKind_PrintWorkflowForegroundTask) = 1018, GameUIProvider (ActivationKind_GameUIProvider) = 1019, StartupTask (ActivationKind_StartupTask) = 1020, CommandLineLaunch (ActivationKind_CommandLineLaunch) = 1021, BarcodeScannerProvider (ActivationKind_BarcodeScannerProvider) = 1022,
 }}
-RT_ENUM! { enum ApplicationExecutionState: i32 {
+RT_ENUM! { enum ApplicationExecutionState: i32 ["Windows.ApplicationModel.Activation.ApplicationExecutionState"] {
     NotRunning (ApplicationExecutionState_NotRunning) = 0, Running (ApplicationExecutionState_Running) = 1, Suspended (ApplicationExecutionState_Suspended) = 2, Terminated (ApplicationExecutionState_Terminated) = 3, ClosedByUser (ApplicationExecutionState_ClosedByUser) = 4,
 }}
 DEFINE_IID!(IID_IApplicationViewActivatedEventArgs, 2467098443, 47145, 16636, 136, 244, 133, 19, 232, 166, 71, 56);
@@ -1353,7 +1353,7 @@ impl IAppointmentsProviderAddAppointmentActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentsProviderAddAppointmentActivatedEventArgs: IAppointmentsProviderAddAppointmentActivatedEventArgs}
+RT_CLASS!{class AppointmentsProviderAddAppointmentActivatedEventArgs: IAppointmentsProviderAddAppointmentActivatedEventArgs ["Windows.ApplicationModel.Activation.AppointmentsProviderAddAppointmentActivatedEventArgs"]}
 DEFINE_IID!(IID_IAppointmentsProviderRemoveAppointmentActivatedEventArgs, 1964980920, 2958, 17692, 159, 21, 150, 110, 105, 155, 172, 37);
 RT_INTERFACE!{interface IAppointmentsProviderRemoveAppointmentActivatedEventArgs(IAppointmentsProviderRemoveAppointmentActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentsProviderRemoveAppointmentActivatedEventArgs] {
     fn get_RemoveAppointmentOperation(&self, out: *mut *mut super::appointments::appointmentsprovider::RemoveAppointmentOperation) -> HRESULT
@@ -1365,7 +1365,7 @@ impl IAppointmentsProviderRemoveAppointmentActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentsProviderRemoveAppointmentActivatedEventArgs: IAppointmentsProviderRemoveAppointmentActivatedEventArgs}
+RT_CLASS!{class AppointmentsProviderRemoveAppointmentActivatedEventArgs: IAppointmentsProviderRemoveAppointmentActivatedEventArgs ["Windows.ApplicationModel.Activation.AppointmentsProviderRemoveAppointmentActivatedEventArgs"]}
 DEFINE_IID!(IID_IAppointmentsProviderReplaceAppointmentActivatedEventArgs, 357677012, 43393, 16487, 138, 98, 5, 36, 228, 173, 225, 33);
 RT_INTERFACE!{interface IAppointmentsProviderReplaceAppointmentActivatedEventArgs(IAppointmentsProviderReplaceAppointmentActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentsProviderReplaceAppointmentActivatedEventArgs] {
     fn get_ReplaceAppointmentOperation(&self, out: *mut *mut super::appointments::appointmentsprovider::ReplaceAppointmentOperation) -> HRESULT
@@ -1377,7 +1377,7 @@ impl IAppointmentsProviderReplaceAppointmentActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentsProviderReplaceAppointmentActivatedEventArgs: IAppointmentsProviderReplaceAppointmentActivatedEventArgs}
+RT_CLASS!{class AppointmentsProviderReplaceAppointmentActivatedEventArgs: IAppointmentsProviderReplaceAppointmentActivatedEventArgs ["Windows.ApplicationModel.Activation.AppointmentsProviderReplaceAppointmentActivatedEventArgs"]}
 DEFINE_IID!(IID_IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs, 962130021, 38977, 19621, 153, 155, 136, 81, 152, 185, 239, 42);
 RT_INTERFACE!{interface IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs(IAppointmentsProviderShowAppointmentDetailsActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs] {
     fn get_InstanceStartDate(&self, out: *mut *mut foundation::IReference<foundation::DateTime>) -> HRESULT,
@@ -1401,7 +1401,7 @@ impl IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentsProviderShowAppointmentDetailsActivatedEventArgs: IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs}
+RT_CLASS!{class AppointmentsProviderShowAppointmentDetailsActivatedEventArgs: IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs ["Windows.ApplicationModel.Activation.AppointmentsProviderShowAppointmentDetailsActivatedEventArgs"]}
 DEFINE_IID!(IID_IAppointmentsProviderShowTimeFrameActivatedEventArgs, 2611915686, 3595, 18858, 186, 188, 18, 177, 220, 119, 73, 134);
 RT_INTERFACE!{interface IAppointmentsProviderShowTimeFrameActivatedEventArgs(IAppointmentsProviderShowTimeFrameActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentsProviderShowTimeFrameActivatedEventArgs] {
     fn get_TimeToShow(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -1419,7 +1419,7 @@ impl IAppointmentsProviderShowTimeFrameActivatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentsProviderShowTimeFrameActivatedEventArgs: IAppointmentsProviderShowTimeFrameActivatedEventArgs}
+RT_CLASS!{class AppointmentsProviderShowTimeFrameActivatedEventArgs: IAppointmentsProviderShowTimeFrameActivatedEventArgs ["Windows.ApplicationModel.Activation.AppointmentsProviderShowTimeFrameActivatedEventArgs"]}
 DEFINE_IID!(IID_IBackgroundActivatedEventArgs, 2870263520, 59232, 17422, 169, 28, 68, 121, 109, 227, 169, 45);
 RT_INTERFACE!{interface IBackgroundActivatedEventArgs(IBackgroundActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundActivatedEventArgs] {
     fn get_TaskInstance(&self, out: *mut *mut super::background::IBackgroundTaskInstance) -> HRESULT
@@ -1431,7 +1431,7 @@ impl IBackgroundActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundActivatedEventArgs: IBackgroundActivatedEventArgs}
+RT_CLASS!{class BackgroundActivatedEventArgs: IBackgroundActivatedEventArgs ["Windows.ApplicationModel.Activation.BackgroundActivatedEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerPreviewActivatedEventArgs, 1735555452, 39359, 17225, 175, 34, 228, 18, 53, 96, 55, 28);
 RT_INTERFACE!{interface IBarcodeScannerPreviewActivatedEventArgs(IBarcodeScannerPreviewActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerPreviewActivatedEventArgs] {
     fn get_ConnectionId(&self, out: *mut HSTRING) -> HRESULT
@@ -1443,7 +1443,7 @@ impl IBarcodeScannerPreviewActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerPreviewActivatedEventArgs: IBarcodeScannerPreviewActivatedEventArgs}
+RT_CLASS!{class BarcodeScannerPreviewActivatedEventArgs: IBarcodeScannerPreviewActivatedEventArgs ["Windows.ApplicationModel.Activation.BarcodeScannerPreviewActivatedEventArgs"]}
 DEFINE_IID!(IID_ICachedFileUpdaterActivatedEventArgs, 3496915399, 14341, 20171, 183, 87, 108, 241, 94, 38, 254, 243);
 RT_INTERFACE!{interface ICachedFileUpdaterActivatedEventArgs(ICachedFileUpdaterActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileUpdaterActivatedEventArgs] {
     #[cfg(feature="windows-storage")] fn get_CachedFileUpdaterUI(&self, out: *mut *mut super::super::storage::provider::CachedFileUpdaterUI) -> HRESULT
@@ -1455,7 +1455,7 @@ impl ICachedFileUpdaterActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CachedFileUpdaterActivatedEventArgs: ICachedFileUpdaterActivatedEventArgs}
+RT_CLASS!{class CachedFileUpdaterActivatedEventArgs: ICachedFileUpdaterActivatedEventArgs ["Windows.ApplicationModel.Activation.CachedFileUpdaterActivatedEventArgs"]}
 DEFINE_IID!(IID_ICameraSettingsActivatedEventArgs, 4217873672, 11693, 18698, 145, 112, 220, 160, 54, 235, 17, 75);
 RT_INTERFACE!{interface ICameraSettingsActivatedEventArgs(ICameraSettingsActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICameraSettingsActivatedEventArgs] {
     fn get_VideoDeviceController(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -1473,7 +1473,7 @@ impl ICameraSettingsActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CameraSettingsActivatedEventArgs: ICameraSettingsActivatedEventArgs}
+RT_CLASS!{class CameraSettingsActivatedEventArgs: ICameraSettingsActivatedEventArgs ["Windows.ApplicationModel.Activation.CameraSettingsActivatedEventArgs"]}
 DEFINE_IID!(IID_ICommandLineActivatedEventArgs, 1158039340, 106, 18667, 138, 251, 208, 122, 178, 94, 51, 102);
 RT_INTERFACE!{interface ICommandLineActivatedEventArgs(ICommandLineActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICommandLineActivatedEventArgs] {
     fn get_Operation(&self, out: *mut *mut CommandLineActivationOperation) -> HRESULT
@@ -1485,7 +1485,7 @@ impl ICommandLineActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CommandLineActivatedEventArgs: ICommandLineActivatedEventArgs}
+RT_CLASS!{class CommandLineActivatedEventArgs: ICommandLineActivatedEventArgs ["Windows.ApplicationModel.Activation.CommandLineActivatedEventArgs"]}
 DEFINE_IID!(IID_ICommandLineActivationOperation, 2571839553, 50590, 20329, 188, 253, 182, 30, 212, 230, 34, 235);
 RT_INTERFACE!{interface ICommandLineActivationOperation(ICommandLineActivationOperationVtbl): IInspectable(IInspectableVtbl) [IID_ICommandLineActivationOperation] {
     fn get_Arguments(&self, out: *mut HSTRING) -> HRESULT,
@@ -1520,7 +1520,7 @@ impl ICommandLineActivationOperation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CommandLineActivationOperation: ICommandLineActivationOperation}
+RT_CLASS!{class CommandLineActivationOperation: ICommandLineActivationOperation ["Windows.ApplicationModel.Activation.CommandLineActivationOperation"]}
 DEFINE_IID!(IID_IContactActivatedEventArgs, 3592921540, 49189, 19521, 157, 239, 241, 234, 250, 208, 117, 231);
 RT_INTERFACE!{interface IContactActivatedEventArgs(IContactActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactActivatedEventArgs] {
     fn get_Verb(&self, out: *mut HSTRING) -> HRESULT
@@ -1555,7 +1555,7 @@ impl IContactCallActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactCallActivatedEventArgs: IContactCallActivatedEventArgs}
+RT_CLASS!{class ContactCallActivatedEventArgs: IContactCallActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactCallActivatedEventArgs"]}
 DEFINE_IID!(IID_IContactMapActivatedEventArgs, 3006003312, 61159, 19154, 170, 241, 168, 126, 255, 207, 0, 164);
 RT_INTERFACE!{interface IContactMapActivatedEventArgs(IContactMapActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactMapActivatedEventArgs] {
     fn get_Address(&self, out: *mut *mut super::contacts::ContactAddress) -> HRESULT,
@@ -1573,7 +1573,7 @@ impl IContactMapActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactMapActivatedEventArgs: IContactMapActivatedEventArgs}
+RT_CLASS!{class ContactMapActivatedEventArgs: IContactMapActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactMapActivatedEventArgs"]}
 DEFINE_IID!(IID_IContactMessageActivatedEventArgs, 3730410930, 3587, 17328, 191, 86, 188, 196, 11, 49, 98, 223);
 RT_INTERFACE!{interface IContactMessageActivatedEventArgs(IContactMessageActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactMessageActivatedEventArgs] {
     fn get_ServiceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -1597,7 +1597,7 @@ impl IContactMessageActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactMessageActivatedEventArgs: IContactMessageActivatedEventArgs}
+RT_CLASS!{class ContactMessageActivatedEventArgs: IContactMessageActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactMessageActivatedEventArgs"]}
 DEFINE_IID!(IID_IContactPanelActivatedEventArgs, 1388012516, 54228, 19299, 128, 81, 74, 242, 8, 44, 171, 128);
 RT_INTERFACE!{interface IContactPanelActivatedEventArgs(IContactPanelActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactPanelActivatedEventArgs] {
     fn get_ContactPanel(&self, out: *mut *mut super::contacts::ContactPanel) -> HRESULT,
@@ -1615,7 +1615,7 @@ impl IContactPanelActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPanelActivatedEventArgs: IContactPanelActivatedEventArgs}
+RT_CLASS!{class ContactPanelActivatedEventArgs: IContactPanelActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactPanelActivatedEventArgs"]}
 DEFINE_IID!(IID_IContactPickerActivatedEventArgs, 3461851879, 25673, 17831, 151, 31, 209, 19, 190, 122, 137, 54);
 RT_INTERFACE!{interface IContactPickerActivatedEventArgs(IContactPickerActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactPickerActivatedEventArgs] {
     fn get_ContactPickerUI(&self, out: *mut *mut super::contacts::provider::ContactPickerUI) -> HRESULT
@@ -1627,7 +1627,7 @@ impl IContactPickerActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPickerActivatedEventArgs: IContactPickerActivatedEventArgs}
+RT_CLASS!{class ContactPickerActivatedEventArgs: IContactPickerActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactPickerActivatedEventArgs"]}
 DEFINE_IID!(IID_IContactPostActivatedEventArgs, 3009035367, 61927, 18005, 173, 110, 72, 87, 88, 143, 85, 47);
 RT_INTERFACE!{interface IContactPostActivatedEventArgs(IContactPostActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactPostActivatedEventArgs] {
     fn get_ServiceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -1651,7 +1651,7 @@ impl IContactPostActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPostActivatedEventArgs: IContactPostActivatedEventArgs}
+RT_CLASS!{class ContactPostActivatedEventArgs: IContactPostActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactPostActivatedEventArgs"]}
 DEFINE_IID!(IID_IContactsProviderActivatedEventArgs, 1166073000, 22352, 18710, 170, 82, 192, 130, 149, 33, 235, 148);
 RT_INTERFACE!{interface IContactsProviderActivatedEventArgs(IContactsProviderActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactsProviderActivatedEventArgs] {
     fn get_Verb(&self, out: *mut HSTRING) -> HRESULT
@@ -1686,7 +1686,7 @@ impl IContactVideoCallActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactVideoCallActivatedEventArgs: IContactVideoCallActivatedEventArgs}
+RT_CLASS!{class ContactVideoCallActivatedEventArgs: IContactVideoCallActivatedEventArgs ["Windows.ApplicationModel.Activation.ContactVideoCallActivatedEventArgs"]}
 DEFINE_IID!(IID_IContinuationActivatedEventArgs, 3850438325, 5471, 19092, 167, 66, 199, 224, 143, 78, 24, 140);
 RT_INTERFACE!{interface IContinuationActivatedEventArgs(IContinuationActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContinuationActivatedEventArgs] {
     fn get_ContinuationData(&self, out: *mut *mut foundation::collections::ValueSet) -> HRESULT
@@ -1715,7 +1715,7 @@ impl IDeviceActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceActivatedEventArgs: IDeviceActivatedEventArgs}
+RT_CLASS!{class DeviceActivatedEventArgs: IDeviceActivatedEventArgs ["Windows.ApplicationModel.Activation.DeviceActivatedEventArgs"]}
 DEFINE_IID!(IID_IDevicePairingActivatedEventArgs, 3953185252, 60614, 16712, 148, 237, 244, 179, 126, 192, 91, 62);
 RT_INTERFACE!{interface IDevicePairingActivatedEventArgs(IDevicePairingActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePairingActivatedEventArgs] {
     #[cfg(feature="windows-devices")] fn get_DeviceInformation(&self, out: *mut *mut super::super::devices::enumeration::DeviceInformation) -> HRESULT
@@ -1727,7 +1727,7 @@ impl IDevicePairingActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePairingActivatedEventArgs: IDevicePairingActivatedEventArgs}
+RT_CLASS!{class DevicePairingActivatedEventArgs: IDevicePairingActivatedEventArgs ["Windows.ApplicationModel.Activation.DevicePairingActivatedEventArgs"]}
 DEFINE_IID!(IID_IDialReceiverActivatedEventArgs, 4218912471, 34286, 17774, 164, 77, 133, 215, 48, 231, 10, 237);
 RT_INTERFACE!{interface IDialReceiverActivatedEventArgs(IDialReceiverActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDialReceiverActivatedEventArgs] {
     fn get_AppName(&self, out: *mut HSTRING) -> HRESULT
@@ -1739,7 +1739,7 @@ impl IDialReceiverActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialReceiverActivatedEventArgs: IDialReceiverActivatedEventArgs}
+RT_CLASS!{class DialReceiverActivatedEventArgs: IDialReceiverActivatedEventArgs ["Windows.ApplicationModel.Activation.DialReceiverActivatedEventArgs"]}
 DEFINE_IID!(IID_IFileActivatedEventArgs, 3140156467, 37809, 17133, 139, 38, 35, 109, 217, 199, 132, 150);
 RT_INTERFACE!{interface IFileActivatedEventArgs(IFileActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IFileActivatedEventArgs] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -1758,7 +1758,7 @@ impl IFileActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileActivatedEventArgs: IFileActivatedEventArgs}
+RT_CLASS!{class FileActivatedEventArgs: IFileActivatedEventArgs ["Windows.ApplicationModel.Activation.FileActivatedEventArgs"]}
 DEFINE_IID!(IID_IFileActivatedEventArgsWithCallerPackageFamilyName, 761327723, 53855, 19749, 134, 83, 225, 197, 225, 16, 131, 9);
 RT_INTERFACE!{interface IFileActivatedEventArgsWithCallerPackageFamilyName(IFileActivatedEventArgsWithCallerPackageFamilyNameVtbl): IInspectable(IInspectableVtbl) [IID_IFileActivatedEventArgsWithCallerPackageFamilyName] {
     fn get_CallerPackageFamilyName(&self, out: *mut HSTRING) -> HRESULT
@@ -1792,7 +1792,7 @@ impl IFileOpenPickerActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileOpenPickerActivatedEventArgs: IFileOpenPickerActivatedEventArgs}
+RT_CLASS!{class FileOpenPickerActivatedEventArgs: IFileOpenPickerActivatedEventArgs ["Windows.ApplicationModel.Activation.FileOpenPickerActivatedEventArgs"]}
 DEFINE_IID!(IID_IFileOpenPickerActivatedEventArgs2, 1584602982, 36127, 17915, 175, 29, 115, 32, 92, 143, 199, 161);
 RT_INTERFACE!{interface IFileOpenPickerActivatedEventArgs2(IFileOpenPickerActivatedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IFileOpenPickerActivatedEventArgs2] {
     fn get_CallerPackageFamilyName(&self, out: *mut HSTRING) -> HRESULT
@@ -1815,7 +1815,7 @@ impl IFileOpenPickerContinuationEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileOpenPickerContinuationEventArgs: IFileOpenPickerContinuationEventArgs}
+RT_CLASS!{class FileOpenPickerContinuationEventArgs: IFileOpenPickerContinuationEventArgs ["Windows.ApplicationModel.Activation.FileOpenPickerContinuationEventArgs"]}
 DEFINE_IID!(IID_IFileSavePickerActivatedEventArgs, 2176949489, 29926, 17287, 130, 235, 187, 143, 214, 75, 67, 70);
 RT_INTERFACE!{interface IFileSavePickerActivatedEventArgs(IFileSavePickerActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IFileSavePickerActivatedEventArgs] {
     #[cfg(feature="windows-storage")] fn get_FileSavePickerUI(&self, out: *mut *mut super::super::storage::pickers::provider::FileSavePickerUI) -> HRESULT
@@ -1827,7 +1827,7 @@ impl IFileSavePickerActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileSavePickerActivatedEventArgs: IFileSavePickerActivatedEventArgs}
+RT_CLASS!{class FileSavePickerActivatedEventArgs: IFileSavePickerActivatedEventArgs ["Windows.ApplicationModel.Activation.FileSavePickerActivatedEventArgs"]}
 DEFINE_IID!(IID_IFileSavePickerActivatedEventArgs2, 1802763795, 11506, 19784, 140, 188, 175, 103, 210, 63, 28, 231);
 RT_INTERFACE!{interface IFileSavePickerActivatedEventArgs2(IFileSavePickerActivatedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IFileSavePickerActivatedEventArgs2] {
     fn get_CallerPackageFamilyName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1856,7 +1856,7 @@ impl IFileSavePickerContinuationEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileSavePickerContinuationEventArgs: IFileSavePickerContinuationEventArgs}
+RT_CLASS!{class FileSavePickerContinuationEventArgs: IFileSavePickerContinuationEventArgs ["Windows.ApplicationModel.Activation.FileSavePickerContinuationEventArgs"]}
 DEFINE_IID!(IID_IFolderPickerContinuationEventArgs, 1367876454, 40779, 18831, 190, 176, 66, 104, 79, 110, 28, 41);
 RT_INTERFACE!{interface IFolderPickerContinuationEventArgs(IFolderPickerContinuationEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IFolderPickerContinuationEventArgs] {
     #[cfg(feature="windows-storage")] fn get_Folder(&self, out: *mut *mut super::super::storage::StorageFolder) -> HRESULT
@@ -1868,7 +1868,7 @@ impl IFolderPickerContinuationEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FolderPickerContinuationEventArgs: IFolderPickerContinuationEventArgs}
+RT_CLASS!{class FolderPickerContinuationEventArgs: IFolderPickerContinuationEventArgs ["Windows.ApplicationModel.Activation.FolderPickerContinuationEventArgs"]}
 DEFINE_IID!(IID_ILaunchActivatedEventArgs, 4224269862, 41290, 19279, 130, 176, 51, 190, 217, 32, 175, 82);
 RT_INTERFACE!{interface ILaunchActivatedEventArgs(ILaunchActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILaunchActivatedEventArgs] {
     fn get_Arguments(&self, out: *mut HSTRING) -> HRESULT,
@@ -1886,7 +1886,7 @@ impl ILaunchActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LaunchActivatedEventArgs: ILaunchActivatedEventArgs}
+RT_CLASS!{class LaunchActivatedEventArgs: ILaunchActivatedEventArgs ["Windows.ApplicationModel.Activation.LaunchActivatedEventArgs"]}
 DEFINE_IID!(IID_ILaunchActivatedEventArgs2, 265518780, 40393, 18101, 154, 206, 189, 149, 212, 86, 83, 69);
 RT_INTERFACE!{interface ILaunchActivatedEventArgs2(ILaunchActivatedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_ILaunchActivatedEventArgs2] {
     fn get_TileActivatedInfo(&self, out: *mut *mut TileActivatedInfo) -> HRESULT
@@ -1909,7 +1909,7 @@ impl ILockScreenActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenActivatedEventArgs: ILockScreenActivatedEventArgs}
+RT_CLASS!{class LockScreenActivatedEventArgs: ILockScreenActivatedEventArgs ["Windows.ApplicationModel.Activation.LockScreenActivatedEventArgs"]}
 DEFINE_IID!(IID_ILockScreenCallActivatedEventArgs, 116621246, 46578, 17547, 177, 62, 227, 40, 172, 28, 81, 106);
 RT_INTERFACE!{interface ILockScreenCallActivatedEventArgs(ILockScreenCallActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenCallActivatedEventArgs] {
     fn get_CallUI(&self, out: *mut *mut super::calls::LockScreenCallUI) -> HRESULT
@@ -1921,8 +1921,8 @@ impl ILockScreenCallActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenCallActivatedEventArgs: ILockScreenCallActivatedEventArgs}
-RT_CLASS!{class LockScreenComponentActivatedEventArgs: IActivatedEventArgs}
+RT_CLASS!{class LockScreenCallActivatedEventArgs: ILockScreenCallActivatedEventArgs ["Windows.ApplicationModel.Activation.LockScreenCallActivatedEventArgs"]}
+RT_CLASS!{class LockScreenComponentActivatedEventArgs: IActivatedEventArgs ["Windows.ApplicationModel.Activation.LockScreenComponentActivatedEventArgs"]}
 DEFINE_IID!(IID_IPickerReturnedActivatedEventArgs, 906883001, 43475, 18820, 164, 237, 158, 199, 52, 96, 73, 33);
 RT_INTERFACE!{interface IPickerReturnedActivatedEventArgs(IPickerReturnedActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPickerReturnedActivatedEventArgs] {
     fn get_PickerOperationId(&self, out: *mut HSTRING) -> HRESULT
@@ -1934,7 +1934,7 @@ impl IPickerReturnedActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PickerReturnedActivatedEventArgs: IPickerReturnedActivatedEventArgs}
+RT_CLASS!{class PickerReturnedActivatedEventArgs: IPickerReturnedActivatedEventArgs ["Windows.ApplicationModel.Activation.PickerReturnedActivatedEventArgs"]}
 DEFINE_IID!(IID_IPrelaunchActivatedEventArgs, 205812091, 6647, 18646, 176, 70, 207, 34, 130, 110, 170, 116);
 RT_INTERFACE!{interface IPrelaunchActivatedEventArgs(IPrelaunchActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrelaunchActivatedEventArgs] {
     fn get_PrelaunchActivated(&self, out: *mut bool) -> HRESULT
@@ -1957,7 +1957,7 @@ impl IPrint3DWorkflowActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DWorkflowActivatedEventArgs: IPrint3DWorkflowActivatedEventArgs}
+RT_CLASS!{class Print3DWorkflowActivatedEventArgs: IPrint3DWorkflowActivatedEventArgs ["Windows.ApplicationModel.Activation.Print3DWorkflowActivatedEventArgs"]}
 DEFINE_IID!(IID_IPrintTaskSettingsActivatedEventArgs, 3996164297, 52822, 18533, 186, 142, 137, 84, 172, 39, 17, 7);
 RT_INTERFACE!{interface IPrintTaskSettingsActivatedEventArgs(IPrintTaskSettingsActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskSettingsActivatedEventArgs] {
     #[cfg(feature="windows-devices")] fn get_Configuration(&self, out: *mut *mut super::super::devices::printers::extensions::PrintTaskConfiguration) -> HRESULT
@@ -1969,7 +1969,7 @@ impl IPrintTaskSettingsActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskSettingsActivatedEventArgs: IPrintTaskSettingsActivatedEventArgs}
+RT_CLASS!{class PrintTaskSettingsActivatedEventArgs: IPrintTaskSettingsActivatedEventArgs ["Windows.ApplicationModel.Activation.PrintTaskSettingsActivatedEventArgs"]}
 DEFINE_IID!(IID_IProtocolActivatedEventArgs, 1620440285, 47040, 18091, 129, 254, 217, 15, 54, 208, 13, 36);
 RT_INTERFACE!{interface IProtocolActivatedEventArgs(IProtocolActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IProtocolActivatedEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT
@@ -1981,7 +1981,7 @@ impl IProtocolActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtocolActivatedEventArgs: IProtocolActivatedEventArgs}
+RT_CLASS!{class ProtocolActivatedEventArgs: IProtocolActivatedEventArgs ["Windows.ApplicationModel.Activation.ProtocolActivatedEventArgs"]}
 DEFINE_IID!(IID_IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData, 3628731410, 23695, 17292, 131, 203, 194, 143, 204, 11, 47, 219);
 RT_INTERFACE!{interface IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData(IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndDataVtbl): IInspectable(IInspectableVtbl) [IID_IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData] {
     fn get_CallerPackageFamilyName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2010,7 +2010,7 @@ impl IProtocolForResultsActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtocolForResultsActivatedEventArgs: IProtocolForResultsActivatedEventArgs}
+RT_CLASS!{class ProtocolForResultsActivatedEventArgs: IProtocolForResultsActivatedEventArgs ["Windows.ApplicationModel.Activation.ProtocolForResultsActivatedEventArgs"]}
 DEFINE_IID!(IID_IRestrictedLaunchActivatedEventArgs, 3770133633, 49091, 17220, 165, 218, 25, 253, 90, 39, 186, 174);
 RT_INTERFACE!{interface IRestrictedLaunchActivatedEventArgs(IRestrictedLaunchActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRestrictedLaunchActivatedEventArgs] {
     fn get_SharedContext(&self, out: *mut *mut IInspectable) -> HRESULT
@@ -2022,7 +2022,7 @@ impl IRestrictedLaunchActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RestrictedLaunchActivatedEventArgs: IRestrictedLaunchActivatedEventArgs}
+RT_CLASS!{class RestrictedLaunchActivatedEventArgs: IRestrictedLaunchActivatedEventArgs ["Windows.ApplicationModel.Activation.RestrictedLaunchActivatedEventArgs"]}
 DEFINE_IID!(IID_ISearchActivatedEventArgs, 2360568145, 22728, 17379, 148, 188, 65, 211, 63, 139, 99, 14);
 RT_INTERFACE!{interface ISearchActivatedEventArgs(ISearchActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchActivatedEventArgs] {
     fn get_QueryText(&self, out: *mut HSTRING) -> HRESULT,
@@ -2040,7 +2040,7 @@ impl ISearchActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchActivatedEventArgs: ISearchActivatedEventArgs}
+RT_CLASS!{class SearchActivatedEventArgs: ISearchActivatedEventArgs ["Windows.ApplicationModel.Activation.SearchActivatedEventArgs"]}
 DEFINE_IID!(IID_ISearchActivatedEventArgsWithLinguisticDetails, 3231658970, 2219, 18737, 155, 124, 69, 16, 37, 242, 31, 129);
 RT_INTERFACE!{interface ISearchActivatedEventArgsWithLinguisticDetails(ISearchActivatedEventArgsWithLinguisticDetailsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchActivatedEventArgsWithLinguisticDetails] {
     fn get_LinguisticDetails(&self, out: *mut *mut super::search::SearchPaneQueryLinguisticDetails) -> HRESULT
@@ -2063,7 +2063,7 @@ impl IShareTargetActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareTargetActivatedEventArgs: IShareTargetActivatedEventArgs}
+RT_CLASS!{class ShareTargetActivatedEventArgs: IShareTargetActivatedEventArgs ["Windows.ApplicationModel.Activation.ShareTargetActivatedEventArgs"]}
 DEFINE_IID!(IID_ISplashScreen, 3394082652, 54486, 17392, 151, 192, 8, 51, 198, 57, 28, 36);
 RT_INTERFACE!{interface ISplashScreen(ISplashScreenVtbl): IInspectable(IInspectableVtbl) [IID_ISplashScreen] {
     fn get_ImageLocation(&self, out: *mut foundation::Rect) -> HRESULT,
@@ -2086,7 +2086,7 @@ impl ISplashScreen {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SplashScreen: ISplashScreen}
+RT_CLASS!{class SplashScreen: ISplashScreen ["Windows.ApplicationModel.Activation.SplashScreen"]}
 DEFINE_IID!(IID_IStartupTaskActivatedEventArgs, 61938264, 21110, 19857, 134, 33, 84, 97, 24, 100, 213, 250);
 RT_INTERFACE!{interface IStartupTaskActivatedEventArgs(IStartupTaskActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IStartupTaskActivatedEventArgs] {
     fn get_TaskId(&self, out: *mut HSTRING) -> HRESULT
@@ -2098,7 +2098,7 @@ impl IStartupTaskActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StartupTaskActivatedEventArgs: IStartupTaskActivatedEventArgs}
+RT_CLASS!{class StartupTaskActivatedEventArgs: IStartupTaskActivatedEventArgs ["Windows.ApplicationModel.Activation.StartupTaskActivatedEventArgs"]}
 DEFINE_IID!(IID_ITileActivatedInfo, 2162467761, 14720, 20247, 183, 56, 137, 25, 78, 11, 143, 101);
 RT_INTERFACE!{interface ITileActivatedInfo(ITileActivatedInfoVtbl): IInspectable(IInspectableVtbl) [IID_ITileActivatedInfo] {
     #[cfg(feature="windows-ui")] fn get_RecentlyShownNotifications(&self, out: *mut *mut foundation::collections::IVectorView<super::super::ui::notifications::ShownTileNotification>) -> HRESULT
@@ -2110,7 +2110,7 @@ impl ITileActivatedInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileActivatedInfo: ITileActivatedInfo}
+RT_CLASS!{class TileActivatedInfo: ITileActivatedInfo ["Windows.ApplicationModel.Activation.TileActivatedInfo"]}
 DEFINE_IID!(IID_IToastNotificationActivatedEventArgs, 2460512130, 21136, 17181, 190, 133, 196, 170, 238, 184, 104, 95);
 RT_INTERFACE!{interface IToastNotificationActivatedEventArgs(IToastNotificationActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationActivatedEventArgs] {
     fn get_Argument(&self, out: *mut HSTRING) -> HRESULT,
@@ -2128,7 +2128,7 @@ impl IToastNotificationActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationActivatedEventArgs: IToastNotificationActivatedEventArgs}
+RT_CLASS!{class ToastNotificationActivatedEventArgs: IToastNotificationActivatedEventArgs ["Windows.ApplicationModel.Activation.ToastNotificationActivatedEventArgs"]}
 DEFINE_IID!(IID_IUserDataAccountProviderActivatedEventArgs, 466220835, 36593, 19025, 166, 58, 254, 113, 30, 234, 182, 7);
 RT_INTERFACE!{interface IUserDataAccountProviderActivatedEventArgs(IUserDataAccountProviderActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountProviderActivatedEventArgs] {
     fn get_Operation(&self, out: *mut *mut super::userdataaccounts::provider::IUserDataAccountProviderOperation) -> HRESULT
@@ -2140,7 +2140,7 @@ impl IUserDataAccountProviderActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountProviderActivatedEventArgs: IUserDataAccountProviderActivatedEventArgs}
+RT_CLASS!{class UserDataAccountProviderActivatedEventArgs: IUserDataAccountProviderActivatedEventArgs ["Windows.ApplicationModel.Activation.UserDataAccountProviderActivatedEventArgs"]}
 DEFINE_IID!(IID_IViewSwitcherProvider, 871532710, 23596, 19751, 186, 199, 117, 54, 8, 143, 18, 25);
 RT_INTERFACE!{interface IViewSwitcherProvider(IViewSwitcherProviderVtbl): IInspectable(IInspectableVtbl) [IID_IViewSwitcherProvider] {
     #[cfg(feature="windows-ui")] fn get_ViewSwitcher(&self, out: *mut *mut super::super::ui::viewmanagement::ActivationViewSwitcher) -> HRESULT
@@ -2163,7 +2163,7 @@ impl IVoiceCommandActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandActivatedEventArgs: IVoiceCommandActivatedEventArgs}
+RT_CLASS!{class VoiceCommandActivatedEventArgs: IVoiceCommandActivatedEventArgs ["Windows.ApplicationModel.Activation.VoiceCommandActivatedEventArgs"]}
 DEFINE_IID!(IID_IWalletActionActivatedEventArgs, 4244374139, 6682, 19746, 146, 63, 174, 111, 69, 250, 82, 217);
 RT_INTERFACE!{interface IWalletActionActivatedEventArgs(IWalletActionActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWalletActionActivatedEventArgs] {
     fn get_ItemId(&self, out: *mut HSTRING) -> HRESULT,
@@ -2187,7 +2187,7 @@ impl IWalletActionActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletActionActivatedEventArgs: IWalletActionActivatedEventArgs}
+RT_CLASS!{class WalletActionActivatedEventArgs: IWalletActionActivatedEventArgs ["Windows.ApplicationModel.Activation.WalletActionActivatedEventArgs"]}
 DEFINE_IID!(IID_IWebAccountProviderActivatedEventArgs, 1924601716, 39146, 19663, 151, 82, 70, 217, 5, 16, 4, 241);
 RT_INTERFACE!{interface IWebAccountProviderActivatedEventArgs(IWebAccountProviderActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderActivatedEventArgs] {
     #[cfg(feature="windows-security")] fn get_Operation(&self, out: *mut *mut super::super::security::authentication::web::provider::IWebAccountProviderOperation) -> HRESULT
@@ -2199,7 +2199,7 @@ impl IWebAccountProviderActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderActivatedEventArgs: IWebAccountProviderActivatedEventArgs}
+RT_CLASS!{class WebAccountProviderActivatedEventArgs: IWebAccountProviderActivatedEventArgs ["Windows.ApplicationModel.Activation.WebAccountProviderActivatedEventArgs"]}
 DEFINE_IID!(IID_IWebAuthenticationBrokerContinuationEventArgs, 1977459668, 30484, 17725, 183, 255, 185, 94, 58, 23, 9, 218);
 RT_INTERFACE!{interface IWebAuthenticationBrokerContinuationEventArgs(IWebAuthenticationBrokerContinuationEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebAuthenticationBrokerContinuationEventArgs] {
     #[cfg(feature="windows-security")] fn get_WebAuthenticationResult(&self, out: *mut *mut super::super::security::authentication::web::WebAuthenticationResult) -> HRESULT
@@ -2211,7 +2211,7 @@ impl IWebAuthenticationBrokerContinuationEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAuthenticationBrokerContinuationEventArgs: IWebAuthenticationBrokerContinuationEventArgs}
+RT_CLASS!{class WebAuthenticationBrokerContinuationEventArgs: IWebAuthenticationBrokerContinuationEventArgs ["Windows.ApplicationModel.Activation.WebAuthenticationBrokerContinuationEventArgs"]}
 } // Windows.ApplicationModel.Activation
 pub mod appextensions { // Windows.ApplicationModel.AppExtensions
 use ::prelude::*;
@@ -2262,7 +2262,7 @@ impl IAppExtension {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtension: IAppExtension}
+RT_CLASS!{class AppExtension: IAppExtension ["Windows.ApplicationModel.AppExtensions.AppExtension"]}
 DEFINE_IID!(IID_IAppExtensionCatalog, 2542215218, 33830, 19153, 144, 132, 146, 232, 140, 45, 162, 0);
 RT_INTERFACE!{interface IAppExtensionCatalog(IAppExtensionCatalogVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtensionCatalog] {
     fn FindAllAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppExtension>>) -> HRESULT,
@@ -2335,7 +2335,7 @@ impl IAppExtensionCatalog {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtensionCatalog: IAppExtensionCatalog}
+RT_CLASS!{class AppExtensionCatalog: IAppExtensionCatalog ["Windows.ApplicationModel.AppExtensions.AppExtensionCatalog"]}
 impl RtActivatable<IAppExtensionCatalogStatics> for AppExtensionCatalog {}
 impl AppExtensionCatalog {
     #[inline] pub fn open(appExtensionName: &HStringArg) -> Result<Option<ComPtr<AppExtensionCatalog>>> {
@@ -2377,7 +2377,7 @@ impl IAppExtensionPackageInstalledEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtensionPackageInstalledEventArgs: IAppExtensionPackageInstalledEventArgs}
+RT_CLASS!{class AppExtensionPackageInstalledEventArgs: IAppExtensionPackageInstalledEventArgs ["Windows.ApplicationModel.AppExtensions.AppExtensionPackageInstalledEventArgs"]}
 DEFINE_IID!(IID_IAppExtensionPackageStatusChangedEventArgs, 484537395, 4435, 17661, 135, 177, 138, 225, 5, 3, 3, 223);
 RT_INTERFACE!{interface IAppExtensionPackageStatusChangedEventArgs(IAppExtensionPackageStatusChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtensionPackageStatusChangedEventArgs] {
     fn get_AppExtensionName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2395,7 +2395,7 @@ impl IAppExtensionPackageStatusChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtensionPackageStatusChangedEventArgs: IAppExtensionPackageStatusChangedEventArgs}
+RT_CLASS!{class AppExtensionPackageStatusChangedEventArgs: IAppExtensionPackageStatusChangedEventArgs ["Windows.ApplicationModel.AppExtensions.AppExtensionPackageStatusChangedEventArgs"]}
 DEFINE_IID!(IID_IAppExtensionPackageUninstallingEventArgs, 1626431685, 5918, 16639, 174, 152, 171, 44, 32, 221, 77, 117);
 RT_INTERFACE!{interface IAppExtensionPackageUninstallingEventArgs(IAppExtensionPackageUninstallingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtensionPackageUninstallingEventArgs] {
     fn get_AppExtensionName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2413,7 +2413,7 @@ impl IAppExtensionPackageUninstallingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtensionPackageUninstallingEventArgs: IAppExtensionPackageUninstallingEventArgs}
+RT_CLASS!{class AppExtensionPackageUninstallingEventArgs: IAppExtensionPackageUninstallingEventArgs ["Windows.ApplicationModel.AppExtensions.AppExtensionPackageUninstallingEventArgs"]}
 DEFINE_IID!(IID_IAppExtensionPackageUpdatedEventArgs, 981713983, 31102, 17589, 186, 36, 164, 200, 181, 165, 67, 215);
 RT_INTERFACE!{interface IAppExtensionPackageUpdatedEventArgs(IAppExtensionPackageUpdatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtensionPackageUpdatedEventArgs] {
     fn get_AppExtensionName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2437,7 +2437,7 @@ impl IAppExtensionPackageUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtensionPackageUpdatedEventArgs: IAppExtensionPackageUpdatedEventArgs}
+RT_CLASS!{class AppExtensionPackageUpdatedEventArgs: IAppExtensionPackageUpdatedEventArgs ["Windows.ApplicationModel.AppExtensions.AppExtensionPackageUpdatedEventArgs"]}
 DEFINE_IID!(IID_IAppExtensionPackageUpdatingEventArgs, 2127926057, 6757, 18432, 167, 0, 179, 33, 0, 158, 48, 106);
 RT_INTERFACE!{interface IAppExtensionPackageUpdatingEventArgs(IAppExtensionPackageUpdatingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppExtensionPackageUpdatingEventArgs] {
     fn get_AppExtensionName(&self, out: *mut HSTRING) -> HRESULT,
@@ -2455,7 +2455,7 @@ impl IAppExtensionPackageUpdatingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExtensionPackageUpdatingEventArgs: IAppExtensionPackageUpdatingEventArgs}
+RT_CLASS!{class AppExtensionPackageUpdatingEventArgs: IAppExtensionPackageUpdatingEventArgs ["Windows.ApplicationModel.AppExtensions.AppExtensionPackageUpdatingEventArgs"]}
 } // Windows.ApplicationModel.AppExtensions
 pub mod appservice { // Windows.ApplicationModel.AppService
 use ::prelude::*;
@@ -2489,8 +2489,8 @@ impl IAppServiceClosedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceClosedEventArgs: IAppServiceClosedEventArgs}
-RT_ENUM! { enum AppServiceClosedStatus: i32 {
+RT_CLASS!{class AppServiceClosedEventArgs: IAppServiceClosedEventArgs ["Windows.ApplicationModel.AppService.AppServiceClosedEventArgs"]}
+RT_ENUM! { enum AppServiceClosedStatus: i32 ["Windows.ApplicationModel.AppService.AppServiceClosedStatus"] {
     Completed (AppServiceClosedStatus_Completed) = 0, Canceled (AppServiceClosedStatus_Canceled) = 1, ResourceLimitsExceeded (AppServiceClosedStatus_ResourceLimitsExceeded) = 2, Unknown (AppServiceClosedStatus_Unknown) = 3,
 }}
 DEFINE_IID!(IID_IAppServiceConnection, 2647946402, 34591, 19794, 137, 169, 158, 9, 5, 49, 189, 39);
@@ -2554,7 +2554,7 @@ impl IAppServiceConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceConnection: IAppServiceConnection}
+RT_CLASS!{class AppServiceConnection: IAppServiceConnection ["Windows.ApplicationModel.AppService.AppServiceConnection"]}
 impl RtActivatable<IActivationFactory> for AppServiceConnection {}
 DEFINE_CLSID!(AppServiceConnection(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,83,101,114,118,105,99,101,46,65,112,112,83,101,114,118,105,99,101,67,111,110,110,101,99,116,105,111,110,0]) [CLSID_AppServiceConnection]);
 DEFINE_IID!(IID_IAppServiceConnection2, 2346700127, 8962, 20413, 128, 97, 82, 81, 28, 47, 139, 249);
@@ -2579,7 +2579,7 @@ impl IAppServiceConnection2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppServiceConnectionStatus: i32 {
+RT_ENUM! { enum AppServiceConnectionStatus: i32 ["Windows.ApplicationModel.AppService.AppServiceConnectionStatus"] {
     Success (AppServiceConnectionStatus_Success) = 0, AppNotInstalled (AppServiceConnectionStatus_AppNotInstalled) = 1, AppUnavailable (AppServiceConnectionStatus_AppUnavailable) = 2, AppServiceUnavailable (AppServiceConnectionStatus_AppServiceUnavailable) = 3, Unknown (AppServiceConnectionStatus_Unknown) = 4, RemoteSystemUnavailable (AppServiceConnectionStatus_RemoteSystemUnavailable) = 5, RemoteSystemNotSupportedByApp (AppServiceConnectionStatus_RemoteSystemNotSupportedByApp) = 6, NotAuthorized (AppServiceConnectionStatus_NotAuthorized) = 7,
 }}
 DEFINE_IID!(IID_IAppServiceDeferral, 2115719970, 60080, 16968, 174, 4, 253, 249, 56, 56, 228, 114);
@@ -2592,7 +2592,7 @@ impl IAppServiceDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceDeferral: IAppServiceDeferral}
+RT_CLASS!{class AppServiceDeferral: IAppServiceDeferral ["Windows.ApplicationModel.AppService.AppServiceDeferral"]}
 DEFINE_IID!(IID_IAppServiceRequest, 551914909, 6366, 19201, 128, 186, 144, 167, 98, 4, 227, 200);
 RT_INTERFACE!{interface IAppServiceRequest(IAppServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppServiceRequest] {
     fn get_Message(&self, out: *mut *mut foundation::collections::ValueSet) -> HRESULT,
@@ -2610,7 +2610,7 @@ impl IAppServiceRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceRequest: IAppServiceRequest}
+RT_CLASS!{class AppServiceRequest: IAppServiceRequest ["Windows.ApplicationModel.AppService.AppServiceRequest"]}
 DEFINE_IID!(IID_IAppServiceRequestReceivedEventArgs, 1846682464, 65381, 17582, 158, 69, 133, 127, 228, 24, 6, 129);
 RT_INTERFACE!{interface IAppServiceRequestReceivedEventArgs(IAppServiceRequestReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppServiceRequestReceivedEventArgs] {
     fn get_Request(&self, out: *mut *mut AppServiceRequest) -> HRESULT,
@@ -2628,7 +2628,7 @@ impl IAppServiceRequestReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceRequestReceivedEventArgs: IAppServiceRequestReceivedEventArgs}
+RT_CLASS!{class AppServiceRequestReceivedEventArgs: IAppServiceRequestReceivedEventArgs ["Windows.ApplicationModel.AppService.AppServiceRequestReceivedEventArgs"]}
 DEFINE_IID!(IID_IAppServiceResponse, 2370845932, 39587, 20072, 149, 89, 157, 230, 62, 55, 44, 228);
 RT_INTERFACE!{interface IAppServiceResponse(IAppServiceResponseVtbl): IInspectable(IInspectableVtbl) [IID_IAppServiceResponse] {
     fn get_Message(&self, out: *mut *mut foundation::collections::ValueSet) -> HRESULT,
@@ -2646,8 +2646,8 @@ impl IAppServiceResponse {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceResponse: IAppServiceResponse}
-RT_ENUM! { enum AppServiceResponseStatus: i32 {
+RT_CLASS!{class AppServiceResponse: IAppServiceResponse ["Windows.ApplicationModel.AppService.AppServiceResponse"]}
+RT_ENUM! { enum AppServiceResponseStatus: i32 ["Windows.ApplicationModel.AppService.AppServiceResponseStatus"] {
     Success (AppServiceResponseStatus_Success) = 0, Failure (AppServiceResponseStatus_Failure) = 1, ResourceLimitsExceeded (AppServiceResponseStatus_ResourceLimitsExceeded) = 2, Unknown (AppServiceResponseStatus_Unknown) = 3, RemoteSystemUnavailable (AppServiceResponseStatus_RemoteSystemUnavailable) = 4, MessageSizeTooLarge (AppServiceResponseStatus_MessageSizeTooLarge) = 5,
 }}
 DEFINE_IID!(IID_IAppServiceTriggerDetails, 2292374700, 44328, 16824, 128, 187, 189, 241, 178, 22, 158, 25);
@@ -2673,7 +2673,7 @@ impl IAppServiceTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppServiceTriggerDetails: IAppServiceTriggerDetails}
+RT_CLASS!{class AppServiceTriggerDetails: IAppServiceTriggerDetails ["Windows.ApplicationModel.AppService.AppServiceTriggerDetails"]}
 DEFINE_IID!(IID_IAppServiceTriggerDetails2, 3896333490, 10444, 17394, 180, 101, 192, 72, 46, 89, 226, 220);
 RT_INTERFACE!{interface IAppServiceTriggerDetails2(IAppServiceTriggerDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppServiceTriggerDetails2] {
     fn get_IsRemoteSystemConnection(&self, out: *mut bool) -> HRESULT
@@ -2842,7 +2842,7 @@ impl IAppointment {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Appointment: IAppointment}
+RT_CLASS!{class Appointment: IAppointment ["Windows.ApplicationModel.Appointments.Appointment"]}
 impl RtActivatable<IActivationFactory> for Appointment {}
 DEFINE_CLSID!(Appointment(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,0]) [CLSID_Appointment]);
 DEFINE_IID!(IID_IAppointment2, 1585813564, 21519, 13394, 155, 92, 13, 215, 173, 76, 101, 162);
@@ -2995,7 +2995,7 @@ impl IAppointment3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentBusyStatus: i32 {
+RT_ENUM! { enum AppointmentBusyStatus: i32 ["Windows.ApplicationModel.Appointments.AppointmentBusyStatus"] {
     Busy (AppointmentBusyStatus_Busy) = 0, Tentative (AppointmentBusyStatus_Tentative) = 1, Free (AppointmentBusyStatus_Free) = 2, OutOfOffice (AppointmentBusyStatus_OutOfOffice) = 3, WorkingElsewhere (AppointmentBusyStatus_WorkingElsewhere) = 4,
 }}
 DEFINE_IID!(IID_IAppointmentCalendar, 1383301533, 33593, 15695, 160, 47, 100, 8, 68, 82, 187, 93);
@@ -3156,7 +3156,7 @@ impl IAppointmentCalendar {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendar: IAppointmentCalendar}
+RT_CLASS!{class AppointmentCalendar: IAppointmentCalendar ["Windows.ApplicationModel.Appointments.AppointmentCalendar"]}
 DEFINE_IID!(IID_IAppointmentCalendar2, 417850402, 9319, 19996, 164, 89, 216, 162, 147, 3, 208, 146);
 RT_INTERFACE!{interface IAppointmentCalendar2(IAppointmentCalendar2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendar2] {
     fn get_SyncManager(&self, out: *mut *mut AppointmentCalendarSyncManager) -> HRESULT,
@@ -3314,10 +3314,10 @@ impl IAppointmentCalendar3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentCalendarOtherAppReadAccess: i32 {
+RT_ENUM! { enum AppointmentCalendarOtherAppReadAccess: i32 ["Windows.ApplicationModel.Appointments.AppointmentCalendarOtherAppReadAccess"] {
     SystemOnly (AppointmentCalendarOtherAppReadAccess_SystemOnly) = 0, Limited (AppointmentCalendarOtherAppReadAccess_Limited) = 1, Full (AppointmentCalendarOtherAppReadAccess_Full) = 2, None (AppointmentCalendarOtherAppReadAccess_None) = 3,
 }}
-RT_ENUM! { enum AppointmentCalendarOtherAppWriteAccess: i32 {
+RT_ENUM! { enum AppointmentCalendarOtherAppWriteAccess: i32 ["Windows.ApplicationModel.Appointments.AppointmentCalendarOtherAppWriteAccess"] {
     None (AppointmentCalendarOtherAppWriteAccess_None) = 0, SystemOnly (AppointmentCalendarOtherAppWriteAccess_SystemOnly) = 1, Limited (AppointmentCalendarOtherAppWriteAccess_Limited) = 2,
 }}
 DEFINE_IID!(IID_IAppointmentCalendarSyncManager, 723628960, 19199, 17298, 188, 95, 86, 69, 255, 207, 251, 23);
@@ -3360,7 +3360,7 @@ impl IAppointmentCalendarSyncManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarSyncManager: IAppointmentCalendarSyncManager}
+RT_CLASS!{class AppointmentCalendarSyncManager: IAppointmentCalendarSyncManager ["Windows.ApplicationModel.Appointments.AppointmentCalendarSyncManager"]}
 DEFINE_IID!(IID_IAppointmentCalendarSyncManager2, 1685399725, 3369, 19580, 170, 167, 191, 153, 104, 5, 83, 124);
 RT_INTERFACE!{interface IAppointmentCalendarSyncManager2(IAppointmentCalendarSyncManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarSyncManager2] {
     fn put_Status(&self, value: AppointmentCalendarSyncStatus) -> HRESULT,
@@ -3381,7 +3381,7 @@ impl IAppointmentCalendarSyncManager2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentCalendarSyncStatus: i32 {
+RT_ENUM! { enum AppointmentCalendarSyncStatus: i32 ["Windows.ApplicationModel.Appointments.AppointmentCalendarSyncStatus"] {
     Idle (AppointmentCalendarSyncStatus_Idle) = 0, Syncing (AppointmentCalendarSyncStatus_Syncing) = 1, UpToDate (AppointmentCalendarSyncStatus_UpToDate) = 2, AuthenticationError (AppointmentCalendarSyncStatus_AuthenticationError) = 3, PolicyError (AppointmentCalendarSyncStatus_PolicyError) = 4, UnknownError (AppointmentCalendarSyncStatus_UnknownError) = 5, ManualAccountRemovalRequired (AppointmentCalendarSyncStatus_ManualAccountRemovalRequired) = 6,
 }}
 DEFINE_IID!(IID_IAppointmentConflictResult, 3587043518, 12079, 15229, 175, 10, 167, 226, 15, 58, 70, 227);
@@ -3401,14 +3401,14 @@ impl IAppointmentConflictResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentConflictResult: IAppointmentConflictResult}
-RT_ENUM! { enum AppointmentConflictType: i32 {
+RT_CLASS!{class AppointmentConflictResult: IAppointmentConflictResult ["Windows.ApplicationModel.Appointments.AppointmentConflictResult"]}
+RT_ENUM! { enum AppointmentConflictType: i32 ["Windows.ApplicationModel.Appointments.AppointmentConflictType"] {
     None (AppointmentConflictType_None) = 0, Adjacent (AppointmentConflictType_Adjacent) = 1, Overlap (AppointmentConflictType_Overlap) = 2,
 }}
-RT_ENUM! { enum AppointmentDaysOfWeek: u32 {
+RT_ENUM! { enum AppointmentDaysOfWeek: u32 ["Windows.ApplicationModel.Appointments.AppointmentDaysOfWeek"] {
     None (AppointmentDaysOfWeek_None) = 0, Sunday (AppointmentDaysOfWeek_Sunday) = 1, Monday (AppointmentDaysOfWeek_Monday) = 2, Tuesday (AppointmentDaysOfWeek_Tuesday) = 4, Wednesday (AppointmentDaysOfWeek_Wednesday) = 8, Thursday (AppointmentDaysOfWeek_Thursday) = 16, Friday (AppointmentDaysOfWeek_Friday) = 32, Saturday (AppointmentDaysOfWeek_Saturday) = 64,
 }}
-RT_ENUM! { enum AppointmentDetailsKind: i32 {
+RT_ENUM! { enum AppointmentDetailsKind: i32 ["Windows.ApplicationModel.Appointments.AppointmentDetailsKind"] {
     PlainText (AppointmentDetailsKind_PlainText) = 0, Html (AppointmentDetailsKind_Html) = 1,
 }}
 DEFINE_IID!(IID_IAppointmentException, 2718394215, 5878, 19406, 159, 90, 134, 0, 184, 1, 159, 203);
@@ -3434,7 +3434,7 @@ impl IAppointmentException {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentException: IAppointmentException}
+RT_CLASS!{class AppointmentException: IAppointmentException ["Windows.ApplicationModel.Appointments.AppointmentException"]}
 DEFINE_IID!(IID_IAppointmentInvitee, 331286422, 38978, 18779, 176, 231, 239, 143, 121, 192, 112, 29);
 RT_INTERFACE!{interface IAppointmentInvitee(IAppointmentInviteeVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentInvitee] {
     fn get_Role(&self, out: *mut AppointmentParticipantRole) -> HRESULT,
@@ -3462,7 +3462,7 @@ impl IAppointmentInvitee {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentInvitee: IAppointmentInvitee}
+RT_CLASS!{class AppointmentInvitee: IAppointmentInvitee ["Windows.ApplicationModel.Appointments.AppointmentInvitee"]}
 impl RtActivatable<IActivationFactory> for AppointmentInvitee {}
 DEFINE_CLSID!(AppointmentInvitee(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,73,110,118,105,116,101,101,0]) [CLSID_AppointmentInvitee]);
 RT_CLASS!{static class AppointmentManager}
@@ -3608,7 +3608,7 @@ impl IAppointmentManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentManagerForUser: IAppointmentManagerForUser}
+RT_CLASS!{class AppointmentManagerForUser: IAppointmentManagerForUser ["Windows.ApplicationModel.Appointments.AppointmentManagerForUser"]}
 DEFINE_IID!(IID_IAppointmentManagerStatics, 976288257, 23616, 18845, 179, 63, 164, 48, 80, 247, 79, 196);
 RT_INTERFACE!{static interface IAppointmentManagerStatics(IAppointmentManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentManagerStatics] {
     fn ShowAddAppointmentAsync(&self, appointment: *mut Appointment, selection: foundation::Rect, out: *mut *mut foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -3713,7 +3713,7 @@ impl IAppointmentManagerStatics3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentOrganizer: IAppointmentParticipant}
+RT_CLASS!{class AppointmentOrganizer: IAppointmentParticipant ["Windows.ApplicationModel.Appointments.AppointmentOrganizer"]}
 impl RtActivatable<IActivationFactory> for AppointmentOrganizer {}
 DEFINE_CLSID!(AppointmentOrganizer(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,79,114,103,97,110,105,122,101,114,0]) [CLSID_AppointmentOrganizer]);
 DEFINE_IID!(IID_IAppointmentParticipant, 1633560834, 38680, 18043, 131, 251, 178, 147, 161, 145, 33, 222);
@@ -3743,10 +3743,10 @@ impl IAppointmentParticipant {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentParticipantResponse: i32 {
+RT_ENUM! { enum AppointmentParticipantResponse: i32 ["Windows.ApplicationModel.Appointments.AppointmentParticipantResponse"] {
     None (AppointmentParticipantResponse_None) = 0, Tentative (AppointmentParticipantResponse_Tentative) = 1, Accepted (AppointmentParticipantResponse_Accepted) = 2, Declined (AppointmentParticipantResponse_Declined) = 3, Unknown (AppointmentParticipantResponse_Unknown) = 4,
 }}
-RT_ENUM! { enum AppointmentParticipantRole: i32 {
+RT_ENUM! { enum AppointmentParticipantRole: i32 ["Windows.ApplicationModel.Appointments.AppointmentParticipantRole"] {
     RequiredAttendee (AppointmentParticipantRole_RequiredAttendee) = 0, OptionalAttendee (AppointmentParticipantRole_OptionalAttendee) = 1, Resource (AppointmentParticipantRole_Resource) = 2,
 }}
 RT_CLASS!{static class AppointmentProperties}
@@ -4092,7 +4092,7 @@ impl IAppointmentRecurrence {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentRecurrence: IAppointmentRecurrence}
+RT_CLASS!{class AppointmentRecurrence: IAppointmentRecurrence ["Windows.ApplicationModel.Appointments.AppointmentRecurrence"]}
 impl RtActivatable<IActivationFactory> for AppointmentRecurrence {}
 DEFINE_CLSID!(AppointmentRecurrence(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,65,112,112,111,105,110,116,109,101,110,116,82,101,99,117,114,114,101,110,99,101,0]) [CLSID_AppointmentRecurrence]);
 DEFINE_IID!(IID_IAppointmentRecurrence2, 1039377120, 1447, 20304, 159, 134, 176, 63, 148, 54, 37, 77);
@@ -4128,10 +4128,10 @@ impl IAppointmentRecurrence3 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentRecurrenceUnit: i32 {
+RT_ENUM! { enum AppointmentRecurrenceUnit: i32 ["Windows.ApplicationModel.Appointments.AppointmentRecurrenceUnit"] {
     Daily (AppointmentRecurrenceUnit_Daily) = 0, Weekly (AppointmentRecurrenceUnit_Weekly) = 1, Monthly (AppointmentRecurrenceUnit_Monthly) = 2, MonthlyOnDay (AppointmentRecurrenceUnit_MonthlyOnDay) = 3, Yearly (AppointmentRecurrenceUnit_Yearly) = 4, YearlyOnDay (AppointmentRecurrenceUnit_YearlyOnDay) = 5,
 }}
-RT_ENUM! { enum AppointmentSensitivity: i32 {
+RT_ENUM! { enum AppointmentSensitivity: i32 ["Windows.ApplicationModel.Appointments.AppointmentSensitivity"] {
     Public (AppointmentSensitivity_Public) = 0, Private (AppointmentSensitivity_Private) = 1,
 }}
 DEFINE_IID!(IID_IAppointmentStore, 2757857676, 31303, 19862, 150, 201, 21, 205, 138, 5, 167, 53);
@@ -4267,7 +4267,7 @@ impl IAppointmentStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentStore: IAppointmentStore}
+RT_CLASS!{class AppointmentStore: IAppointmentStore ["Windows.ApplicationModel.Appointments.AppointmentStore"]}
 DEFINE_IID!(IID_IAppointmentStore2, 633637920, 7233, 16975, 128, 132, 103, 193, 207, 224, 168, 84);
 RT_INTERFACE!{interface IAppointmentStore2(IAppointmentStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStore2] {
     fn add_StoreChanged(&self, pHandler: *mut foundation::TypedEventHandler<AppointmentStore, AppointmentStoreChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -4301,7 +4301,7 @@ impl IAppointmentStore3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentStoreAccessType: i32 {
+RT_ENUM! { enum AppointmentStoreAccessType: i32 ["Windows.ApplicationModel.Appointments.AppointmentStoreAccessType"] {
     AppCalendarsReadWrite (AppointmentStoreAccessType_AppCalendarsReadWrite) = 0, AllCalendarsReadOnly (AppointmentStoreAccessType_AllCalendarsReadOnly) = 1, AllCalendarsReadWrite (AppointmentStoreAccessType_AllCalendarsReadWrite) = 2,
 }}
 DEFINE_IID!(IID_IAppointmentStoreChange, 2779177013, 2611, 13908, 132, 99, 181, 67, 233, 12, 59, 121);
@@ -4321,7 +4321,7 @@ impl IAppointmentStoreChange {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentStoreChange: IAppointmentStoreChange}
+RT_CLASS!{class AppointmentStoreChange: IAppointmentStoreChange ["Windows.ApplicationModel.Appointments.AppointmentStoreChange"]}
 DEFINE_IID!(IID_IAppointmentStoreChange2, 3011317198, 21009, 17410, 166, 8, 169, 111, 231, 11, 142, 226);
 RT_INTERFACE!{interface IAppointmentStoreChange2(IAppointmentStoreChange2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreChange2] {
     fn get_AppointmentCalendar(&self, out: *mut *mut AppointmentCalendar) -> HRESULT
@@ -4343,7 +4343,7 @@ impl IAppointmentStoreChangedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentStoreChangedDeferral: IAppointmentStoreChangedDeferral}
+RT_CLASS!{class AppointmentStoreChangedDeferral: IAppointmentStoreChangedDeferral ["Windows.ApplicationModel.Appointments.AppointmentStoreChangedDeferral"]}
 DEFINE_IID!(IID_IAppointmentStoreChangedEventArgs, 579205305, 1937, 16766, 191, 234, 204, 109, 65, 99, 108, 140);
 RT_INTERFACE!{interface IAppointmentStoreChangedEventArgs(IAppointmentStoreChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreChangedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut AppointmentStoreChangedDeferral) -> HRESULT
@@ -4355,7 +4355,7 @@ impl IAppointmentStoreChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentStoreChangedEventArgs: IAppointmentStoreChangedEventArgs}
+RT_CLASS!{class AppointmentStoreChangedEventArgs: IAppointmentStoreChangedEventArgs ["Windows.ApplicationModel.Appointments.AppointmentStoreChangedEventArgs"]}
 DEFINE_IID!(IID_IAppointmentStoreChangeReader, 2334394865, 26099, 17056, 150, 29, 76, 32, 155, 243, 3, 112);
 RT_INTERFACE!{interface IAppointmentStoreChangeReader(IAppointmentStoreChangeReaderVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreChangeReader] {
     fn ReadBatchAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<AppointmentStoreChange>>) -> HRESULT,
@@ -4377,7 +4377,7 @@ impl IAppointmentStoreChangeReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentStoreChangeReader: IAppointmentStoreChangeReader}
+RT_CLASS!{class AppointmentStoreChangeReader: IAppointmentStoreChangeReader ["Windows.ApplicationModel.Appointments.AppointmentStoreChangeReader"]}
 DEFINE_IID!(IID_IAppointmentStoreChangeTracker, 455472305, 36558, 20247, 147, 200, 230, 65, 36, 88, 253, 92);
 RT_INTERFACE!{interface IAppointmentStoreChangeTracker(IAppointmentStoreChangeTrackerVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreChangeTracker] {
     fn GetChangeReader(&self, out: *mut *mut AppointmentStoreChangeReader) -> HRESULT,
@@ -4399,7 +4399,7 @@ impl IAppointmentStoreChangeTracker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentStoreChangeTracker: IAppointmentStoreChangeTracker}
+RT_CLASS!{class AppointmentStoreChangeTracker: IAppointmentStoreChangeTracker ["Windows.ApplicationModel.Appointments.AppointmentStoreChangeTracker"]}
 DEFINE_IID!(IID_IAppointmentStoreChangeTracker2, 3060444997, 38210, 19703, 133, 80, 235, 55, 14, 12, 8, 211);
 RT_INTERFACE!{interface IAppointmentStoreChangeTracker2(IAppointmentStoreChangeTracker2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreChangeTracker2] {
     fn get_IsTracking(&self, out: *mut bool) -> HRESULT
@@ -4411,21 +4411,21 @@ impl IAppointmentStoreChangeTracker2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppointmentStoreChangeType: i32 {
+RT_ENUM! { enum AppointmentStoreChangeType: i32 ["Windows.ApplicationModel.Appointments.AppointmentStoreChangeType"] {
     AppointmentCreated (AppointmentStoreChangeType_AppointmentCreated) = 0, AppointmentModified (AppointmentStoreChangeType_AppointmentModified) = 1, AppointmentDeleted (AppointmentStoreChangeType_AppointmentDeleted) = 2, ChangeTrackingLost (AppointmentStoreChangeType_ChangeTrackingLost) = 3, CalendarCreated (AppointmentStoreChangeType_CalendarCreated) = 4, CalendarModified (AppointmentStoreChangeType_CalendarModified) = 5, CalendarDeleted (AppointmentStoreChangeType_CalendarDeleted) = 6,
 }}
 DEFINE_IID!(IID_IAppointmentStoreNotificationTriggerDetails, 2603862801, 49921, 16926, 175, 239, 4, 126, 207, 167, 106, 219);
 RT_INTERFACE!{interface IAppointmentStoreNotificationTriggerDetails(IAppointmentStoreNotificationTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreNotificationTriggerDetails] {
     
 }}
-RT_CLASS!{class AppointmentStoreNotificationTriggerDetails: IAppointmentStoreNotificationTriggerDetails}
-RT_ENUM! { enum AppointmentSummaryCardView: i32 {
+RT_CLASS!{class AppointmentStoreNotificationTriggerDetails: IAppointmentStoreNotificationTriggerDetails ["Windows.ApplicationModel.Appointments.AppointmentStoreNotificationTriggerDetails"]}
+RT_ENUM! { enum AppointmentSummaryCardView: i32 ["Windows.ApplicationModel.Appointments.AppointmentSummaryCardView"] {
     System (AppointmentSummaryCardView_System) = 0, App (AppointmentSummaryCardView_App) = 1,
 }}
-RT_ENUM! { enum AppointmentWeekOfMonth: i32 {
+RT_ENUM! { enum AppointmentWeekOfMonth: i32 ["Windows.ApplicationModel.Appointments.AppointmentWeekOfMonth"] {
     First (AppointmentWeekOfMonth_First) = 0, Second (AppointmentWeekOfMonth_Second) = 1, Third (AppointmentWeekOfMonth_Third) = 2, Fourth (AppointmentWeekOfMonth_Fourth) = 3, Last (AppointmentWeekOfMonth_Last) = 4,
 }}
-RT_ENUM! { enum FindAppointmentCalendarsOptions: u32 {
+RT_ENUM! { enum FindAppointmentCalendarsOptions: u32 ["Windows.ApplicationModel.Appointments.FindAppointmentCalendarsOptions"] {
     None (FindAppointmentCalendarsOptions_None) = 0, IncludeHidden (FindAppointmentCalendarsOptions_IncludeHidden) = 1,
 }}
 DEFINE_IID!(IID_IFindAppointmentsOptions, 1442307157, 39234, 12422, 130, 181, 44, 178, 159, 100, 213, 245);
@@ -4467,10 +4467,10 @@ impl IFindAppointmentsOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FindAppointmentsOptions: IFindAppointmentsOptions}
+RT_CLASS!{class FindAppointmentsOptions: IFindAppointmentsOptions ["Windows.ApplicationModel.Appointments.FindAppointmentsOptions"]}
 impl RtActivatable<IActivationFactory> for FindAppointmentsOptions {}
 DEFINE_CLSID!(FindAppointmentsOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,65,112,112,111,105,110,116,109,101,110,116,115,46,70,105,110,100,65,112,112,111,105,110,116,109,101,110,116,115,79,112,116,105,111,110,115,0]) [CLSID_FindAppointmentsOptions]);
-RT_ENUM! { enum RecurrenceType: i32 {
+RT_ENUM! { enum RecurrenceType: i32 ["Windows.ApplicationModel.Appointments.RecurrenceType"] {
     Master (RecurrenceType_Master) = 0, Instance (RecurrenceType_Instance) = 1, ExceptionInstance (RecurrenceType_ExceptionInstance) = 2,
 }}
 pub mod appointmentsprovider { // Windows.ApplicationModel.Appointments.AppointmentsProvider
@@ -4512,7 +4512,7 @@ impl IAddAppointmentOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AddAppointmentOperation: IAddAppointmentOperation}
+RT_CLASS!{class AddAppointmentOperation: IAddAppointmentOperation ["Windows.ApplicationModel.Appointments.AppointmentsProvider.AddAppointmentOperation"]}
 RT_CLASS!{static class AppointmentsProviderLaunchActionVerbs}
 impl RtActivatable<IAppointmentsProviderLaunchActionVerbsStatics> for AppointmentsProviderLaunchActionVerbs {}
 impl RtActivatable<IAppointmentsProviderLaunchActionVerbsStatics2> for AppointmentsProviderLaunchActionVerbs {}
@@ -4617,7 +4617,7 @@ impl IRemoveAppointmentOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoveAppointmentOperation: IRemoveAppointmentOperation}
+RT_CLASS!{class RemoveAppointmentOperation: IRemoveAppointmentOperation ["Windows.ApplicationModel.Appointments.AppointmentsProvider.RemoveAppointmentOperation"]}
 DEFINE_IID!(IID_IReplaceAppointmentOperation, 4103093659, 40545, 19938, 167, 50, 38, 135, 192, 125, 29, 232);
 RT_INTERFACE!{interface IReplaceAppointmentOperation(IReplaceAppointmentOperationVtbl): IInspectable(IInspectableVtbl) [IID_IReplaceAppointmentOperation] {
     fn get_AppointmentId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4667,7 +4667,7 @@ impl IReplaceAppointmentOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ReplaceAppointmentOperation: IReplaceAppointmentOperation}
+RT_CLASS!{class ReplaceAppointmentOperation: IReplaceAppointmentOperation ["Windows.ApplicationModel.Appointments.AppointmentsProvider.ReplaceAppointmentOperation"]}
 } // Windows.ApplicationModel.Appointments.AppointmentsProvider
 pub mod dataprovider { // Windows.ApplicationModel.Appointments.DataProvider
 use ::prelude::*;
@@ -4724,7 +4724,7 @@ impl IAppointmentCalendarCancelMeetingRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarCancelMeetingRequest: IAppointmentCalendarCancelMeetingRequest}
+RT_CLASS!{class AppointmentCalendarCancelMeetingRequest: IAppointmentCalendarCancelMeetingRequest ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCancelMeetingRequest"]}
 DEFINE_IID!(IID_IAppointmentCalendarCancelMeetingRequestEventArgs, 444186134, 32560, 20021, 190, 239, 157, 44, 123, 109, 202, 225);
 RT_INTERFACE!{interface IAppointmentCalendarCancelMeetingRequestEventArgs(IAppointmentCalendarCancelMeetingRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarCancelMeetingRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut AppointmentCalendarCancelMeetingRequest) -> HRESULT,
@@ -4742,7 +4742,7 @@ impl IAppointmentCalendarCancelMeetingRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarCancelMeetingRequestEventArgs: IAppointmentCalendarCancelMeetingRequestEventArgs}
+RT_CLASS!{class AppointmentCalendarCancelMeetingRequestEventArgs: IAppointmentCalendarCancelMeetingRequestEventArgs ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCancelMeetingRequestEventArgs"]}
 DEFINE_IID!(IID_IAppointmentCalendarCreateOrUpdateAppointmentRequest, 778236594, 51862, 18604, 145, 36, 64, 107, 25, 254, 250, 112);
 RT_INTERFACE!{interface IAppointmentCalendarCreateOrUpdateAppointmentRequest(IAppointmentCalendarCreateOrUpdateAppointmentRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarCreateOrUpdateAppointmentRequest] {
     fn get_AppointmentCalendarLocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4784,7 +4784,7 @@ impl IAppointmentCalendarCreateOrUpdateAppointmentRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarCreateOrUpdateAppointmentRequest: IAppointmentCalendarCreateOrUpdateAppointmentRequest}
+RT_CLASS!{class AppointmentCalendarCreateOrUpdateAppointmentRequest: IAppointmentCalendarCreateOrUpdateAppointmentRequest ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCreateOrUpdateAppointmentRequest"]}
 DEFINE_IID!(IID_IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs, 3482185000, 46, 19447, 142, 157, 94, 32, 212, 154, 163, 186);
 RT_INTERFACE!{interface IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs(IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut AppointmentCalendarCreateOrUpdateAppointmentRequest) -> HRESULT,
@@ -4802,7 +4802,7 @@ impl IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs: IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs}
+RT_CLASS!{class AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs: IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs"]}
 DEFINE_IID!(IID_IAppointmentCalendarForwardMeetingRequest, 2196106838, 9910, 16979, 138, 143, 108, 245, 242, 255, 120, 132);
 RT_INTERFACE!{interface IAppointmentCalendarForwardMeetingRequest(IAppointmentCalendarForwardMeetingRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarForwardMeetingRequest] {
     fn get_AppointmentCalendarLocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4862,7 +4862,7 @@ impl IAppointmentCalendarForwardMeetingRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarForwardMeetingRequest: IAppointmentCalendarForwardMeetingRequest}
+RT_CLASS!{class AppointmentCalendarForwardMeetingRequest: IAppointmentCalendarForwardMeetingRequest ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarForwardMeetingRequest"]}
 DEFINE_IID!(IID_IAppointmentCalendarForwardMeetingRequestEventArgs, 822678810, 9122, 17149, 156, 130, 201, 166, 13, 89, 248, 168);
 RT_INTERFACE!{interface IAppointmentCalendarForwardMeetingRequestEventArgs(IAppointmentCalendarForwardMeetingRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarForwardMeetingRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut AppointmentCalendarForwardMeetingRequest) -> HRESULT,
@@ -4880,7 +4880,7 @@ impl IAppointmentCalendarForwardMeetingRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarForwardMeetingRequestEventArgs: IAppointmentCalendarForwardMeetingRequestEventArgs}
+RT_CLASS!{class AppointmentCalendarForwardMeetingRequestEventArgs: IAppointmentCalendarForwardMeetingRequestEventArgs ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarForwardMeetingRequestEventArgs"]}
 DEFINE_IID!(IID_IAppointmentCalendarProposeNewTimeForMeetingRequest, 3457967093, 60918, 17347, 130, 183, 190, 107, 54, 140, 105, 0);
 RT_INTERFACE!{interface IAppointmentCalendarProposeNewTimeForMeetingRequest(IAppointmentCalendarProposeNewTimeForMeetingRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarProposeNewTimeForMeetingRequest] {
     fn get_AppointmentCalendarLocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4940,7 +4940,7 @@ impl IAppointmentCalendarProposeNewTimeForMeetingRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarProposeNewTimeForMeetingRequest: IAppointmentCalendarProposeNewTimeForMeetingRequest}
+RT_CLASS!{class AppointmentCalendarProposeNewTimeForMeetingRequest: IAppointmentCalendarProposeNewTimeForMeetingRequest ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarProposeNewTimeForMeetingRequest"]}
 DEFINE_IID!(IID_IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs, 3537336280, 65233, 17024, 163, 186, 46, 31, 71, 96, 154, 162);
 RT_INTERFACE!{interface IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs(IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut AppointmentCalendarProposeNewTimeForMeetingRequest) -> HRESULT,
@@ -4958,7 +4958,7 @@ impl IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs: IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs}
+RT_CLASS!{class AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs: IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs"]}
 DEFINE_IID!(IID_IAppointmentCalendarSyncManagerSyncRequest, 313210923, 29027, 19030, 154, 78, 114, 35, 168, 74, 223, 70);
 RT_INTERFACE!{interface IAppointmentCalendarSyncManagerSyncRequest(IAppointmentCalendarSyncManagerSyncRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarSyncManagerSyncRequest] {
     fn get_AppointmentCalendarLocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4982,7 +4982,7 @@ impl IAppointmentCalendarSyncManagerSyncRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarSyncManagerSyncRequest: IAppointmentCalendarSyncManagerSyncRequest}
+RT_CLASS!{class AppointmentCalendarSyncManagerSyncRequest: IAppointmentCalendarSyncManagerSyncRequest ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarSyncManagerSyncRequest"]}
 DEFINE_IID!(IID_IAppointmentCalendarSyncManagerSyncRequestEventArgs, 3390555895, 644, 20189, 135, 186, 77, 143, 105, 220, 245, 192);
 RT_INTERFACE!{interface IAppointmentCalendarSyncManagerSyncRequestEventArgs(IAppointmentCalendarSyncManagerSyncRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarSyncManagerSyncRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut AppointmentCalendarSyncManagerSyncRequest) -> HRESULT,
@@ -5000,7 +5000,7 @@ impl IAppointmentCalendarSyncManagerSyncRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarSyncManagerSyncRequestEventArgs: IAppointmentCalendarSyncManagerSyncRequestEventArgs}
+RT_CLASS!{class AppointmentCalendarSyncManagerSyncRequestEventArgs: IAppointmentCalendarSyncManagerSyncRequestEventArgs ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarSyncManagerSyncRequestEventArgs"]}
 DEFINE_IID!(IID_IAppointmentCalendarUpdateMeetingResponseRequest, 2741854348, 49821, 19348, 176, 134, 126, 159, 247, 189, 132, 160);
 RT_INTERFACE!{interface IAppointmentCalendarUpdateMeetingResponseRequest(IAppointmentCalendarUpdateMeetingResponseRequestVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarUpdateMeetingResponseRequest] {
     fn get_AppointmentCalendarLocalId(&self, out: *mut HSTRING) -> HRESULT,
@@ -5060,7 +5060,7 @@ impl IAppointmentCalendarUpdateMeetingResponseRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarUpdateMeetingResponseRequest: IAppointmentCalendarUpdateMeetingResponseRequest}
+RT_CLASS!{class AppointmentCalendarUpdateMeetingResponseRequest: IAppointmentCalendarUpdateMeetingResponseRequest ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarUpdateMeetingResponseRequest"]}
 DEFINE_IID!(IID_IAppointmentCalendarUpdateMeetingResponseRequestEventArgs, 2289408131, 38847, 18333, 174, 213, 11, 232, 206, 86, 125, 30);
 RT_INTERFACE!{interface IAppointmentCalendarUpdateMeetingResponseRequestEventArgs(IAppointmentCalendarUpdateMeetingResponseRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentCalendarUpdateMeetingResponseRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut AppointmentCalendarUpdateMeetingResponseRequest) -> HRESULT,
@@ -5078,7 +5078,7 @@ impl IAppointmentCalendarUpdateMeetingResponseRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentCalendarUpdateMeetingResponseRequestEventArgs: IAppointmentCalendarUpdateMeetingResponseRequestEventArgs}
+RT_CLASS!{class AppointmentCalendarUpdateMeetingResponseRequestEventArgs: IAppointmentCalendarUpdateMeetingResponseRequestEventArgs ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarUpdateMeetingResponseRequestEventArgs"]}
 DEFINE_IID!(IID_IAppointmentDataProviderConnection, 4091387267, 12884, 18015, 171, 219, 146, 128, 70, 85, 44, 244);
 RT_INTERFACE!{interface IAppointmentDataProviderConnection(IAppointmentDataProviderConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentDataProviderConnection] {
     fn add_SyncRequested(&self, handler: *mut foundation::TypedEventHandler<AppointmentDataProviderConnection, AppointmentCalendarSyncManagerSyncRequestEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5155,7 +5155,7 @@ impl IAppointmentDataProviderConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentDataProviderConnection: IAppointmentDataProviderConnection}
+RT_CLASS!{class AppointmentDataProviderConnection: IAppointmentDataProviderConnection ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentDataProviderConnection"]}
 DEFINE_IID!(IID_IAppointmentDataProviderTriggerDetails, 3005758465, 32274, 20062, 177, 239, 116, 251, 104, 172, 111, 42);
 RT_INTERFACE!{interface IAppointmentDataProviderTriggerDetails(IAppointmentDataProviderTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentDataProviderTriggerDetails] {
     fn get_Connection(&self, out: *mut *mut AppointmentDataProviderConnection) -> HRESULT
@@ -5167,7 +5167,7 @@ impl IAppointmentDataProviderTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppointmentDataProviderTriggerDetails: IAppointmentDataProviderTriggerDetails}
+RT_CLASS!{class AppointmentDataProviderTriggerDetails: IAppointmentDataProviderTriggerDetails ["Windows.ApplicationModel.Appointments.DataProvider.AppointmentDataProviderTriggerDetails"]}
 } // Windows.ApplicationModel.Appointments.DataProvider
 } // Windows.ApplicationModel.Appointments
 pub mod background { // Windows.ApplicationModel.Background
@@ -5203,7 +5203,7 @@ impl IActivitySensorTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivitySensorTrigger: IActivitySensorTrigger}
+RT_CLASS!{class ActivitySensorTrigger: IActivitySensorTrigger ["Windows.ApplicationModel.Background.ActivitySensorTrigger"]}
 impl RtActivatable<IActivitySensorTriggerFactory> for ActivitySensorTrigger {}
 impl ActivitySensorTrigger {
     #[inline] pub fn create(reportIntervalInMilliseconds: u32) -> Result<ComPtr<ActivitySensorTrigger>> {
@@ -5222,7 +5222,7 @@ impl IActivitySensorTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AlarmAccessStatus: i32 {
+RT_ENUM! { enum AlarmAccessStatus: i32 ["Windows.ApplicationModel.Background.AlarmAccessStatus"] {
     Unspecified (AlarmAccessStatus_Unspecified) = 0, AllowedWithWakeupCapability (AlarmAccessStatus_AllowedWithWakeupCapability) = 1, AllowedWithoutWakeupCapability (AlarmAccessStatus_AllowedWithoutWakeupCapability) = 2, Denied (AlarmAccessStatus_Denied) = 3,
 }}
 RT_CLASS!{static class AlarmApplicationManager}
@@ -5269,7 +5269,7 @@ impl IAppBroadcastTrigger {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastTrigger: IAppBroadcastTrigger}
+RT_CLASS!{class AppBroadcastTrigger: IAppBroadcastTrigger ["Windows.ApplicationModel.Background.AppBroadcastTrigger"]}
 impl RtActivatable<IAppBroadcastTriggerFactory> for AppBroadcastTrigger {}
 impl AppBroadcastTrigger {
     #[inline] pub fn create_app_broadcast_trigger(providerKey: &HStringArg) -> Result<ComPtr<AppBroadcastTrigger>> {
@@ -5359,7 +5359,7 @@ impl IAppBroadcastTriggerProviderInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastTriggerProviderInfo: IAppBroadcastTriggerProviderInfo}
+RT_CLASS!{class AppBroadcastTriggerProviderInfo: IAppBroadcastTriggerProviderInfo ["Windows.ApplicationModel.Background.AppBroadcastTriggerProviderInfo"]}
 DEFINE_IID!(IID_IApplicationTrigger, 189171248, 38260, 18732, 158, 147, 26, 58, 230, 51, 95, 233);
 RT_INTERFACE!{interface IApplicationTrigger(IApplicationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationTrigger] {
     fn RequestAsync(&self, out: *mut *mut foundation::IAsyncOperation<ApplicationTriggerResult>) -> HRESULT,
@@ -5377,7 +5377,7 @@ impl IApplicationTrigger {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationTrigger: IApplicationTrigger}
+RT_CLASS!{class ApplicationTrigger: IApplicationTrigger ["Windows.ApplicationModel.Background.ApplicationTrigger"]}
 impl RtActivatable<IActivationFactory> for ApplicationTrigger {}
 DEFINE_CLSID!(ApplicationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,112,112,108,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ApplicationTrigger]);
 DEFINE_IID!(IID_IApplicationTriggerDetails, 2547804850, 8729, 19102, 156, 94, 65, 208, 71, 247, 110, 130);
@@ -5391,21 +5391,21 @@ impl IApplicationTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationTriggerDetails: IApplicationTriggerDetails}
-RT_ENUM! { enum ApplicationTriggerResult: i32 {
+RT_CLASS!{class ApplicationTriggerDetails: IApplicationTriggerDetails ["Windows.ApplicationModel.Background.ApplicationTriggerDetails"]}
+RT_ENUM! { enum ApplicationTriggerResult: i32 ["Windows.ApplicationModel.Background.ApplicationTriggerResult"] {
     Allowed (ApplicationTriggerResult_Allowed) = 0, CurrentlyRunning (ApplicationTriggerResult_CurrentlyRunning) = 1, DisabledByPolicy (ApplicationTriggerResult_DisabledByPolicy) = 2, UnknownError (ApplicationTriggerResult_UnknownError) = 3,
 }}
 DEFINE_IID!(IID_IAppointmentStoreNotificationTrigger, 1691616268, 49665, 17069, 170, 42, 226, 27, 163, 66, 91, 109);
 RT_INTERFACE!{interface IAppointmentStoreNotificationTrigger(IAppointmentStoreNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IAppointmentStoreNotificationTrigger] {
     
 }}
-RT_CLASS!{class AppointmentStoreNotificationTrigger: IAppointmentStoreNotificationTrigger}
+RT_CLASS!{class AppointmentStoreNotificationTrigger: IAppointmentStoreNotificationTrigger ["Windows.ApplicationModel.Background.AppointmentStoreNotificationTrigger"]}
 impl RtActivatable<IActivationFactory> for AppointmentStoreNotificationTrigger {}
 DEFINE_CLSID!(AppointmentStoreNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,65,112,112,111,105,110,116,109,101,110,116,83,116,111,114,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_AppointmentStoreNotificationTrigger]);
-RT_ENUM! { enum BackgroundAccessRequestKind: i32 {
+RT_ENUM! { enum BackgroundAccessRequestKind: i32 ["Windows.ApplicationModel.Background.BackgroundAccessRequestKind"] {
     AlwaysAllowed (BackgroundAccessRequestKind_AlwaysAllowed) = 0, AllowedSubjectToSystemPolicy (BackgroundAccessRequestKind_AllowedSubjectToSystemPolicy) = 1,
 }}
-RT_ENUM! { enum BackgroundAccessStatus: i32 {
+RT_ENUM! { enum BackgroundAccessStatus: i32 ["Windows.ApplicationModel.Background.BackgroundAccessStatus"] {
     Unspecified (BackgroundAccessStatus_Unspecified) = 0, AllowedWithAlwaysOnRealTimeConnectivity (BackgroundAccessStatus_AllowedWithAlwaysOnRealTimeConnectivity) = 1, AllowedMayUseActiveRealTimeConnectivity (BackgroundAccessStatus_AllowedMayUseActiveRealTimeConnectivity) = 2, Denied (BackgroundAccessStatus_Denied) = 3, AlwaysAllowed (BackgroundAccessStatus_AlwaysAllowed) = 4, AllowedSubjectToSystemPolicy (BackgroundAccessStatus_AllowedSubjectToSystemPolicy) = 5, DeniedBySystemPolicy (BackgroundAccessStatus_DeniedBySystemPolicy) = 6, DeniedByUser (BackgroundAccessStatus_DeniedByUser) = 7,
 }}
 DEFINE_IID!(IID_IBackgroundCondition, 2923995630, 35153, 16394, 131, 2, 156, 156, 154, 42, 58, 59);
@@ -5542,7 +5542,7 @@ impl IBackgroundTaskBuilder {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTaskBuilder: IBackgroundTaskBuilder}
+RT_CLASS!{class BackgroundTaskBuilder: IBackgroundTaskBuilder ["Windows.ApplicationModel.Background.BackgroundTaskBuilder"]}
 impl RtActivatable<IActivationFactory> for BackgroundTaskBuilder {}
 DEFINE_CLSID!(BackgroundTaskBuilder(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,97,99,107,103,114,111,117,110,100,84,97,115,107,66,117,105,108,100,101,114,0]) [CLSID_BackgroundTaskBuilder]);
 DEFINE_IID!(IID_IBackgroundTaskBuilder2, 1793576881, 4175, 16493, 141, 182, 132, 74, 87, 15, 66, 187);
@@ -5603,7 +5603,7 @@ impl BackgroundTaskCanceledEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BackgroundTaskCancellationReason: i32 {
+RT_ENUM! { enum BackgroundTaskCancellationReason: i32 ["Windows.ApplicationModel.Background.BackgroundTaskCancellationReason"] {
     Abort (BackgroundTaskCancellationReason_Abort) = 0, Terminating (BackgroundTaskCancellationReason_Terminating) = 1, LoggingOff (BackgroundTaskCancellationReason_LoggingOff) = 2, ServicingUpdate (BackgroundTaskCancellationReason_ServicingUpdate) = 3, IdleTask (BackgroundTaskCancellationReason_IdleTask) = 4, Uninstall (BackgroundTaskCancellationReason_Uninstall) = 5, ConditionLoss (BackgroundTaskCancellationReason_ConditionLoss) = 6, SystemPolicy (BackgroundTaskCancellationReason_SystemPolicy) = 7, QuietHoursEntered (BackgroundTaskCancellationReason_QuietHoursEntered) = 8, ExecutionTimeExceeded (BackgroundTaskCancellationReason_ExecutionTimeExceeded) = 9, ResourceRevocation (BackgroundTaskCancellationReason_ResourceRevocation) = 10, EnergySaver (BackgroundTaskCancellationReason_EnergySaver) = 11,
 }}
 DEFINE_IID!(IID_IBackgroundTaskCompletedEventArgs, 1448945103, 61961, 18676, 153, 103, 43, 24, 79, 123, 251, 240);
@@ -5622,7 +5622,7 @@ impl IBackgroundTaskCompletedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTaskCompletedEventArgs: IBackgroundTaskCompletedEventArgs}
+RT_CLASS!{class BackgroundTaskCompletedEventArgs: IBackgroundTaskCompletedEventArgs ["Windows.ApplicationModel.Background.BackgroundTaskCompletedEventArgs"]}
 DEFINE_IID!(IID_BackgroundTaskCompletedEventHandler, 1530456361, 41094, 18087, 166, 120, 67, 145, 53, 130, 43, 207);
 RT_DELEGATE!{delegate BackgroundTaskCompletedEventHandler(BackgroundTaskCompletedEventHandlerVtbl, BackgroundTaskCompletedEventHandlerImpl) [IID_BackgroundTaskCompletedEventHandler] {
     fn Invoke(&self, sender: *mut BackgroundTaskRegistration, args: *mut BackgroundTaskCompletedEventArgs) -> HRESULT
@@ -5643,7 +5643,7 @@ impl IBackgroundTaskDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTaskDeferral: IBackgroundTaskDeferral}
+RT_CLASS!{class BackgroundTaskDeferral: IBackgroundTaskDeferral ["Windows.ApplicationModel.Background.BackgroundTaskDeferral"]}
 DEFINE_IID!(IID_IBackgroundTaskInstance, 2254166650, 8664, 17779, 143, 50, 146, 138, 27, 6, 65, 246);
 RT_INTERFACE!{interface IBackgroundTaskInstance(IBackgroundTaskInstanceVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTaskInstance] {
     fn get_InstanceId(&self, out: *mut Guid) -> HRESULT,
@@ -5740,7 +5740,7 @@ impl IBackgroundTaskProgressEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTaskProgressEventArgs: IBackgroundTaskProgressEventArgs}
+RT_CLASS!{class BackgroundTaskProgressEventArgs: IBackgroundTaskProgressEventArgs ["Windows.ApplicationModel.Background.BackgroundTaskProgressEventArgs"]}
 DEFINE_IID!(IID_BackgroundTaskProgressEventHandler, 1189111868, 35464, 19609, 128, 76, 118, 137, 127, 98, 119, 166);
 RT_DELEGATE!{delegate BackgroundTaskProgressEventHandler(BackgroundTaskProgressEventHandlerVtbl, BackgroundTaskProgressEventHandlerImpl) [IID_BackgroundTaskProgressEventHandler] {
     fn Invoke(&self, sender: *mut BackgroundTaskRegistration, args: *mut BackgroundTaskProgressEventArgs) -> HRESULT
@@ -5795,7 +5795,7 @@ impl IBackgroundTaskRegistration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTaskRegistration: IBackgroundTaskRegistration}
+RT_CLASS!{class BackgroundTaskRegistration: IBackgroundTaskRegistration ["Windows.ApplicationModel.Background.BackgroundTaskRegistration"]}
 impl RtActivatable<IBackgroundTaskRegistrationStatics> for BackgroundTaskRegistration {}
 impl RtActivatable<IBackgroundTaskRegistrationStatics2> for BackgroundTaskRegistration {}
 impl BackgroundTaskRegistration {
@@ -5866,7 +5866,7 @@ impl IBackgroundTaskRegistrationGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTaskRegistrationGroup: IBackgroundTaskRegistrationGroup}
+RT_CLASS!{class BackgroundTaskRegistrationGroup: IBackgroundTaskRegistrationGroup ["Windows.ApplicationModel.Background.BackgroundTaskRegistrationGroup"]}
 impl RtActivatable<IBackgroundTaskRegistrationGroupFactory> for BackgroundTaskRegistrationGroup {}
 impl BackgroundTaskRegistrationGroup {
     #[inline] pub fn create(id: &HStringArg) -> Result<ComPtr<BackgroundTaskRegistrationGroup>> {
@@ -5922,7 +5922,7 @@ impl IBackgroundTaskRegistrationStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BackgroundTaskThrottleCounter: i32 {
+RT_ENUM! { enum BackgroundTaskThrottleCounter: i32 ["Windows.ApplicationModel.Background.BackgroundTaskThrottleCounter"] {
     All (BackgroundTaskThrottleCounter_All) = 0, Cpu (BackgroundTaskThrottleCounter_Cpu) = 1, Network (BackgroundTaskThrottleCounter_Network) = 2,
 }}
 DEFINE_IID!(IID_IBackgroundTrigger, 2226364504, 24615, 19335, 151, 144, 189, 243, 247, 87, 219, 215);
@@ -5948,7 +5948,7 @@ impl IBackgroundWorkCostStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BackgroundWorkCostValue: i32 {
+RT_ENUM! { enum BackgroundWorkCostValue: i32 ["Windows.ApplicationModel.Background.BackgroundWorkCostValue"] {
     Low (BackgroundWorkCostValue_Low) = 0, Medium (BackgroundWorkCostValue_Medium) = 1, High (BackgroundWorkCostValue_High) = 2,
 }}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementPublisherTrigger, 2872976914, 9683, 18606, 135, 36, 216, 24, 119, 174, 97, 41);
@@ -5962,7 +5962,7 @@ impl IBluetoothLEAdvertisementPublisherTrigger {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementPublisherTrigger: IBluetoothLEAdvertisementPublisherTrigger}
+RT_CLASS!{class BluetoothLEAdvertisementPublisherTrigger: IBluetoothLEAdvertisementPublisherTrigger ["Windows.ApplicationModel.Background.BluetoothLEAdvertisementPublisherTrigger"]}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementPublisherTrigger {}
 DEFINE_CLSID!(BluetoothLEAdvertisementPublisherTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,80,117,98,108,105,115,104,101,114,84,114,105,103,103,101,114,0]) [CLSID_BluetoothLEAdvertisementPublisherTrigger]);
 DEFINE_IID!(IID_IBluetoothLEAdvertisementWatcherTrigger, 447420441, 48353, 18667, 168, 39, 89, 251, 124, 238, 82, 166);
@@ -6016,14 +6016,14 @@ impl IBluetoothLEAdvertisementWatcherTrigger {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementWatcherTrigger: IBluetoothLEAdvertisementWatcherTrigger}
+RT_CLASS!{class BluetoothLEAdvertisementWatcherTrigger: IBluetoothLEAdvertisementWatcherTrigger ["Windows.ApplicationModel.Background.BluetoothLEAdvertisementWatcherTrigger"]}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementWatcherTrigger {}
 DEFINE_CLSID!(BluetoothLEAdvertisementWatcherTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,87,97,116,99,104,101,114,84,114,105,103,103,101,114,0]) [CLSID_BluetoothLEAdvertisementWatcherTrigger]);
 DEFINE_IID!(IID_ICachedFileUpdaterTrigger, 3793530603, 13042, 19761, 181, 83, 185, 224, 27, 222, 55, 224);
 RT_INTERFACE!{interface ICachedFileUpdaterTrigger(ICachedFileUpdaterTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileUpdaterTrigger] {
     
 }}
-RT_CLASS!{class CachedFileUpdaterTrigger: ICachedFileUpdaterTrigger}
+RT_CLASS!{class CachedFileUpdaterTrigger: ICachedFileUpdaterTrigger ["Windows.ApplicationModel.Background.CachedFileUpdaterTrigger"]}
 impl RtActivatable<IActivationFactory> for CachedFileUpdaterTrigger {}
 DEFINE_CLSID!(CachedFileUpdaterTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,97,99,104,101,100,70,105,108,101,85,112,100,97,116,101,114,84,114,105,103,103,101,114,0]) [CLSID_CachedFileUpdaterTrigger]);
 DEFINE_IID!(IID_ICachedFileUpdaterTriggerDetails, 1904446483, 4884, 18356, 149, 151, 220, 126, 36, 140, 23, 204);
@@ -6051,33 +6051,33 @@ impl ICachedFileUpdaterTriggerDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CachedFileUpdaterTriggerDetails: ICachedFileUpdaterTriggerDetails}
+RT_CLASS!{class CachedFileUpdaterTriggerDetails: ICachedFileUpdaterTriggerDetails ["Windows.ApplicationModel.Background.CachedFileUpdaterTriggerDetails"]}
 DEFINE_IID!(IID_IChatMessageNotificationTrigger, 1362838463, 7488, 23645, 120, 245, 201, 35, 254, 227, 115, 158);
 RT_INTERFACE!{interface IChatMessageNotificationTrigger(IChatMessageNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageNotificationTrigger] {
     
 }}
-RT_CLASS!{class ChatMessageNotificationTrigger: IChatMessageNotificationTrigger}
+RT_CLASS!{class ChatMessageNotificationTrigger: IChatMessageNotificationTrigger ["Windows.ApplicationModel.Background.ChatMessageNotificationTrigger"]}
 impl RtActivatable<IActivationFactory> for ChatMessageNotificationTrigger {}
 DEFINE_CLSID!(ChatMessageNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,104,97,116,77,101,115,115,97,103,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ChatMessageNotificationTrigger]);
 DEFINE_IID!(IID_IChatMessageReceivedNotificationTrigger, 1050899982, 47861, 16503, 136, 233, 6, 12, 246, 240, 198, 213);
 RT_INTERFACE!{interface IChatMessageReceivedNotificationTrigger(IChatMessageReceivedNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageReceivedNotificationTrigger] {
     
 }}
-RT_CLASS!{class ChatMessageReceivedNotificationTrigger: IChatMessageReceivedNotificationTrigger}
+RT_CLASS!{class ChatMessageReceivedNotificationTrigger: IChatMessageReceivedNotificationTrigger ["Windows.ApplicationModel.Background.ChatMessageReceivedNotificationTrigger"]}
 impl RtActivatable<IActivationFactory> for ChatMessageReceivedNotificationTrigger {}
 DEFINE_CLSID!(ChatMessageReceivedNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,104,97,116,77,101,115,115,97,103,101,82,101,99,101,105,118,101,100,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ChatMessageReceivedNotificationTrigger]);
 DEFINE_IID!(IID_ICommunicationBlockingAppSetAsActiveTrigger, 4220646026, 5797, 18541, 151, 76, 120, 53, 168, 71, 123, 226);
 RT_INTERFACE!{interface ICommunicationBlockingAppSetAsActiveTrigger(ICommunicationBlockingAppSetAsActiveTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ICommunicationBlockingAppSetAsActiveTrigger] {
     
 }}
-RT_CLASS!{class CommunicationBlockingAppSetAsActiveTrigger: ICommunicationBlockingAppSetAsActiveTrigger}
+RT_CLASS!{class CommunicationBlockingAppSetAsActiveTrigger: ICommunicationBlockingAppSetAsActiveTrigger ["Windows.ApplicationModel.Background.CommunicationBlockingAppSetAsActiveTrigger"]}
 impl RtActivatable<IActivationFactory> for CommunicationBlockingAppSetAsActiveTrigger {}
 DEFINE_CLSID!(CommunicationBlockingAppSetAsActiveTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,111,109,109,117,110,105,99,97,116,105,111,110,66,108,111,99,107,105,110,103,65,112,112,83,101,116,65,115,65,99,116,105,118,101,84,114,105,103,103,101,114,0]) [CLSID_CommunicationBlockingAppSetAsActiveTrigger]);
 DEFINE_IID!(IID_IContactStoreNotificationTrigger, 3358802331, 18181, 17777, 154, 22, 6, 185, 151, 191, 156, 150);
 RT_INTERFACE!{interface IContactStoreNotificationTrigger(IContactStoreNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IContactStoreNotificationTrigger] {
     
 }}
-RT_CLASS!{class ContactStoreNotificationTrigger: IContactStoreNotificationTrigger}
+RT_CLASS!{class ContactStoreNotificationTrigger: IContactStoreNotificationTrigger ["Windows.ApplicationModel.Background.ContactStoreNotificationTrigger"]}
 impl RtActivatable<IActivationFactory> for ContactStoreNotificationTrigger {}
 DEFINE_CLSID!(ContactStoreNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,67,111,110,116,97,99,116,83,116,111,114,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_ContactStoreNotificationTrigger]);
 DEFINE_IID!(IID_IContentPrefetchTrigger, 1896228846, 1274, 17419, 128, 192, 23, 50, 2, 25, 158, 93);
@@ -6091,7 +6091,7 @@ impl IContentPrefetchTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContentPrefetchTrigger: IContentPrefetchTrigger}
+RT_CLASS!{class ContentPrefetchTrigger: IContentPrefetchTrigger ["Windows.ApplicationModel.Background.ContentPrefetchTrigger"]}
 impl RtActivatable<IContentPrefetchTriggerFactory> for ContentPrefetchTrigger {}
 impl RtActivatable<IActivationFactory> for ContentPrefetchTrigger {}
 impl ContentPrefetchTrigger {
@@ -6128,7 +6128,7 @@ impl ICustomSystemEventTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CustomSystemEventTrigger: ICustomSystemEventTrigger}
+RT_CLASS!{class CustomSystemEventTrigger: ICustomSystemEventTrigger ["Windows.ApplicationModel.Background.CustomSystemEventTrigger"]}
 impl RtActivatable<ICustomSystemEventTriggerFactory> for CustomSystemEventTrigger {}
 impl CustomSystemEventTrigger {
     #[inline] pub fn create(triggerId: &HStringArg, recurrence: CustomSystemEventTriggerRecurrence) -> Result<ComPtr<CustomSystemEventTrigger>> {
@@ -6147,7 +6147,7 @@ impl ICustomSystemEventTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CustomSystemEventTriggerRecurrence: i32 {
+RT_ENUM! { enum CustomSystemEventTriggerRecurrence: i32 ["Windows.ApplicationModel.Background.CustomSystemEventTriggerRecurrence"] {
     Once (CustomSystemEventTriggerRecurrence_Once) = 0, Always (CustomSystemEventTriggerRecurrence_Always) = 1,
 }}
 DEFINE_IID!(IID_IDeviceConnectionChangeTrigger, 2424790628, 15581, 20219, 171, 28, 91, 59, 106, 96, 206, 52);
@@ -6178,7 +6178,7 @@ impl IDeviceConnectionChangeTrigger {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceConnectionChangeTrigger: IDeviceConnectionChangeTrigger}
+RT_CLASS!{class DeviceConnectionChangeTrigger: IDeviceConnectionChangeTrigger ["Windows.ApplicationModel.Background.DeviceConnectionChangeTrigger"]}
 impl RtActivatable<IDeviceConnectionChangeTriggerStatics> for DeviceConnectionChangeTrigger {}
 impl DeviceConnectionChangeTrigger {
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<DeviceConnectionChangeTrigger>>> {
@@ -6214,7 +6214,7 @@ impl IDeviceManufacturerNotificationTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceManufacturerNotificationTrigger: IDeviceManufacturerNotificationTrigger}
+RT_CLASS!{class DeviceManufacturerNotificationTrigger: IDeviceManufacturerNotificationTrigger ["Windows.ApplicationModel.Background.DeviceManufacturerNotificationTrigger"]}
 impl RtActivatable<IDeviceManufacturerNotificationTriggerFactory> for DeviceManufacturerNotificationTrigger {}
 impl DeviceManufacturerNotificationTrigger {
     #[inline] pub fn create(triggerQualifier: &HStringArg, oneShot: bool) -> Result<ComPtr<DeviceManufacturerNotificationTrigger>> {
@@ -6250,10 +6250,10 @@ impl IDeviceServicingTrigger {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceServicingTrigger: IDeviceServicingTrigger}
+RT_CLASS!{class DeviceServicingTrigger: IDeviceServicingTrigger ["Windows.ApplicationModel.Background.DeviceServicingTrigger"]}
 impl RtActivatable<IActivationFactory> for DeviceServicingTrigger {}
 DEFINE_CLSID!(DeviceServicingTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,68,101,118,105,99,101,83,101,114,118,105,99,105,110,103,84,114,105,103,103,101,114,0]) [CLSID_DeviceServicingTrigger]);
-RT_ENUM! { enum DeviceTriggerResult: i32 {
+RT_ENUM! { enum DeviceTriggerResult: i32 ["Windows.ApplicationModel.Background.DeviceTriggerResult"] {
     Allowed (DeviceTriggerResult_Allowed) = 0, DeniedByUser (DeviceTriggerResult_DeniedByUser) = 1, DeniedBySystem (DeviceTriggerResult_DeniedBySystem) = 2, LowBattery (DeviceTriggerResult_LowBattery) = 3,
 }}
 DEFINE_IID!(IID_IDeviceUseTrigger, 229015569, 13135, 19799, 182, 236, 109, 202, 100, 180, 18, 228);
@@ -6273,19 +6273,19 @@ impl IDeviceUseTrigger {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceUseTrigger: IDeviceUseTrigger}
+RT_CLASS!{class DeviceUseTrigger: IDeviceUseTrigger ["Windows.ApplicationModel.Background.DeviceUseTrigger"]}
 impl RtActivatable<IActivationFactory> for DeviceUseTrigger {}
 DEFINE_CLSID!(DeviceUseTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,68,101,118,105,99,101,85,115,101,84,114,105,103,103,101,114,0]) [CLSID_DeviceUseTrigger]);
 DEFINE_IID!(IID_IDeviceWatcherTrigger, 2757853149, 34163, 16992, 190, 252, 91, 236, 137, 203, 105, 61);
 RT_INTERFACE!{interface IDeviceWatcherTrigger(IDeviceWatcherTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceWatcherTrigger] {
     
 }}
-RT_CLASS!{class DeviceWatcherTrigger: IDeviceWatcherTrigger}
+RT_CLASS!{class DeviceWatcherTrigger: IDeviceWatcherTrigger ["Windows.ApplicationModel.Background.DeviceWatcherTrigger"]}
 DEFINE_IID!(IID_IEmailStoreNotificationTrigger, 2557282010, 18411, 17000, 164, 242, 243, 247, 113, 136, 56, 138);
 RT_INTERFACE!{interface IEmailStoreNotificationTrigger(IEmailStoreNotificationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IEmailStoreNotificationTrigger] {
     
 }}
-RT_CLASS!{class EmailStoreNotificationTrigger: IEmailStoreNotificationTrigger}
+RT_CLASS!{class EmailStoreNotificationTrigger: IEmailStoreNotificationTrigger ["Windows.ApplicationModel.Background.EmailStoreNotificationTrigger"]}
 impl RtActivatable<IActivationFactory> for EmailStoreNotificationTrigger {}
 DEFINE_CLSID!(EmailStoreNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,69,109,97,105,108,83,116,111,114,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_EmailStoreNotificationTrigger]);
 DEFINE_IID!(IID_IGattCharacteristicNotificationTrigger, 3797913544, 1686, 18255, 167, 50, 242, 146, 176, 206, 188, 93);
@@ -6299,7 +6299,7 @@ impl IGattCharacteristicNotificationTrigger {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattCharacteristicNotificationTrigger: IGattCharacteristicNotificationTrigger}
+RT_CLASS!{class GattCharacteristicNotificationTrigger: IGattCharacteristicNotificationTrigger ["Windows.ApplicationModel.Background.GattCharacteristicNotificationTrigger"]}
 impl RtActivatable<IGattCharacteristicNotificationTriggerFactory> for GattCharacteristicNotificationTrigger {}
 impl RtActivatable<IGattCharacteristicNotificationTriggerFactory2> for GattCharacteristicNotificationTrigger {}
 impl GattCharacteristicNotificationTrigger {
@@ -6372,7 +6372,7 @@ impl IGattServiceProviderTrigger {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderTrigger: IGattServiceProviderTrigger}
+RT_CLASS!{class GattServiceProviderTrigger: IGattServiceProviderTrigger ["Windows.ApplicationModel.Background.GattServiceProviderTrigger"]}
 impl RtActivatable<IGattServiceProviderTriggerStatics> for GattServiceProviderTrigger {}
 impl GattServiceProviderTrigger {
     #[inline] pub fn create_async(triggerId: &HStringArg, serviceUuid: Guid) -> Result<ComPtr<foundation::IAsyncOperation<GattServiceProviderTriggerResult>>> {
@@ -6397,7 +6397,7 @@ impl IGattServiceProviderTriggerResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderTriggerResult: IGattServiceProviderTriggerResult}
+RT_CLASS!{class GattServiceProviderTriggerResult: IGattServiceProviderTriggerResult ["Windows.ApplicationModel.Background.GattServiceProviderTriggerResult"]}
 DEFINE_IID!(IID_IGattServiceProviderTriggerStatics, 3021185898, 58004, 17809, 165, 166, 100, 137, 26, 130, 129, 83);
 RT_INTERFACE!{static interface IGattServiceProviderTriggerStatics(IGattServiceProviderTriggerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProviderTriggerStatics] {
     fn CreateAsync(&self, triggerId: HSTRING, serviceUuid: Guid, out: *mut *mut foundation::IAsyncOperation<GattServiceProviderTriggerResult>) -> HRESULT
@@ -6425,7 +6425,7 @@ impl IGeovisitTrigger {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeovisitTrigger: IGeovisitTrigger}
+RT_CLASS!{class GeovisitTrigger: IGeovisitTrigger ["Windows.ApplicationModel.Background.GeovisitTrigger"]}
 impl RtActivatable<IActivationFactory> for GeovisitTrigger {}
 DEFINE_CLSID!(GeovisitTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,71,101,111,118,105,115,105,116,84,114,105,103,103,101,114,0]) [CLSID_GeovisitTrigger]);
 DEFINE_IID!(IID_ILocationTrigger, 1197894172, 26743, 18462, 128, 38, 255, 126, 20, 168, 17, 160);
@@ -6439,7 +6439,7 @@ impl ILocationTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LocationTrigger: ILocationTrigger}
+RT_CLASS!{class LocationTrigger: ILocationTrigger ["Windows.ApplicationModel.Background.LocationTrigger"]}
 impl RtActivatable<ILocationTriggerFactory> for LocationTrigger {}
 impl LocationTrigger {
     #[inline] pub fn create(triggerType: LocationTriggerType) -> Result<ComPtr<LocationTrigger>> {
@@ -6458,7 +6458,7 @@ impl ILocationTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LocationTriggerType: i32 {
+RT_ENUM! { enum LocationTriggerType: i32 ["Windows.ApplicationModel.Background.LocationTriggerType"] {
     Geofence (LocationTriggerType_Geofence) = 0,
 }}
 DEFINE_IID!(IID_IMaintenanceTrigger, 1746422915, 64546, 19685, 132, 26, 114, 57, 169, 129, 0, 71);
@@ -6478,7 +6478,7 @@ impl IMaintenanceTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MaintenanceTrigger: IMaintenanceTrigger}
+RT_CLASS!{class MaintenanceTrigger: IMaintenanceTrigger ["Windows.ApplicationModel.Background.MaintenanceTrigger"]}
 impl RtActivatable<IMaintenanceTriggerFactory> for MaintenanceTrigger {}
 impl MaintenanceTrigger {
     #[inline] pub fn create(freshnessTime: u32, oneShot: bool) -> Result<ComPtr<MaintenanceTrigger>> {
@@ -6514,35 +6514,35 @@ impl IMediaProcessingTrigger {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaProcessingTrigger: IMediaProcessingTrigger}
+RT_CLASS!{class MediaProcessingTrigger: IMediaProcessingTrigger ["Windows.ApplicationModel.Background.MediaProcessingTrigger"]}
 impl RtActivatable<IActivationFactory> for MediaProcessingTrigger {}
 DEFINE_CLSID!(MediaProcessingTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,101,100,105,97,80,114,111,99,101,115,115,105,110,103,84,114,105,103,103,101,114,0]) [CLSID_MediaProcessingTrigger]);
-RT_ENUM! { enum MediaProcessingTriggerResult: i32 {
+RT_ENUM! { enum MediaProcessingTriggerResult: i32 ["Windows.ApplicationModel.Background.MediaProcessingTriggerResult"] {
     Allowed (MediaProcessingTriggerResult_Allowed) = 0, CurrentlyRunning (MediaProcessingTriggerResult_CurrentlyRunning) = 1, DisabledByPolicy (MediaProcessingTriggerResult_DisabledByPolicy) = 2, UnknownError (MediaProcessingTriggerResult_UnknownError) = 3,
 }}
-RT_CLASS!{class MobileBroadbandDeviceServiceNotificationTrigger: IBackgroundTrigger}
+RT_CLASS!{class MobileBroadbandDeviceServiceNotificationTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.MobileBroadbandDeviceServiceNotificationTrigger"]}
 impl RtActivatable<IActivationFactory> for MobileBroadbandDeviceServiceNotificationTrigger {}
 DEFINE_CLSID!(MobileBroadbandDeviceServiceNotificationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,68,101,118,105,99,101,83,101,114,118,105,99,101,78,111,116,105,102,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandDeviceServiceNotificationTrigger]);
-RT_CLASS!{class MobileBroadbandPcoDataChangeTrigger: IBackgroundTrigger}
+RT_CLASS!{class MobileBroadbandPcoDataChangeTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.MobileBroadbandPcoDataChangeTrigger"]}
 impl RtActivatable<IActivationFactory> for MobileBroadbandPcoDataChangeTrigger {}
 DEFINE_CLSID!(MobileBroadbandPcoDataChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,80,99,111,68,97,116,97,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandPcoDataChangeTrigger]);
-RT_CLASS!{class MobileBroadbandPinLockStateChangeTrigger: IBackgroundTrigger}
+RT_CLASS!{class MobileBroadbandPinLockStateChangeTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.MobileBroadbandPinLockStateChangeTrigger"]}
 impl RtActivatable<IActivationFactory> for MobileBroadbandPinLockStateChangeTrigger {}
 DEFINE_CLSID!(MobileBroadbandPinLockStateChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,80,105,110,76,111,99,107,83,116,97,116,101,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandPinLockStateChangeTrigger]);
-RT_CLASS!{class MobileBroadbandRadioStateChangeTrigger: IBackgroundTrigger}
+RT_CLASS!{class MobileBroadbandRadioStateChangeTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.MobileBroadbandRadioStateChangeTrigger"]}
 impl RtActivatable<IActivationFactory> for MobileBroadbandRadioStateChangeTrigger {}
 DEFINE_CLSID!(MobileBroadbandRadioStateChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,82,97,100,105,111,83,116,97,116,101,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandRadioStateChangeTrigger]);
-RT_CLASS!{class MobileBroadbandRegistrationStateChangeTrigger: IBackgroundTrigger}
+RT_CLASS!{class MobileBroadbandRegistrationStateChangeTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.MobileBroadbandRegistrationStateChangeTrigger"]}
 impl RtActivatable<IActivationFactory> for MobileBroadbandRegistrationStateChangeTrigger {}
 DEFINE_CLSID!(MobileBroadbandRegistrationStateChangeTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,82,101,103,105,115,116,114,97,116,105,111,110,83,116,97,116,101,67,104,97,110,103,101,84,114,105,103,103,101,114,0]) [CLSID_MobileBroadbandRegistrationStateChangeTrigger]);
-RT_CLASS!{class NetworkOperatorDataUsageTrigger: IBackgroundTrigger}
+RT_CLASS!{class NetworkOperatorDataUsageTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.NetworkOperatorDataUsageTrigger"]}
 impl RtActivatable<IActivationFactory> for NetworkOperatorDataUsageTrigger {}
 DEFINE_CLSID!(NetworkOperatorDataUsageTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,68,97,116,97,85,115,97,103,101,84,114,105,103,103,101,114,0]) [CLSID_NetworkOperatorDataUsageTrigger]);
 DEFINE_IID!(IID_INetworkOperatorHotspotAuthenticationTrigger, 3881224081, 12289, 19941, 131, 199, 222, 97, 216, 136, 49, 208);
 RT_INTERFACE!{interface INetworkOperatorHotspotAuthenticationTrigger(INetworkOperatorHotspotAuthenticationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorHotspotAuthenticationTrigger] {
     
 }}
-RT_CLASS!{class NetworkOperatorHotspotAuthenticationTrigger: INetworkOperatorHotspotAuthenticationTrigger}
+RT_CLASS!{class NetworkOperatorHotspotAuthenticationTrigger: INetworkOperatorHotspotAuthenticationTrigger ["Windows.ApplicationModel.Background.NetworkOperatorHotspotAuthenticationTrigger"]}
 impl RtActivatable<IActivationFactory> for NetworkOperatorHotspotAuthenticationTrigger {}
 DEFINE_CLSID!(NetworkOperatorHotspotAuthenticationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,72,111,116,115,112,111,116,65,117,116,104,101,110,116,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_NetworkOperatorHotspotAuthenticationTrigger]);
 DEFINE_IID!(IID_INetworkOperatorNotificationTrigger, 2416483526, 25549, 18444, 149, 209, 110, 106, 239, 128, 30, 74);
@@ -6556,7 +6556,7 @@ impl INetworkOperatorNotificationTrigger {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorNotificationTrigger: INetworkOperatorNotificationTrigger}
+RT_CLASS!{class NetworkOperatorNotificationTrigger: INetworkOperatorNotificationTrigger ["Windows.ApplicationModel.Background.NetworkOperatorNotificationTrigger"]}
 impl RtActivatable<INetworkOperatorNotificationTriggerFactory> for NetworkOperatorNotificationTrigger {}
 impl NetworkOperatorNotificationTrigger {
     #[inline] pub fn create(networkAccountId: &HStringArg) -> Result<ComPtr<NetworkOperatorNotificationTrigger>> {
@@ -6575,7 +6575,7 @@ impl INetworkOperatorNotificationTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentAppCanMakePaymentTrigger: IBackgroundTrigger}
+RT_CLASS!{class PaymentAppCanMakePaymentTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.PaymentAppCanMakePaymentTrigger"]}
 impl RtActivatable<IActivationFactory> for PaymentAppCanMakePaymentTrigger {}
 DEFINE_CLSID!(PaymentAppCanMakePaymentTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,80,97,121,109,101,110,116,65,112,112,67,97,110,77,97,107,101,80,97,121,109,101,110,116,84,114,105,103,103,101,114,0]) [CLSID_PaymentAppCanMakePaymentTrigger]);
 DEFINE_IID!(IID_IPhoneTrigger, 2379213211, 54469, 18929, 183, 211, 130, 232, 122, 14, 157, 222);
@@ -6595,7 +6595,7 @@ impl IPhoneTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneTrigger: IPhoneTrigger}
+RT_CLASS!{class PhoneTrigger: IPhoneTrigger ["Windows.ApplicationModel.Background.PhoneTrigger"]}
 impl RtActivatable<IPhoneTriggerFactory> for PhoneTrigger {}
 impl PhoneTrigger {
     #[inline] pub fn create(type_: super::calls::background::PhoneTriggerType, oneShot: bool) -> Result<ComPtr<PhoneTrigger>> {
@@ -6614,7 +6614,7 @@ impl IPhoneTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PushNotificationTrigger: IBackgroundTrigger}
+RT_CLASS!{class PushNotificationTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.PushNotificationTrigger"]}
 impl RtActivatable<IPushNotificationTriggerFactory> for PushNotificationTrigger {}
 impl RtActivatable<IActivationFactory> for PushNotificationTrigger {}
 impl PushNotificationTrigger {
@@ -6638,7 +6638,7 @@ DEFINE_IID!(IID_IRcsEndUserMessageAvailableTrigger, 2557283690, 45814, 18047, 16
 RT_INTERFACE!{interface IRcsEndUserMessageAvailableTrigger(IRcsEndUserMessageAvailableTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IRcsEndUserMessageAvailableTrigger] {
     
 }}
-RT_CLASS!{class RcsEndUserMessageAvailableTrigger: IRcsEndUserMessageAvailableTrigger}
+RT_CLASS!{class RcsEndUserMessageAvailableTrigger: IRcsEndUserMessageAvailableTrigger ["Windows.ApplicationModel.Background.RcsEndUserMessageAvailableTrigger"]}
 impl RtActivatable<IActivationFactory> for RcsEndUserMessageAvailableTrigger {}
 DEFINE_CLSID!(RcsEndUserMessageAvailableTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,82,99,115,69,110,100,85,115,101,114,77,101,115,115,97,103,101,65,118,97,105,108,97,98,108,101,84,114,105,103,103,101,114,0]) [CLSID_RcsEndUserMessageAvailableTrigger]);
 DEFINE_IID!(IID_IRfcommConnectionTrigger, 3905211106, 2899, 17508, 147, 148, 253, 135, 86, 84, 222, 100);
@@ -6693,21 +6693,21 @@ impl IRfcommConnectionTrigger {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommConnectionTrigger: IRfcommConnectionTrigger}
+RT_CLASS!{class RfcommConnectionTrigger: IRfcommConnectionTrigger ["Windows.ApplicationModel.Background.RfcommConnectionTrigger"]}
 impl RtActivatable<IActivationFactory> for RfcommConnectionTrigger {}
 DEFINE_CLSID!(RfcommConnectionTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,82,102,99,111,109,109,67,111,110,110,101,99,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_RfcommConnectionTrigger]);
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationTrigger, 4063752999, 20865, 20260, 150, 167, 112, 10, 78, 95, 172, 98);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorAuthenticationTrigger(ISecondaryAuthenticationFactorAuthenticationTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorAuthenticationTrigger] {
     
 }}
-RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationTrigger: ISecondaryAuthenticationFactorAuthenticationTrigger}
+RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationTrigger: ISecondaryAuthenticationFactorAuthenticationTrigger ["Windows.ApplicationModel.Background.SecondaryAuthenticationFactorAuthenticationTrigger"]}
 impl RtActivatable<IActivationFactory> for SecondaryAuthenticationFactorAuthenticationTrigger {}
 DEFINE_CLSID!(SecondaryAuthenticationFactorAuthenticationTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,101,99,111,110,100,97,114,121,65,117,116,104,101,110,116,105,99,97,116,105,111,110,70,97,99,116,111,114,65,117,116,104,101,110,116,105,99,97,116,105,111,110,84,114,105,103,103,101,114,0]) [CLSID_SecondaryAuthenticationFactorAuthenticationTrigger]);
 DEFINE_IID!(IID_ISensorDataThresholdTrigger, 1539371890, 54411, 19327, 171, 236, 21, 249, 186, 204, 18, 226);
 RT_INTERFACE!{interface ISensorDataThresholdTrigger(ISensorDataThresholdTriggerVtbl): IInspectable(IInspectableVtbl) [IID_ISensorDataThresholdTrigger] {
     
 }}
-RT_CLASS!{class SensorDataThresholdTrigger: ISensorDataThresholdTrigger}
+RT_CLASS!{class SensorDataThresholdTrigger: ISensorDataThresholdTrigger ["Windows.ApplicationModel.Background.SensorDataThresholdTrigger"]}
 impl RtActivatable<ISensorDataThresholdTriggerFactory> for SensorDataThresholdTrigger {}
 impl SensorDataThresholdTrigger {
     #[cfg(feature="windows-devices")] #[inline] pub fn create(threshold: &super::super::devices::sensors::ISensorDataThreshold) -> Result<ComPtr<SensorDataThresholdTrigger>> {
@@ -6737,7 +6737,7 @@ impl ISmartCardTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardTrigger: ISmartCardTrigger}
+RT_CLASS!{class SmartCardTrigger: ISmartCardTrigger ["Windows.ApplicationModel.Background.SmartCardTrigger"]}
 impl RtActivatable<ISmartCardTriggerFactory> for SmartCardTrigger {}
 impl SmartCardTrigger {
     #[cfg(feature="windows-devices")] #[inline] pub fn create(triggerType: super::super::devices::smartcards::SmartCardTriggerType) -> Result<ComPtr<SmartCardTrigger>> {
@@ -6756,7 +6756,7 @@ impl ISmartCardTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsMessageReceivedTrigger: IBackgroundTrigger}
+RT_CLASS!{class SmsMessageReceivedTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.SmsMessageReceivedTrigger"]}
 impl RtActivatable<ISmsMessageReceivedTriggerFactory> for SmsMessageReceivedTrigger {}
 impl SmsMessageReceivedTrigger {
     #[cfg(feature="windows-devices")] #[inline] pub fn create(filterRules: &super::super::devices::sms::SmsFilterRules) -> Result<ComPtr<SmsMessageReceivedTrigger>> {
@@ -6786,10 +6786,10 @@ impl ISocketActivityTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocketActivityTrigger: IBackgroundTrigger}
+RT_CLASS!{class SocketActivityTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.SocketActivityTrigger"]}
 impl RtActivatable<IActivationFactory> for SocketActivityTrigger {}
 DEFINE_CLSID!(SocketActivityTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,83,111,99,107,101,116,65,99,116,105,118,105,116,121,84,114,105,103,103,101,114,0]) [CLSID_SocketActivityTrigger]);
-RT_CLASS!{class StorageLibraryChangeTrackerTrigger: IBackgroundTrigger}
+RT_CLASS!{class StorageLibraryChangeTrackerTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.StorageLibraryChangeTrackerTrigger"]}
 impl RtActivatable<IStorageLibraryChangeTrackerTriggerFactory> for StorageLibraryChangeTrackerTrigger {}
 impl StorageLibraryChangeTrackerTrigger {
     #[cfg(feature="windows-storage")] #[inline] pub fn create(tracker: &super::super::storage::StorageLibraryChangeTracker) -> Result<ComPtr<StorageLibraryChangeTrackerTrigger>> {
@@ -6812,7 +6812,7 @@ DEFINE_IID!(IID_IStorageLibraryContentChangedTrigger, 372760743, 33436, 17852, 1
 RT_INTERFACE!{interface IStorageLibraryContentChangedTrigger(IStorageLibraryContentChangedTriggerVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryContentChangedTrigger] {
     
 }}
-RT_CLASS!{class StorageLibraryContentChangedTrigger: IStorageLibraryContentChangedTrigger}
+RT_CLASS!{class StorageLibraryContentChangedTrigger: IStorageLibraryContentChangedTrigger ["Windows.ApplicationModel.Background.StorageLibraryContentChangedTrigger"]}
 impl RtActivatable<IStorageLibraryContentChangedTriggerStatics> for StorageLibraryContentChangedTrigger {}
 impl StorageLibraryContentChangedTrigger {
     #[cfg(feature="windows-storage")] #[inline] pub fn create(storageLibrary: &super::super::storage::StorageLibrary) -> Result<Option<ComPtr<StorageLibraryContentChangedTrigger>>> {
@@ -6851,7 +6851,7 @@ impl ISystemCondition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemCondition: ISystemCondition}
+RT_CLASS!{class SystemCondition: ISystemCondition ["Windows.ApplicationModel.Background.SystemCondition"]}
 impl RtActivatable<ISystemConditionFactory> for SystemCondition {}
 impl SystemCondition {
     #[inline] pub fn create(conditionType: SystemConditionType) -> Result<ComPtr<SystemCondition>> {
@@ -6870,7 +6870,7 @@ impl ISystemConditionFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SystemConditionType: i32 {
+RT_ENUM! { enum SystemConditionType: i32 ["Windows.ApplicationModel.Background.SystemConditionType"] {
     Invalid (SystemConditionType_Invalid) = 0, UserPresent (SystemConditionType_UserPresent) = 1, UserNotPresent (SystemConditionType_UserNotPresent) = 2, InternetAvailable (SystemConditionType_InternetAvailable) = 3, InternetNotAvailable (SystemConditionType_InternetNotAvailable) = 4, SessionConnected (SystemConditionType_SessionConnected) = 5, SessionDisconnected (SystemConditionType_SessionDisconnected) = 6, FreeNetworkAvailable (SystemConditionType_FreeNetworkAvailable) = 7, BackgroundWorkCostNotHigh (SystemConditionType_BackgroundWorkCostNotHigh) = 8,
 }}
 DEFINE_IID!(IID_ISystemTrigger, 494978934, 14152, 17507, 141, 126, 39, 109, 193, 57, 172, 28);
@@ -6890,7 +6890,7 @@ impl ISystemTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemTrigger: ISystemTrigger}
+RT_CLASS!{class SystemTrigger: ISystemTrigger ["Windows.ApplicationModel.Background.SystemTrigger"]}
 impl RtActivatable<ISystemTriggerFactory> for SystemTrigger {}
 impl SystemTrigger {
     #[inline] pub fn create(triggerType: SystemTriggerType, oneShot: bool) -> Result<ComPtr<SystemTrigger>> {
@@ -6909,10 +6909,10 @@ impl ISystemTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SystemTriggerType: i32 {
+RT_ENUM! { enum SystemTriggerType: i32 ["Windows.ApplicationModel.Background.SystemTriggerType"] {
     Invalid (SystemTriggerType_Invalid) = 0, SmsReceived (SystemTriggerType_SmsReceived) = 1, UserPresent (SystemTriggerType_UserPresent) = 2, UserAway (SystemTriggerType_UserAway) = 3, NetworkStateChange (SystemTriggerType_NetworkStateChange) = 4, ControlChannelReset (SystemTriggerType_ControlChannelReset) = 5, InternetAvailable (SystemTriggerType_InternetAvailable) = 6, SessionConnected (SystemTriggerType_SessionConnected) = 7, ServicingComplete (SystemTriggerType_ServicingComplete) = 8, LockScreenApplicationAdded (SystemTriggerType_LockScreenApplicationAdded) = 9, LockScreenApplicationRemoved (SystemTriggerType_LockScreenApplicationRemoved) = 10, TimeZoneChange (SystemTriggerType_TimeZoneChange) = 11, OnlineIdConnectedStateChange (SystemTriggerType_OnlineIdConnectedStateChange) = 12, BackgroundWorkCostChange (SystemTriggerType_BackgroundWorkCostChange) = 13, PowerStateChange (SystemTriggerType_PowerStateChange) = 14, DefaultSignInAccountChange (SystemTriggerType_DefaultSignInAccountChange) = 15,
 }}
-RT_CLASS!{class TetheringEntitlementCheckTrigger: IBackgroundTrigger}
+RT_CLASS!{class TetheringEntitlementCheckTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.TetheringEntitlementCheckTrigger"]}
 impl RtActivatable<IActivationFactory> for TetheringEntitlementCheckTrigger {}
 DEFINE_CLSID!(TetheringEntitlementCheckTrigger(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,66,97,99,107,103,114,111,117,110,100,46,84,101,116,104,101,114,105,110,103,69,110,116,105,116,108,101,109,101,110,116,67,104,101,99,107,84,114,105,103,103,101,114,0]) [CLSID_TetheringEntitlementCheckTrigger]);
 DEFINE_IID!(IID_ITimeTrigger, 1701729622, 2858, 17271, 186, 112, 59, 69, 169, 53, 84, 127);
@@ -6932,7 +6932,7 @@ impl ITimeTrigger {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimeTrigger: ITimeTrigger}
+RT_CLASS!{class TimeTrigger: ITimeTrigger ["Windows.ApplicationModel.Background.TimeTrigger"]}
 impl RtActivatable<ITimeTriggerFactory> for TimeTrigger {}
 impl TimeTrigger {
     #[inline] pub fn create(freshnessTime: u32, oneShot: bool) -> Result<ComPtr<TimeTrigger>> {
@@ -6951,7 +6951,7 @@ impl ITimeTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationActionTrigger: IBackgroundTrigger}
+RT_CLASS!{class ToastNotificationActionTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.ToastNotificationActionTrigger"]}
 impl RtActivatable<IToastNotificationActionTriggerFactory> for ToastNotificationActionTrigger {}
 impl RtActivatable<IActivationFactory> for ToastNotificationActionTrigger {}
 impl ToastNotificationActionTrigger {
@@ -6971,7 +6971,7 @@ impl IToastNotificationActionTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationHistoryChangedTrigger: IBackgroundTrigger}
+RT_CLASS!{class ToastNotificationHistoryChangedTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.ToastNotificationHistoryChangedTrigger"]}
 impl RtActivatable<IToastNotificationHistoryChangedTriggerFactory> for ToastNotificationHistoryChangedTrigger {}
 impl RtActivatable<IActivationFactory> for ToastNotificationHistoryChangedTrigger {}
 impl ToastNotificationHistoryChangedTrigger {
@@ -6991,7 +6991,7 @@ impl IToastNotificationHistoryChangedTriggerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserNotificationChangedTrigger: IBackgroundTrigger}
+RT_CLASS!{class UserNotificationChangedTrigger: IBackgroundTrigger ["Windows.ApplicationModel.Background.UserNotificationChangedTrigger"]}
 impl RtActivatable<IUserNotificationChangedTriggerFactory> for UserNotificationChangedTrigger {}
 impl UserNotificationChangedTrigger {
     #[cfg(feature="windows-ui")] #[inline] pub fn create(notificationKinds: super::super::ui::notifications::NotificationKinds) -> Result<ComPtr<UserNotificationChangedTrigger>> {
@@ -7024,7 +7024,7 @@ impl ICallAnswerEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CallAnswerEventArgs: ICallAnswerEventArgs}
+RT_CLASS!{class CallAnswerEventArgs: ICallAnswerEventArgs ["Windows.ApplicationModel.Calls.CallAnswerEventArgs"]}
 DEFINE_IID!(IID_ICallRejectEventArgs, 3662150359, 5076, 19858, 161, 194, 183, 120, 17, 238, 55, 236);
 RT_INTERFACE!{interface ICallRejectEventArgs(ICallRejectEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICallRejectEventArgs] {
     fn get_RejectReason(&self, out: *mut VoipPhoneCallRejectReason) -> HRESULT
@@ -7036,7 +7036,7 @@ impl ICallRejectEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CallRejectEventArgs: ICallRejectEventArgs}
+RT_CLASS!{class CallRejectEventArgs: ICallRejectEventArgs ["Windows.ApplicationModel.Calls.CallRejectEventArgs"]}
 DEFINE_IID!(IID_ICallStateChangeEventArgs, 3937547422, 26357, 18425, 159, 181, 69, 156, 81, 152, 199, 32);
 RT_INTERFACE!{interface ICallStateChangeEventArgs(ICallStateChangeEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICallStateChangeEventArgs] {
     fn get_State(&self, out: *mut VoipPhoneCallState) -> HRESULT
@@ -7048,8 +7048,8 @@ impl ICallStateChangeEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CallStateChangeEventArgs: ICallStateChangeEventArgs}
-RT_ENUM! { enum CellularDtmfMode: i32 {
+RT_CLASS!{class CallStateChangeEventArgs: ICallStateChangeEventArgs ["Windows.ApplicationModel.Calls.CallStateChangeEventArgs"]}
+RT_ENUM! { enum CellularDtmfMode: i32 ["Windows.ApplicationModel.Calls.CellularDtmfMode"] {
     Continuous (CellularDtmfMode_Continuous) = 0, Burst (CellularDtmfMode_Burst) = 1,
 }}
 DEFINE_IID!(IID_ILockScreenCallEndCallDeferral, 769125645, 39149, 16449, 150, 50, 80, 255, 129, 43, 119, 63);
@@ -7062,7 +7062,7 @@ impl ILockScreenCallEndCallDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenCallEndCallDeferral: ILockScreenCallEndCallDeferral}
+RT_CLASS!{class LockScreenCallEndCallDeferral: ILockScreenCallEndCallDeferral ["Windows.ApplicationModel.Calls.LockScreenCallEndCallDeferral"]}
 DEFINE_IID!(IID_ILockScreenCallEndRequestedEventArgs, 2173739875, 28455, 18153, 174, 182, 192, 174, 131, 228, 125, 199);
 RT_INTERFACE!{interface ILockScreenCallEndRequestedEventArgs(ILockScreenCallEndRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenCallEndRequestedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut LockScreenCallEndCallDeferral) -> HRESULT,
@@ -7080,7 +7080,7 @@ impl ILockScreenCallEndRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenCallEndRequestedEventArgs: ILockScreenCallEndRequestedEventArgs}
+RT_CLASS!{class LockScreenCallEndRequestedEventArgs: ILockScreenCallEndRequestedEventArgs ["Windows.ApplicationModel.Calls.LockScreenCallEndRequestedEventArgs"]}
 DEFINE_IID!(IID_ILockScreenCallUI, 3315006861, 29641, 18964, 176, 33, 236, 28, 80, 163, 183, 39);
 RT_INTERFACE!{interface ILockScreenCallUI(ILockScreenCallUIVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenCallUI] {
     fn Dismiss(&self) -> HRESULT,
@@ -7124,7 +7124,7 @@ impl ILockScreenCallUI {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenCallUI: ILockScreenCallUI}
+RT_CLASS!{class LockScreenCallUI: ILockScreenCallUI ["Windows.ApplicationModel.Calls.LockScreenCallUI"]}
 DEFINE_IID!(IID_IMuteChangeEventArgs, 2240143705, 3137, 17196, 129, 77, 197, 241, 253, 245, 48, 190);
 RT_INTERFACE!{interface IMuteChangeEventArgs(IMuteChangeEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMuteChangeEventArgs] {
     fn get_Muted(&self, out: *mut bool) -> HRESULT
@@ -7136,8 +7136,8 @@ impl IMuteChangeEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MuteChangeEventArgs: IMuteChangeEventArgs}
-RT_ENUM! { enum PhoneAudioRoutingEndpoint: i32 {
+RT_CLASS!{class MuteChangeEventArgs: IMuteChangeEventArgs ["Windows.ApplicationModel.Calls.MuteChangeEventArgs"]}
+RT_ENUM! { enum PhoneAudioRoutingEndpoint: i32 ["Windows.ApplicationModel.Calls.PhoneAudioRoutingEndpoint"] {
     Default (PhoneAudioRoutingEndpoint_Default) = 0, Bluetooth (PhoneAudioRoutingEndpoint_Bluetooth) = 1, Speakerphone (PhoneAudioRoutingEndpoint_Speakerphone) = 2,
 }}
 RT_CLASS!{static class PhoneCallBlocking}
@@ -7386,7 +7386,7 @@ impl IPhoneCallHistoryEntry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallHistoryEntry: IPhoneCallHistoryEntry}
+RT_CLASS!{class PhoneCallHistoryEntry: IPhoneCallHistoryEntry ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntry"]}
 impl RtActivatable<IActivationFactory> for PhoneCallHistoryEntry {}
 DEFINE_CLSID!(PhoneCallHistoryEntry(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,67,97,108,108,72,105,115,116,111,114,121,69,110,116,114,121,0]) [CLSID_PhoneCallHistoryEntry]);
 DEFINE_IID!(IID_IPhoneCallHistoryEntryAddress, 821123546, 14677, 16450, 132, 230, 102, 238, 191, 130, 230, 127);
@@ -7438,7 +7438,7 @@ impl IPhoneCallHistoryEntryAddress {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallHistoryEntryAddress: IPhoneCallHistoryEntryAddress}
+RT_CLASS!{class PhoneCallHistoryEntryAddress: IPhoneCallHistoryEntryAddress ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryAddress"]}
 impl RtActivatable<IPhoneCallHistoryEntryAddressFactory> for PhoneCallHistoryEntryAddress {}
 impl RtActivatable<IActivationFactory> for PhoneCallHistoryEntryAddress {}
 impl PhoneCallHistoryEntryAddress {
@@ -7458,13 +7458,13 @@ impl IPhoneCallHistoryEntryAddressFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PhoneCallHistoryEntryMedia: i32 {
+RT_ENUM! { enum PhoneCallHistoryEntryMedia: i32 ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryMedia"] {
     Audio (PhoneCallHistoryEntryMedia_Audio) = 0, Video (PhoneCallHistoryEntryMedia_Video) = 1,
 }}
-RT_ENUM! { enum PhoneCallHistoryEntryOtherAppReadAccess: i32 {
+RT_ENUM! { enum PhoneCallHistoryEntryOtherAppReadAccess: i32 ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryOtherAppReadAccess"] {
     Full (PhoneCallHistoryEntryOtherAppReadAccess_Full) = 0, SystemOnly (PhoneCallHistoryEntryOtherAppReadAccess_SystemOnly) = 1,
 }}
-RT_ENUM! { enum PhoneCallHistoryEntryQueryDesiredMedia: u32 {
+RT_ENUM! { enum PhoneCallHistoryEntryQueryDesiredMedia: u32 ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryQueryDesiredMedia"] {
     None (PhoneCallHistoryEntryQueryDesiredMedia_None) = 0, Audio (PhoneCallHistoryEntryQueryDesiredMedia_Audio) = 1, Video (PhoneCallHistoryEntryQueryDesiredMedia_Video) = 2, All (PhoneCallHistoryEntryQueryDesiredMedia_All) = 4294967295,
 }}
 DEFINE_IID!(IID_IPhoneCallHistoryEntryQueryOptions, 2623529308, 35821, 16586, 176, 110, 196, 202, 142, 174, 92, 135);
@@ -7489,10 +7489,10 @@ impl IPhoneCallHistoryEntryQueryOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallHistoryEntryQueryOptions: IPhoneCallHistoryEntryQueryOptions}
+RT_CLASS!{class PhoneCallHistoryEntryQueryOptions: IPhoneCallHistoryEntryQueryOptions ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryQueryOptions"]}
 impl RtActivatable<IActivationFactory> for PhoneCallHistoryEntryQueryOptions {}
 DEFINE_CLSID!(PhoneCallHistoryEntryQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,67,97,108,108,72,105,115,116,111,114,121,69,110,116,114,121,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_PhoneCallHistoryEntryQueryOptions]);
-RT_ENUM! { enum PhoneCallHistoryEntryRawAddressKind: i32 {
+RT_ENUM! { enum PhoneCallHistoryEntryRawAddressKind: i32 ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryRawAddressKind"] {
     PhoneNumber (PhoneCallHistoryEntryRawAddressKind_PhoneNumber) = 0, Custom (PhoneCallHistoryEntryRawAddressKind_Custom) = 1,
 }}
 DEFINE_IID!(IID_IPhoneCallHistoryEntryReader, 1642915006, 36230, 18335, 132, 4, 169, 132, 105, 32, 254, 230);
@@ -7506,7 +7506,7 @@ impl IPhoneCallHistoryEntryReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallHistoryEntryReader: IPhoneCallHistoryEntryReader}
+RT_CLASS!{class PhoneCallHistoryEntryReader: IPhoneCallHistoryEntryReader ["Windows.ApplicationModel.Calls.PhoneCallHistoryEntryReader"]}
 RT_CLASS!{static class PhoneCallHistoryManager}
 impl RtActivatable<IPhoneCallHistoryManagerStatics> for PhoneCallHistoryManager {}
 impl RtActivatable<IPhoneCallHistoryManagerStatics2> for PhoneCallHistoryManager {}
@@ -7536,7 +7536,7 @@ impl IPhoneCallHistoryManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallHistoryManagerForUser: IPhoneCallHistoryManagerForUser}
+RT_CLASS!{class PhoneCallHistoryManagerForUser: IPhoneCallHistoryManagerForUser ["Windows.ApplicationModel.Calls.PhoneCallHistoryManagerForUser"]}
 DEFINE_IID!(IID_IPhoneCallHistoryManagerStatics, 4121352761, 45855, 20293, 172, 142, 27, 8, 137, 60, 27, 80);
 RT_INTERFACE!{static interface IPhoneCallHistoryManagerStatics(IPhoneCallHistoryManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallHistoryManagerStatics] {
     fn RequestStoreAsync(&self, accessType: PhoneCallHistoryStoreAccessType, out: *mut *mut foundation::IAsyncOperation<PhoneCallHistoryStore>) -> HRESULT
@@ -7559,7 +7559,7 @@ impl IPhoneCallHistoryManagerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PhoneCallHistorySourceIdKind: i32 {
+RT_ENUM! { enum PhoneCallHistorySourceIdKind: i32 ["Windows.ApplicationModel.Calls.PhoneCallHistorySourceIdKind"] {
     CellularPhoneLineId (PhoneCallHistorySourceIdKind_CellularPhoneLineId) = 0, PackageFamilyName (PhoneCallHistorySourceIdKind_PackageFamilyName) = 1,
 }}
 DEFINE_IID!(IID_IPhoneCallHistoryStore, 797998520, 46094, 16939, 133, 69, 203, 25, 16, 166, 28, 82);
@@ -7639,8 +7639,8 @@ impl IPhoneCallHistoryStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallHistoryStore: IPhoneCallHistoryStore}
-RT_ENUM! { enum PhoneCallHistoryStoreAccessType: i32 {
+RT_CLASS!{class PhoneCallHistoryStore: IPhoneCallHistoryStore ["Windows.ApplicationModel.Calls.PhoneCallHistoryStore"]}
+RT_ENUM! { enum PhoneCallHistoryStoreAccessType: i32 ["Windows.ApplicationModel.Calls.PhoneCallHistoryStoreAccessType"] {
     AppEntriesReadWrite (PhoneCallHistoryStoreAccessType_AppEntriesReadWrite) = 0, AllEntriesLimitedReadWrite (PhoneCallHistoryStoreAccessType_AllEntriesLimitedReadWrite) = 1, AllEntriesReadWrite (PhoneCallHistoryStoreAccessType_AllEntriesReadWrite) = 2,
 }}
 RT_CLASS!{static class PhoneCallManager}
@@ -7719,7 +7719,7 @@ impl IPhoneCallManagerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PhoneCallMedia: i32 {
+RT_ENUM! { enum PhoneCallMedia: i32 ["Windows.ApplicationModel.Calls.PhoneCallMedia"] {
     Audio (PhoneCallMedia_Audio) = 0, AudioAndVideo (PhoneCallMedia_AudioAndVideo) = 1, AudioAndRealTimeText (PhoneCallMedia_AudioAndRealTimeText) = 2,
 }}
 DEFINE_IID!(IID_IPhoneCallStore, 1600194376, 6310, 16755, 134, 209, 40, 190, 157, 198, 45, 186);
@@ -7745,7 +7745,7 @@ impl IPhoneCallStore {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallStore: IPhoneCallStore}
+RT_CLASS!{class PhoneCallStore: IPhoneCallStore ["Windows.ApplicationModel.Calls.PhoneCallStore"]}
 DEFINE_IID!(IID_IPhoneCallVideoCapabilities, 37234566, 45418, 20443, 190, 59, 196, 36, 14, 19, 173, 13);
 RT_INTERFACE!{interface IPhoneCallVideoCapabilities(IPhoneCallVideoCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallVideoCapabilities] {
     fn get_IsVideoCallingCapable(&self, out: *mut bool) -> HRESULT
@@ -7757,7 +7757,7 @@ impl IPhoneCallVideoCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallVideoCapabilities: IPhoneCallVideoCapabilities}
+RT_CLASS!{class PhoneCallVideoCapabilities: IPhoneCallVideoCapabilities ["Windows.ApplicationModel.Calls.PhoneCallVideoCapabilities"]}
 RT_CLASS!{static class PhoneCallVideoCapabilitiesManager}
 impl RtActivatable<IPhoneCallVideoCapabilitiesManagerStatics> for PhoneCallVideoCapabilitiesManager {}
 impl PhoneCallVideoCapabilitiesManager {
@@ -7848,7 +7848,7 @@ impl IPhoneDialOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneDialOptions: IPhoneDialOptions}
+RT_CLASS!{class PhoneDialOptions: IPhoneDialOptions ["Windows.ApplicationModel.Calls.PhoneDialOptions"]}
 impl RtActivatable<IActivationFactory> for PhoneDialOptions {}
 DEFINE_CLSID!(PhoneDialOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,104,111,110,101,68,105,97,108,79,112,116,105,111,110,115,0]) [CLSID_PhoneDialOptions]);
 DEFINE_IID!(IID_IPhoneLine, 667316016, 27241, 13514, 162, 186, 101, 48, 37, 48, 195, 17);
@@ -7956,7 +7956,7 @@ impl IPhoneLine {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneLine: IPhoneLine}
+RT_CLASS!{class PhoneLine: IPhoneLine ["Windows.ApplicationModel.Calls.PhoneLine"]}
 impl RtActivatable<IPhoneLineStatics> for PhoneLine {}
 impl PhoneLine {
     #[inline] pub fn from_id_async(lineId: Guid) -> Result<ComPtr<foundation::IAsyncOperation<PhoneLine>>> {
@@ -7999,7 +7999,7 @@ impl IPhoneLineCellularDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneLineCellularDetails: IPhoneLineCellularDetails}
+RT_CLASS!{class PhoneLineCellularDetails: IPhoneLineCellularDetails ["Windows.ApplicationModel.Calls.PhoneLineCellularDetails"]}
 DEFINE_IID!(IID_IPhoneLineConfiguration, 4263925858, 63055, 17170, 178, 168, 78, 37, 119, 33, 170, 149);
 RT_INTERFACE!{interface IPhoneLineConfiguration(IPhoneLineConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneLineConfiguration] {
     fn get_IsVideoCallingEnabled(&self, out: *mut bool) -> HRESULT,
@@ -8017,8 +8017,8 @@ impl IPhoneLineConfiguration {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneLineConfiguration: IPhoneLineConfiguration}
-RT_ENUM! { enum PhoneLineNetworkOperatorDisplayTextLocation: i32 {
+RT_CLASS!{class PhoneLineConfiguration: IPhoneLineConfiguration ["Windows.ApplicationModel.Calls.PhoneLineConfiguration"]}
+RT_ENUM! { enum PhoneLineNetworkOperatorDisplayTextLocation: i32 ["Windows.ApplicationModel.Calls.PhoneLineNetworkOperatorDisplayTextLocation"] {
     Default (PhoneLineNetworkOperatorDisplayTextLocation_Default) = 0, Tile (PhoneLineNetworkOperatorDisplayTextLocation_Tile) = 1, Dialer (PhoneLineNetworkOperatorDisplayTextLocation_Dialer) = 2, InCallUI (PhoneLineNetworkOperatorDisplayTextLocation_InCallUI) = 3,
 }}
 DEFINE_IID!(IID_IPhoneLineStatics, 4085997347, 52912, 16463, 188, 242, 186, 159, 105, 125, 138, 223);
@@ -8032,7 +8032,7 @@ impl IPhoneLineStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PhoneLineTransport: i32 {
+RT_ENUM! { enum PhoneLineTransport: i32 ["Windows.ApplicationModel.Calls.PhoneLineTransport"] {
     Cellular (PhoneLineTransport_Cellular) = 0, VoipApp (PhoneLineTransport_VoipApp) = 1,
 }}
 DEFINE_IID!(IID_IPhoneLineWatcher, 2319830282, 25379, 17632, 166, 246, 159, 33, 246, 77, 201, 10);
@@ -8111,7 +8111,7 @@ impl IPhoneLineWatcher {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneLineWatcher: IPhoneLineWatcher}
+RT_CLASS!{class PhoneLineWatcher: IPhoneLineWatcher ["Windows.ApplicationModel.Calls.PhoneLineWatcher"]}
 DEFINE_IID!(IID_IPhoneLineWatcherEventArgs, 3497817406, 40466, 18999, 130, 183, 173, 83, 93, 173, 106, 103);
 RT_INTERFACE!{interface IPhoneLineWatcherEventArgs(IPhoneLineWatcherEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneLineWatcherEventArgs] {
     fn get_LineId(&self, out: *mut Guid) -> HRESULT
@@ -8123,14 +8123,14 @@ impl IPhoneLineWatcherEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneLineWatcherEventArgs: IPhoneLineWatcherEventArgs}
-RT_ENUM! { enum PhoneLineWatcherStatus: i32 {
+RT_CLASS!{class PhoneLineWatcherEventArgs: IPhoneLineWatcherEventArgs ["Windows.ApplicationModel.Calls.PhoneLineWatcherEventArgs"]}
+RT_ENUM! { enum PhoneLineWatcherStatus: i32 ["Windows.ApplicationModel.Calls.PhoneLineWatcherStatus"] {
     Created (PhoneLineWatcherStatus_Created) = 0, Started (PhoneLineWatcherStatus_Started) = 1, EnumerationCompleted (PhoneLineWatcherStatus_EnumerationCompleted) = 2, Stopped (PhoneLineWatcherStatus_Stopped) = 3,
 }}
-RT_ENUM! { enum PhoneNetworkState: i32 {
+RT_ENUM! { enum PhoneNetworkState: i32 ["Windows.ApplicationModel.Calls.PhoneNetworkState"] {
     Unknown (PhoneNetworkState_Unknown) = 0, NoSignal (PhoneNetworkState_NoSignal) = 1, Deregistered (PhoneNetworkState_Deregistered) = 2, Denied (PhoneNetworkState_Denied) = 3, Searching (PhoneNetworkState_Searching) = 4, Home (PhoneNetworkState_Home) = 5, RoamingInternational (PhoneNetworkState_RoamingInternational) = 6, RoamingDomestic (PhoneNetworkState_RoamingDomestic) = 7,
 }}
-RT_ENUM! { enum PhoneSimState: i32 {
+RT_ENUM! { enum PhoneSimState: i32 ["Windows.ApplicationModel.Calls.PhoneSimState"] {
     Unknown (PhoneSimState_Unknown) = 0, PinNotRequired (PhoneSimState_PinNotRequired) = 1, PinUnlocked (PhoneSimState_PinUnlocked) = 2, PinLocked (PhoneSimState_PinLocked) = 3, PukLocked (PhoneSimState_PukLocked) = 4, NotInserted (PhoneSimState_NotInserted) = 5, Invalid (PhoneSimState_Invalid) = 6, Disabled (PhoneSimState_Disabled) = 7,
 }}
 DEFINE_IID!(IID_IPhoneVoicemail, 3385751542, 28319, 14987, 183, 39, 110, 12, 246, 153, 130, 36);
@@ -8162,8 +8162,8 @@ impl IPhoneVoicemail {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneVoicemail: IPhoneVoicemail}
-RT_ENUM! { enum PhoneVoicemailType: i32 {
+RT_CLASS!{class PhoneVoicemail: IPhoneVoicemail ["Windows.ApplicationModel.Calls.PhoneVoicemail"]}
+RT_ENUM! { enum PhoneVoicemailType: i32 ["Windows.ApplicationModel.Calls.PhoneVoicemailType"] {
     None (PhoneVoicemailType_None) = 0, Traditional (PhoneVoicemailType_Traditional) = 1, Visual (PhoneVoicemailType_Visual) = 2,
 }}
 DEFINE_IID!(IID_IVoipCallCoordinator, 1326549967, 59631, 17460, 156, 95, 168, 216, 147, 250, 254, 121);
@@ -8232,7 +8232,7 @@ impl IVoipCallCoordinator {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoipCallCoordinator: IVoipCallCoordinator}
+RT_CLASS!{class VoipCallCoordinator: IVoipCallCoordinator ["Windows.ApplicationModel.Calls.VoipCallCoordinator"]}
 impl RtActivatable<IVoipCallCoordinatorStatics> for VoipCallCoordinator {}
 impl VoipCallCoordinator {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<VoipCallCoordinator>>> {
@@ -8403,7 +8403,7 @@ impl IVoipPhoneCall {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoipPhoneCall: IVoipPhoneCall}
+RT_CLASS!{class VoipPhoneCall: IVoipPhoneCall ["Windows.ApplicationModel.Calls.VoipPhoneCall"]}
 DEFINE_IID!(IID_IVoipPhoneCall2, 1947944673, 9311, 16883, 147, 153, 49, 65, 210, 91, 82, 227);
 RT_INTERFACE!{interface IVoipPhoneCall2(IVoipPhoneCall2Vtbl): IInspectable(IInspectableVtbl) [IID_IVoipPhoneCall2] {
     fn TryShowAppUI(&self) -> HRESULT
@@ -8424,21 +8424,21 @@ impl IVoipPhoneCall3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VoipPhoneCallMedia: u32 {
+RT_ENUM! { enum VoipPhoneCallMedia: u32 ["Windows.ApplicationModel.Calls.VoipPhoneCallMedia"] {
     None (VoipPhoneCallMedia_None) = 0, Audio (VoipPhoneCallMedia_Audio) = 1, Video (VoipPhoneCallMedia_Video) = 2,
 }}
-RT_ENUM! { enum VoipPhoneCallRejectReason: i32 {
+RT_ENUM! { enum VoipPhoneCallRejectReason: i32 ["Windows.ApplicationModel.Calls.VoipPhoneCallRejectReason"] {
     UserIgnored (VoipPhoneCallRejectReason_UserIgnored) = 0, TimedOut (VoipPhoneCallRejectReason_TimedOut) = 1, OtherIncomingCall (VoipPhoneCallRejectReason_OtherIncomingCall) = 2, EmergencyCallExists (VoipPhoneCallRejectReason_EmergencyCallExists) = 3, InvalidCallState (VoipPhoneCallRejectReason_InvalidCallState) = 4,
 }}
-RT_ENUM! { enum VoipPhoneCallResourceReservationStatus: i32 {
+RT_ENUM! { enum VoipPhoneCallResourceReservationStatus: i32 ["Windows.ApplicationModel.Calls.VoipPhoneCallResourceReservationStatus"] {
     Success (VoipPhoneCallResourceReservationStatus_Success) = 0, ResourcesNotAvailable (VoipPhoneCallResourceReservationStatus_ResourcesNotAvailable) = 1,
 }}
-RT_ENUM! { enum VoipPhoneCallState: i32 {
+RT_ENUM! { enum VoipPhoneCallState: i32 ["Windows.ApplicationModel.Calls.VoipPhoneCallState"] {
     Ended (VoipPhoneCallState_Ended) = 0, Held (VoipPhoneCallState_Held) = 1, Active (VoipPhoneCallState_Active) = 2, Incoming (VoipPhoneCallState_Incoming) = 3, Outgoing (VoipPhoneCallState_Outgoing) = 4,
 }}
 pub mod background { // Windows.ApplicationModel.Calls.Background
 use ::prelude::*;
-RT_ENUM! { enum PhoneCallBlockedReason: i32 {
+RT_ENUM! { enum PhoneCallBlockedReason: i32 ["Windows.ApplicationModel.Calls.Background.PhoneCallBlockedReason"] {
     InCallBlockingList (PhoneCallBlockedReason_InCallBlockingList) = 0, PrivateNumber (PhoneCallBlockedReason_PrivateNumber) = 1, UnknownNumber (PhoneCallBlockedReason_UnknownNumber) = 2,
 }}
 DEFINE_IID!(IID_IPhoneCallBlockedTriggerDetails, 2762379426, 58561, 17023, 134, 78, 228, 112, 71, 125, 219, 103);
@@ -8464,7 +8464,7 @@ impl IPhoneCallBlockedTriggerDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallBlockedTriggerDetails: IPhoneCallBlockedTriggerDetails}
+RT_CLASS!{class PhoneCallBlockedTriggerDetails: IPhoneCallBlockedTriggerDetails ["Windows.ApplicationModel.Calls.Background.PhoneCallBlockedTriggerDetails"]}
 DEFINE_IID!(IID_IPhoneCallOriginDataRequestTriggerDetails, 1855675199, 50507, 20098, 76, 201, 227, 41, 164, 24, 69, 146);
 RT_INTERFACE!{interface IPhoneCallOriginDataRequestTriggerDetails(IPhoneCallOriginDataRequestTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneCallOriginDataRequestTriggerDetails] {
     fn get_RequestId(&self, out: *mut Guid) -> HRESULT,
@@ -8482,7 +8482,7 @@ impl IPhoneCallOriginDataRequestTriggerDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallOriginDataRequestTriggerDetails: IPhoneCallOriginDataRequestTriggerDetails}
+RT_CLASS!{class PhoneCallOriginDataRequestTriggerDetails: IPhoneCallOriginDataRequestTriggerDetails ["Windows.ApplicationModel.Calls.Background.PhoneCallOriginDataRequestTriggerDetails"]}
 DEFINE_IID!(IID_IPhoneLineChangedTriggerDetails, 3335725543, 53533, 16600, 178, 183, 228, 10, 1, 214, 98, 73);
 RT_INTERFACE!{interface IPhoneLineChangedTriggerDetails(IPhoneLineChangedTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPhoneLineChangedTriggerDetails] {
     fn get_LineId(&self, out: *mut Guid) -> HRESULT,
@@ -8506,11 +8506,11 @@ impl IPhoneLineChangedTriggerDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneLineChangedTriggerDetails: IPhoneLineChangedTriggerDetails}
-RT_ENUM! { enum PhoneLineChangeKind: i32 {
+RT_CLASS!{class PhoneLineChangedTriggerDetails: IPhoneLineChangedTriggerDetails ["Windows.ApplicationModel.Calls.Background.PhoneLineChangedTriggerDetails"]}
+RT_ENUM! { enum PhoneLineChangeKind: i32 ["Windows.ApplicationModel.Calls.Background.PhoneLineChangeKind"] {
     Added (PhoneLineChangeKind_Added) = 0, Removed (PhoneLineChangeKind_Removed) = 1, PropertiesChanged (PhoneLineChangeKind_PropertiesChanged) = 2,
 }}
-RT_ENUM! { enum PhoneLineProperties: u32 {
+RT_ENUM! { enum PhoneLineProperties: u32 ["Windows.ApplicationModel.Calls.Background.PhoneLineProperties"] {
     None (PhoneLineProperties_None) = 0, BrandingOptions (PhoneLineProperties_BrandingOptions) = 1, CanDial (PhoneLineProperties_CanDial) = 2, CellularDetails (PhoneLineProperties_CellularDetails) = 4, DisplayColor (PhoneLineProperties_DisplayColor) = 8, DisplayName (PhoneLineProperties_DisplayName) = 16, NetworkName (PhoneLineProperties_NetworkName) = 32, NetworkState (PhoneLineProperties_NetworkState) = 64, Transport (PhoneLineProperties_Transport) = 128, Voicemail (PhoneLineProperties_Voicemail) = 256,
 }}
 DEFINE_IID!(IID_IPhoneNewVoicemailMessageTriggerDetails, 329826331, 47153, 18643, 139, 169, 141, 34, 166, 88, 13, 207);
@@ -8536,8 +8536,8 @@ impl IPhoneNewVoicemailMessageTriggerDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneNewVoicemailMessageTriggerDetails: IPhoneNewVoicemailMessageTriggerDetails}
-RT_ENUM! { enum PhoneTriggerType: i32 {
+RT_CLASS!{class PhoneNewVoicemailMessageTriggerDetails: IPhoneNewVoicemailMessageTriggerDetails ["Windows.ApplicationModel.Calls.Background.PhoneNewVoicemailMessageTriggerDetails"]}
+RT_ENUM! { enum PhoneTriggerType: i32 ["Windows.ApplicationModel.Calls.Background.PhoneTriggerType"] {
     NewVoicemailMessage (PhoneTriggerType_NewVoicemailMessage) = 0, CallHistoryChanged (PhoneTriggerType_CallHistoryChanged) = 1, LineChanged (PhoneTriggerType_LineChanged) = 2, AirplaneModeDisabledForEmergencyCall (PhoneTriggerType_AirplaneModeDisabledForEmergencyCall) = 3, CallOriginDataRequest (PhoneTriggerType_CallOriginDataRequest) = 4, CallBlocked (PhoneTriggerType_CallBlocked) = 5,
 }}
 } // Windows.ApplicationModel.Calls.Background
@@ -8581,7 +8581,7 @@ impl IPhoneCallOrigin {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneCallOrigin: IPhoneCallOrigin}
+RT_CLASS!{class PhoneCallOrigin: IPhoneCallOrigin ["Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin"]}
 impl RtActivatable<IActivationFactory> for PhoneCallOrigin {}
 DEFINE_CLSID!(PhoneCallOrigin(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,97,108,108,115,46,80,114,111,118,105,100,101,114,46,80,104,111,110,101,67,97,108,108,79,114,105,103,105,110,0]) [CLSID_PhoneCallOrigin]);
 DEFINE_IID!(IID_IPhoneCallOrigin2, 80210304, 39618, 18280, 181, 54, 182, 141, 164, 149, 125, 2);
@@ -8705,7 +8705,7 @@ impl IChatCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatCapabilities: IChatCapabilities}
+RT_CLASS!{class ChatCapabilities: IChatCapabilities ["Windows.ApplicationModel.Chat.ChatCapabilities"]}
 RT_CLASS!{static class ChatCapabilitiesManager}
 impl RtActivatable<IChatCapabilitiesManagerStatics> for ChatCapabilitiesManager {}
 impl RtActivatable<IChatCapabilitiesManagerStatics2> for ChatCapabilitiesManager {}
@@ -8866,7 +8866,7 @@ impl IChatConversation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatConversation: IChatConversation}
+RT_CLASS!{class ChatConversation: IChatConversation ["Windows.ApplicationModel.Chat.ChatConversation"]}
 DEFINE_IID!(IID_IChatConversation2, 167972049, 38970, 18346, 154, 144, 238, 72, 238, 153, 123, 89);
 RT_INTERFACE!{interface IChatConversation2(IChatConversation2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatConversation2] {
     fn get_CanModifyParticipants(&self, out: *mut bool) -> HRESULT,
@@ -8900,7 +8900,7 @@ impl IChatConversationReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatConversationReader: IChatConversationReader}
+RT_CLASS!{class ChatConversationReader: IChatConversationReader ["Windows.ApplicationModel.Chat.ChatConversationReader"]}
 DEFINE_IID!(IID_IChatConversationThreadingInfo, 857481692, 31239, 17442, 163, 44, 36, 190, 124, 109, 171, 36);
 RT_INTERFACE!{interface IChatConversationThreadingInfo(IChatConversationThreadingInfoVtbl): IInspectable(IInspectableVtbl) [IID_IChatConversationThreadingInfo] {
     fn get_ContactId(&self, out: *mut HSTRING) -> HRESULT,
@@ -8956,10 +8956,10 @@ impl IChatConversationThreadingInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatConversationThreadingInfo: IChatConversationThreadingInfo}
+RT_CLASS!{class ChatConversationThreadingInfo: IChatConversationThreadingInfo ["Windows.ApplicationModel.Chat.ChatConversationThreadingInfo"]}
 impl RtActivatable<IActivationFactory> for ChatConversationThreadingInfo {}
 DEFINE_CLSID!(ChatConversationThreadingInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,67,111,110,118,101,114,115,97,116,105,111,110,84,104,114,101,97,100,105,110,103,73,110,102,111,0]) [CLSID_ChatConversationThreadingInfo]);
-RT_ENUM! { enum ChatConversationThreadingKind: i32 {
+RT_ENUM! { enum ChatConversationThreadingKind: i32 ["Windows.ApplicationModel.Chat.ChatConversationThreadingKind"] {
     Participants (ChatConversationThreadingKind_Participants) = 0, ContactId (ChatConversationThreadingKind_ContactId) = 1, ConversationId (ChatConversationThreadingKind_ConversationId) = 2, Custom (ChatConversationThreadingKind_Custom) = 3,
 }}
 DEFINE_IID!(IID_IChatItem, 2270285824, 52913, 16963, 184, 3, 21, 212, 90, 29, 212, 40);
@@ -8973,7 +8973,7 @@ impl IChatItem {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ChatItemKind: i32 {
+RT_ENUM! { enum ChatItemKind: i32 ["Windows.ApplicationModel.Chat.ChatItemKind"] {
     Message (ChatItemKind_Message) = 0, Conversation (ChatItemKind_Conversation) = 1,
 }}
 DEFINE_IID!(IID_IChatMessage, 1262028074, 4418, 20617, 118, 218, 242, 219, 61, 23, 205, 5);
@@ -9081,7 +9081,7 @@ impl IChatMessage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessage: IChatMessage}
+RT_CLASS!{class ChatMessage: IChatMessage ["Windows.ApplicationModel.Chat.ChatMessage"]}
 impl RtActivatable<IActivationFactory> for ChatMessage {}
 DEFINE_CLSID!(ChatMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,77,101,115,115,97,103,101,0]) [CLSID_ChatMessage]);
 DEFINE_IID!(IID_IChatMessage2, 2254865202, 21567, 18933, 172, 113, 108, 42, 252, 101, 101, 253);
@@ -9318,7 +9318,7 @@ impl IChatMessageAttachment {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageAttachment: IChatMessageAttachment}
+RT_CLASS!{class ChatMessageAttachment: IChatMessageAttachment ["Windows.ApplicationModel.Chat.ChatMessageAttachment"]}
 impl RtActivatable<IChatMessageAttachmentFactory> for ChatMessageAttachment {}
 impl ChatMessageAttachment {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_chat_message_attachment(mimeType: &HStringArg, dataStreamReference: &super::super::storage::streams::IRandomAccessStreamReference) -> Result<ComPtr<ChatMessageAttachment>> {
@@ -9413,7 +9413,7 @@ impl IChatMessageChange {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageChange: IChatMessageChange}
+RT_CLASS!{class ChatMessageChange: IChatMessageChange ["Windows.ApplicationModel.Chat.ChatMessageChange"]}
 DEFINE_IID!(IID_IChatMessageChangedDeferral, 4224103180, 30860, 19916, 172, 231, 98, 130, 56, 41, 104, 207);
 RT_INTERFACE!{interface IChatMessageChangedDeferral(IChatMessageChangedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageChangedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -9424,7 +9424,7 @@ impl IChatMessageChangedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageChangedDeferral: IChatMessageChangedDeferral}
+RT_CLASS!{class ChatMessageChangedDeferral: IChatMessageChangedDeferral ["Windows.ApplicationModel.Chat.ChatMessageChangedDeferral"]}
 DEFINE_IID!(IID_IChatMessageChangedEventArgs, 3065462317, 26908, 20191, 134, 96, 110, 185, 137, 104, 146, 227);
 RT_INTERFACE!{interface IChatMessageChangedEventArgs(IChatMessageChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageChangedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut ChatMessageChangedDeferral) -> HRESULT
@@ -9436,7 +9436,7 @@ impl IChatMessageChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageChangedEventArgs: IChatMessageChangedEventArgs}
+RT_CLASS!{class ChatMessageChangedEventArgs: IChatMessageChangedEventArgs ["Windows.ApplicationModel.Chat.ChatMessageChangedEventArgs"]}
 DEFINE_IID!(IID_IChatMessageChangeReader, 338063392, 10446, 24358, 123, 5, 154, 92, 124, 206, 135, 202);
 RT_INTERFACE!{interface IChatMessageChangeReader(IChatMessageChangeReaderVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageChangeReader] {
     fn AcceptChanges(&self) -> HRESULT,
@@ -9458,7 +9458,7 @@ impl IChatMessageChangeReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageChangeReader: IChatMessageChangeReader}
+RT_CLASS!{class ChatMessageChangeReader: IChatMessageChangeReader ["Windows.ApplicationModel.Chat.ChatMessageChangeReader"]}
 DEFINE_IID!(IID_IChatMessageChangeTracker, 1622667366, 28832, 21028, 80, 140, 36, 46, 247, 193, 208, 111);
 RT_INTERFACE!{interface IChatMessageChangeTracker(IChatMessageChangeTrackerVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageChangeTracker] {
     fn Enable(&self) -> HRESULT,
@@ -9480,11 +9480,11 @@ impl IChatMessageChangeTracker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageChangeTracker: IChatMessageChangeTracker}
-RT_ENUM! { enum ChatMessageChangeType: i32 {
+RT_CLASS!{class ChatMessageChangeTracker: IChatMessageChangeTracker ["Windows.ApplicationModel.Chat.ChatMessageChangeTracker"]}
+RT_ENUM! { enum ChatMessageChangeType: i32 ["Windows.ApplicationModel.Chat.ChatMessageChangeType"] {
     MessageCreated (ChatMessageChangeType_MessageCreated) = 0, MessageModified (ChatMessageChangeType_MessageModified) = 1, MessageDeleted (ChatMessageChangeType_MessageDeleted) = 2, ChangeTrackingLost (ChatMessageChangeType_ChangeTrackingLost) = 3,
 }}
-RT_ENUM! { enum ChatMessageKind: i32 {
+RT_ENUM! { enum ChatMessageKind: i32 ["Windows.ApplicationModel.Chat.ChatMessageKind"] {
     Standard (ChatMessageKind_Standard) = 0, FileTransferRequest (ChatMessageKind_FileTransferRequest) = 1, TransportCustom (ChatMessageKind_TransportCustom) = 2, JoinedConversation (ChatMessageKind_JoinedConversation) = 3, LeftConversation (ChatMessageKind_LeftConversation) = 4, OtherParticipantJoinedConversation (ChatMessageKind_OtherParticipantJoinedConversation) = 5, OtherParticipantLeftConversation (ChatMessageKind_OtherParticipantLeftConversation) = 6,
 }}
 RT_CLASS!{static class ChatMessageManager}
@@ -9582,7 +9582,7 @@ impl IChatMessageNotificationTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageNotificationTriggerDetails: IChatMessageNotificationTriggerDetails}
+RT_CLASS!{class ChatMessageNotificationTriggerDetails: IChatMessageNotificationTriggerDetails ["Windows.ApplicationModel.Chat.ChatMessageNotificationTriggerDetails"]}
 DEFINE_IID!(IID_IChatMessageNotificationTriggerDetails2, 1807033056, 43527, 20433, 148, 113, 119, 147, 79, 183, 94, 230);
 RT_INTERFACE!{interface IChatMessageNotificationTriggerDetails2(IChatMessageNotificationTriggerDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageNotificationTriggerDetails2] {
     fn get_ShouldDisplayToast(&self, out: *mut bool) -> HRESULT,
@@ -9612,7 +9612,7 @@ impl IChatMessageNotificationTriggerDetails2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ChatMessageOperatorKind: i32 {
+RT_ENUM! { enum ChatMessageOperatorKind: i32 ["Windows.ApplicationModel.Chat.ChatMessageOperatorKind"] {
     Unspecified (ChatMessageOperatorKind_Unspecified) = 0, Sms (ChatMessageOperatorKind_Sms) = 1, Mms (ChatMessageOperatorKind_Mms) = 2, Rcs (ChatMessageOperatorKind_Rcs) = 3,
 }}
 DEFINE_IID!(IID_IChatMessageReader, 3068819662, 17545, 22265, 118, 170, 226, 4, 104, 37, 20, 207);
@@ -9626,7 +9626,7 @@ impl IChatMessageReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageReader: IChatMessageReader}
+RT_CLASS!{class ChatMessageReader: IChatMessageReader ["Windows.ApplicationModel.Chat.ChatMessageReader"]}
 DEFINE_IID!(IID_IChatMessageReader2, 2305046147, 25787, 18189, 157, 244, 13, 232, 190, 26, 5, 191);
 RT_INTERFACE!{interface IChatMessageReader2(IChatMessageReader2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageReader2] {
     fn ReadBatchWithCountAsync(&self, count: i32, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<ChatMessage>>) -> HRESULT
@@ -9638,7 +9638,7 @@ impl IChatMessageReader2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ChatMessageStatus: i32 {
+RT_ENUM! { enum ChatMessageStatus: i32 ["Windows.ApplicationModel.Chat.ChatMessageStatus"] {
     Draft (ChatMessageStatus_Draft) = 0, Sending (ChatMessageStatus_Sending) = 1, Sent (ChatMessageStatus_Sent) = 2, SendRetryNeeded (ChatMessageStatus_SendRetryNeeded) = 3, SendFailed (ChatMessageStatus_SendFailed) = 4, Received (ChatMessageStatus_Received) = 5, ReceiveDownloadNeeded (ChatMessageStatus_ReceiveDownloadNeeded) = 6, ReceiveDownloadFailed (ChatMessageStatus_ReceiveDownloadFailed) = 7, ReceiveDownloading (ChatMessageStatus_ReceiveDownloading) = 8, Deleted (ChatMessageStatus_Deleted) = 9, Declined (ChatMessageStatus_Declined) = 10, Cancelled (ChatMessageStatus_Cancelled) = 11, Recalled (ChatMessageStatus_Recalled) = 12, ReceiveRetryNeeded (ChatMessageStatus_ReceiveRetryNeeded) = 13,
 }}
 DEFINE_IID!(IID_IChatMessageStore, 838008065, 52470, 22539, 73, 118, 10, 7, 221, 93, 59, 71);
@@ -9717,7 +9717,7 @@ impl IChatMessageStore {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageStore: IChatMessageStore}
+RT_CLASS!{class ChatMessageStore: IChatMessageStore ["Windows.ApplicationModel.Chat.ChatMessageStore"]}
 DEFINE_IID!(IID_IChatMessageStore2, 2907555054, 15060, 18715, 179, 17, 171, 223, 155, 178, 39, 104);
 RT_INTERFACE!{interface IChatMessageStore2(IChatMessageStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageStore2] {
     fn ForwardMessageAsync(&self, localChatMessageId: HSTRING, addresses: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncOperation<ChatMessage>) -> HRESULT,
@@ -9852,7 +9852,7 @@ impl IChatMessageStoreChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageStoreChangedEventArgs: IChatMessageStoreChangedEventArgs}
+RT_CLASS!{class ChatMessageStoreChangedEventArgs: IChatMessageStoreChangedEventArgs ["Windows.ApplicationModel.Chat.ChatMessageStoreChangedEventArgs"]}
 DEFINE_IID!(IID_IChatMessageTransport, 1672076280, 59059, 23706, 95, 133, 212, 121, 37, 185, 189, 24);
 RT_INTERFACE!{interface IChatMessageTransport(IChatMessageTransportVtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageTransport] {
     fn get_IsAppSetAsNotificationProvider(&self, out: *mut bool) -> HRESULT,
@@ -9888,7 +9888,7 @@ impl IChatMessageTransport {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageTransport: IChatMessageTransport}
+RT_CLASS!{class ChatMessageTransport: IChatMessageTransport ["Windows.ApplicationModel.Chat.ChatMessageTransport"]}
 DEFINE_IID!(IID_IChatMessageTransport2, 2426885666, 55370, 19490, 169, 77, 84, 68, 68, 237, 200, 161);
 RT_INTERFACE!{interface IChatMessageTransport2(IChatMessageTransport2Vtbl): IInspectable(IInspectableVtbl) [IID_IChatMessageTransport2] {
     fn get_Configuration(&self, out: *mut *mut ChatMessageTransportConfiguration) -> HRESULT,
@@ -9942,8 +9942,8 @@ impl IChatMessageTransportConfiguration {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageTransportConfiguration: IChatMessageTransportConfiguration}
-RT_ENUM! { enum ChatMessageTransportKind: i32 {
+RT_CLASS!{class ChatMessageTransportConfiguration: IChatMessageTransportConfiguration ["Windows.ApplicationModel.Chat.ChatMessageTransportConfiguration"]}
+RT_ENUM! { enum ChatMessageTransportKind: i32 ["Windows.ApplicationModel.Chat.ChatMessageTransportKind"] {
     Text (ChatMessageTransportKind_Text) = 0, Untriaged (ChatMessageTransportKind_Untriaged) = 1, Blocked (ChatMessageTransportKind_Blocked) = 2, Custom (ChatMessageTransportKind_Custom) = 3,
 }}
 DEFINE_IID!(IID_IChatMessageValidationResult, 636041731, 10476, 22665, 86, 155, 126, 72, 107, 18, 111, 24);
@@ -9975,8 +9975,8 @@ impl IChatMessageValidationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatMessageValidationResult: IChatMessageValidationResult}
-RT_ENUM! { enum ChatMessageValidationStatus: i32 {
+RT_CLASS!{class ChatMessageValidationResult: IChatMessageValidationResult ["Windows.ApplicationModel.Chat.ChatMessageValidationResult"]}
+RT_ENUM! { enum ChatMessageValidationStatus: i32 ["Windows.ApplicationModel.Chat.ChatMessageValidationStatus"] {
     Valid (ChatMessageValidationStatus_Valid) = 0, NoRecipients (ChatMessageValidationStatus_NoRecipients) = 1, InvalidData (ChatMessageValidationStatus_InvalidData) = 2, MessageTooLarge (ChatMessageValidationStatus_MessageTooLarge) = 3, TooManyRecipients (ChatMessageValidationStatus_TooManyRecipients) = 4, TransportInactive (ChatMessageValidationStatus_TransportInactive) = 5, TransportNotFound (ChatMessageValidationStatus_TransportNotFound) = 6, TooManyAttachments (ChatMessageValidationStatus_TooManyAttachments) = 7, InvalidRecipients (ChatMessageValidationStatus_InvalidRecipients) = 8, InvalidBody (ChatMessageValidationStatus_InvalidBody) = 9, InvalidOther (ChatMessageValidationStatus_InvalidOther) = 10, ValidWithLargeMessage (ChatMessageValidationStatus_ValidWithLargeMessage) = 11, VoiceRoamingRestriction (ChatMessageValidationStatus_VoiceRoamingRestriction) = 12, DataRoamingRestriction (ChatMessageValidationStatus_DataRoamingRestriction) = 13,
 }}
 DEFINE_IID!(IID_IChatQueryOptions, 802383014, 48950, 17143, 183, 231, 146, 60, 10, 171, 254, 22);
@@ -9995,7 +9995,7 @@ impl IChatQueryOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatQueryOptions: IChatQueryOptions}
+RT_CLASS!{class ChatQueryOptions: IChatQueryOptions ["Windows.ApplicationModel.Chat.ChatQueryOptions"]}
 impl RtActivatable<IActivationFactory> for ChatQueryOptions {}
 DEFINE_CLSID!(ChatQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_ChatQueryOptions]);
 DEFINE_IID!(IID_IChatRecipientDeliveryInfo, 4291277474, 10300, 19466, 138, 14, 140, 51, 189, 191, 5, 69);
@@ -10066,10 +10066,10 @@ impl IChatRecipientDeliveryInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatRecipientDeliveryInfo: IChatRecipientDeliveryInfo}
+RT_CLASS!{class ChatRecipientDeliveryInfo: IChatRecipientDeliveryInfo ["Windows.ApplicationModel.Chat.ChatRecipientDeliveryInfo"]}
 impl RtActivatable<IActivationFactory> for ChatRecipientDeliveryInfo {}
 DEFINE_CLSID!(ChatRecipientDeliveryInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,104,97,116,46,67,104,97,116,82,101,99,105,112,105,101,110,116,68,101,108,105,118,101,114,121,73,110,102,111,0]) [CLSID_ChatRecipientDeliveryInfo]);
-RT_ENUM! { enum ChatRestoreHistorySpan: i32 {
+RT_ENUM! { enum ChatRestoreHistorySpan: i32 ["Windows.ApplicationModel.Chat.ChatRestoreHistorySpan"] {
     LastMonth (ChatRestoreHistorySpan_LastMonth) = 0, LastYear (ChatRestoreHistorySpan_LastYear) = 1, AnyTime (ChatRestoreHistorySpan_AnyTime) = 2,
 }}
 DEFINE_IID!(IID_IChatSearchReader, 1181089353, 36896, 18258, 152, 13, 57, 97, 35, 37, 245, 137);
@@ -10089,8 +10089,8 @@ impl IChatSearchReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatSearchReader: IChatSearchReader}
-RT_ENUM! { enum ChatStoreChangedEventKind: i32 {
+RT_CLASS!{class ChatSearchReader: IChatSearchReader ["Windows.ApplicationModel.Chat.ChatSearchReader"]}
+RT_ENUM! { enum ChatStoreChangedEventKind: i32 ["Windows.ApplicationModel.Chat.ChatStoreChangedEventKind"] {
     NotificationsMissed (ChatStoreChangedEventKind_NotificationsMissed) = 0, StoreModified (ChatStoreChangedEventKind_StoreModified) = 1, MessageCreated (ChatStoreChangedEventKind_MessageCreated) = 2, MessageModified (ChatStoreChangedEventKind_MessageModified) = 3, MessageDeleted (ChatStoreChangedEventKind_MessageDeleted) = 4, ConversationModified (ChatStoreChangedEventKind_ConversationModified) = 5, ConversationDeleted (ChatStoreChangedEventKind_ConversationDeleted) = 6, ConversationTransportDeleted (ChatStoreChangedEventKind_ConversationTransportDeleted) = 7,
 }}
 DEFINE_IID!(IID_IChatSyncConfiguration, 167274930, 27124, 19199, 130, 182, 6, 153, 47, 244, 2, 210);
@@ -10120,7 +10120,7 @@ impl IChatSyncConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatSyncConfiguration: IChatSyncConfiguration}
+RT_CLASS!{class ChatSyncConfiguration: IChatSyncConfiguration ["Windows.ApplicationModel.Chat.ChatSyncConfiguration"]}
 DEFINE_IID!(IID_IChatSyncManager, 2074422371, 9808, 18543, 180, 180, 107, 217, 211, 214, 60, 132);
 RT_INTERFACE!{interface IChatSyncManager(IChatSyncManagerVtbl): IInspectable(IInspectableVtbl) [IID_IChatSyncManager] {
     fn get_Configuration(&self, out: *mut *mut ChatSyncConfiguration) -> HRESULT,
@@ -10163,11 +10163,11 @@ impl IChatSyncManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChatSyncManager: IChatSyncManager}
-RT_ENUM! { enum ChatTransportErrorCodeCategory: i32 {
+RT_CLASS!{class ChatSyncManager: IChatSyncManager ["Windows.ApplicationModel.Chat.ChatSyncManager"]}
+RT_ENUM! { enum ChatTransportErrorCodeCategory: i32 ["Windows.ApplicationModel.Chat.ChatTransportErrorCodeCategory"] {
     None (ChatTransportErrorCodeCategory_None) = 0, Http (ChatTransportErrorCodeCategory_Http) = 1, Network (ChatTransportErrorCodeCategory_Network) = 2, MmsServer (ChatTransportErrorCodeCategory_MmsServer) = 3,
 }}
-RT_ENUM! { enum ChatTransportInterpretedErrorCode: i32 {
+RT_ENUM! { enum ChatTransportInterpretedErrorCode: i32 ["Windows.ApplicationModel.Chat.ChatTransportInterpretedErrorCode"] {
     None (ChatTransportInterpretedErrorCode_None) = 0, Unknown (ChatTransportInterpretedErrorCode_Unknown) = 1, InvalidRecipientAddress (ChatTransportInterpretedErrorCode_InvalidRecipientAddress) = 2, NetworkConnectivity (ChatTransportInterpretedErrorCode_NetworkConnectivity) = 3, ServiceDenied (ChatTransportInterpretedErrorCode_ServiceDenied) = 4, Timeout (ChatTransportInterpretedErrorCode_Timeout) = 5,
 }}
 DEFINE_IID!(IID_IRcsEndUserMessage, 3620578795, 52183, 20283, 133, 38, 181, 6, 222, 195, 92, 83);
@@ -10217,7 +10217,7 @@ impl IRcsEndUserMessage {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsEndUserMessage: IRcsEndUserMessage}
+RT_CLASS!{class RcsEndUserMessage: IRcsEndUserMessage ["Windows.ApplicationModel.Chat.RcsEndUserMessage"]}
 DEFINE_IID!(IID_IRcsEndUserMessageAction, 2453112631, 39746, 18131, 157, 94, 60, 27, 45, 174, 124, 184);
 RT_INTERFACE!{interface IRcsEndUserMessageAction(IRcsEndUserMessageActionVtbl): IInspectable(IInspectableVtbl) [IID_IRcsEndUserMessageAction] {
     fn get_Label(&self, out: *mut HSTRING) -> HRESULT
@@ -10229,7 +10229,7 @@ impl IRcsEndUserMessageAction {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsEndUserMessageAction: IRcsEndUserMessageAction}
+RT_CLASS!{class RcsEndUserMessageAction: IRcsEndUserMessageAction ["Windows.ApplicationModel.Chat.RcsEndUserMessageAction"]}
 DEFINE_IID!(IID_IRcsEndUserMessageAvailableEventArgs, 759541249, 16265, 16874, 151, 2, 158, 158, 212, 17, 170, 152);
 RT_INTERFACE!{interface IRcsEndUserMessageAvailableEventArgs(IRcsEndUserMessageAvailableEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRcsEndUserMessageAvailableEventArgs] {
     fn get_IsMessageAvailable(&self, out: *mut bool) -> HRESULT,
@@ -10247,7 +10247,7 @@ impl IRcsEndUserMessageAvailableEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsEndUserMessageAvailableEventArgs: IRcsEndUserMessageAvailableEventArgs}
+RT_CLASS!{class RcsEndUserMessageAvailableEventArgs: IRcsEndUserMessageAvailableEventArgs ["Windows.ApplicationModel.Chat.RcsEndUserMessageAvailableEventArgs"]}
 DEFINE_IID!(IID_IRcsEndUserMessageAvailableTriggerDetails, 1536652333, 13599, 18066, 180, 30, 27, 3, 93, 193, 137, 134);
 RT_INTERFACE!{interface IRcsEndUserMessageAvailableTriggerDetails(IRcsEndUserMessageAvailableTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IRcsEndUserMessageAvailableTriggerDetails] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -10265,7 +10265,7 @@ impl IRcsEndUserMessageAvailableTriggerDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsEndUserMessageAvailableTriggerDetails: IRcsEndUserMessageAvailableTriggerDetails}
+RT_CLASS!{class RcsEndUserMessageAvailableTriggerDetails: IRcsEndUserMessageAvailableTriggerDetails ["Windows.ApplicationModel.Chat.RcsEndUserMessageAvailableTriggerDetails"]}
 DEFINE_IID!(IID_IRcsEndUserMessageManager, 810856026, 19743, 19289, 148, 51, 18, 108, 115, 78, 134, 166);
 RT_INTERFACE!{interface IRcsEndUserMessageManager(IRcsEndUserMessageManagerVtbl): IInspectable(IInspectableVtbl) [IID_IRcsEndUserMessageManager] {
     fn add_MessageAvailableChanged(&self, handler: *mut foundation::TypedEventHandler<RcsEndUserMessageManager, RcsEndUserMessageAvailableEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -10282,7 +10282,7 @@ impl IRcsEndUserMessageManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsEndUserMessageManager: IRcsEndUserMessageManager}
+RT_CLASS!{class RcsEndUserMessageManager: IRcsEndUserMessageManager ["Windows.ApplicationModel.Chat.RcsEndUserMessageManager"]}
 RT_CLASS!{static class RcsManager}
 impl RtActivatable<IRcsManagerStatics> for RcsManager {}
 impl RtActivatable<IRcsManagerStatics2> for RcsManager {}
@@ -10352,7 +10352,7 @@ impl IRcsManagerStatics2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RcsServiceKind: i32 {
+RT_ENUM! { enum RcsServiceKind: i32 ["Windows.ApplicationModel.Chat.RcsServiceKind"] {
     Chat (RcsServiceKind_Chat) = 0, GroupChat (RcsServiceKind_GroupChat) = 1, FileTransfer (RcsServiceKind_FileTransfer) = 2, Capability (RcsServiceKind_Capability) = 3,
 }}
 DEFINE_IID!(IID_IRcsServiceKindSupportedChangedEventArgs, 4101939780, 59267, 18534, 179, 167, 78, 92, 207, 2, 48, 112);
@@ -10366,7 +10366,7 @@ impl IRcsServiceKindSupportedChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsServiceKindSupportedChangedEventArgs: IRcsServiceKindSupportedChangedEventArgs}
+RT_CLASS!{class RcsServiceKindSupportedChangedEventArgs: IRcsServiceKindSupportedChangedEventArgs ["Windows.ApplicationModel.Chat.RcsServiceKindSupportedChangedEventArgs"]}
 DEFINE_IID!(IID_IRcsTransport, 4272113497, 62332, 17177, 133, 70, 236, 132, 210, 29, 48, 255);
 RT_INTERFACE!{interface IRcsTransport(IRcsTransportVtbl): IInspectable(IInspectableVtbl) [IID_IRcsTransport] {
     fn get_ExtendedProperties(&self, out: *mut *mut foundation::collections::IMapView<HString, IInspectable>) -> HRESULT,
@@ -10425,7 +10425,7 @@ impl IRcsTransport {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsTransport: IRcsTransport}
+RT_CLASS!{class RcsTransport: IRcsTransport ["Windows.ApplicationModel.Chat.RcsTransport"]}
 DEFINE_IID!(IID_IRcsTransportConfiguration, 533508354, 9330, 19385, 153, 136, 193, 33, 28, 131, 232, 169);
 RT_INTERFACE!{interface IRcsTransportConfiguration(IRcsTransportConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IRcsTransportConfiguration] {
     fn get_MaxAttachmentCount(&self, out: *mut i32) -> HRESULT,
@@ -10467,7 +10467,7 @@ impl IRcsTransportConfiguration {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RcsTransportConfiguration: IRcsTransportConfiguration}
+RT_CLASS!{class RcsTransportConfiguration: IRcsTransportConfiguration ["Windows.ApplicationModel.Chat.RcsTransportConfiguration"]}
 DEFINE_IID!(IID_IRemoteParticipantComposingChangedEventArgs, 515917223, 53193, 17865, 152, 118, 68, 159, 43, 193, 128, 245);
 RT_INTERFACE!{interface IRemoteParticipantComposingChangedEventArgs(IRemoteParticipantComposingChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteParticipantComposingChangedEventArgs] {
     fn get_TransportId(&self, out: *mut HSTRING) -> HRESULT,
@@ -10491,7 +10491,7 @@ impl IRemoteParticipantComposingChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteParticipantComposingChangedEventArgs: IRemoteParticipantComposingChangedEventArgs}
+RT_CLASS!{class RemoteParticipantComposingChangedEventArgs: IRemoteParticipantComposingChangedEventArgs ["Windows.ApplicationModel.Chat.RemoteParticipantComposingChangedEventArgs"]}
 } // Windows.ApplicationModel.Chat
 pub mod communicationblocking { // Windows.ApplicationModel.CommunicationBlocking
 use ::prelude::*;
@@ -10631,7 +10631,7 @@ impl IAggregateContactManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AggregateContactManager: IAggregateContactManager}
+RT_CLASS!{class AggregateContactManager: IAggregateContactManager ["Windows.ApplicationModel.Contacts.AggregateContactManager"]}
 DEFINE_IID!(IID_IAggregateContactManager2, 1586283224, 43469, 17456, 156, 75, 1, 52, 141, 178, 202, 80);
 RT_INTERFACE!{interface IAggregateContactManager2(IAggregateContactManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IAggregateContactManager2] {
     fn SetRemoteIdentificationInformationAsync(&self, contactListId: HSTRING, remoteSourceId: HSTRING, accountId: HSTRING, out: *mut *mut foundation::IAsyncAction) -> HRESULT
@@ -10678,7 +10678,7 @@ impl IContact {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Contact: IContact}
+RT_CLASS!{class Contact: IContact ["Windows.ApplicationModel.Contacts.Contact"]}
 impl RtActivatable<IActivationFactory> for Contact {}
 DEFINE_CLSID!(Contact(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,0]) [CLSID_Contact]);
 DEFINE_IID!(IID_IContact2, 4078105445, 47991, 19604, 128, 45, 131, 40, 206, 228, 12, 8);
@@ -10990,10 +10990,10 @@ impl IContactAddress {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactAddress: IContactAddress}
+RT_CLASS!{class ContactAddress: IContactAddress ["Windows.ApplicationModel.Contacts.ContactAddress"]}
 impl RtActivatable<IActivationFactory> for ContactAddress {}
 DEFINE_CLSID!(ContactAddress(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,65,100,100,114,101,115,115,0]) [CLSID_ContactAddress]);
-RT_ENUM! { enum ContactAddressKind: i32 {
+RT_ENUM! { enum ContactAddressKind: i32 ["Windows.ApplicationModel.Contacts.ContactAddressKind"] {
     Home (ContactAddressKind_Home) = 0, Work (ContactAddressKind_Work) = 1, Other (ContactAddressKind_Other) = 2,
 }}
 DEFINE_IID!(IID_IContactAnnotation, 2183119599, 32065, 17570, 132, 195, 96, 162, 129, 221, 123, 134);
@@ -11058,7 +11058,7 @@ impl IContactAnnotation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactAnnotation: IContactAnnotation}
+RT_CLASS!{class ContactAnnotation: IContactAnnotation ["Windows.ApplicationModel.Contacts.ContactAnnotation"]}
 impl RtActivatable<IActivationFactory> for ContactAnnotation {}
 DEFINE_CLSID!(ContactAnnotation(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,65,110,110,111,116,97,116,105,111,110,0]) [CLSID_ContactAnnotation]);
 DEFINE_IID!(IID_IContactAnnotation2, 3063016691, 19127, 18975, 153, 65, 12, 156, 243, 23, 27, 117);
@@ -11136,8 +11136,8 @@ impl IContactAnnotationList {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactAnnotationList: IContactAnnotationList}
-RT_ENUM! { enum ContactAnnotationOperations: u32 {
+RT_CLASS!{class ContactAnnotationList: IContactAnnotationList ["Windows.ApplicationModel.Contacts.ContactAnnotationList"]}
+RT_ENUM! { enum ContactAnnotationOperations: u32 ["Windows.ApplicationModel.Contacts.ContactAnnotationOperations"] {
     None (ContactAnnotationOperations_None) = 0, ContactProfile (ContactAnnotationOperations_ContactProfile) = 1, Message (ContactAnnotationOperations_Message) = 2, AudioCall (ContactAnnotationOperations_AudioCall) = 4, VideoCall (ContactAnnotationOperations_VideoCall) = 8, SocialFeeds (ContactAnnotationOperations_SocialFeeds) = 16, Share (ContactAnnotationOperations_Share) = 32,
 }}
 DEFINE_IID!(IID_IContactAnnotationStore, 598537386, 31351, 17789, 130, 3, 152, 127, 75, 49, 175, 9);
@@ -11193,7 +11193,7 @@ impl IContactAnnotationStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactAnnotationStore: IContactAnnotationStore}
+RT_CLASS!{class ContactAnnotationStore: IContactAnnotationStore ["Windows.ApplicationModel.Contacts.ContactAnnotationStore"]}
 DEFINE_IID!(IID_IContactAnnotationStore2, 2128487421, 25063, 18791, 142, 197, 189, 242, 128, 162, 64, 99);
 RT_INTERFACE!{interface IContactAnnotationStore2(IContactAnnotationStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactAnnotationStore2] {
     fn FindAnnotationsForContactListAsync(&self, contactListId: HSTRING, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<ContactAnnotation>>) -> HRESULT
@@ -11205,7 +11205,7 @@ impl IContactAnnotationStore2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactAnnotationStoreAccessType: i32 {
+RT_ENUM! { enum ContactAnnotationStoreAccessType: i32 ["Windows.ApplicationModel.Contacts.ContactAnnotationStoreAccessType"] {
     AppAnnotationsReadWrite (ContactAnnotationStoreAccessType_AppAnnotationsReadWrite) = 0, AllAnnotationsReadWrite (ContactAnnotationStoreAccessType_AllAnnotationsReadWrite) = 1,
 }}
 DEFINE_IID!(IID_IContactBatch, 902928173, 49102, 18107, 147, 248, 165, 176, 110, 197, 226, 1);
@@ -11225,8 +11225,8 @@ impl IContactBatch {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactBatch: IContactBatch}
-RT_ENUM! { enum ContactBatchStatus: i32 {
+RT_CLASS!{class ContactBatch: IContactBatch ["Windows.ApplicationModel.Contacts.ContactBatch"]}
+RT_ENUM! { enum ContactBatchStatus: i32 ["Windows.ApplicationModel.Contacts.ContactBatchStatus"] {
     Success (ContactBatchStatus_Success) = 0, ServerSearchSyncManagerError (ContactBatchStatus_ServerSearchSyncManagerError) = 1, ServerSearchUnknownError (ContactBatchStatus_ServerSearchUnknownError) = 2,
 }}
 DEFINE_IID!(IID_IContactCardDelayedDataLoader, 3054172418, 5446, 17229, 134, 156, 110, 53, 32, 118, 14, 243);
@@ -11239,8 +11239,8 @@ impl IContactCardDelayedDataLoader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactCardDelayedDataLoader: IContactCardDelayedDataLoader}
-RT_ENUM! { enum ContactCardHeaderKind: i32 {
+RT_CLASS!{class ContactCardDelayedDataLoader: IContactCardDelayedDataLoader ["Windows.ApplicationModel.Contacts.ContactCardDelayedDataLoader"]}
+RT_ENUM! { enum ContactCardHeaderKind: i32 ["Windows.ApplicationModel.Contacts.ContactCardHeaderKind"] {
     Default (ContactCardHeaderKind_Default) = 0, Basic (ContactCardHeaderKind_Basic) = 1, Enterprise (ContactCardHeaderKind_Enterprise) = 2,
 }}
 DEFINE_IID!(IID_IContactCardOptions, 2349485950, 27318, 20287, 190, 114, 129, 114, 54, 238, 234, 91);
@@ -11270,7 +11270,7 @@ impl IContactCardOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactCardOptions: IContactCardOptions}
+RT_CLASS!{class ContactCardOptions: IContactCardOptions ["Windows.ApplicationModel.Contacts.ContactCardOptions"]}
 impl RtActivatable<IActivationFactory> for ContactCardOptions {}
 DEFINE_CLSID!(ContactCardOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,67,97,114,100,79,112,116,105,111,110,115,0]) [CLSID_ContactCardOptions]);
 DEFINE_IID!(IID_IContactCardOptions2, 2401704864, 55115, 19654, 159, 83, 27, 14, 181, 209, 39, 60);
@@ -11284,7 +11284,7 @@ impl IContactCardOptions2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactCardTabKind: i32 {
+RT_ENUM! { enum ContactCardTabKind: i32 ["Windows.ApplicationModel.Contacts.ContactCardTabKind"] {
     Default (ContactCardTabKind_Default) = 0, Email (ContactCardTabKind_Email) = 1, Messaging (ContactCardTabKind_Messaging) = 2, Phone (ContactCardTabKind_Phone) = 3, Video (ContactCardTabKind_Video) = 4, OrganizationalHierarchy (ContactCardTabKind_OrganizationalHierarchy) = 5,
 }}
 DEFINE_IID!(IID_IContactChange, 2501724944, 27225, 18208, 164, 225, 54, 61, 152, 193, 53, 213);
@@ -11304,7 +11304,7 @@ impl IContactChange {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactChange: IContactChange}
+RT_CLASS!{class ContactChange: IContactChange ["Windows.ApplicationModel.Contacts.ContactChange"]}
 DEFINE_IID!(IID_IContactChangedDeferral, 3306437352, 6915, 18168, 182, 148, 165, 35, 232, 60, 252, 182);
 RT_INTERFACE!{interface IContactChangedDeferral(IContactChangedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IContactChangedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -11315,7 +11315,7 @@ impl IContactChangedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactChangedDeferral: IContactChangedDeferral}
+RT_CLASS!{class ContactChangedDeferral: IContactChangedDeferral ["Windows.ApplicationModel.Contacts.ContactChangedDeferral"]}
 DEFINE_IID!(IID_IContactChangedEventArgs, 1381924817, 29683, 19325, 169, 24, 88, 11, 228, 54, 97, 33);
 RT_INTERFACE!{interface IContactChangedEventArgs(IContactChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactChangedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut ContactChangedDeferral) -> HRESULT
@@ -11327,7 +11327,7 @@ impl IContactChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactChangedEventArgs: IContactChangedEventArgs}
+RT_CLASS!{class ContactChangedEventArgs: IContactChangedEventArgs ["Windows.ApplicationModel.Contacts.ContactChangedEventArgs"]}
 DEFINE_IID!(IID_IContactChangeReader, 561191418, 11532, 17120, 169, 218, 62, 205, 86, 167, 138, 71);
 RT_INTERFACE!{interface IContactChangeReader(IContactChangeReaderVtbl): IInspectable(IInspectableVtbl) [IID_IContactChangeReader] {
     fn AcceptChanges(&self) -> HRESULT,
@@ -11349,7 +11349,7 @@ impl IContactChangeReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactChangeReader: IContactChangeReader}
+RT_CLASS!{class ContactChangeReader: IContactChangeReader ["Windows.ApplicationModel.Contacts.ContactChangeReader"]}
 DEFINE_IID!(IID_IContactChangeTracker, 1855531346, 12443, 16461, 151, 18, 179, 123, 211, 2, 120, 170);
 RT_INTERFACE!{interface IContactChangeTracker(IContactChangeTrackerVtbl): IInspectable(IInspectableVtbl) [IID_IContactChangeTracker] {
     fn Enable(&self) -> HRESULT,
@@ -11371,7 +11371,7 @@ impl IContactChangeTracker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactChangeTracker: IContactChangeTracker}
+RT_CLASS!{class ContactChangeTracker: IContactChangeTracker ["Windows.ApplicationModel.Contacts.ContactChangeTracker"]}
 DEFINE_IID!(IID_IContactChangeTracker2, 2139803900, 37665, 19736, 156, 9, 215, 8, 198, 63, 205, 49);
 RT_INTERFACE!{interface IContactChangeTracker2(IContactChangeTracker2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactChangeTracker2] {
     fn get_IsTracking(&self, out: *mut bool) -> HRESULT
@@ -11383,7 +11383,7 @@ impl IContactChangeTracker2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactChangeType: i32 {
+RT_ENUM! { enum ContactChangeType: i32 ["Windows.ApplicationModel.Contacts.ContactChangeType"] {
     Created (ContactChangeType_Created) = 0, Modified (ContactChangeType_Modified) = 1, Deleted (ContactChangeType_Deleted) = 2, ChangeTrackingLost (ContactChangeType_ChangeTrackingLost) = 3,
 }}
 DEFINE_IID!(IID_IContactConnectedServiceAccount, 4143461715, 43559, 18225, 142, 74, 61, 236, 92, 233, 238, 201);
@@ -11413,7 +11413,7 @@ impl IContactConnectedServiceAccount {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactConnectedServiceAccount: IContactConnectedServiceAccount}
+RT_CLASS!{class ContactConnectedServiceAccount: IContactConnectedServiceAccount ["Windows.ApplicationModel.Contacts.ContactConnectedServiceAccount"]}
 impl RtActivatable<IActivationFactory> for ContactConnectedServiceAccount {}
 DEFINE_CLSID!(ContactConnectedServiceAccount(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,67,111,110,110,101,99,116,101,100,83,101,114,118,105,99,101,65,99,99,111,117,110,116,0]) [CLSID_ContactConnectedServiceAccount]);
 DEFINE_IID!(IID_IContactDate, 4271418982, 45573, 18740, 145, 116, 15, 242, 176, 86, 87, 7);
@@ -11476,10 +11476,10 @@ impl IContactDate {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactDate: IContactDate}
+RT_CLASS!{class ContactDate: IContactDate ["Windows.ApplicationModel.Contacts.ContactDate"]}
 impl RtActivatable<IActivationFactory> for ContactDate {}
 DEFINE_CLSID!(ContactDate(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,68,97,116,101,0]) [CLSID_ContactDate]);
-RT_ENUM! { enum ContactDateKind: i32 {
+RT_ENUM! { enum ContactDateKind: i32 ["Windows.ApplicationModel.Contacts.ContactDateKind"] {
     Birthday (ContactDateKind_Birthday) = 0, Anniversary (ContactDateKind_Anniversary) = 1, Other (ContactDateKind_Other) = 2,
 }}
 DEFINE_IID!(IID_IContactEmail, 2426542505, 58323, 19811, 153, 59, 5, 185, 165, 57, 58, 191);
@@ -11520,10 +11520,10 @@ impl IContactEmail {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactEmail: IContactEmail}
+RT_CLASS!{class ContactEmail: IContactEmail ["Windows.ApplicationModel.Contacts.ContactEmail"]}
 impl RtActivatable<IActivationFactory> for ContactEmail {}
 DEFINE_CLSID!(ContactEmail(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,69,109,97,105,108,0]) [CLSID_ContactEmail]);
-RT_ENUM! { enum ContactEmailKind: i32 {
+RT_ENUM! { enum ContactEmailKind: i32 ["Windows.ApplicationModel.Contacts.ContactEmailKind"] {
     Personal (ContactEmailKind_Personal) = 0, Work (ContactEmailKind_Work) = 1, Other (ContactEmailKind_Other) = 2,
 }}
 DEFINE_IID!(IID_IContactField, 2977319018, 53907, 18732, 160, 88, 219, 87, 91, 62, 60, 15);
@@ -11555,7 +11555,7 @@ impl IContactField {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactField: IContactField}
+RT_CLASS!{class ContactField: IContactField ["Windows.ApplicationModel.Contacts.ContactField"]}
 impl RtActivatable<IContactFieldFactory> for ContactField {}
 impl ContactField {
     #[inline] pub fn create_field_default(value: &HStringArg, type_: ContactFieldType) -> Result<ComPtr<ContactField>> {
@@ -11569,7 +11569,7 @@ impl ContactField {
     }
 }
 DEFINE_CLSID!(ContactField(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,70,105,101,108,100,0]) [CLSID_ContactField]);
-RT_ENUM! { enum ContactFieldCategory: i32 {
+RT_ENUM! { enum ContactFieldCategory: i32 ["Windows.ApplicationModel.Contacts.ContactFieldCategory"] {
     None (ContactFieldCategory_None) = 0, Home (ContactFieldCategory_Home) = 1, Work (ContactFieldCategory_Work) = 2, Mobile (ContactFieldCategory_Mobile) = 3, Other (ContactFieldCategory_Other) = 4,
 }}
 DEFINE_IID!(IID_IContactFieldFactory, 2246218047, 3658, 19006, 137, 148, 64, 106, 231, 237, 100, 110);
@@ -11595,17 +11595,17 @@ impl IContactFieldFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactFieldFactory: IContactFieldFactory}
+RT_CLASS!{class ContactFieldFactory: IContactFieldFactory ["Windows.ApplicationModel.Contacts.ContactFieldFactory"]}
 impl RtActivatable<IActivationFactory> for ContactFieldFactory {}
 DEFINE_CLSID!(ContactFieldFactory(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,70,105,101,108,100,70,97,99,116,111,114,121,0]) [CLSID_ContactFieldFactory]);
-RT_ENUM! { enum ContactFieldType: i32 {
+RT_ENUM! { enum ContactFieldType: i32 ["Windows.ApplicationModel.Contacts.ContactFieldType"] {
     Email (ContactFieldType_Email) = 0, PhoneNumber (ContactFieldType_PhoneNumber) = 1, Location (ContactFieldType_Location) = 2, InstantMessage (ContactFieldType_InstantMessage) = 3, Custom (ContactFieldType_Custom) = 4, ConnectedServiceAccount (ContactFieldType_ConnectedServiceAccount) = 5, ImportantDate (ContactFieldType_ImportantDate) = 6, Address (ContactFieldType_Address) = 7, SignificantOther (ContactFieldType_SignificantOther) = 8, Notes (ContactFieldType_Notes) = 9, Website (ContactFieldType_Website) = 10, JobInfo (ContactFieldType_JobInfo) = 11,
 }}
 DEFINE_IID!(IID_IContactGroup, 1505618689, 40602, 18269, 191, 229, 163, 123, 128, 109, 133, 44);
 RT_INTERFACE!{interface IContactGroup(IContactGroupVtbl): IInspectable(IInspectableVtbl) [IID_IContactGroup] {
     
 }}
-RT_CLASS!{class ContactGroup: IContactGroup}
+RT_CLASS!{class ContactGroup: IContactGroup ["Windows.ApplicationModel.Contacts.ContactGroup"]}
 DEFINE_IID!(IID_IContactInformation, 660518612, 27182, 17016, 169, 20, 228, 96, 213, 240, 136, 246);
 RT_INTERFACE!{interface IContactInformation(IContactInformationVtbl): IInspectable(IInspectableVtbl) [IID_IContactInformation] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -11660,7 +11660,7 @@ impl IContactInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactInformation: IContactInformation}
+RT_CLASS!{class ContactInformation: IContactInformation ["Windows.ApplicationModel.Contacts.ContactInformation"]}
 DEFINE_IID!(IID_IContactInstantMessageField, 3437443895, 3461, 16890, 180, 61, 218, 89, 156, 62, 176, 9);
 RT_INTERFACE!{interface IContactInstantMessageField(IContactInstantMessageFieldVtbl): IInspectable(IInspectableVtbl) [IID_IContactInstantMessageField] {
     fn get_UserName(&self, out: *mut HSTRING) -> HRESULT,
@@ -11690,7 +11690,7 @@ impl IContactInstantMessageField {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactInstantMessageField: IContactInstantMessageField}
+RT_CLASS!{class ContactInstantMessageField: IContactInstantMessageField ["Windows.ApplicationModel.Contacts.ContactInstantMessageField"]}
 impl RtActivatable<IContactInstantMessageFieldFactory> for ContactInstantMessageField {}
 impl ContactInstantMessageField {
     #[inline] pub fn create_instant_message_default(userName: &HStringArg) -> Result<ComPtr<ContactInstantMessageField>> {
@@ -11820,7 +11820,7 @@ impl IContactJobInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactJobInfo: IContactJobInfo}
+RT_CLASS!{class ContactJobInfo: IContactJobInfo ["Windows.ApplicationModel.Contacts.ContactJobInfo"]}
 impl RtActivatable<IActivationFactory> for ContactJobInfo {}
 DEFINE_CLSID!(ContactJobInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,74,111,98,73,110,102,111,0]) [CLSID_ContactJobInfo]);
 RT_CLASS!{static class ContactLaunchActionVerbs}
@@ -12028,7 +12028,7 @@ impl IContactList {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactList: IContactList}
+RT_CLASS!{class ContactList: IContactList ["Windows.ApplicationModel.Contacts.ContactList"]}
 DEFINE_IID!(IID_IContactList2, 3409527732, 17744, 19915, 146, 41, 64, 255, 145, 251, 2, 3);
 RT_INTERFACE!{interface IContactList2(IContactList2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactList2] {
     fn RegisterSyncManagerAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -12085,11 +12085,11 @@ impl IContactListLimitedWriteOperations {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListLimitedWriteOperations: IContactListLimitedWriteOperations}
-RT_ENUM! { enum ContactListOtherAppReadAccess: i32 {
+RT_CLASS!{class ContactListLimitedWriteOperations: IContactListLimitedWriteOperations ["Windows.ApplicationModel.Contacts.ContactListLimitedWriteOperations"]}
+RT_ENUM! { enum ContactListOtherAppReadAccess: i32 ["Windows.ApplicationModel.Contacts.ContactListOtherAppReadAccess"] {
     SystemOnly (ContactListOtherAppReadAccess_SystemOnly) = 0, Limited (ContactListOtherAppReadAccess_Limited) = 1, Full (ContactListOtherAppReadAccess_Full) = 2, None (ContactListOtherAppReadAccess_None) = 3,
 }}
-RT_ENUM! { enum ContactListOtherAppWriteAccess: i32 {
+RT_ENUM! { enum ContactListOtherAppWriteAccess: i32 ["Windows.ApplicationModel.Contacts.ContactListOtherAppWriteAccess"] {
     None (ContactListOtherAppWriteAccess_None) = 0, SystemOnly (ContactListOtherAppWriteAccess_SystemOnly) = 1, Limited (ContactListOtherAppWriteAccess_Limited) = 2,
 }}
 DEFINE_IID!(IID_IContactListSyncConstraints, 2997927681, 12386, 20014, 150, 157, 1, 141, 25, 135, 243, 20);
@@ -12405,7 +12405,7 @@ impl IContactListSyncConstraints {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListSyncConstraints: IContactListSyncConstraints}
+RT_CLASS!{class ContactListSyncConstraints: IContactListSyncConstraints ["Windows.ApplicationModel.Contacts.ContactListSyncConstraints"]}
 DEFINE_IID!(IID_IContactListSyncManager, 342787006, 31013, 19148, 157, 229, 33, 221, 208, 111, 134, 116);
 RT_INTERFACE!{interface IContactListSyncManager(IContactListSyncManagerVtbl): IInspectable(IInspectableVtbl) [IID_IContactListSyncManager] {
     fn get_Status(&self, out: *mut ContactListSyncStatus) -> HRESULT,
@@ -12446,7 +12446,7 @@ impl IContactListSyncManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListSyncManager: IContactListSyncManager}
+RT_CLASS!{class ContactListSyncManager: IContactListSyncManager ["Windows.ApplicationModel.Contacts.ContactListSyncManager"]}
 DEFINE_IID!(IID_IContactListSyncManager2, 2841186887, 47957, 20003, 129, 40, 55, 1, 52, 168, 93, 13);
 RT_INTERFACE!{interface IContactListSyncManager2(IContactListSyncManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactListSyncManager2] {
     fn put_Status(&self, value: ContactListSyncStatus) -> HRESULT,
@@ -12467,7 +12467,7 @@ impl IContactListSyncManager2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactListSyncStatus: i32 {
+RT_ENUM! { enum ContactListSyncStatus: i32 ["Windows.ApplicationModel.Contacts.ContactListSyncStatus"] {
     Idle (ContactListSyncStatus_Idle) = 0, Syncing (ContactListSyncStatus_Syncing) = 1, UpToDate (ContactListSyncStatus_UpToDate) = 2, AuthenticationError (ContactListSyncStatus_AuthenticationError) = 3, PolicyError (ContactListSyncStatus_PolicyError) = 4, UnknownError (ContactListSyncStatus_UnknownError) = 5, ManualAccountRemovalRequired (ContactListSyncStatus_ManualAccountRemovalRequired) = 6,
 }}
 DEFINE_IID!(IID_IContactLocationField, 2663387010, 43886, 19254, 137, 227, 178, 59, 192, 161, 218, 204);
@@ -12511,7 +12511,7 @@ impl IContactLocationField {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactLocationField: IContactLocationField}
+RT_CLASS!{class ContactLocationField: IContactLocationField ["Windows.ApplicationModel.Contacts.ContactLocationField"]}
 impl RtActivatable<IContactLocationFieldFactory> for ContactLocationField {}
 impl ContactLocationField {
     #[inline] pub fn create_location_default(unstructuredAddress: &HStringArg) -> Result<ComPtr<ContactLocationField>> {
@@ -12689,7 +12689,7 @@ impl IContactManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactManagerForUser: IContactManagerForUser}
+RT_CLASS!{class ContactManagerForUser: IContactManagerForUser ["Windows.ApplicationModel.Contacts.ContactManagerForUser"]}
 DEFINE_IID!(IID_IContactManagerForUser2, 1296473134, 15221, 19059, 187, 48, 115, 102, 69, 71, 34, 86);
 RT_INTERFACE!{interface IContactManagerForUser2(IContactManagerForUser2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactManagerForUser2] {
     fn ShowFullContactCard(&self, contact: *mut Contact, fullContactCardOptions: *mut FullContactCardOptions) -> HRESULT
@@ -12879,8 +12879,8 @@ impl IContactMatchReason {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactMatchReason: IContactMatchReason}
-RT_ENUM! { enum ContactMatchReasonKind: i32 {
+RT_CLASS!{class ContactMatchReason: IContactMatchReason ["Windows.ApplicationModel.Contacts.ContactMatchReason"]}
+RT_ENUM! { enum ContactMatchReasonKind: i32 ["Windows.ApplicationModel.Contacts.ContactMatchReasonKind"] {
     Name (ContactMatchReasonKind_Name) = 0, EmailAddress (ContactMatchReasonKind_EmailAddress) = 1, PhoneNumber (ContactMatchReasonKind_PhoneNumber) = 2, JobInfo (ContactMatchReasonKind_JobInfo) = 3, YomiName (ContactMatchReasonKind_YomiName) = 4, Other (ContactMatchReasonKind_Other) = 5,
 }}
 DEFINE_IID!(IID_IContactName, 4093962619, 36916, 17724, 142, 191, 20, 10, 56, 200, 111, 29);
@@ -12977,7 +12977,7 @@ impl IContactName {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactNameOrder: i32 {
+RT_ENUM! { enum ContactNameOrder: i32 ["Windows.ApplicationModel.Contacts.ContactNameOrder"] {
     FirstNameLastName (ContactNameOrder_FirstNameLastName) = 0, LastNameFirstName (ContactNameOrder_LastNameFirstName) = 1,
 }}
 DEFINE_IID!(IID_IContactPanel, 1103041125, 53998, 19351, 168, 10, 125, 141, 100, 204, 166, 245);
@@ -13025,7 +13025,7 @@ impl IContactPanel {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPanel: IContactPanel}
+RT_CLASS!{class ContactPanel: IContactPanel ["Windows.ApplicationModel.Contacts.ContactPanel"]}
 DEFINE_IID!(IID_IContactPanelClosingEventArgs, 572617939, 53067, 18135, 183, 57, 110, 220, 22, 17, 11, 251);
 RT_INTERFACE!{interface IContactPanelClosingEventArgs(IContactPanelClosingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactPanelClosingEventArgs] {
     fn GetDeferral(&self, out: *mut *mut foundation::Deferral) -> HRESULT
@@ -13037,7 +13037,7 @@ impl IContactPanelClosingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPanelClosingEventArgs: IContactPanelClosingEventArgs}
+RT_CLASS!{class ContactPanelClosingEventArgs: IContactPanelClosingEventArgs ["Windows.ApplicationModel.Contacts.ContactPanelClosingEventArgs"]}
 DEFINE_IID!(IID_IContactPanelLaunchFullAppRequestedEventArgs, 2295733262, 9140, 19432, 138, 252, 7, 44, 37, 164, 25, 13);
 RT_INTERFACE!{interface IContactPanelLaunchFullAppRequestedEventArgs(IContactPanelLaunchFullAppRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactPanelLaunchFullAppRequestedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -13054,7 +13054,7 @@ impl IContactPanelLaunchFullAppRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPanelLaunchFullAppRequestedEventArgs: IContactPanelLaunchFullAppRequestedEventArgs}
+RT_CLASS!{class ContactPanelLaunchFullAppRequestedEventArgs: IContactPanelLaunchFullAppRequestedEventArgs ["Windows.ApplicationModel.Contacts.ContactPanelLaunchFullAppRequestedEventArgs"]}
 DEFINE_IID!(IID_IContactPhone, 1182640997, 10002, 20306, 183, 131, 158, 168, 17, 28, 99, 205);
 RT_INTERFACE!{interface IContactPhone(IContactPhoneVtbl): IInspectable(IInspectableVtbl) [IID_IContactPhone] {
     fn get_Number(&self, out: *mut HSTRING) -> HRESULT,
@@ -13093,10 +13093,10 @@ impl IContactPhone {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPhone: IContactPhone}
+RT_CLASS!{class ContactPhone: IContactPhone ["Windows.ApplicationModel.Contacts.ContactPhone"]}
 impl RtActivatable<IActivationFactory> for ContactPhone {}
 DEFINE_CLSID!(ContactPhone(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,80,104,111,110,101,0]) [CLSID_ContactPhone]);
-RT_ENUM! { enum ContactPhoneKind: i32 {
+RT_ENUM! { enum ContactPhoneKind: i32 ["Windows.ApplicationModel.Contacts.ContactPhoneKind"] {
     Home (ContactPhoneKind_Home) = 0, Mobile (ContactPhoneKind_Mobile) = 1, Work (ContactPhoneKind_Work) = 2, Other (ContactPhoneKind_Other) = 3, Pager (ContactPhoneKind_Pager) = 4, BusinessFax (ContactPhoneKind_BusinessFax) = 5, HomeFax (ContactPhoneKind_HomeFax) = 6, Company (ContactPhoneKind_Company) = 7, Assistant (ContactPhoneKind_Assistant) = 8, Radio (ContactPhoneKind_Radio) = 9,
 }}
 DEFINE_IID!(IID_IContactPicker, 235535761, 17144, 16469, 144, 160, 137, 111, 150, 115, 137, 54);
@@ -13144,7 +13144,7 @@ impl IContactPicker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPicker: IContactPicker}
+RT_CLASS!{class ContactPicker: IContactPicker ["Windows.ApplicationModel.Contacts.ContactPicker"]}
 impl RtActivatable<IContactPickerStatics> for ContactPicker {}
 impl RtActivatable<IActivationFactory> for ContactPicker {}
 impl ContactPicker {
@@ -13208,7 +13208,7 @@ impl IContactPickerStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactQueryDesiredFields: u32 {
+RT_ENUM! { enum ContactQueryDesiredFields: u32 ["Windows.ApplicationModel.Contacts.ContactQueryDesiredFields"] {
     None (ContactQueryDesiredFields_None) = 0, PhoneNumber (ContactQueryDesiredFields_PhoneNumber) = 1, EmailAddress (ContactQueryDesiredFields_EmailAddress) = 2, PostalAddress (ContactQueryDesiredFields_PostalAddress) = 4,
 }}
 DEFINE_IID!(IID_IContactQueryOptions, 1141427358, 32124, 17136, 138, 199, 245, 7, 51, 236, 219, 193);
@@ -13267,7 +13267,7 @@ impl IContactQueryOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactQueryOptions: IContactQueryOptions}
+RT_CLASS!{class ContactQueryOptions: IContactQueryOptions ["Windows.ApplicationModel.Contacts.ContactQueryOptions"]}
 impl RtActivatable<IContactQueryOptionsFactory> for ContactQueryOptions {}
 impl RtActivatable<IActivationFactory> for ContactQueryOptions {}
 impl ContactQueryOptions {
@@ -13296,10 +13296,10 @@ impl IContactQueryOptionsFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactQuerySearchFields: u32 {
+RT_ENUM! { enum ContactQuerySearchFields: u32 ["Windows.ApplicationModel.Contacts.ContactQuerySearchFields"] {
     None (ContactQuerySearchFields_None) = 0, Name (ContactQuerySearchFields_Name) = 1, Email (ContactQuerySearchFields_Email) = 2, Phone (ContactQuerySearchFields_Phone) = 4, All (ContactQuerySearchFields_All) = 4294967295,
 }}
-RT_ENUM! { enum ContactQuerySearchScope: i32 {
+RT_ENUM! { enum ContactQuerySearchScope: i32 ["Windows.ApplicationModel.Contacts.ContactQuerySearchScope"] {
     Local (ContactQuerySearchScope_Local) = 0, Server (ContactQuerySearchScope_Server) = 1,
 }}
 DEFINE_IID!(IID_IContactQueryTextSearch, 4158912971, 43351, 17307, 160, 183, 28, 2, 161, 150, 63, 240);
@@ -13340,7 +13340,7 @@ impl IContactQueryTextSearch {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactQueryTextSearch: IContactQueryTextSearch}
+RT_CLASS!{class ContactQueryTextSearch: IContactQueryTextSearch ["Windows.ApplicationModel.Contacts.ContactQueryTextSearch"]}
 DEFINE_IID!(IID_IContactReader, 3549946926, 5256, 17138, 191, 100, 37, 63, 72, 132, 191, 237);
 RT_INTERFACE!{interface IContactReader(IContactReaderVtbl): IInspectable(IInspectableVtbl) [IID_IContactReader] {
     fn ReadBatchAsync(&self, out: *mut *mut foundation::IAsyncOperation<ContactBatch>) -> HRESULT,
@@ -13358,11 +13358,11 @@ impl IContactReader {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactReader: IContactReader}
-RT_ENUM! { enum ContactRelationship: i32 {
+RT_CLASS!{class ContactReader: IContactReader ["Windows.ApplicationModel.Contacts.ContactReader"]}
+RT_ENUM! { enum ContactRelationship: i32 ["Windows.ApplicationModel.Contacts.ContactRelationship"] {
     Other (ContactRelationship_Other) = 0, Spouse (ContactRelationship_Spouse) = 1, Partner (ContactRelationship_Partner) = 2, Sibling (ContactRelationship_Sibling) = 3, Parent (ContactRelationship_Parent) = 4, Child (ContactRelationship_Child) = 5,
 }}
-RT_ENUM! { enum ContactSelectionMode: i32 {
+RT_ENUM! { enum ContactSelectionMode: i32 ["Windows.ApplicationModel.Contacts.ContactSelectionMode"] {
     Contacts (ContactSelectionMode_Contacts) = 0, Fields (ContactSelectionMode_Fields) = 1,
 }}
 DEFINE_IID!(IID_IContactSignificantOther, 2289284523, 50683, 18136, 147, 254, 218, 63, 241, 147, 64, 84);
@@ -13392,7 +13392,7 @@ impl IContactSignificantOther {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactSignificantOther: IContactSignificantOther}
+RT_CLASS!{class ContactSignificantOther: IContactSignificantOther ["Windows.ApplicationModel.Contacts.ContactSignificantOther"]}
 impl RtActivatable<IActivationFactory> for ContactSignificantOther {}
 DEFINE_CLSID!(ContactSignificantOther(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,83,105,103,110,105,102,105,99,97,110,116,79,116,104,101,114,0]) [CLSID_ContactSignificantOther]);
 DEFINE_IID!(IID_IContactSignificantOther2, 2373702772, 16131, 17912, 186, 15, 196, 237, 55, 214, 66, 25);
@@ -13434,7 +13434,7 @@ impl IContactStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactStore: IContactStore}
+RT_CLASS!{class ContactStore: IContactStore ["Windows.ApplicationModel.Contacts.ContactStore"]}
 DEFINE_IID!(IID_IContactStore2, 416160802, 60373, 19451, 182, 144, 95, 79, 39, 196, 240, 232);
 RT_INTERFACE!{interface IContactStore2(IContactStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactStore2] {
     fn get_ChangeTracker(&self, out: *mut *mut ContactChangeTracker) -> HRESULT,
@@ -13516,14 +13516,14 @@ impl IContactStore3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ContactStoreAccessType: i32 {
+RT_ENUM! { enum ContactStoreAccessType: i32 ["Windows.ApplicationModel.Contacts.ContactStoreAccessType"] {
     AppContactsReadWrite (ContactStoreAccessType_AppContactsReadWrite) = 0, AllContactsReadOnly (ContactStoreAccessType_AllContactsReadOnly) = 1, AllContactsReadWrite (ContactStoreAccessType_AllContactsReadWrite) = 2,
 }}
 DEFINE_IID!(IID_IContactStoreNotificationTriggerDetails, 2880608470, 34698, 20363, 169, 206, 70, 187, 125, 28, 132, 206);
 RT_INTERFACE!{interface IContactStoreNotificationTriggerDetails(IContactStoreNotificationTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IContactStoreNotificationTriggerDetails] {
     
 }}
-RT_CLASS!{class ContactStoreNotificationTriggerDetails: IContactStoreNotificationTriggerDetails}
+RT_CLASS!{class ContactStoreNotificationTriggerDetails: IContactStoreNotificationTriggerDetails ["Windows.ApplicationModel.Contacts.ContactStoreNotificationTriggerDetails"]}
 DEFINE_IID!(IID_IContactWebsite, 2668822902, 56347, 16469, 173, 102, 101, 47, 57, 217, 144, 232);
 RT_INTERFACE!{interface IContactWebsite(IContactWebsiteVtbl): IInspectable(IInspectableVtbl) [IID_IContactWebsite] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -13551,7 +13551,7 @@ impl IContactWebsite {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactWebsite: IContactWebsite}
+RT_CLASS!{class ContactWebsite: IContactWebsite ["Windows.ApplicationModel.Contacts.ContactWebsite"]}
 impl RtActivatable<IActivationFactory> for ContactWebsite {}
 DEFINE_CLSID!(ContactWebsite(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,67,111,110,116,97,99,116,87,101,98,115,105,116,101,0]) [CLSID_ContactWebsite]);
 DEFINE_IID!(IID_IContactWebsite2, 4169066782, 22087, 16488, 187, 94, 75, 111, 67, 124, 227, 8);
@@ -13586,7 +13586,7 @@ impl IFullContactCardOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FullContactCardOptions: IFullContactCardOptions}
+RT_CLASS!{class FullContactCardOptions: IFullContactCardOptions ["Windows.ApplicationModel.Contacts.FullContactCardOptions"]}
 impl RtActivatable<IActivationFactory> for FullContactCardOptions {}
 DEFINE_CLSID!(FullContactCardOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,67,111,110,116,97,99,116,115,46,70,117,108,108,67,111,110,116,97,99,116,67,97,114,100,79,112,116,105,111,110,115,0]) [CLSID_FullContactCardOptions]);
 RT_CLASS!{static class KnownContactField}
@@ -13664,7 +13664,7 @@ impl IPinnedContactIdsQueryResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PinnedContactIdsQueryResult: IPinnedContactIdsQueryResult}
+RT_CLASS!{class PinnedContactIdsQueryResult: IPinnedContactIdsQueryResult ["Windows.ApplicationModel.Contacts.PinnedContactIdsQueryResult"]}
 DEFINE_IID!(IID_IPinnedContactManager, 4240208908, 57814, 17859, 184, 182, 163, 86, 4, 225, 103, 160);
 RT_INTERFACE!{interface IPinnedContactManager(IPinnedContactManagerVtbl): IInspectable(IInspectableVtbl) [IID_IPinnedContactManager] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -13718,7 +13718,7 @@ impl IPinnedContactManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PinnedContactManager: IPinnedContactManager}
+RT_CLASS!{class PinnedContactManager: IPinnedContactManager ["Windows.ApplicationModel.Contacts.PinnedContactManager"]}
 impl RtActivatable<IPinnedContactManagerStatics> for PinnedContactManager {}
 impl PinnedContactManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<PinnedContactManager>>> {
@@ -13756,7 +13756,7 @@ impl IPinnedContactManagerStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PinnedContactSurface: i32 {
+RT_ENUM! { enum PinnedContactSurface: i32 ["Windows.ApplicationModel.Contacts.PinnedContactSurface"] {
     StartMenu (PinnedContactSurface_StartMenu) = 0, Taskbar (PinnedContactSurface_Taskbar) = 1,
 }}
 pub mod dataprovider { // Windows.ApplicationModel.Contacts.DataProvider
@@ -13793,7 +13793,7 @@ impl IContactDataProviderConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactDataProviderConnection: IContactDataProviderConnection}
+RT_CLASS!{class ContactDataProviderConnection: IContactDataProviderConnection ["Windows.ApplicationModel.Contacts.DataProvider.ContactDataProviderConnection"]}
 DEFINE_IID!(IID_IContactDataProviderConnection2, 2714970032, 6508, 19453, 143, 15, 198, 141, 103, 242, 73, 211);
 RT_INTERFACE!{interface IContactDataProviderConnection2(IContactDataProviderConnection2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactDataProviderConnection2] {
     fn add_CreateOrUpdateContactRequested(&self, handler: *mut foundation::TypedEventHandler<ContactDataProviderConnection, ContactListCreateOrUpdateContactRequestEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -13832,7 +13832,7 @@ impl IContactDataProviderTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactDataProviderTriggerDetails: IContactDataProviderTriggerDetails}
+RT_CLASS!{class ContactDataProviderTriggerDetails: IContactDataProviderTriggerDetails ["Windows.ApplicationModel.Contacts.DataProvider.ContactDataProviderTriggerDetails"]}
 DEFINE_IID!(IID_IContactListCreateOrUpdateContactRequest, 3031384351, 51273, 18384, 177, 25, 145, 207, 96, 91, 47, 42);
 RT_INTERFACE!{interface IContactListCreateOrUpdateContactRequest(IContactListCreateOrUpdateContactRequestVtbl): IInspectable(IInspectableVtbl) [IID_IContactListCreateOrUpdateContactRequest] {
     fn get_ContactListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -13862,7 +13862,7 @@ impl IContactListCreateOrUpdateContactRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListCreateOrUpdateContactRequest: IContactListCreateOrUpdateContactRequest}
+RT_CLASS!{class ContactListCreateOrUpdateContactRequest: IContactListCreateOrUpdateContactRequest ["Windows.ApplicationModel.Contacts.DataProvider.ContactListCreateOrUpdateContactRequest"]}
 DEFINE_IID!(IID_IContactListCreateOrUpdateContactRequestEventArgs, 2233210512, 6737, 19212, 174, 239, 18, 64, 172, 91, 237, 117);
 RT_INTERFACE!{interface IContactListCreateOrUpdateContactRequestEventArgs(IContactListCreateOrUpdateContactRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactListCreateOrUpdateContactRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut ContactListCreateOrUpdateContactRequest) -> HRESULT,
@@ -13880,7 +13880,7 @@ impl IContactListCreateOrUpdateContactRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListCreateOrUpdateContactRequestEventArgs: IContactListCreateOrUpdateContactRequestEventArgs}
+RT_CLASS!{class ContactListCreateOrUpdateContactRequestEventArgs: IContactListCreateOrUpdateContactRequestEventArgs ["Windows.ApplicationModel.Contacts.DataProvider.ContactListCreateOrUpdateContactRequestEventArgs"]}
 DEFINE_IID!(IID_IContactListDeleteContactRequest, 1578190471, 52739, 19941, 133, 87, 156, 207, 85, 45, 71, 42);
 RT_INTERFACE!{interface IContactListDeleteContactRequest(IContactListDeleteContactRequestVtbl): IInspectable(IInspectableVtbl) [IID_IContactListDeleteContactRequest] {
     fn get_ContactListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -13910,7 +13910,7 @@ impl IContactListDeleteContactRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListDeleteContactRequest: IContactListDeleteContactRequest}
+RT_CLASS!{class ContactListDeleteContactRequest: IContactListDeleteContactRequest ["Windows.ApplicationModel.Contacts.DataProvider.ContactListDeleteContactRequest"]}
 DEFINE_IID!(IID_IContactListDeleteContactRequestEventArgs, 2988463265, 59642, 19893, 147, 137, 45, 18, 238, 125, 21, 238);
 RT_INTERFACE!{interface IContactListDeleteContactRequestEventArgs(IContactListDeleteContactRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactListDeleteContactRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut ContactListDeleteContactRequest) -> HRESULT,
@@ -13928,7 +13928,7 @@ impl IContactListDeleteContactRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListDeleteContactRequestEventArgs: IContactListDeleteContactRequestEventArgs}
+RT_CLASS!{class ContactListDeleteContactRequestEventArgs: IContactListDeleteContactRequestEventArgs ["Windows.ApplicationModel.Contacts.DataProvider.ContactListDeleteContactRequestEventArgs"]}
 DEFINE_IID!(IID_IContactListServerSearchReadBatchRequest, 3128388247, 16432, 18725, 159, 180, 20, 59, 41, 94, 101, 59);
 RT_INTERFACE!{interface IContactListServerSearchReadBatchRequest(IContactListServerSearchReadBatchRequestVtbl): IInspectable(IInspectableVtbl) [IID_IContactListServerSearchReadBatchRequest] {
     fn get_SessionId(&self, out: *mut HSTRING) -> HRESULT,
@@ -13976,7 +13976,7 @@ impl IContactListServerSearchReadBatchRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListServerSearchReadBatchRequest: IContactListServerSearchReadBatchRequest}
+RT_CLASS!{class ContactListServerSearchReadBatchRequest: IContactListServerSearchReadBatchRequest ["Windows.ApplicationModel.Contacts.DataProvider.ContactListServerSearchReadBatchRequest"]}
 DEFINE_IID!(IID_IContactListServerSearchReadBatchRequestEventArgs, 438823035, 27095, 20046, 128, 66, 134, 28, 186, 97, 71, 30);
 RT_INTERFACE!{interface IContactListServerSearchReadBatchRequestEventArgs(IContactListServerSearchReadBatchRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactListServerSearchReadBatchRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut ContactListServerSearchReadBatchRequest) -> HRESULT,
@@ -13994,7 +13994,7 @@ impl IContactListServerSearchReadBatchRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListServerSearchReadBatchRequestEventArgs: IContactListServerSearchReadBatchRequestEventArgs}
+RT_CLASS!{class ContactListServerSearchReadBatchRequestEventArgs: IContactListServerSearchReadBatchRequestEventArgs ["Windows.ApplicationModel.Contacts.DataProvider.ContactListServerSearchReadBatchRequestEventArgs"]}
 DEFINE_IID!(IID_IContactListSyncManagerSyncRequest, 1007572900, 50407, 18800, 154, 143, 154, 102, 162, 187, 108, 26);
 RT_INTERFACE!{interface IContactListSyncManagerSyncRequest(IContactListSyncManagerSyncRequestVtbl): IInspectable(IInspectableVtbl) [IID_IContactListSyncManagerSyncRequest] {
     fn get_ContactListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -14018,7 +14018,7 @@ impl IContactListSyncManagerSyncRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListSyncManagerSyncRequest: IContactListSyncManagerSyncRequest}
+RT_CLASS!{class ContactListSyncManagerSyncRequest: IContactListSyncManagerSyncRequest ["Windows.ApplicationModel.Contacts.DataProvider.ContactListSyncManagerSyncRequest"]}
 DEFINE_IID!(IID_IContactListSyncManagerSyncRequestEventArgs, 361647532, 17517, 20240, 175, 194, 2, 104, 62, 197, 51, 166);
 RT_INTERFACE!{interface IContactListSyncManagerSyncRequestEventArgs(IContactListSyncManagerSyncRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IContactListSyncManagerSyncRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut ContactListSyncManagerSyncRequest) -> HRESULT,
@@ -14036,11 +14036,11 @@ impl IContactListSyncManagerSyncRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactListSyncManagerSyncRequestEventArgs: IContactListSyncManagerSyncRequestEventArgs}
+RT_CLASS!{class ContactListSyncManagerSyncRequestEventArgs: IContactListSyncManagerSyncRequestEventArgs ["Windows.ApplicationModel.Contacts.DataProvider.ContactListSyncManagerSyncRequestEventArgs"]}
 } // Windows.ApplicationModel.Contacts.DataProvider
 pub mod provider { // Windows.ApplicationModel.Contacts.Provider
 use ::prelude::*;
-RT_ENUM! { enum AddContactResult: i32 {
+RT_ENUM! { enum AddContactResult: i32 ["Windows.ApplicationModel.Contacts.Provider.AddContactResult"] {
     Added (AddContactResult_Added) = 0, AlreadyAdded (AddContactResult_AlreadyAdded) = 1, Unavailable (AddContactResult_Unavailable) = 2,
 }}
 DEFINE_IID!(IID_IContactPickerUI, 3805025126, 53094, 17348, 169, 106, 165, 161, 18, 219, 71, 70);
@@ -14088,7 +14088,7 @@ impl IContactPickerUI {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactPickerUI: IContactPickerUI}
+RT_CLASS!{class ContactPickerUI: IContactPickerUI ["Windows.ApplicationModel.Contacts.Provider.ContactPickerUI"]}
 DEFINE_IID!(IID_IContactPickerUI2, 1849990696, 31525, 18841, 155, 11, 135, 84, 0, 161, 232, 200);
 RT_INTERFACE!{interface IContactPickerUI2(IContactPickerUI2Vtbl): IInspectable(IInspectableVtbl) [IID_IContactPickerUI2] {
     fn AddContact(&self, contact: *mut super::Contact, out: *mut AddContactResult) -> HRESULT,
@@ -14117,7 +14117,7 @@ impl IContactRemovedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContactRemovedEventArgs: IContactRemovedEventArgs}
+RT_CLASS!{class ContactRemovedEventArgs: IContactRemovedEventArgs ["Windows.ApplicationModel.Contacts.Provider.ContactRemovedEventArgs"]}
 } // Windows.ApplicationModel.Contacts.Provider
 } // Windows.ApplicationModel.Contacts
 pub mod core { // Windows.ApplicationModel.Core
@@ -14139,7 +14139,7 @@ impl IAppListEntry {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppListEntry: IAppListEntry}
+RT_CLASS!{class AppListEntry: IAppListEntry ["Windows.ApplicationModel.Core.AppListEntry"]}
 DEFINE_IID!(IID_IAppListEntry2, 3500546221, 48949, 17068, 172, 6, 134, 238, 235, 65, 208, 75);
 RT_INTERFACE!{interface IAppListEntry2(IAppListEntry2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppListEntry2] {
     fn get_AppUserModelId(&self, out: *mut HSTRING) -> HRESULT
@@ -14162,7 +14162,7 @@ impl IAppListEntry3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppRestartFailureReason: i32 {
+RT_ENUM! { enum AppRestartFailureReason: i32 ["Windows.ApplicationModel.Core.AppRestartFailureReason"] {
     RestartPending (AppRestartFailureReason_RestartPending) = 0, NotInForeground (AppRestartFailureReason_NotInForeground) = 1, InvalidUser (AppRestartFailureReason_InvalidUser) = 2, Other (AppRestartFailureReason_Other) = 3,
 }}
 DEFINE_IID!(IID_ICoreApplication, 179107748, 24093, 18911, 128, 52, 251, 106, 104, 188, 94, 209);
@@ -14470,7 +14470,7 @@ impl ICoreApplicationView {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreApplicationView: ICoreApplicationView}
+RT_CLASS!{class CoreApplicationView: ICoreApplicationView ["Windows.ApplicationModel.Core.CoreApplicationView"]}
 DEFINE_IID!(IID_ICoreApplicationView2, 1760262879, 37247, 18667, 154, 235, 125, 229, 62, 8, 106, 177);
 RT_INTERFACE!{interface ICoreApplicationView2(ICoreApplicationView2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreApplicationView2] {
     #[cfg(feature="windows-ui")] fn get_Dispatcher(&self, out: *mut *mut super::super::ui::core::CoreDispatcher) -> HRESULT
@@ -14594,7 +14594,7 @@ impl ICoreApplicationViewTitleBar {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreApplicationViewTitleBar: ICoreApplicationViewTitleBar}
+RT_CLASS!{class CoreApplicationViewTitleBar: ICoreApplicationViewTitleBar ["Windows.ApplicationModel.Core.CoreApplicationViewTitleBar"]}
 DEFINE_IID!(IID_ICoreImmersiveApplication, 450498110, 58530, 16675, 180, 81, 220, 150, 191, 128, 4, 25);
 RT_INTERFACE!{static interface ICoreImmersiveApplication(ICoreImmersiveApplicationVtbl): IInspectable(IInspectableVtbl) [IID_ICoreImmersiveApplication] {
     fn get_Views(&self, out: *mut *mut foundation::collections::IVectorView<CoreApplicationView>) -> HRESULT,
@@ -14693,7 +14693,7 @@ impl IHostedViewClosingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HostedViewClosingEventArgs: IHostedViewClosingEventArgs}
+RT_CLASS!{class HostedViewClosingEventArgs: IHostedViewClosingEventArgs ["Windows.ApplicationModel.Core.HostedViewClosingEventArgs"]}
 DEFINE_IID!(IID_IUnhandledError, 2488907558, 21429, 18054, 158, 175, 250, 129, 98, 220, 57, 128);
 RT_INTERFACE!{interface IUnhandledError(IUnhandledErrorVtbl): IInspectable(IInspectableVtbl) [IID_IUnhandledError] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -14710,7 +14710,7 @@ impl IUnhandledError {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UnhandledError: IUnhandledError}
+RT_CLASS!{class UnhandledError: IUnhandledError ["Windows.ApplicationModel.Core.UnhandledError"]}
 DEFINE_IID!(IID_IUnhandledErrorDetectedEventArgs, 1738192779, 45878, 18466, 172, 64, 13, 117, 15, 11, 122, 43);
 RT_INTERFACE!{interface IUnhandledErrorDetectedEventArgs(IUnhandledErrorDetectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUnhandledErrorDetectedEventArgs] {
     fn get_UnhandledError(&self, out: *mut *mut UnhandledError) -> HRESULT
@@ -14722,7 +14722,7 @@ impl IUnhandledErrorDetectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UnhandledErrorDetectedEventArgs: IUnhandledErrorDetectedEventArgs}
+RT_CLASS!{class UnhandledErrorDetectedEventArgs: IUnhandledErrorDetectedEventArgs ["Windows.ApplicationModel.Core.UnhandledErrorDetectedEventArgs"]}
 } // Windows.ApplicationModel.Core
 pub mod datatransfer { // Windows.ApplicationModel.DataTransfer
 use ::prelude::*;
@@ -14828,14 +14828,14 @@ impl IClipboardContentOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClipboardContentOptions: IClipboardContentOptions}
+RT_CLASS!{class ClipboardContentOptions: IClipboardContentOptions ["Windows.ApplicationModel.DataTransfer.ClipboardContentOptions"]}
 impl RtActivatable<IActivationFactory> for ClipboardContentOptions {}
 DEFINE_CLSID!(ClipboardContentOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,67,108,105,112,98,111,97,114,100,67,111,110,116,101,110,116,79,112,116,105,111,110,115,0]) [CLSID_ClipboardContentOptions]);
 DEFINE_IID!(IID_IClipboardHistoryChangedEventArgs, 3233695039, 36514, 21454, 154, 186, 141, 34, 18, 87, 52, 82);
 RT_INTERFACE!{interface IClipboardHistoryChangedEventArgs(IClipboardHistoryChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClipboardHistoryChangedEventArgs] {
     
 }}
-RT_CLASS!{class ClipboardHistoryChangedEventArgs: IClipboardHistoryChangedEventArgs}
+RT_CLASS!{class ClipboardHistoryChangedEventArgs: IClipboardHistoryChangedEventArgs ["Windows.ApplicationModel.DataTransfer.ClipboardHistoryChangedEventArgs"]}
 DEFINE_IID!(IID_IClipboardHistoryItem, 24362378, 45055, 23632, 171, 146, 61, 25, 244, 129, 236, 88);
 RT_INTERFACE!{interface IClipboardHistoryItem(IClipboardHistoryItemVtbl): IInspectable(IInspectableVtbl) [IID_IClipboardHistoryItem] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -14859,7 +14859,7 @@ impl IClipboardHistoryItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClipboardHistoryItem: IClipboardHistoryItem}
+RT_CLASS!{class ClipboardHistoryItem: IClipboardHistoryItem ["Windows.ApplicationModel.DataTransfer.ClipboardHistoryItem"]}
 DEFINE_IID!(IID_IClipboardHistoryItemsResult, 3873431270, 3810, 21219, 133, 43, 242, 149, 219, 101, 147, 154);
 RT_INTERFACE!{interface IClipboardHistoryItemsResult(IClipboardHistoryItemsResultVtbl): IInspectable(IInspectableVtbl) [IID_IClipboardHistoryItemsResult] {
     fn get_Status(&self, out: *mut ClipboardHistoryItemsResultStatus) -> HRESULT,
@@ -14877,8 +14877,8 @@ impl IClipboardHistoryItemsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClipboardHistoryItemsResult: IClipboardHistoryItemsResult}
-RT_ENUM! { enum ClipboardHistoryItemsResultStatus: i32 {
+RT_CLASS!{class ClipboardHistoryItemsResult: IClipboardHistoryItemsResult ["Windows.ApplicationModel.DataTransfer.ClipboardHistoryItemsResult"]}
+RT_ENUM! { enum ClipboardHistoryItemsResultStatus: i32 ["Windows.ApplicationModel.DataTransfer.ClipboardHistoryItemsResultStatus"] {
     Success (ClipboardHistoryItemsResultStatus_Success) = 0, AccessDenied (ClipboardHistoryItemsResultStatus_AccessDenied) = 1, ClipboardHistoryDisabled (ClipboardHistoryItemsResultStatus_ClipboardHistoryDisabled) = 2,
 }}
 DEFINE_IID!(IID_IClipboardStatics, 3324502673, 13538, 18787, 142, 237, 147, 203, 176, 234, 61, 112);
@@ -15099,7 +15099,7 @@ impl IDataPackage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataPackage: IDataPackage}
+RT_CLASS!{class DataPackage: IDataPackage ["Windows.ApplicationModel.DataTransfer.DataPackage"]}
 impl RtActivatable<IActivationFactory> for DataPackage {}
 DEFINE_CLSID!(DataPackage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,68,97,116,97,80,97,99,107,97,103,101,0]) [CLSID_DataPackage]);
 DEFINE_IID!(IID_IDataPackage2, 68952041, 9225, 17889, 165, 56, 76, 83, 238, 238, 4, 167);
@@ -15133,7 +15133,7 @@ impl IDataPackage3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DataPackageOperation: u32 {
+RT_ENUM! { enum DataPackageOperation: u32 ["Windows.ApplicationModel.DataTransfer.DataPackageOperation"] {
     None (DataPackageOperation_None) = 0, Copy (DataPackageOperation_Copy) = 1, Move (DataPackageOperation_Move) = 2, Link (DataPackageOperation_Link) = 4,
 }}
 DEFINE_IID!(IID_IDataPackagePropertySet, 3441202155, 19532, 17466, 168, 211, 245, 194, 65, 233, 22, 137);
@@ -15204,7 +15204,7 @@ impl IDataPackagePropertySet {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataPackagePropertySet: IDataPackagePropertySet}
+RT_CLASS!{class DataPackagePropertySet: IDataPackagePropertySet ["Windows.ApplicationModel.DataTransfer.DataPackagePropertySet"]}
 DEFINE_IID!(IID_IDataPackagePropertySet2, 3947912522, 38912, 18090, 177, 129, 123, 111, 15, 43, 145, 154);
 RT_INTERFACE!{interface IDataPackagePropertySet2(IDataPackagePropertySet2Vtbl): IInspectable(IInspectableVtbl) [IID_IDataPackagePropertySet2] {
     fn get_ContentSourceWebLink(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -15341,7 +15341,7 @@ impl IDataPackagePropertySetView {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataPackagePropertySetView: IDataPackagePropertySetView}
+RT_CLASS!{class DataPackagePropertySetView: IDataPackagePropertySetView ["Windows.ApplicationModel.DataTransfer.DataPackagePropertySetView"]}
 DEFINE_IID!(IID_IDataPackagePropertySetView2, 1616138395, 36542, 20459, 156, 30, 117, 230, 157, 229, 75, 132);
 RT_INTERFACE!{interface IDataPackagePropertySetView2(IDataPackagePropertySetView2Vtbl): IInspectable(IInspectableVtbl) [IID_IDataPackagePropertySetView2] {
     fn get_PackageFamilyName(&self, out: *mut HSTRING) -> HRESULT,
@@ -15499,7 +15499,7 @@ impl IDataPackageView {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataPackageView: IDataPackageView}
+RT_CLASS!{class DataPackageView: IDataPackageView ["Windows.ApplicationModel.DataTransfer.DataPackageView"]}
 DEFINE_IID!(IID_IDataPackageView2, 1089256085, 9296, 19485, 182, 180, 237, 69, 70, 61, 238, 156);
 RT_INTERFACE!{interface IDataPackageView2(IDataPackageView2Vtbl): IInspectable(IInspectableVtbl) [IID_IDataPackageView2] {
     fn GetApplicationLinkAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::Uri>) -> HRESULT,
@@ -15560,7 +15560,7 @@ impl IDataProviderDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataProviderDeferral: IDataProviderDeferral}
+RT_CLASS!{class DataProviderDeferral: IDataProviderDeferral ["Windows.ApplicationModel.DataTransfer.DataProviderDeferral"]}
 DEFINE_IID!(IID_DataProviderHandler, 3891058464, 62196, 18989, 146, 14, 23, 10, 47, 72, 42, 39);
 RT_DELEGATE!{delegate DataProviderHandler(DataProviderHandlerVtbl, DataProviderHandlerImpl) [IID_DataProviderHandler] {
     fn Invoke(&self, request: *mut DataProviderRequest) -> HRESULT
@@ -15599,7 +15599,7 @@ impl IDataProviderRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataProviderRequest: IDataProviderRequest}
+RT_CLASS!{class DataProviderRequest: IDataProviderRequest ["Windows.ApplicationModel.DataTransfer.DataProviderRequest"]}
 DEFINE_IID!(IID_IDataRequest, 1128377915, 64530, 20051, 140, 2, 172, 113, 76, 65, 90, 39);
 RT_INTERFACE!{interface IDataRequest(IDataRequestVtbl): IInspectable(IInspectableVtbl) [IID_IDataRequest] {
     fn get_Data(&self, out: *mut *mut DataPackage) -> HRESULT,
@@ -15633,7 +15633,7 @@ impl IDataRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataRequest: IDataRequest}
+RT_CLASS!{class DataRequest: IDataRequest ["Windows.ApplicationModel.DataTransfer.DataRequest"]}
 DEFINE_IID!(IID_IDataRequestDeferral, 1841608863, 902, 16995, 135, 193, 237, 125, 206, 48, 137, 14);
 RT_INTERFACE!{interface IDataRequestDeferral(IDataRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IDataRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -15644,7 +15644,7 @@ impl IDataRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataRequestDeferral: IDataRequestDeferral}
+RT_CLASS!{class DataRequestDeferral: IDataRequestDeferral ["Windows.ApplicationModel.DataTransfer.DataRequestDeferral"]}
 DEFINE_IID!(IID_IDataRequestedEventArgs, 3414927367, 27333, 17353, 138, 197, 155, 162, 50, 22, 49, 130);
 RT_INTERFACE!{interface IDataRequestedEventArgs(IDataRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDataRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut DataRequest) -> HRESULT
@@ -15656,7 +15656,7 @@ impl IDataRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataRequestedEventArgs: IDataRequestedEventArgs}
+RT_CLASS!{class DataRequestedEventArgs: IDataRequestedEventArgs ["Windows.ApplicationModel.DataTransfer.DataRequestedEventArgs"]}
 DEFINE_IID!(IID_IDataTransferManager, 2781539995, 34568, 18897, 141, 54, 103, 210, 90, 141, 160, 12);
 RT_INTERFACE!{interface IDataTransferManager(IDataTransferManagerVtbl): IInspectable(IInspectableVtbl) [IID_IDataTransferManager] {
     fn add_DataRequested(&self, eventHandler: *mut foundation::TypedEventHandler<DataTransferManager, DataRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -15684,7 +15684,7 @@ impl IDataTransferManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataTransferManager: IDataTransferManager}
+RT_CLASS!{class DataTransferManager: IDataTransferManager ["Windows.ApplicationModel.DataTransfer.DataTransferManager"]}
 impl RtActivatable<IDataTransferManagerStatics> for DataTransferManager {}
 impl RtActivatable<IDataTransferManagerStatics2> for DataTransferManager {}
 impl RtActivatable<IDataTransferManagerStatics3> for DataTransferManager {}
@@ -15795,7 +15795,7 @@ impl IOperationCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OperationCompletedEventArgs: IOperationCompletedEventArgs}
+RT_CLASS!{class OperationCompletedEventArgs: IOperationCompletedEventArgs ["Windows.ApplicationModel.DataTransfer.OperationCompletedEventArgs"]}
 DEFINE_IID!(IID_IOperationCompletedEventArgs2, 2240782451, 7705, 16645, 178, 247, 200, 71, 136, 8, 213, 98);
 RT_INTERFACE!{interface IOperationCompletedEventArgs2(IOperationCompletedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IOperationCompletedEventArgs2] {
     fn get_AcceptedFormatId(&self, out: *mut HSTRING) -> HRESULT
@@ -15807,7 +15807,7 @@ impl IOperationCompletedEventArgs2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SetHistoryItemAsContentStatus: i32 {
+RT_ENUM! { enum SetHistoryItemAsContentStatus: i32 ["Windows.ApplicationModel.DataTransfer.SetHistoryItemAsContentStatus"] {
     Success (SetHistoryItemAsContentStatus_Success) = 0, AccessDenied (SetHistoryItemAsContentStatus_AccessDenied) = 1, ItemDeleted (SetHistoryItemAsContentStatus_ItemDeleted) = 2,
 }}
 DEFINE_IID!(IID_IShareCompletedEventArgs, 1165280322, 63763, 20320, 157, 247, 204, 64, 96, 171, 25, 22);
@@ -15821,7 +15821,7 @@ impl IShareCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareCompletedEventArgs: IShareCompletedEventArgs}
+RT_CLASS!{class ShareCompletedEventArgs: IShareCompletedEventArgs ["Windows.ApplicationModel.DataTransfer.ShareCompletedEventArgs"]}
 RT_CLASS!{static class SharedStorageAccessManager}
 impl RtActivatable<ISharedStorageAccessManagerStatics> for SharedStorageAccessManager {}
 impl SharedStorageAccessManager {
@@ -15896,7 +15896,7 @@ impl IShareProvider {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareProvider: IShareProvider}
+RT_CLASS!{class ShareProvider: IShareProvider ["Windows.ApplicationModel.DataTransfer.ShareProvider"]}
 impl RtActivatable<IShareProviderFactory> for ShareProvider {}
 impl ShareProvider {
     #[cfg(all(feature="windows-storage",feature="windows-ui"))] #[inline] pub fn create(title: &HStringArg, displayIcon: &super::super::storage::streams::RandomAccessStreamReference, backgroundColor: super::super::ui::Color, handler: &ShareProviderHandler) -> Result<ComPtr<ShareProvider>> {
@@ -15947,7 +15947,7 @@ impl IShareProviderOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareProviderOperation: IShareProviderOperation}
+RT_CLASS!{class ShareProviderOperation: IShareProviderOperation ["Windows.ApplicationModel.DataTransfer.ShareProviderOperation"]}
 DEFINE_IID!(IID_IShareProvidersRequestedEventArgs, 4169724758, 41976, 20430, 133, 228, 136, 38, 230, 59, 231, 153);
 RT_INTERFACE!{interface IShareProvidersRequestedEventArgs(IShareProvidersRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IShareProvidersRequestedEventArgs] {
     fn get_Providers(&self, out: *mut *mut foundation::collections::IVector<ShareProvider>) -> HRESULT,
@@ -15971,7 +15971,7 @@ impl IShareProvidersRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareProvidersRequestedEventArgs: IShareProvidersRequestedEventArgs}
+RT_CLASS!{class ShareProvidersRequestedEventArgs: IShareProvidersRequestedEventArgs ["Windows.ApplicationModel.DataTransfer.ShareProvidersRequestedEventArgs"]}
 DEFINE_IID!(IID_IShareTargetInfo, 945546759, 50920, 16660, 178, 148, 40, 243, 187, 111, 153, 4);
 RT_INTERFACE!{interface IShareTargetInfo(IShareTargetInfoVtbl): IInspectable(IInspectableVtbl) [IID_IShareTargetInfo] {
     fn get_AppUserModelId(&self, out: *mut HSTRING) -> HRESULT,
@@ -15989,7 +15989,7 @@ impl IShareTargetInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareTargetInfo: IShareTargetInfo}
+RT_CLASS!{class ShareTargetInfo: IShareTargetInfo ["Windows.ApplicationModel.DataTransfer.ShareTargetInfo"]}
 DEFINE_IID!(IID_IShareUIOptions, 1929022080, 13359, 19856, 149, 81, 42, 224, 78, 55, 104, 12);
 RT_INTERFACE!{interface IShareUIOptions(IShareUIOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IShareUIOptions] {
     fn get_Theme(&self, out: *mut ShareUITheme) -> HRESULT,
@@ -16017,10 +16017,10 @@ impl IShareUIOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareUIOptions: IShareUIOptions}
+RT_CLASS!{class ShareUIOptions: IShareUIOptions ["Windows.ApplicationModel.DataTransfer.ShareUIOptions"]}
 impl RtActivatable<IActivationFactory> for ShareUIOptions {}
 DEFINE_CLSID!(ShareUIOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,104,97,114,101,85,73,79,112,116,105,111,110,115,0]) [CLSID_ShareUIOptions]);
-RT_ENUM! { enum ShareUITheme: i32 {
+RT_ENUM! { enum ShareUITheme: i32 ["Windows.ApplicationModel.DataTransfer.ShareUITheme"] {
     Default (ShareUITheme_Default) = 0, Light (ShareUITheme_Light) = 1, Dark (ShareUITheme_Dark) = 2,
 }}
 RT_CLASS!{static class StandardDataFormats}
@@ -16137,10 +16137,10 @@ impl ITargetApplicationChosenEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetApplicationChosenEventArgs: ITargetApplicationChosenEventArgs}
+RT_CLASS!{class TargetApplicationChosenEventArgs: ITargetApplicationChosenEventArgs ["Windows.ApplicationModel.DataTransfer.TargetApplicationChosenEventArgs"]}
 pub mod dragdrop { // Windows.ApplicationModel.DataTransfer.DragDrop
 use ::prelude::*;
-RT_ENUM! { enum DragDropModifiers: u32 {
+RT_ENUM! { enum DragDropModifiers: u32 ["Windows.ApplicationModel.DataTransfer.DragDrop.DragDropModifiers"] {
     None (DragDropModifiers_None) = 0, Shift (DragDropModifiers_Shift) = 1, Control (DragDropModifiers_Control) = 2, Alt (DragDropModifiers_Alt) = 4, LeftButton (DragDropModifiers_LeftButton) = 8, MiddleButton (DragDropModifiers_MiddleButton) = 16, RightButton (DragDropModifiers_RightButton) = 32,
 }}
 pub mod core { // Windows.ApplicationModel.DataTransfer.DragDrop.Core
@@ -16172,7 +16172,7 @@ impl ICoreDragDropManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreDragDropManager: ICoreDragDropManager}
+RT_CLASS!{class CoreDragDropManager: ICoreDragDropManager ["Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragDropManager"]}
 impl RtActivatable<ICoreDragDropManagerStatics> for CoreDragDropManager {}
 impl CoreDragDropManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<CoreDragDropManager>>> {
@@ -16214,7 +16214,7 @@ impl ICoreDragInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreDragInfo: ICoreDragInfo}
+RT_CLASS!{class CoreDragInfo: ICoreDragInfo ["Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragInfo"]}
 DEFINE_IID!(IID_ICoreDragInfo2, 3309736421, 59131, 19828, 180, 177, 138, 60, 23, 242, 94, 158);
 RT_INTERFACE!{interface ICoreDragInfo2(ICoreDragInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreDragInfo2] {
     fn get_AllowedOperations(&self, out: *mut super::super::DataPackageOperation) -> HRESULT
@@ -16271,7 +16271,7 @@ impl ICoreDragOperation {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreDragOperation: ICoreDragOperation}
+RT_CLASS!{class CoreDragOperation: ICoreDragOperation ["Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragOperation"]}
 impl RtActivatable<IActivationFactory> for CoreDragOperation {}
 DEFINE_CLSID!(CoreDragOperation(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,68,114,97,103,68,114,111,112,46,67,111,114,101,46,67,111,114,101,68,114,97,103,79,112,101,114,97,116,105,111,110,0]) [CLSID_CoreDragOperation]);
 DEFINE_IID!(IID_ICoreDragOperation2, 2185961004, 55706, 20419, 133, 7, 108, 24, 47, 51, 180, 106);
@@ -16290,7 +16290,7 @@ impl ICoreDragOperation2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreDragUIContentMode: u32 {
+RT_ENUM! { enum CoreDragUIContentMode: u32 ["Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragUIContentMode"] {
     Auto (CoreDragUIContentMode_Auto) = 0, Deferred (CoreDragUIContentMode_Deferred) = 1,
 }}
 DEFINE_IID!(IID_ICoreDragUIOverride, 2309509220, 13193, 20303, 136, 151, 126, 138, 63, 251, 60, 147);
@@ -16359,7 +16359,7 @@ impl ICoreDragUIOverride {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreDragUIOverride: ICoreDragUIOverride}
+RT_CLASS!{class CoreDragUIOverride: ICoreDragUIOverride ["Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragUIOverride"]}
 DEFINE_IID!(IID_ICoreDropOperationTarget, 3641860502, 19547, 16765, 187, 55, 118, 56, 29, 239, 141, 180);
 RT_INTERFACE!{interface ICoreDropOperationTarget(ICoreDropOperationTargetVtbl): IInspectable(IInspectableVtbl) [IID_ICoreDropOperationTarget] {
     fn EnterAsync(&self, dragInfo: *mut CoreDragInfo, dragUIOverride: *mut CoreDragUIOverride, out: *mut *mut foundation::IAsyncOperation<super::super::DataPackageOperation>) -> HRESULT,
@@ -16399,7 +16399,7 @@ impl ICoreDropOperationTargetRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreDropOperationTargetRequestedEventArgs: ICoreDropOperationTargetRequestedEventArgs}
+RT_CLASS!{class CoreDropOperationTargetRequestedEventArgs: ICoreDropOperationTargetRequestedEventArgs ["Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDropOperationTargetRequestedEventArgs"]}
 } // Windows.ApplicationModel.DataTransfer.DragDrop.Core
 } // Windows.ApplicationModel.DataTransfer.DragDrop
 pub mod sharetarget { // Windows.ApplicationModel.DataTransfer.ShareTarget
@@ -16456,7 +16456,7 @@ impl IQuickLink {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class QuickLink: IQuickLink}
+RT_CLASS!{class QuickLink: IQuickLink ["Windows.ApplicationModel.DataTransfer.ShareTarget.QuickLink"]}
 impl RtActivatable<IActivationFactory> for QuickLink {}
 DEFINE_CLSID!(QuickLink(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,68,97,116,97,84,114,97,110,115,102,101,114,46,83,104,97,114,101,84,97,114,103,101,116,46,81,117,105,99,107,76,105,110,107,0]) [CLSID_QuickLink]);
 DEFINE_IID!(IID_IShareOperation, 575060664, 53496, 16833, 168, 42, 65, 55, 219, 101, 4, 251);
@@ -16511,7 +16511,7 @@ impl IShareOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShareOperation: IShareOperation}
+RT_CLASS!{class ShareOperation: IShareOperation ["Windows.ApplicationModel.DataTransfer.ShareTarget.ShareOperation"]}
 DEFINE_IID!(IID_IShareOperation2, 268146625, 38776, 18953, 142, 91, 203, 94, 72, 45, 5, 85);
 RT_INTERFACE!{interface IShareOperation2(IShareOperation2Vtbl): IInspectable(IInspectableVtbl) [IID_IShareOperation2] {
     fn DismissUI(&self) -> HRESULT
@@ -16564,7 +16564,7 @@ impl IEmailAttachment {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailAttachment: IEmailAttachment}
+RT_CLASS!{class EmailAttachment: IEmailAttachment ["Windows.ApplicationModel.Email.EmailAttachment"]}
 impl RtActivatable<IEmailAttachmentFactory> for EmailAttachment {}
 impl RtActivatable<IEmailAttachmentFactory2> for EmailAttachment {}
 impl RtActivatable<IActivationFactory> for EmailAttachment {}
@@ -16660,7 +16660,7 @@ impl IEmailAttachment2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailAttachmentDownloadState: i32 {
+RT_ENUM! { enum EmailAttachmentDownloadState: i32 ["Windows.ApplicationModel.Email.EmailAttachmentDownloadState"] {
     NotDownloaded (EmailAttachmentDownloadState_NotDownloaded) = 0, Downloading (EmailAttachmentDownloadState_Downloading) = 1, Downloaded (EmailAttachmentDownloadState_Downloaded) = 2, Failed (EmailAttachmentDownloadState_Failed) = 3,
 }}
 DEFINE_IID!(IID_IEmailAttachmentFactory, 2037296198, 60758, 18809, 135, 8, 171, 184, 188, 133, 75, 125);
@@ -16685,10 +16685,10 @@ impl IEmailAttachmentFactory2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailBatchStatus: i32 {
+RT_ENUM! { enum EmailBatchStatus: i32 ["Windows.ApplicationModel.Email.EmailBatchStatus"] {
     Success (EmailBatchStatus_Success) = 0, ServerSearchSyncManagerError (EmailBatchStatus_ServerSearchSyncManagerError) = 1, ServerSearchUnknownError (EmailBatchStatus_ServerSearchUnknownError) = 2,
 }}
-RT_ENUM! { enum EmailCertificateValidationStatus: i32 {
+RT_ENUM! { enum EmailCertificateValidationStatus: i32 ["Windows.ApplicationModel.Email.EmailCertificateValidationStatus"] {
     Success (EmailCertificateValidationStatus_Success) = 0, NoMatch (EmailCertificateValidationStatus_NoMatch) = 1, InvalidUsage (EmailCertificateValidationStatus_InvalidUsage) = 2, InvalidCertificate (EmailCertificateValidationStatus_InvalidCertificate) = 3, Revoked (EmailCertificateValidationStatus_Revoked) = 4, ChainRevoked (EmailCertificateValidationStatus_ChainRevoked) = 5, RevocationServerFailure (EmailCertificateValidationStatus_RevocationServerFailure) = 6, Expired (EmailCertificateValidationStatus_Expired) = 7, Untrusted (EmailCertificateValidationStatus_Untrusted) = 8, ServerError (EmailCertificateValidationStatus_ServerError) = 9, UnknownFailure (EmailCertificateValidationStatus_UnknownFailure) = 10,
 }}
 DEFINE_IID!(IID_IEmailConversation, 3659055688, 41148, 17225, 144, 45, 144, 246, 99, 137, 245, 27);
@@ -16786,7 +16786,7 @@ impl IEmailConversation {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailConversation: IEmailConversation}
+RT_CLASS!{class EmailConversation: IEmailConversation ["Windows.ApplicationModel.Email.EmailConversation"]}
 DEFINE_IID!(IID_IEmailConversationBatch, 3099700097, 453, 17194, 157, 241, 254, 133, 217, 138, 39, 154);
 RT_INTERFACE!{interface IEmailConversationBatch(IEmailConversationBatchVtbl): IInspectable(IInspectableVtbl) [IID_IEmailConversationBatch] {
     fn get_Conversations(&self, out: *mut *mut foundation::collections::IVectorView<EmailConversation>) -> HRESULT,
@@ -16804,7 +16804,7 @@ impl IEmailConversationBatch {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailConversationBatch: IEmailConversationBatch}
+RT_CLASS!{class EmailConversationBatch: IEmailConversationBatch ["Windows.ApplicationModel.Email.EmailConversationBatch"]}
 DEFINE_IID!(IID_IEmailConversationReader, 3026390914, 10357, 17608, 155, 140, 133, 190, 179, 163, 198, 83);
 RT_INTERFACE!{interface IEmailConversationReader(IEmailConversationReaderVtbl): IInspectable(IInspectableVtbl) [IID_IEmailConversationReader] {
     fn ReadBatchAsync(&self, out: *mut *mut foundation::IAsyncOperation<EmailConversationBatch>) -> HRESULT
@@ -16816,8 +16816,8 @@ impl IEmailConversationReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailConversationReader: IEmailConversationReader}
-RT_ENUM! { enum EmailFlagState: i32 {
+RT_CLASS!{class EmailConversationReader: IEmailConversationReader ["Windows.ApplicationModel.Email.EmailConversationReader"]}
+RT_ENUM! { enum EmailFlagState: i32 ["Windows.ApplicationModel.Email.EmailFlagState"] {
     Unflagged (EmailFlagState_Unflagged) = 0, Flagged (EmailFlagState_Flagged) = 1, Completed (EmailFlagState_Completed) = 2, Cleared (EmailFlagState_Cleared) = 3,
 }}
 DEFINE_IID!(IID_IEmailFolder, 2723116913, 39276, 18532, 177, 186, 237, 18, 64, 229, 125, 17);
@@ -16971,8 +16971,8 @@ impl IEmailFolder {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailFolder: IEmailFolder}
-RT_ENUM! { enum EmailImportance: i32 {
+RT_CLASS!{class EmailFolder: IEmailFolder ["Windows.ApplicationModel.Email.EmailFolder"]}
+RT_ENUM! { enum EmailImportance: i32 ["Windows.ApplicationModel.Email.EmailImportance"] {
     Normal (EmailImportance_Normal) = 0, High (EmailImportance_High) = 1, Low (EmailImportance_Low) = 2,
 }}
 DEFINE_IID!(IID_IEmailIrmInfo, 2431984019, 45472, 20157, 166, 182, 221, 202, 85, 96, 110, 14);
@@ -17112,7 +17112,7 @@ impl IEmailIrmInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailIrmInfo: IEmailIrmInfo}
+RT_CLASS!{class EmailIrmInfo: IEmailIrmInfo ["Windows.ApplicationModel.Email.EmailIrmInfo"]}
 impl RtActivatable<IEmailIrmInfoFactory> for EmailIrmInfo {}
 impl RtActivatable<IActivationFactory> for EmailIrmInfo {}
 impl EmailIrmInfo {
@@ -17170,7 +17170,7 @@ impl IEmailIrmTemplate {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailIrmTemplate: IEmailIrmTemplate}
+RT_CLASS!{class EmailIrmTemplate: IEmailIrmTemplate ["Windows.ApplicationModel.Email.EmailIrmTemplate"]}
 impl RtActivatable<IEmailIrmTemplateFactory> for EmailIrmTemplate {}
 impl RtActivatable<IActivationFactory> for EmailIrmTemplate {}
 impl EmailIrmTemplate {
@@ -17219,7 +17219,7 @@ impl IEmailItemCounts {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailItemCounts: IEmailItemCounts}
+RT_CLASS!{class EmailItemCounts: IEmailItemCounts ["Windows.ApplicationModel.Email.EmailItemCounts"]}
 DEFINE_IID!(IID_IEmailMailbox, 2826503753, 53083, 16667, 128, 177, 74, 106, 20, 132, 206, 37);
 RT_INTERFACE!{interface IEmailMailbox(IEmailMailboxVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailbox] {
     fn get_Capabilities(&self, out: *mut *mut EmailMailboxCapabilities) -> HRESULT,
@@ -17520,7 +17520,7 @@ impl IEmailMailbox {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailbox: IEmailMailbox}
+RT_CLASS!{class EmailMailbox: IEmailMailbox ["Windows.ApplicationModel.Email.EmailMailbox"]}
 DEFINE_IID!(IID_IEmailMailbox2, 351855620, 27810, 19122, 146, 65, 121, 205, 123, 244, 99, 70);
 RT_INTERFACE!{interface IEmailMailbox2(IEmailMailbox2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailbox2] {
     fn get_LinkedMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -17619,11 +17619,11 @@ impl IEmailMailboxAction {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxAction: IEmailMailboxAction}
-RT_ENUM! { enum EmailMailboxActionKind: i32 {
+RT_CLASS!{class EmailMailboxAction: IEmailMailboxAction ["Windows.ApplicationModel.Email.EmailMailboxAction"]}
+RT_ENUM! { enum EmailMailboxActionKind: i32 ["Windows.ApplicationModel.Email.EmailMailboxActionKind"] {
     MarkMessageAsSeen (EmailMailboxActionKind_MarkMessageAsSeen) = 0, MarkMessageRead (EmailMailboxActionKind_MarkMessageRead) = 1, ChangeMessageFlagState (EmailMailboxActionKind_ChangeMessageFlagState) = 2, MoveMessage (EmailMailboxActionKind_MoveMessage) = 3, SaveDraft (EmailMailboxActionKind_SaveDraft) = 4, SendMessage (EmailMailboxActionKind_SendMessage) = 5, CreateResponseReplyMessage (EmailMailboxActionKind_CreateResponseReplyMessage) = 6, CreateResponseReplyAllMessage (EmailMailboxActionKind_CreateResponseReplyAllMessage) = 7, CreateResponseForwardMessage (EmailMailboxActionKind_CreateResponseForwardMessage) = 8, MoveFolder (EmailMailboxActionKind_MoveFolder) = 9, MarkFolderForSyncEnabled (EmailMailboxActionKind_MarkFolderForSyncEnabled) = 10,
 }}
-RT_ENUM! { enum EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation: i32 {
+RT_ENUM! { enum EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation: i32 ["Windows.ApplicationModel.Email.EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation"] {
     None (EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation_None) = 0, StrongAlgorithm (EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation_StrongAlgorithm) = 1, AnyAlgorithm (EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation_AnyAlgorithm) = 2,
 }}
 DEFINE_IID!(IID_IEmailMailboxAutoReply, 3793954124, 35508, 18523, 179, 31, 4, 209, 84, 118, 189, 89);
@@ -17653,8 +17653,8 @@ impl IEmailMailboxAutoReply {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxAutoReply: IEmailMailboxAutoReply}
-RT_ENUM! { enum EmailMailboxAutoReplyMessageResponseKind: i32 {
+RT_CLASS!{class EmailMailboxAutoReply: IEmailMailboxAutoReply ["Windows.ApplicationModel.Email.EmailMailboxAutoReply"]}
+RT_ENUM! { enum EmailMailboxAutoReplyMessageResponseKind: i32 ["Windows.ApplicationModel.Email.EmailMailboxAutoReplyMessageResponseKind"] {
     Html (EmailMailboxAutoReplyMessageResponseKind_Html) = 0, PlainText (EmailMailboxAutoReplyMessageResponseKind_PlainText) = 1,
 }}
 DEFINE_IID!(IID_IEmailMailboxAutoReplySettings, 2826608552, 2758, 19319, 186, 119, 166, 185, 158, 154, 39, 184);
@@ -17724,7 +17724,7 @@ impl IEmailMailboxAutoReplySettings {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxAutoReplySettings: IEmailMailboxAutoReplySettings}
+RT_CLASS!{class EmailMailboxAutoReplySettings: IEmailMailboxAutoReplySettings ["Windows.ApplicationModel.Email.EmailMailboxAutoReplySettings"]}
 impl RtActivatable<IActivationFactory> for EmailMailboxAutoReplySettings {}
 DEFINE_CLSID!(EmailMailboxAutoReplySettings(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,97,105,108,98,111,120,65,117,116,111,82,101,112,108,121,83,101,116,116,105,110,103,115,0]) [CLSID_EmailMailboxAutoReplySettings]);
 DEFINE_IID!(IID_IEmailMailboxCapabilities, 4007576486, 35291, 17157, 130, 196, 67, 158, 10, 51, 218, 17);
@@ -17780,7 +17780,7 @@ impl IEmailMailboxCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxCapabilities: IEmailMailboxCapabilities}
+RT_CLASS!{class EmailMailboxCapabilities: IEmailMailboxCapabilities ["Windows.ApplicationModel.Email.EmailMailboxCapabilities"]}
 DEFINE_IID!(IID_IEmailMailboxCapabilities2, 1769094884, 12065, 19644, 136, 171, 46, 118, 2, 164, 128, 107);
 RT_INTERFACE!{interface IEmailMailboxCapabilities2(IEmailMailboxCapabilities2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxCapabilities2] {
     fn get_CanResolveRecipients(&self, out: *mut bool) -> HRESULT,
@@ -17926,7 +17926,7 @@ impl IEmailMailboxChange {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxChange: IEmailMailboxChange}
+RT_CLASS!{class EmailMailboxChange: IEmailMailboxChange ["Windows.ApplicationModel.Email.EmailMailboxChange"]}
 DEFINE_IID!(IID_IEmailMailboxChangedDeferral, 2006611137, 38853, 19284, 179, 13, 48, 98, 50, 98, 62, 109);
 RT_INTERFACE!{interface IEmailMailboxChangedDeferral(IEmailMailboxChangedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxChangedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -17937,7 +17937,7 @@ impl IEmailMailboxChangedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxChangedDeferral: IEmailMailboxChangedDeferral}
+RT_CLASS!{class EmailMailboxChangedDeferral: IEmailMailboxChangedDeferral ["Windows.ApplicationModel.Email.EmailMailboxChangedDeferral"]}
 DEFINE_IID!(IID_IEmailMailboxChangedEventArgs, 1023237998, 468, 20042, 164, 76, 178, 45, 212, 46, 194, 7);
 RT_INTERFACE!{interface IEmailMailboxChangedEventArgs(IEmailMailboxChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxChangedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut EmailMailboxChangedDeferral) -> HRESULT
@@ -17949,7 +17949,7 @@ impl IEmailMailboxChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxChangedEventArgs: IEmailMailboxChangedEventArgs}
+RT_CLASS!{class EmailMailboxChangedEventArgs: IEmailMailboxChangedEventArgs ["Windows.ApplicationModel.Email.EmailMailboxChangedEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxChangeReader, 3183283899, 50493, 17201, 151, 190, 190, 117, 162, 20, 106, 117);
 RT_INTERFACE!{interface IEmailMailboxChangeReader(IEmailMailboxChangeReaderVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxChangeReader] {
     fn AcceptChanges(&self) -> HRESULT,
@@ -17971,7 +17971,7 @@ impl IEmailMailboxChangeReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxChangeReader: IEmailMailboxChangeReader}
+RT_CLASS!{class EmailMailboxChangeReader: IEmailMailboxChangeReader ["Windows.ApplicationModel.Email.EmailMailboxChangeReader"]}
 DEFINE_IID!(IID_IEmailMailboxChangeTracker, 2061796920, 20838, 17079, 136, 130, 253, 33, 201, 43, 221, 75);
 RT_INTERFACE!{interface IEmailMailboxChangeTracker(IEmailMailboxChangeTrackerVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxChangeTracker] {
     fn get_IsTracking(&self, out: *mut bool) -> HRESULT,
@@ -17999,8 +17999,8 @@ impl IEmailMailboxChangeTracker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxChangeTracker: IEmailMailboxChangeTracker}
-RT_ENUM! { enum EmailMailboxChangeType: i32 {
+RT_CLASS!{class EmailMailboxChangeTracker: IEmailMailboxChangeTracker ["Windows.ApplicationModel.Email.EmailMailboxChangeTracker"]}
+RT_ENUM! { enum EmailMailboxChangeType: i32 ["Windows.ApplicationModel.Email.EmailMailboxChangeType"] {
     MessageCreated (EmailMailboxChangeType_MessageCreated) = 0, MessageModified (EmailMailboxChangeType_MessageModified) = 1, MessageDeleted (EmailMailboxChangeType_MessageDeleted) = 2, FolderCreated (EmailMailboxChangeType_FolderCreated) = 3, FolderModified (EmailMailboxChangeType_FolderModified) = 4, FolderDeleted (EmailMailboxChangeType_FolderDeleted) = 5, ChangeTrackingLost (EmailMailboxChangeType_ChangeTrackingLost) = 6,
 }}
 DEFINE_IID!(IID_IEmailMailboxCreateFolderResult, 2988987775, 10373, 18840, 181, 149, 138, 45, 55, 76, 233, 80);
@@ -18020,20 +18020,20 @@ impl IEmailMailboxCreateFolderResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxCreateFolderResult: IEmailMailboxCreateFolderResult}
-RT_ENUM! { enum EmailMailboxCreateFolderStatus: i32 {
+RT_CLASS!{class EmailMailboxCreateFolderResult: IEmailMailboxCreateFolderResult ["Windows.ApplicationModel.Email.EmailMailboxCreateFolderResult"]}
+RT_ENUM! { enum EmailMailboxCreateFolderStatus: i32 ["Windows.ApplicationModel.Email.EmailMailboxCreateFolderStatus"] {
     Success (EmailMailboxCreateFolderStatus_Success) = 0, NetworkError (EmailMailboxCreateFolderStatus_NetworkError) = 1, PermissionsError (EmailMailboxCreateFolderStatus_PermissionsError) = 2, ServerError (EmailMailboxCreateFolderStatus_ServerError) = 3, UnknownFailure (EmailMailboxCreateFolderStatus_UnknownFailure) = 4, NameCollision (EmailMailboxCreateFolderStatus_NameCollision) = 5, ServerRejected (EmailMailboxCreateFolderStatus_ServerRejected) = 6,
 }}
-RT_ENUM! { enum EmailMailboxDeleteFolderStatus: i32 {
+RT_ENUM! { enum EmailMailboxDeleteFolderStatus: i32 ["Windows.ApplicationModel.Email.EmailMailboxDeleteFolderStatus"] {
     Success (EmailMailboxDeleteFolderStatus_Success) = 0, NetworkError (EmailMailboxDeleteFolderStatus_NetworkError) = 1, PermissionsError (EmailMailboxDeleteFolderStatus_PermissionsError) = 2, ServerError (EmailMailboxDeleteFolderStatus_ServerError) = 3, UnknownFailure (EmailMailboxDeleteFolderStatus_UnknownFailure) = 4, CouldNotDeleteEverything (EmailMailboxDeleteFolderStatus_CouldNotDeleteEverything) = 5,
 }}
-RT_ENUM! { enum EmailMailboxEmptyFolderStatus: i32 {
+RT_ENUM! { enum EmailMailboxEmptyFolderStatus: i32 ["Windows.ApplicationModel.Email.EmailMailboxEmptyFolderStatus"] {
     Success (EmailMailboxEmptyFolderStatus_Success) = 0, NetworkError (EmailMailboxEmptyFolderStatus_NetworkError) = 1, PermissionsError (EmailMailboxEmptyFolderStatus_PermissionsError) = 2, ServerError (EmailMailboxEmptyFolderStatus_ServerError) = 3, UnknownFailure (EmailMailboxEmptyFolderStatus_UnknownFailure) = 4, CouldNotDeleteEverything (EmailMailboxEmptyFolderStatus_CouldNotDeleteEverything) = 5,
 }}
-RT_ENUM! { enum EmailMailboxOtherAppReadAccess: i32 {
+RT_ENUM! { enum EmailMailboxOtherAppReadAccess: i32 ["Windows.ApplicationModel.Email.EmailMailboxOtherAppReadAccess"] {
     SystemOnly (EmailMailboxOtherAppReadAccess_SystemOnly) = 0, Full (EmailMailboxOtherAppReadAccess_Full) = 1, None (EmailMailboxOtherAppReadAccess_None) = 2,
 }}
-RT_ENUM! { enum EmailMailboxOtherAppWriteAccess: i32 {
+RT_ENUM! { enum EmailMailboxOtherAppWriteAccess: i32 ["Windows.ApplicationModel.Email.EmailMailboxOtherAppWriteAccess"] {
     None (EmailMailboxOtherAppWriteAccess_None) = 0, Limited (EmailMailboxOtherAppWriteAccess_Limited) = 1,
 }}
 DEFINE_IID!(IID_IEmailMailboxPolicies, 523453893, 7227, 19911, 180, 16, 99, 115, 120, 62, 84, 93);
@@ -18065,7 +18065,7 @@ impl IEmailMailboxPolicies {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxPolicies: IEmailMailboxPolicies}
+RT_CLASS!{class EmailMailboxPolicies: IEmailMailboxPolicies ["Windows.ApplicationModel.Email.EmailMailboxPolicies"]}
 DEFINE_IID!(IID_IEmailMailboxPolicies2, 3132459771, 41291, 18812, 168, 226, 85, 234, 194, 156, 196, 181);
 RT_INTERFACE!{interface IEmailMailboxPolicies2(IEmailMailboxPolicies2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxPolicies2] {
     fn get_MustEncryptSmimeMessages(&self, out: *mut bool) -> HRESULT,
@@ -18118,10 +18118,10 @@ impl IEmailMailboxPolicies3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailMailboxSmimeEncryptionAlgorithm: i32 {
+RT_ENUM! { enum EmailMailboxSmimeEncryptionAlgorithm: i32 ["Windows.ApplicationModel.Email.EmailMailboxSmimeEncryptionAlgorithm"] {
     Any (EmailMailboxSmimeEncryptionAlgorithm_Any) = 0, TripleDes (EmailMailboxSmimeEncryptionAlgorithm_TripleDes) = 1, Des (EmailMailboxSmimeEncryptionAlgorithm_Des) = 2, RC2128Bit (EmailMailboxSmimeEncryptionAlgorithm_RC2128Bit) = 3, RC264Bit (EmailMailboxSmimeEncryptionAlgorithm_RC264Bit) = 4, RC240Bit (EmailMailboxSmimeEncryptionAlgorithm_RC240Bit) = 5,
 }}
-RT_ENUM! { enum EmailMailboxSmimeSigningAlgorithm: i32 {
+RT_ENUM! { enum EmailMailboxSmimeSigningAlgorithm: i32 ["Windows.ApplicationModel.Email.EmailMailboxSmimeSigningAlgorithm"] {
     Any (EmailMailboxSmimeSigningAlgorithm_Any) = 0, Sha1 (EmailMailboxSmimeSigningAlgorithm_Sha1) = 1, MD5 (EmailMailboxSmimeSigningAlgorithm_MD5) = 2,
 }}
 DEFINE_IID!(IID_IEmailMailboxSyncManager, 1367000410, 13713, 19293, 133, 188, 199, 29, 222, 134, 34, 99);
@@ -18164,7 +18164,7 @@ impl IEmailMailboxSyncManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxSyncManager: IEmailMailboxSyncManager}
+RT_CLASS!{class EmailMailboxSyncManager: IEmailMailboxSyncManager ["Windows.ApplicationModel.Email.EmailMailboxSyncManager"]}
 DEFINE_IID!(IID_IEmailMailboxSyncManager2, 3448621438, 38337, 20361, 129, 183, 230, 174, 203, 102, 149, 252);
 RT_INTERFACE!{interface IEmailMailboxSyncManager2(IEmailMailboxSyncManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxSyncManager2] {
     fn put_Status(&self, value: EmailMailboxSyncStatus) -> HRESULT,
@@ -18185,7 +18185,7 @@ impl IEmailMailboxSyncManager2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailMailboxSyncStatus: i32 {
+RT_ENUM! { enum EmailMailboxSyncStatus: i32 ["Windows.ApplicationModel.Email.EmailMailboxSyncStatus"] {
     Idle (EmailMailboxSyncStatus_Idle) = 0, Syncing (EmailMailboxSyncStatus_Syncing) = 1, UpToDate (EmailMailboxSyncStatus_UpToDate) = 2, AuthenticationError (EmailMailboxSyncStatus_AuthenticationError) = 3, PolicyError (EmailMailboxSyncStatus_PolicyError) = 4, UnknownError (EmailMailboxSyncStatus_UnknownError) = 5, ManualAccountRemovalRequired (EmailMailboxSyncStatus_ManualAccountRemovalRequired) = 6,
 }}
 RT_CLASS!{static class EmailManager}
@@ -18227,7 +18227,7 @@ impl IEmailManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailManagerForUser: IEmailManagerForUser}
+RT_CLASS!{class EmailManagerForUser: IEmailManagerForUser ["Windows.ApplicationModel.Email.EmailManagerForUser"]}
 DEFINE_IID!(IID_IEmailManagerStatics, 4111631956, 21957, 18576, 168, 36, 33, 108, 38, 24, 206, 127);
 RT_INTERFACE!{static interface IEmailManagerStatics(IEmailManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailManagerStatics] {
     fn ShowComposeNewEmailAsync(&self, message: *mut EmailMessage, out: *mut *mut foundation::IAsyncAction) -> HRESULT
@@ -18409,7 +18409,7 @@ impl IEmailMeetingInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMeetingInfo: IEmailMeetingInfo}
+RT_CLASS!{class EmailMeetingInfo: IEmailMeetingInfo ["Windows.ApplicationModel.Email.EmailMeetingInfo"]}
 impl RtActivatable<IActivationFactory> for EmailMeetingInfo {}
 DEFINE_CLSID!(EmailMeetingInfo(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,101,101,116,105,110,103,73,110,102,111,0]) [CLSID_EmailMeetingInfo]);
 DEFINE_IID!(IID_IEmailMeetingInfo2, 2119776365, 45273, 20453, 134, 124, 227, 30, 210, 181, 136, 184);
@@ -18423,7 +18423,7 @@ impl IEmailMeetingInfo2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailMeetingResponseType: i32 {
+RT_ENUM! { enum EmailMeetingResponseType: i32 ["Windows.ApplicationModel.Email.EmailMeetingResponseType"] {
     Accept (EmailMeetingResponseType_Accept) = 0, Decline (EmailMeetingResponseType_Decline) = 1, Tentative (EmailMeetingResponseType_Tentative) = 2,
 }}
 DEFINE_IID!(IID_IEmailMessage, 1819120781, 32949, 18680, 176, 177, 224, 78, 67, 15, 68, 229);
@@ -18477,7 +18477,7 @@ impl IEmailMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMessage: IEmailMessage}
+RT_CLASS!{class EmailMessage: IEmailMessage ["Windows.ApplicationModel.Email.EmailMessage"]}
 impl RtActivatable<IActivationFactory> for EmailMessage {}
 DEFINE_CLSID!(EmailMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,77,101,115,115,97,103,101,0]) [CLSID_EmailMessage]);
 DEFINE_IID!(IID_IEmailMessage2, 4257752203, 40730, 17627, 189, 60, 101, 195, 132, 119, 15, 134);
@@ -18806,11 +18806,11 @@ impl IEmailMessageBatch {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMessageBatch: IEmailMessageBatch}
-RT_ENUM! { enum EmailMessageBodyKind: i32 {
+RT_CLASS!{class EmailMessageBatch: IEmailMessageBatch ["Windows.ApplicationModel.Email.EmailMessageBatch"]}
+RT_ENUM! { enum EmailMessageBodyKind: i32 ["Windows.ApplicationModel.Email.EmailMessageBodyKind"] {
     Html (EmailMessageBodyKind_Html) = 0, PlainText (EmailMessageBodyKind_PlainText) = 1,
 }}
-RT_ENUM! { enum EmailMessageDownloadState: i32 {
+RT_ENUM! { enum EmailMessageDownloadState: i32 ["Windows.ApplicationModel.Email.EmailMessageDownloadState"] {
     PartiallyDownloaded (EmailMessageDownloadState_PartiallyDownloaded) = 0, Downloading (EmailMessageDownloadState_Downloading) = 1, Downloaded (EmailMessageDownloadState_Downloaded) = 2, Failed (EmailMessageDownloadState_Failed) = 3,
 }}
 DEFINE_IID!(IID_IEmailMessageReader, 793427615, 25107, 19077, 163, 176, 249, 45, 26, 131, 157, 25);
@@ -18824,14 +18824,14 @@ impl IEmailMessageReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMessageReader: IEmailMessageReader}
-RT_ENUM! { enum EmailMessageResponseKind: i32 {
+RT_CLASS!{class EmailMessageReader: IEmailMessageReader ["Windows.ApplicationModel.Email.EmailMessageReader"]}
+RT_ENUM! { enum EmailMessageResponseKind: i32 ["Windows.ApplicationModel.Email.EmailMessageResponseKind"] {
     None (EmailMessageResponseKind_None) = 0, Reply (EmailMessageResponseKind_Reply) = 1, ReplyAll (EmailMessageResponseKind_ReplyAll) = 2, Forward (EmailMessageResponseKind_Forward) = 3,
 }}
-RT_ENUM! { enum EmailMessageSmimeKind: i32 {
+RT_ENUM! { enum EmailMessageSmimeKind: i32 ["Windows.ApplicationModel.Email.EmailMessageSmimeKind"] {
     None (EmailMessageSmimeKind_None) = 0, ClearSigned (EmailMessageSmimeKind_ClearSigned) = 1, OpaqueSigned (EmailMessageSmimeKind_OpaqueSigned) = 2, Encrypted (EmailMessageSmimeKind_Encrypted) = 3,
 }}
-RT_ENUM! { enum EmailQueryKind: i32 {
+RT_ENUM! { enum EmailQueryKind: i32 ["Windows.ApplicationModel.Email.EmailQueryKind"] {
     All (EmailQueryKind_All) = 0, Important (EmailQueryKind_Important) = 1, Flagged (EmailQueryKind_Flagged) = 2, Unread (EmailQueryKind_Unread) = 3, Read (EmailQueryKind_Read) = 4, Unseen (EmailQueryKind_Unseen) = 5,
 }}
 DEFINE_IID!(IID_IEmailQueryOptions, 1162890139, 15999, 19794, 182, 221, 214, 253, 78, 31, 189, 154);
@@ -18884,7 +18884,7 @@ impl IEmailQueryOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailQueryOptions: IEmailQueryOptions}
+RT_CLASS!{class EmailQueryOptions: IEmailQueryOptions ["Windows.ApplicationModel.Email.EmailQueryOptions"]}
 impl RtActivatable<IEmailQueryOptionsFactory> for EmailQueryOptions {}
 impl RtActivatable<IActivationFactory> for EmailQueryOptions {}
 impl EmailQueryOptions {
@@ -18913,16 +18913,16 @@ impl IEmailQueryOptionsFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailQuerySearchFields: u32 {
+RT_ENUM! { enum EmailQuerySearchFields: u32 ["Windows.ApplicationModel.Email.EmailQuerySearchFields"] {
     None (EmailQuerySearchFields_None) = 0, Subject (EmailQuerySearchFields_Subject) = 1, Sender (EmailQuerySearchFields_Sender) = 2, Preview (EmailQuerySearchFields_Preview) = 4, Recipients (EmailQuerySearchFields_Recipients) = 8, All (EmailQuerySearchFields_All) = 4294967295,
 }}
-RT_ENUM! { enum EmailQuerySearchScope: i32 {
+RT_ENUM! { enum EmailQuerySearchScope: i32 ["Windows.ApplicationModel.Email.EmailQuerySearchScope"] {
     Local (EmailQuerySearchScope_Local) = 0, Server (EmailQuerySearchScope_Server) = 1,
 }}
-RT_ENUM! { enum EmailQuerySortDirection: i32 {
+RT_ENUM! { enum EmailQuerySortDirection: i32 ["Windows.ApplicationModel.Email.EmailQuerySortDirection"] {
     Descending (EmailQuerySortDirection_Descending) = 0, Ascending (EmailQuerySortDirection_Ascending) = 1,
 }}
-RT_ENUM! { enum EmailQuerySortProperty: i32 {
+RT_ENUM! { enum EmailQuerySortProperty: i32 ["Windows.ApplicationModel.Email.EmailQuerySortProperty"] {
     Date (EmailQuerySortProperty_Date) = 0,
 }}
 DEFINE_IID!(IID_IEmailQueryTextSearch, 2678104712, 15453, 18085, 166, 226, 49, 214, 253, 23, 229, 64);
@@ -18963,7 +18963,7 @@ impl IEmailQueryTextSearch {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailQueryTextSearch: IEmailQueryTextSearch}
+RT_CLASS!{class EmailQueryTextSearch: IEmailQueryTextSearch ["Windows.ApplicationModel.Email.EmailQueryTextSearch"]}
 DEFINE_IID!(IID_IEmailRecipient, 3404211635, 17528, 18452, 185, 0, 201, 2, 181, 225, 155, 83);
 RT_INTERFACE!{interface IEmailRecipient(IEmailRecipientVtbl): IInspectable(IInspectableVtbl) [IID_IEmailRecipient] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -18991,7 +18991,7 @@ impl IEmailRecipient {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailRecipient: IEmailRecipient}
+RT_CLASS!{class EmailRecipient: IEmailRecipient ["Windows.ApplicationModel.Email.EmailRecipient"]}
 impl RtActivatable<IEmailRecipientFactory> for EmailRecipient {}
 impl RtActivatable<IActivationFactory> for EmailRecipient {}
 impl EmailRecipient {
@@ -19037,7 +19037,7 @@ impl IEmailRecipientResolutionResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailRecipientResolutionResult: IEmailRecipientResolutionResult}
+RT_CLASS!{class EmailRecipientResolutionResult: IEmailRecipientResolutionResult ["Windows.ApplicationModel.Email.EmailRecipientResolutionResult"]}
 impl RtActivatable<IActivationFactory> for EmailRecipientResolutionResult {}
 DEFINE_CLSID!(EmailRecipientResolutionResult(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,109,97,105,108,46,69,109,97,105,108,82,101,99,105,112,105,101,110,116,82,101,115,111,108,117,116,105,111,110,82,101,115,117,108,116,0]) [CLSID_EmailRecipientResolutionResult]);
 DEFINE_IID!(IID_IEmailRecipientResolutionResult2, 1581386678, 52827, 19422, 185, 212, 225, 109, 160, 176, 159, 202);
@@ -19055,10 +19055,10 @@ impl IEmailRecipientResolutionResult2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EmailRecipientResolutionStatus: i32 {
+RT_ENUM! { enum EmailRecipientResolutionStatus: i32 ["Windows.ApplicationModel.Email.EmailRecipientResolutionStatus"] {
     Success (EmailRecipientResolutionStatus_Success) = 0, RecipientNotFound (EmailRecipientResolutionStatus_RecipientNotFound) = 1, AmbiguousRecipient (EmailRecipientResolutionStatus_AmbiguousRecipient) = 2, NoCertificate (EmailRecipientResolutionStatus_NoCertificate) = 3, CertificateRequestLimitReached (EmailRecipientResolutionStatus_CertificateRequestLimitReached) = 4, CannotResolveDistributionList (EmailRecipientResolutionStatus_CannotResolveDistributionList) = 5, ServerError (EmailRecipientResolutionStatus_ServerError) = 6, UnknownFailure (EmailRecipientResolutionStatus_UnknownFailure) = 7,
 }}
-RT_ENUM! { enum EmailSpecialFolderKind: i32 {
+RT_ENUM! { enum EmailSpecialFolderKind: i32 ["Windows.ApplicationModel.Email.EmailSpecialFolderKind"] {
     None (EmailSpecialFolderKind_None) = 0, Root (EmailSpecialFolderKind_Root) = 1, Inbox (EmailSpecialFolderKind_Inbox) = 2, Outbox (EmailSpecialFolderKind_Outbox) = 3, Drafts (EmailSpecialFolderKind_Drafts) = 4, DeletedItems (EmailSpecialFolderKind_DeletedItems) = 5, Sent (EmailSpecialFolderKind_Sent) = 6,
 }}
 DEFINE_IID!(IID_IEmailStore, 4160954990, 37175, 20363, 164, 112, 39, 154, 195, 5, 142, 182);
@@ -19132,15 +19132,15 @@ impl IEmailStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailStore: IEmailStore}
-RT_ENUM! { enum EmailStoreAccessType: i32 {
+RT_CLASS!{class EmailStore: IEmailStore ["Windows.ApplicationModel.Email.EmailStore"]}
+RT_ENUM! { enum EmailStoreAccessType: i32 ["Windows.ApplicationModel.Email.EmailStoreAccessType"] {
     AppMailboxesReadWrite (EmailStoreAccessType_AppMailboxesReadWrite) = 0, AllMailboxesLimitedReadWrite (EmailStoreAccessType_AllMailboxesLimitedReadWrite) = 1,
 }}
 DEFINE_IID!(IID_IEmailStoreNotificationTriggerDetails, 3457635900, 18150, 17353, 150, 247, 250, 207, 125, 215, 16, 203);
 RT_INTERFACE!{interface IEmailStoreNotificationTriggerDetails(IEmailStoreNotificationTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailStoreNotificationTriggerDetails] {
     
 }}
-RT_CLASS!{class EmailStoreNotificationTriggerDetails: IEmailStoreNotificationTriggerDetails}
+RT_CLASS!{class EmailStoreNotificationTriggerDetails: IEmailStoreNotificationTriggerDetails ["Windows.ApplicationModel.Email.EmailStoreNotificationTriggerDetails"]}
 pub mod dataprovider { // Windows.ApplicationModel.Email.DataProvider
 use ::prelude::*;
 DEFINE_IID!(IID_IEmailDataProviderConnection, 1000119751, 14258, 19440, 174, 48, 123, 100, 74, 28, 150, 225);
@@ -19318,7 +19318,7 @@ impl IEmailDataProviderConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailDataProviderConnection: IEmailDataProviderConnection}
+RT_CLASS!{class EmailDataProviderConnection: IEmailDataProviderConnection ["Windows.ApplicationModel.Email.DataProvider.EmailDataProviderConnection"]}
 DEFINE_IID!(IID_IEmailDataProviderTriggerDetails, 2403225168, 13342, 17907, 187, 160, 132, 160, 5, 225, 49, 154);
 RT_INTERFACE!{interface IEmailDataProviderTriggerDetails(IEmailDataProviderTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailDataProviderTriggerDetails] {
     fn get_Connection(&self, out: *mut *mut EmailDataProviderConnection) -> HRESULT
@@ -19330,7 +19330,7 @@ impl IEmailDataProviderTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailDataProviderTriggerDetails: IEmailDataProviderTriggerDetails}
+RT_CLASS!{class EmailDataProviderTriggerDetails: IEmailDataProviderTriggerDetails ["Windows.ApplicationModel.Email.DataProvider.EmailDataProviderTriggerDetails"]}
 DEFINE_IID!(IID_IEmailMailboxCreateFolderRequest, 407713653, 51489, 19513, 163, 9, 225, 108, 159, 34, 176, 75);
 RT_INTERFACE!{interface IEmailMailboxCreateFolderRequest(IEmailMailboxCreateFolderRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxCreateFolderRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19366,7 +19366,7 @@ impl IEmailMailboxCreateFolderRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxCreateFolderRequest: IEmailMailboxCreateFolderRequest}
+RT_CLASS!{class EmailMailboxCreateFolderRequest: IEmailMailboxCreateFolderRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxCreateFolderRequest"]}
 DEFINE_IID!(IID_IEmailMailboxCreateFolderRequestEventArgs, 65323052, 9244, 20137, 166, 143, 255, 32, 188, 90, 252, 133);
 RT_INTERFACE!{interface IEmailMailboxCreateFolderRequestEventArgs(IEmailMailboxCreateFolderRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxCreateFolderRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxCreateFolderRequest) -> HRESULT,
@@ -19384,7 +19384,7 @@ impl IEmailMailboxCreateFolderRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxCreateFolderRequestEventArgs: IEmailMailboxCreateFolderRequestEventArgs}
+RT_CLASS!{class EmailMailboxCreateFolderRequestEventArgs: IEmailMailboxCreateFolderRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxCreateFolderRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxDeleteFolderRequest, 2489968778, 43313, 18297, 146, 61, 9, 163, 234, 41, 46, 41);
 RT_INTERFACE!{interface IEmailMailboxDeleteFolderRequest(IEmailMailboxDeleteFolderRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxDeleteFolderRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19414,7 +19414,7 @@ impl IEmailMailboxDeleteFolderRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxDeleteFolderRequest: IEmailMailboxDeleteFolderRequest}
+RT_CLASS!{class EmailMailboxDeleteFolderRequest: IEmailMailboxDeleteFolderRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxDeleteFolderRequest"]}
 DEFINE_IID!(IID_IEmailMailboxDeleteFolderRequestEventArgs, 3033738502, 9010, 18040, 131, 120, 40, 181, 121, 51, 104, 70);
 RT_INTERFACE!{interface IEmailMailboxDeleteFolderRequestEventArgs(IEmailMailboxDeleteFolderRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxDeleteFolderRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxDeleteFolderRequest) -> HRESULT,
@@ -19432,7 +19432,7 @@ impl IEmailMailboxDeleteFolderRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxDeleteFolderRequestEventArgs: IEmailMailboxDeleteFolderRequestEventArgs}
+RT_CLASS!{class EmailMailboxDeleteFolderRequestEventArgs: IEmailMailboxDeleteFolderRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxDeleteFolderRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxDownloadAttachmentRequest, 186497972, 29964, 18657, 188, 228, 141, 88, 150, 132, 255, 188);
 RT_INTERFACE!{interface IEmailMailboxDownloadAttachmentRequest(IEmailMailboxDownloadAttachmentRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxDownloadAttachmentRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19468,7 +19468,7 @@ impl IEmailMailboxDownloadAttachmentRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxDownloadAttachmentRequest: IEmailMailboxDownloadAttachmentRequest}
+RT_CLASS!{class EmailMailboxDownloadAttachmentRequest: IEmailMailboxDownloadAttachmentRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadAttachmentRequest"]}
 DEFINE_IID!(IID_IEmailMailboxDownloadAttachmentRequestEventArgs, 3437085805, 65448, 18551, 159, 157, 254, 215, 188, 175, 65, 4);
 RT_INTERFACE!{interface IEmailMailboxDownloadAttachmentRequestEventArgs(IEmailMailboxDownloadAttachmentRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxDownloadAttachmentRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxDownloadAttachmentRequest) -> HRESULT,
@@ -19486,7 +19486,7 @@ impl IEmailMailboxDownloadAttachmentRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxDownloadAttachmentRequestEventArgs: IEmailMailboxDownloadAttachmentRequestEventArgs}
+RT_CLASS!{class EmailMailboxDownloadAttachmentRequestEventArgs: IEmailMailboxDownloadAttachmentRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadAttachmentRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxDownloadMessageRequest, 1232814471, 23373, 19235, 129, 108, 243, 132, 43, 235, 117, 62);
 RT_INTERFACE!{interface IEmailMailboxDownloadMessageRequest(IEmailMailboxDownloadMessageRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxDownloadMessageRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19516,7 +19516,7 @@ impl IEmailMailboxDownloadMessageRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxDownloadMessageRequest: IEmailMailboxDownloadMessageRequest}
+RT_CLASS!{class EmailMailboxDownloadMessageRequest: IEmailMailboxDownloadMessageRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadMessageRequest"]}
 DEFINE_IID!(IID_IEmailMailboxDownloadMessageRequestEventArgs, 1191446957, 53408, 19035, 187, 42, 55, 98, 16, 57, 197, 62);
 RT_INTERFACE!{interface IEmailMailboxDownloadMessageRequestEventArgs(IEmailMailboxDownloadMessageRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxDownloadMessageRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxDownloadMessageRequest) -> HRESULT,
@@ -19534,7 +19534,7 @@ impl IEmailMailboxDownloadMessageRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxDownloadMessageRequestEventArgs: IEmailMailboxDownloadMessageRequestEventArgs}
+RT_CLASS!{class EmailMailboxDownloadMessageRequestEventArgs: IEmailMailboxDownloadMessageRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadMessageRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxEmptyFolderRequest, 4266329003, 63597, 18137, 180, 206, 188, 138, 109, 158, 146, 104);
 RT_INTERFACE!{interface IEmailMailboxEmptyFolderRequest(IEmailMailboxEmptyFolderRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxEmptyFolderRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19564,7 +19564,7 @@ impl IEmailMailboxEmptyFolderRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxEmptyFolderRequest: IEmailMailboxEmptyFolderRequest}
+RT_CLASS!{class EmailMailboxEmptyFolderRequest: IEmailMailboxEmptyFolderRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxEmptyFolderRequest"]}
 DEFINE_IID!(IID_IEmailMailboxEmptyFolderRequestEventArgs, 1904473220, 39002, 19136, 179, 63, 238, 14, 38, 39, 163, 192);
 RT_INTERFACE!{interface IEmailMailboxEmptyFolderRequestEventArgs(IEmailMailboxEmptyFolderRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxEmptyFolderRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxEmptyFolderRequest) -> HRESULT,
@@ -19582,7 +19582,7 @@ impl IEmailMailboxEmptyFolderRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxEmptyFolderRequestEventArgs: IEmailMailboxEmptyFolderRequestEventArgs}
+RT_CLASS!{class EmailMailboxEmptyFolderRequestEventArgs: IEmailMailboxEmptyFolderRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxEmptyFolderRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxForwardMeetingRequest, 1634560753, 28884, 18482, 184, 105, 184, 5, 66, 174, 155, 232);
 RT_INTERFACE!{interface IEmailMailboxForwardMeetingRequest(IEmailMailboxForwardMeetingRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxForwardMeetingRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19642,7 +19642,7 @@ impl IEmailMailboxForwardMeetingRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxForwardMeetingRequest: IEmailMailboxForwardMeetingRequest}
+RT_CLASS!{class EmailMailboxForwardMeetingRequest: IEmailMailboxForwardMeetingRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxForwardMeetingRequest"]}
 DEFINE_IID!(IID_IEmailMailboxForwardMeetingRequestEventArgs, 735638330, 10612, 18265, 165, 165, 88, 244, 77, 60, 2, 117);
 RT_INTERFACE!{interface IEmailMailboxForwardMeetingRequestEventArgs(IEmailMailboxForwardMeetingRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxForwardMeetingRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxForwardMeetingRequest) -> HRESULT,
@@ -19660,7 +19660,7 @@ impl IEmailMailboxForwardMeetingRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxForwardMeetingRequestEventArgs: IEmailMailboxForwardMeetingRequestEventArgs}
+RT_CLASS!{class EmailMailboxForwardMeetingRequestEventArgs: IEmailMailboxForwardMeetingRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxForwardMeetingRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxGetAutoReplySettingsRequest, 2604140425, 7816, 19969, 132, 204, 19, 134, 173, 154, 44, 47);
 RT_INTERFACE!{interface IEmailMailboxGetAutoReplySettingsRequest(IEmailMailboxGetAutoReplySettingsRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxGetAutoReplySettingsRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19690,7 +19690,7 @@ impl IEmailMailboxGetAutoReplySettingsRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxGetAutoReplySettingsRequest: IEmailMailboxGetAutoReplySettingsRequest}
+RT_CLASS!{class EmailMailboxGetAutoReplySettingsRequest: IEmailMailboxGetAutoReplySettingsRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxGetAutoReplySettingsRequest"]}
 DEFINE_IID!(IID_IEmailMailboxGetAutoReplySettingsRequestEventArgs, 3617543618, 64837, 16388, 138, 145, 155, 172, 243, 139, 112, 34);
 RT_INTERFACE!{interface IEmailMailboxGetAutoReplySettingsRequestEventArgs(IEmailMailboxGetAutoReplySettingsRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxGetAutoReplySettingsRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxGetAutoReplySettingsRequest) -> HRESULT,
@@ -19708,7 +19708,7 @@ impl IEmailMailboxGetAutoReplySettingsRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxGetAutoReplySettingsRequestEventArgs: IEmailMailboxGetAutoReplySettingsRequestEventArgs}
+RT_CLASS!{class EmailMailboxGetAutoReplySettingsRequestEventArgs: IEmailMailboxGetAutoReplySettingsRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxGetAutoReplySettingsRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxMoveFolderRequest, 280635478, 19093, 16488, 145, 204, 103, 204, 122, 207, 69, 79);
 RT_INTERFACE!{interface IEmailMailboxMoveFolderRequest(IEmailMailboxMoveFolderRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxMoveFolderRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19750,7 +19750,7 @@ impl IEmailMailboxMoveFolderRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxMoveFolderRequest: IEmailMailboxMoveFolderRequest}
+RT_CLASS!{class EmailMailboxMoveFolderRequest: IEmailMailboxMoveFolderRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxMoveFolderRequest"]}
 DEFINE_IID!(IID_IEmailMailboxMoveFolderRequestEventArgs, 945958944, 5306, 19592, 134, 152, 114, 57, 227, 200, 170, 167);
 RT_INTERFACE!{interface IEmailMailboxMoveFolderRequestEventArgs(IEmailMailboxMoveFolderRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxMoveFolderRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxMoveFolderRequest) -> HRESULT,
@@ -19768,7 +19768,7 @@ impl IEmailMailboxMoveFolderRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxMoveFolderRequestEventArgs: IEmailMailboxMoveFolderRequestEventArgs}
+RT_CLASS!{class EmailMailboxMoveFolderRequestEventArgs: IEmailMailboxMoveFolderRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxMoveFolderRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxProposeNewTimeForMeetingRequest, 1525674322, 38809, 20383, 163, 153, 255, 7, 243, 238, 240, 78);
 RT_INTERFACE!{interface IEmailMailboxProposeNewTimeForMeetingRequest(IEmailMailboxProposeNewTimeForMeetingRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxProposeNewTimeForMeetingRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19822,7 +19822,7 @@ impl IEmailMailboxProposeNewTimeForMeetingRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxProposeNewTimeForMeetingRequest: IEmailMailboxProposeNewTimeForMeetingRequest}
+RT_CLASS!{class EmailMailboxProposeNewTimeForMeetingRequest: IEmailMailboxProposeNewTimeForMeetingRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxProposeNewTimeForMeetingRequest"]}
 DEFINE_IID!(IID_IEmailMailboxProposeNewTimeForMeetingRequestEventArgs, 4215802776, 13229, 19047, 130, 81, 15, 156, 36, 155, 106, 32);
 RT_INTERFACE!{interface IEmailMailboxProposeNewTimeForMeetingRequestEventArgs(IEmailMailboxProposeNewTimeForMeetingRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxProposeNewTimeForMeetingRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxProposeNewTimeForMeetingRequest) -> HRESULT,
@@ -19840,7 +19840,7 @@ impl IEmailMailboxProposeNewTimeForMeetingRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxProposeNewTimeForMeetingRequestEventArgs: IEmailMailboxProposeNewTimeForMeetingRequestEventArgs}
+RT_CLASS!{class EmailMailboxProposeNewTimeForMeetingRequestEventArgs: IEmailMailboxProposeNewTimeForMeetingRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxProposeNewTimeForMeetingRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxResolveRecipientsRequest, 4020555632, 31545, 19611, 129, 30, 65, 234, 244, 58, 51, 45);
 RT_INTERFACE!{interface IEmailMailboxResolveRecipientsRequest(IEmailMailboxResolveRecipientsRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxResolveRecipientsRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19870,7 +19870,7 @@ impl IEmailMailboxResolveRecipientsRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxResolveRecipientsRequest: IEmailMailboxResolveRecipientsRequest}
+RT_CLASS!{class EmailMailboxResolveRecipientsRequest: IEmailMailboxResolveRecipientsRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxResolveRecipientsRequest"]}
 DEFINE_IID!(IID_IEmailMailboxResolveRecipientsRequestEventArgs, 638557698, 45775, 16632, 140, 40, 227, 237, 67, 177, 232, 154);
 RT_INTERFACE!{interface IEmailMailboxResolveRecipientsRequestEventArgs(IEmailMailboxResolveRecipientsRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxResolveRecipientsRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxResolveRecipientsRequest) -> HRESULT,
@@ -19888,7 +19888,7 @@ impl IEmailMailboxResolveRecipientsRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxResolveRecipientsRequestEventArgs: IEmailMailboxResolveRecipientsRequestEventArgs}
+RT_CLASS!{class EmailMailboxResolveRecipientsRequestEventArgs: IEmailMailboxResolveRecipientsRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxResolveRecipientsRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxServerSearchReadBatchRequest, 151972831, 23190, 16851, 138, 216, 52, 145, 47, 154, 166, 14);
 RT_INTERFACE!{interface IEmailMailboxServerSearchReadBatchRequest(IEmailMailboxServerSearchReadBatchRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxServerSearchReadBatchRequest] {
     fn get_SessionId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19942,7 +19942,7 @@ impl IEmailMailboxServerSearchReadBatchRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxServerSearchReadBatchRequest: IEmailMailboxServerSearchReadBatchRequest}
+RT_CLASS!{class EmailMailboxServerSearchReadBatchRequest: IEmailMailboxServerSearchReadBatchRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxServerSearchReadBatchRequest"]}
 DEFINE_IID!(IID_IEmailMailboxServerSearchReadBatchRequestEventArgs, 336599886, 60830, 17873, 173, 122, 204, 155, 127, 100, 58, 226);
 RT_INTERFACE!{interface IEmailMailboxServerSearchReadBatchRequestEventArgs(IEmailMailboxServerSearchReadBatchRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxServerSearchReadBatchRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxServerSearchReadBatchRequest) -> HRESULT,
@@ -19960,7 +19960,7 @@ impl IEmailMailboxServerSearchReadBatchRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxServerSearchReadBatchRequestEventArgs: IEmailMailboxServerSearchReadBatchRequestEventArgs}
+RT_CLASS!{class EmailMailboxServerSearchReadBatchRequestEventArgs: IEmailMailboxServerSearchReadBatchRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxServerSearchReadBatchRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxSetAutoReplySettingsRequest, 1973691088, 43150, 20052, 141, 199, 194, 67, 24, 107, 119, 78);
 RT_INTERFACE!{interface IEmailMailboxSetAutoReplySettingsRequest(IEmailMailboxSetAutoReplySettingsRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxSetAutoReplySettingsRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19990,7 +19990,7 @@ impl IEmailMailboxSetAutoReplySettingsRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxSetAutoReplySettingsRequest: IEmailMailboxSetAutoReplySettingsRequest}
+RT_CLASS!{class EmailMailboxSetAutoReplySettingsRequest: IEmailMailboxSetAutoReplySettingsRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxSetAutoReplySettingsRequest"]}
 DEFINE_IID!(IID_IEmailMailboxSetAutoReplySettingsRequestEventArgs, 165286317, 55242, 16519, 172, 134, 83, 250, 103, 247, 98, 70);
 RT_INTERFACE!{interface IEmailMailboxSetAutoReplySettingsRequestEventArgs(IEmailMailboxSetAutoReplySettingsRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxSetAutoReplySettingsRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxSetAutoReplySettingsRequest) -> HRESULT,
@@ -20008,7 +20008,7 @@ impl IEmailMailboxSetAutoReplySettingsRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxSetAutoReplySettingsRequestEventArgs: IEmailMailboxSetAutoReplySettingsRequestEventArgs}
+RT_CLASS!{class EmailMailboxSetAutoReplySettingsRequestEventArgs: IEmailMailboxSetAutoReplySettingsRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxSetAutoReplySettingsRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxSyncManagerSyncRequest, 1309731044, 32359, 16474, 182, 115, 220, 96, 201, 16, 144, 252);
 RT_INTERFACE!{interface IEmailMailboxSyncManagerSyncRequest(IEmailMailboxSyncManagerSyncRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxSyncManagerSyncRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -20032,7 +20032,7 @@ impl IEmailMailboxSyncManagerSyncRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxSyncManagerSyncRequest: IEmailMailboxSyncManagerSyncRequest}
+RT_CLASS!{class EmailMailboxSyncManagerSyncRequest: IEmailMailboxSyncManagerSyncRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxSyncManagerSyncRequest"]}
 DEFINE_IID!(IID_IEmailMailboxSyncManagerSyncRequestEventArgs, 1134166810, 36812, 19173, 185, 181, 212, 52, 224, 166, 90, 168);
 RT_INTERFACE!{interface IEmailMailboxSyncManagerSyncRequestEventArgs(IEmailMailboxSyncManagerSyncRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxSyncManagerSyncRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxSyncManagerSyncRequest) -> HRESULT,
@@ -20050,7 +20050,7 @@ impl IEmailMailboxSyncManagerSyncRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxSyncManagerSyncRequestEventArgs: IEmailMailboxSyncManagerSyncRequestEventArgs}
+RT_CLASS!{class EmailMailboxSyncManagerSyncRequestEventArgs: IEmailMailboxSyncManagerSyncRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxSyncManagerSyncRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxUpdateMeetingResponseRequest, 1536797843, 45775, 18568, 186, 79, 48, 107, 107, 102, 223, 48);
 RT_INTERFACE!{interface IEmailMailboxUpdateMeetingResponseRequest(IEmailMailboxUpdateMeetingResponseRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxUpdateMeetingResponseRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -20104,7 +20104,7 @@ impl IEmailMailboxUpdateMeetingResponseRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxUpdateMeetingResponseRequest: IEmailMailboxUpdateMeetingResponseRequest}
+RT_CLASS!{class EmailMailboxUpdateMeetingResponseRequest: IEmailMailboxUpdateMeetingResponseRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxUpdateMeetingResponseRequest"]}
 DEFINE_IID!(IID_IEmailMailboxUpdateMeetingResponseRequestEventArgs, 1754847073, 22217, 20247, 190, 49, 102, 253, 169, 75, 161, 89);
 RT_INTERFACE!{interface IEmailMailboxUpdateMeetingResponseRequestEventArgs(IEmailMailboxUpdateMeetingResponseRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxUpdateMeetingResponseRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxUpdateMeetingResponseRequest) -> HRESULT,
@@ -20122,7 +20122,7 @@ impl IEmailMailboxUpdateMeetingResponseRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxUpdateMeetingResponseRequestEventArgs: IEmailMailboxUpdateMeetingResponseRequestEventArgs}
+RT_CLASS!{class EmailMailboxUpdateMeetingResponseRequestEventArgs: IEmailMailboxUpdateMeetingResponseRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxUpdateMeetingResponseRequestEventArgs"]}
 DEFINE_IID!(IID_IEmailMailboxValidateCertificatesRequest, 2840410417, 57626, 20375, 184, 26, 24, 122, 112, 168, 244, 26);
 RT_INTERFACE!{interface IEmailMailboxValidateCertificatesRequest(IEmailMailboxValidateCertificatesRequestVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxValidateCertificatesRequest] {
     fn get_EmailMailboxId(&self, out: *mut HSTRING) -> HRESULT,
@@ -20153,7 +20153,7 @@ impl IEmailMailboxValidateCertificatesRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxValidateCertificatesRequest: IEmailMailboxValidateCertificatesRequest}
+RT_CLASS!{class EmailMailboxValidateCertificatesRequest: IEmailMailboxValidateCertificatesRequest ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxValidateCertificatesRequest"]}
 DEFINE_IID!(IID_IEmailMailboxValidateCertificatesRequestEventArgs, 629391127, 767, 18942, 167, 60, 3, 243, 117, 102, 198, 145);
 RT_INTERFACE!{interface IEmailMailboxValidateCertificatesRequestEventArgs(IEmailMailboxValidateCertificatesRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IEmailMailboxValidateCertificatesRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut EmailMailboxValidateCertificatesRequest) -> HRESULT,
@@ -20171,15 +20171,15 @@ impl IEmailMailboxValidateCertificatesRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmailMailboxValidateCertificatesRequestEventArgs: IEmailMailboxValidateCertificatesRequestEventArgs}
+RT_CLASS!{class EmailMailboxValidateCertificatesRequestEventArgs: IEmailMailboxValidateCertificatesRequestEventArgs ["Windows.ApplicationModel.Email.DataProvider.EmailMailboxValidateCertificatesRequestEventArgs"]}
 } // Windows.ApplicationModel.Email.DataProvider
 } // Windows.ApplicationModel.Email
 pub mod extendedexecution { // Windows.ApplicationModel.ExtendedExecution
 use ::prelude::*;
-RT_ENUM! { enum ExtendedExecutionReason: i32 {
+RT_ENUM! { enum ExtendedExecutionReason: i32 ["Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionReason"] {
     Unspecified (ExtendedExecutionReason_Unspecified) = 0, LocationTracking (ExtendedExecutionReason_LocationTracking) = 1, SavingData (ExtendedExecutionReason_SavingData) = 2,
 }}
-RT_ENUM! { enum ExtendedExecutionResult: i32 {
+RT_ENUM! { enum ExtendedExecutionResult: i32 ["Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionResult"] {
     Allowed (ExtendedExecutionResult_Allowed) = 0, Denied (ExtendedExecutionResult_Denied) = 1,
 }}
 DEFINE_IID!(IID_IExtendedExecutionRevokedEventArgs, 3216809750, 25525, 19467, 170, 214, 130, 138, 245, 55, 62, 195);
@@ -20193,8 +20193,8 @@ impl IExtendedExecutionRevokedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExtendedExecutionRevokedEventArgs: IExtendedExecutionRevokedEventArgs}
-RT_ENUM! { enum ExtendedExecutionRevokedReason: i32 {
+RT_CLASS!{class ExtendedExecutionRevokedEventArgs: IExtendedExecutionRevokedEventArgs ["Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionRevokedEventArgs"]}
+RT_ENUM! { enum ExtendedExecutionRevokedReason: i32 ["Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionRevokedReason"] {
     Resumed (ExtendedExecutionRevokedReason_Resumed) = 0, SystemPolicy (ExtendedExecutionRevokedReason_SystemPolicy) = 1,
 }}
 DEFINE_IID!(IID_IExtendedExecutionSession, 2945485357, 4491, 18673, 147, 8, 12, 79, 196, 30, 32, 15);
@@ -20252,15 +20252,15 @@ impl IExtendedExecutionSession {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExtendedExecutionSession: IExtendedExecutionSession}
+RT_CLASS!{class ExtendedExecutionSession: IExtendedExecutionSession ["Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionSession"]}
 impl RtActivatable<IActivationFactory> for ExtendedExecutionSession {}
 DEFINE_CLSID!(ExtendedExecutionSession(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,83,101,115,115,105,111,110,0]) [CLSID_ExtendedExecutionSession]);
 pub mod foreground { // Windows.ApplicationModel.ExtendedExecution.Foreground
 use ::prelude::*;
-RT_ENUM! { enum ExtendedExecutionForegroundReason: i32 {
+RT_ENUM! { enum ExtendedExecutionForegroundReason: i32 ["Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundReason"] {
     Unspecified (ExtendedExecutionForegroundReason_Unspecified) = 0, SavingData (ExtendedExecutionForegroundReason_SavingData) = 1, BackgroundAudio (ExtendedExecutionForegroundReason_BackgroundAudio) = 2, Unconstrained (ExtendedExecutionForegroundReason_Unconstrained) = 3,
 }}
-RT_ENUM! { enum ExtendedExecutionForegroundResult: i32 {
+RT_ENUM! { enum ExtendedExecutionForegroundResult: i32 ["Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundResult"] {
     Allowed (ExtendedExecutionForegroundResult_Allowed) = 0, Denied (ExtendedExecutionForegroundResult_Denied) = 1,
 }}
 DEFINE_IID!(IID_IExtendedExecutionForegroundRevokedEventArgs, 2960972096, 38231, 44708, 44, 153, 189, 213, 109, 155, 228, 97);
@@ -20274,8 +20274,8 @@ impl IExtendedExecutionForegroundRevokedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExtendedExecutionForegroundRevokedEventArgs: IExtendedExecutionForegroundRevokedEventArgs}
-RT_ENUM! { enum ExtendedExecutionForegroundRevokedReason: i32 {
+RT_CLASS!{class ExtendedExecutionForegroundRevokedEventArgs: IExtendedExecutionForegroundRevokedEventArgs ["Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundRevokedEventArgs"]}
+RT_ENUM! { enum ExtendedExecutionForegroundRevokedReason: i32 ["Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundRevokedReason"] {
     Resumed (ExtendedExecutionForegroundRevokedReason_Resumed) = 0, SystemPolicy (ExtendedExecutionForegroundRevokedReason_SystemPolicy) = 1,
 }}
 DEFINE_IID!(IID_IExtendedExecutionForegroundSession, 4227088609, 40208, 16897, 176, 30, 200, 50, 117, 41, 111, 46);
@@ -20322,7 +20322,7 @@ impl IExtendedExecutionForegroundSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExtendedExecutionForegroundSession: IExtendedExecutionForegroundSession}
+RT_CLASS!{class ExtendedExecutionForegroundSession: IExtendedExecutionForegroundSession ["Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundSession"]}
 impl RtActivatable<IActivationFactory> for ExtendedExecutionForegroundSession {}
 DEFINE_CLSID!(ExtendedExecutionForegroundSession(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,46,70,111,114,101,103,114,111,117,110,100,46,69,120,116,101,110,100,101,100,69,120,101,99,117,116,105,111,110,70,111,114,101,103,114,111,117,110,100,83,101,115,115,105,111,110,0]) [CLSID_ExtendedExecutionForegroundSession]);
 } // Windows.ApplicationModel.ExtendedExecution.Foreground
@@ -20350,7 +20350,7 @@ impl ILockApplicationHost {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockApplicationHost: ILockApplicationHost}
+RT_CLASS!{class LockApplicationHost: ILockApplicationHost ["Windows.ApplicationModel.LockScreen.LockApplicationHost"]}
 impl RtActivatable<ILockApplicationHostStatics> for LockApplicationHost {}
 impl LockApplicationHost {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<LockApplicationHost>>> {
@@ -20405,7 +20405,7 @@ impl ILockScreenBadge {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenBadge: ILockScreenBadge}
+RT_CLASS!{class LockScreenBadge: ILockScreenBadge ["Windows.ApplicationModel.LockScreen.LockScreenBadge"]}
 DEFINE_IID!(IID_ILockScreenInfo, 4120553052, 38673, 19913, 166, 48, 149, 182, 203, 140, 218, 208);
 RT_INTERFACE!{interface ILockScreenInfo(ILockScreenInfoVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenInfo] {
     fn add_LockScreenImageChanged(&self, handler: *mut foundation::TypedEventHandler<LockScreenInfo, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -20479,7 +20479,7 @@ impl ILockScreenInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenInfo: ILockScreenInfo}
+RT_CLASS!{class LockScreenInfo: ILockScreenInfo ["Windows.ApplicationModel.LockScreen.LockScreenInfo"]}
 DEFINE_IID!(IID_ILockScreenUnlockingDeferral, 2122128086, 20995, 17383, 155, 214, 124, 57, 71, 209, 227, 254);
 RT_INTERFACE!{interface ILockScreenUnlockingDeferral(ILockScreenUnlockingDeferralVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenUnlockingDeferral] {
     fn Complete(&self) -> HRESULT
@@ -20490,7 +20490,7 @@ impl ILockScreenUnlockingDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenUnlockingDeferral: ILockScreenUnlockingDeferral}
+RT_CLASS!{class LockScreenUnlockingDeferral: ILockScreenUnlockingDeferral ["Windows.ApplicationModel.LockScreen.LockScreenUnlockingDeferral"]}
 DEFINE_IID!(IID_ILockScreenUnlockingEventArgs, 1155973127, 30203, 19131, 159, 139, 130, 71, 72, 144, 12, 113);
 RT_INTERFACE!{interface ILockScreenUnlockingEventArgs(ILockScreenUnlockingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILockScreenUnlockingEventArgs] {
     fn GetDeferral(&self, out: *mut *mut LockScreenUnlockingDeferral) -> HRESULT,
@@ -20508,7 +20508,7 @@ impl ILockScreenUnlockingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LockScreenUnlockingEventArgs: ILockScreenUnlockingEventArgs}
+RT_CLASS!{class LockScreenUnlockingEventArgs: ILockScreenUnlockingEventArgs ["Windows.ApplicationModel.LockScreen.LockScreenUnlockingEventArgs"]}
 } // Windows.ApplicationModel.LockScreen
 pub mod payments { // Windows.ApplicationModel.Payments
 use ::prelude::*;
@@ -20644,7 +20644,7 @@ impl IPaymentAddress {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentAddress: IPaymentAddress}
+RT_CLASS!{class PaymentAddress: IPaymentAddress ["Windows.ApplicationModel.Payments.PaymentAddress"]}
 impl RtActivatable<IActivationFactory> for PaymentAddress {}
 DEFINE_CLSID!(PaymentAddress(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,65,100,100,114,101,115,115,0]) [CLSID_PaymentAddress]);
 DEFINE_IID!(IID_IPaymentCanMakePaymentResult, 1989606997, 54739, 19773, 179, 69, 69, 89, 23, 89, 197, 16);
@@ -20658,7 +20658,7 @@ impl IPaymentCanMakePaymentResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentCanMakePaymentResult: IPaymentCanMakePaymentResult}
+RT_CLASS!{class PaymentCanMakePaymentResult: IPaymentCanMakePaymentResult ["Windows.ApplicationModel.Payments.PaymentCanMakePaymentResult"]}
 impl RtActivatable<IPaymentCanMakePaymentResultFactory> for PaymentCanMakePaymentResult {}
 impl PaymentCanMakePaymentResult {
     #[inline] pub fn create(value: PaymentCanMakePaymentResultStatus) -> Result<ComPtr<PaymentCanMakePaymentResult>> {
@@ -20677,7 +20677,7 @@ impl IPaymentCanMakePaymentResultFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PaymentCanMakePaymentResultStatus: i32 {
+RT_ENUM! { enum PaymentCanMakePaymentResultStatus: i32 ["Windows.ApplicationModel.Payments.PaymentCanMakePaymentResultStatus"] {
     Unknown (PaymentCanMakePaymentResultStatus_Unknown) = 0, Yes (PaymentCanMakePaymentResultStatus_Yes) = 1, No (PaymentCanMakePaymentResultStatus_No) = 2, NotAllowed (PaymentCanMakePaymentResultStatus_NotAllowed) = 3, UserNotSignedIn (PaymentCanMakePaymentResultStatus_UserNotSignedIn) = 4, SpecifiedPaymentMethodIdsNotSupported (PaymentCanMakePaymentResultStatus_SpecifiedPaymentMethodIdsNotSupported) = 5, NoQualifyingCardOnFile (PaymentCanMakePaymentResultStatus_NoQualifyingCardOnFile) = 6,
 }}
 DEFINE_IID!(IID_IPaymentCurrencyAmount, 3819170272, 46111, 18823, 189, 203, 7, 19, 49, 242, 218, 164);
@@ -20718,7 +20718,7 @@ impl IPaymentCurrencyAmount {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentCurrencyAmount: IPaymentCurrencyAmount}
+RT_CLASS!{class PaymentCurrencyAmount: IPaymentCurrencyAmount ["Windows.ApplicationModel.Payments.PaymentCurrencyAmount"]}
 impl RtActivatable<IPaymentCurrencyAmountFactory> for PaymentCurrencyAmount {}
 impl PaymentCurrencyAmount {
     #[inline] pub fn create(value: &HStringArg, currency: &HStringArg) -> Result<ComPtr<PaymentCurrencyAmount>> {
@@ -20795,7 +20795,7 @@ impl IPaymentDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentDetails: IPaymentDetails}
+RT_CLASS!{class PaymentDetails: IPaymentDetails ["Windows.ApplicationModel.Payments.PaymentDetails"]}
 impl RtActivatable<IPaymentDetailsFactory> for PaymentDetails {}
 impl RtActivatable<IActivationFactory> for PaymentDetails {}
 impl PaymentDetails {
@@ -20853,7 +20853,7 @@ impl IPaymentDetailsModifier {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentDetailsModifier: IPaymentDetailsModifier}
+RT_CLASS!{class PaymentDetailsModifier: IPaymentDetailsModifier ["Windows.ApplicationModel.Payments.PaymentDetailsModifier"]}
 impl RtActivatable<IPaymentDetailsModifierFactory> for PaymentDetailsModifier {}
 impl PaymentDetailsModifier {
     #[inline] pub fn create(supportedMethodIds: &foundation::collections::IIterable<HString>, total: &PaymentItem) -> Result<ComPtr<PaymentDetailsModifier>> {
@@ -20928,7 +20928,7 @@ impl IPaymentItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentItem: IPaymentItem}
+RT_CLASS!{class PaymentItem: IPaymentItem ["Windows.ApplicationModel.Payments.PaymentItem"]}
 impl RtActivatable<IPaymentItemFactory> for PaymentItem {}
 impl PaymentItem {
     #[inline] pub fn create(label: &HStringArg, amount: &PaymentCurrencyAmount) -> Result<ComPtr<PaymentItem>> {
@@ -20970,7 +20970,7 @@ impl IPaymentMediator {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentMediator: IPaymentMediator}
+RT_CLASS!{class PaymentMediator: IPaymentMediator ["Windows.ApplicationModel.Payments.PaymentMediator"]}
 impl RtActivatable<IActivationFactory> for PaymentMediator {}
 DEFINE_CLSID!(PaymentMediator(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,77,101,100,105,97,116,111,114,0]) [CLSID_PaymentMediator]);
 DEFINE_IID!(IID_IPaymentMediator2, 3471808753, 58375, 16680, 142, 115, 217, 61, 95, 130, 39, 134);
@@ -21001,7 +21001,7 @@ impl IPaymentMerchantInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentMerchantInfo: IPaymentMerchantInfo}
+RT_CLASS!{class PaymentMerchantInfo: IPaymentMerchantInfo ["Windows.ApplicationModel.Payments.PaymentMerchantInfo"]}
 impl RtActivatable<IPaymentMerchantInfoFactory> for PaymentMerchantInfo {}
 impl RtActivatable<IActivationFactory> for PaymentMerchantInfo {}
 impl PaymentMerchantInfo {
@@ -21038,7 +21038,7 @@ impl IPaymentMethodData {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentMethodData: IPaymentMethodData}
+RT_CLASS!{class PaymentMethodData: IPaymentMethodData ["Windows.ApplicationModel.Payments.PaymentMethodData"]}
 impl RtActivatable<IPaymentMethodDataFactory> for PaymentMethodData {}
 impl PaymentMethodData {
     #[inline] pub fn create(supportedMethodIds: &foundation::collections::IIterable<HString>) -> Result<ComPtr<PaymentMethodData>> {
@@ -21066,7 +21066,7 @@ impl IPaymentMethodDataFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PaymentOptionPresence: i32 {
+RT_ENUM! { enum PaymentOptionPresence: i32 ["Windows.ApplicationModel.Payments.PaymentOptionPresence"] {
     None (PaymentOptionPresence_None) = 0, Optional (PaymentOptionPresence_Optional) = 1, Required (PaymentOptionPresence_Required) = 2,
 }}
 DEFINE_IID!(IID_IPaymentOptions, 2862811220, 7979, 17253, 130, 81, 1, 181, 137, 21, 165, 188);
@@ -21129,7 +21129,7 @@ impl IPaymentOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentOptions: IPaymentOptions}
+RT_CLASS!{class PaymentOptions: IPaymentOptions ["Windows.ApplicationModel.Payments.PaymentOptions"]}
 impl RtActivatable<IActivationFactory> for PaymentOptions {}
 DEFINE_CLSID!(PaymentOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,97,121,109,101,110,116,115,46,80,97,121,109,101,110,116,79,112,116,105,111,110,115,0]) [CLSID_PaymentOptions]);
 DEFINE_IID!(IID_IPaymentRequest, 3075031777, 60795, 18411, 188, 8, 120, 204, 93, 104, 150, 182);
@@ -21161,7 +21161,7 @@ impl IPaymentRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentRequest: IPaymentRequest}
+RT_CLASS!{class PaymentRequest: IPaymentRequest ["Windows.ApplicationModel.Payments.PaymentRequest"]}
 impl RtActivatable<IPaymentRequestFactory> for PaymentRequest {}
 impl RtActivatable<IPaymentRequestFactory2> for PaymentRequest {}
 impl PaymentRequest {
@@ -21218,7 +21218,7 @@ impl IPaymentRequestChangedArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentRequestChangedArgs: IPaymentRequestChangedArgs}
+RT_CLASS!{class PaymentRequestChangedArgs: IPaymentRequestChangedArgs ["Windows.ApplicationModel.Payments.PaymentRequestChangedArgs"]}
 DEFINE_IID!(IID_PaymentRequestChangedHandler, 1350089185, 62360, 20268, 162, 126, 148, 211, 113, 207, 108, 125);
 RT_DELEGATE!{delegate PaymentRequestChangedHandler(PaymentRequestChangedHandlerVtbl, PaymentRequestChangedHandlerImpl) [IID_PaymentRequestChangedHandler] {
     fn Invoke(&self, paymentRequest: *mut PaymentRequest, args: *mut PaymentRequestChangedArgs) -> HRESULT
@@ -21267,7 +21267,7 @@ impl IPaymentRequestChangedResult {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentRequestChangedResult: IPaymentRequestChangedResult}
+RT_CLASS!{class PaymentRequestChangedResult: IPaymentRequestChangedResult ["Windows.ApplicationModel.Payments.PaymentRequestChangedResult"]}
 impl RtActivatable<IPaymentRequestChangedResultFactory> for PaymentRequestChangedResult {}
 impl PaymentRequestChangedResult {
     #[inline] pub fn create(changeAcceptedByMerchant: bool) -> Result<ComPtr<PaymentRequestChangedResult>> {
@@ -21295,10 +21295,10 @@ impl IPaymentRequestChangedResultFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PaymentRequestChangeKind: i32 {
+RT_ENUM! { enum PaymentRequestChangeKind: i32 ["Windows.ApplicationModel.Payments.PaymentRequestChangeKind"] {
     ShippingOption (PaymentRequestChangeKind_ShippingOption) = 0, ShippingAddress (PaymentRequestChangeKind_ShippingAddress) = 1,
 }}
-RT_ENUM! { enum PaymentRequestCompletionStatus: i32 {
+RT_ENUM! { enum PaymentRequestCompletionStatus: i32 ["Windows.ApplicationModel.Payments.PaymentRequestCompletionStatus"] {
     Succeeded (PaymentRequestCompletionStatus_Succeeded) = 0, Failed (PaymentRequestCompletionStatus_Failed) = 1, Unknown (PaymentRequestCompletionStatus_Unknown) = 2,
 }}
 DEFINE_IID!(IID_IPaymentRequestFactory, 1049262556, 27508, 17107, 177, 3, 240, 222, 53, 251, 24, 72);
@@ -21335,7 +21335,7 @@ impl IPaymentRequestFactory2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PaymentRequestStatus: i32 {
+RT_ENUM! { enum PaymentRequestStatus: i32 ["Windows.ApplicationModel.Payments.PaymentRequestStatus"] {
     Succeeded (PaymentRequestStatus_Succeeded) = 0, Failed (PaymentRequestStatus_Failed) = 1, Canceled (PaymentRequestStatus_Canceled) = 2,
 }}
 DEFINE_IID!(IID_IPaymentRequestSubmitResult, 2073835794, 12530, 20112, 178, 73, 140, 231, 215, 143, 254, 86);
@@ -21355,7 +21355,7 @@ impl IPaymentRequestSubmitResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentRequestSubmitResult: IPaymentRequestSubmitResult}
+RT_CLASS!{class PaymentRequestSubmitResult: IPaymentRequestSubmitResult ["Windows.ApplicationModel.Payments.PaymentRequestSubmitResult"]}
 DEFINE_IID!(IID_IPaymentResponse, 3778581591, 35794, 18568, 159, 168, 151, 152, 85, 69, 16, 142);
 RT_INTERFACE!{interface IPaymentResponse(IPaymentResponseVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentResponse] {
     fn get_PaymentToken(&self, out: *mut *mut PaymentToken) -> HRESULT,
@@ -21403,7 +21403,7 @@ impl IPaymentResponse {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentResponse: IPaymentResponse}
+RT_CLASS!{class PaymentResponse: IPaymentResponse ["Windows.ApplicationModel.Payments.PaymentResponse"]}
 DEFINE_IID!(IID_IPaymentShippingOption, 322382554, 38739, 17780, 137, 102, 147, 20, 90, 118, 199, 249);
 RT_INTERFACE!{interface IPaymentShippingOption(IPaymentShippingOptionVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentShippingOption] {
     fn get_Label(&self, out: *mut HSTRING) -> HRESULT,
@@ -21453,7 +21453,7 @@ impl IPaymentShippingOption {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentShippingOption: IPaymentShippingOption}
+RT_CLASS!{class PaymentShippingOption: IPaymentShippingOption ["Windows.ApplicationModel.Payments.PaymentShippingOption"]}
 impl RtActivatable<IPaymentShippingOptionFactory> for PaymentShippingOption {}
 impl PaymentShippingOption {
     #[inline] pub fn create(label: &HStringArg, amount: &PaymentCurrencyAmount) -> Result<ComPtr<PaymentShippingOption>> {
@@ -21490,7 +21490,7 @@ impl IPaymentShippingOptionFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PaymentShippingType: i32 {
+RT_ENUM! { enum PaymentShippingType: i32 ["Windows.ApplicationModel.Payments.PaymentShippingType"] {
     Shipping (PaymentShippingType_Shipping) = 0, Delivery (PaymentShippingType_Delivery) = 1, Pickup (PaymentShippingType_Pickup) = 2,
 }}
 DEFINE_IID!(IID_IPaymentToken, 3150626835, 52432, 16882, 178, 161, 10, 46, 75, 93, 206, 37);
@@ -21510,7 +21510,7 @@ impl IPaymentToken {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentToken: IPaymentToken}
+RT_CLASS!{class PaymentToken: IPaymentToken ["Windows.ApplicationModel.Payments.PaymentToken"]}
 impl RtActivatable<IPaymentTokenFactory> for PaymentToken {}
 impl PaymentToken {
     #[inline] pub fn create(paymentMethodId: &HStringArg) -> Result<ComPtr<PaymentToken>> {
@@ -21556,7 +21556,7 @@ impl IPaymentAppCanMakePaymentTriggerDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentAppCanMakePaymentTriggerDetails: IPaymentAppCanMakePaymentTriggerDetails}
+RT_CLASS!{class PaymentAppCanMakePaymentTriggerDetails: IPaymentAppCanMakePaymentTriggerDetails ["Windows.ApplicationModel.Payments.Provider.PaymentAppCanMakePaymentTriggerDetails"]}
 DEFINE_IID!(IID_IPaymentAppManager, 239577683, 34081, 18793, 169, 87, 223, 37, 56, 163, 169, 143);
 RT_INTERFACE!{interface IPaymentAppManager(IPaymentAppManagerVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentAppManager] {
     fn RegisterAsync(&self, supportedPaymentMethodIds: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21574,7 +21574,7 @@ impl IPaymentAppManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentAppManager: IPaymentAppManager}
+RT_CLASS!{class PaymentAppManager: IPaymentAppManager ["Windows.ApplicationModel.Payments.Provider.PaymentAppManager"]}
 impl RtActivatable<IPaymentAppManagerStatics> for PaymentAppManager {}
 impl PaymentAppManager {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<PaymentAppManager>>> {
@@ -21660,7 +21660,7 @@ impl IPaymentTransaction {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentTransaction: IPaymentTransaction}
+RT_CLASS!{class PaymentTransaction: IPaymentTransaction ["Windows.ApplicationModel.Payments.Provider.PaymentTransaction"]}
 impl RtActivatable<IPaymentTransactionStatics> for PaymentTransaction {}
 impl PaymentTransaction {
     #[inline] pub fn from_id_async(id: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<PaymentTransaction>>> {
@@ -21679,7 +21679,7 @@ impl IPaymentTransactionAcceptResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PaymentTransactionAcceptResult: IPaymentTransactionAcceptResult}
+RT_CLASS!{class PaymentTransactionAcceptResult: IPaymentTransactionAcceptResult ["Windows.ApplicationModel.Payments.Provider.PaymentTransactionAcceptResult"]}
 DEFINE_IID!(IID_IPaymentTransactionStatics, 2372114256, 60938, 19957, 155, 30, 28, 15, 158, 197, 152, 129);
 RT_INTERFACE!{static interface IPaymentTransactionStatics(IPaymentTransactionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPaymentTransactionStatics] {
     fn FromIdAsync(&self, id: HSTRING, out: *mut *mut foundation::IAsyncOperation<PaymentTransaction>) -> HRESULT
@@ -21738,7 +21738,7 @@ impl IInkWorkspaceHostedAppManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkWorkspaceHostedAppManager: IInkWorkspaceHostedAppManager}
+RT_CLASS!{class InkWorkspaceHostedAppManager: IInkWorkspaceHostedAppManager ["Windows.ApplicationModel.Preview.InkWorkspace.InkWorkspaceHostedAppManager"]}
 impl RtActivatable<IInkWorkspaceHostedAppManagerStatics> for InkWorkspaceHostedAppManager {}
 impl InkWorkspaceHostedAppManager {
     #[inline] pub fn get_for_current_app() -> Result<Option<ComPtr<InkWorkspaceHostedAppManager>>> {
@@ -21771,7 +21771,7 @@ impl INotePlacementChangedPreviewEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NotePlacementChangedPreviewEventArgs: INotePlacementChangedPreviewEventArgs}
+RT_CLASS!{class NotePlacementChangedPreviewEventArgs: INotePlacementChangedPreviewEventArgs ["Windows.ApplicationModel.Preview.Notes.NotePlacementChangedPreviewEventArgs"]}
 DEFINE_IID!(IID_INotesWindowManagerPreview, 3693789758, 18512, 20243, 156, 199, 255, 72, 126, 253, 252, 222);
 RT_INTERFACE!{interface INotesWindowManagerPreview(INotesWindowManagerPreviewVtbl): IInspectable(IInspectableVtbl) [IID_INotesWindowManagerPreview] {
     fn get_IsScreenLocked(&self, out: *mut bool) -> HRESULT,
@@ -21862,7 +21862,7 @@ impl INotesWindowManagerPreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NotesWindowManagerPreview: INotesWindowManagerPreview}
+RT_CLASS!{class NotesWindowManagerPreview: INotesWindowManagerPreview ["Windows.ApplicationModel.Preview.Notes.NotesWindowManagerPreview"]}
 impl RtActivatable<INotesWindowManagerPreviewStatics> for NotesWindowManagerPreview {}
 impl NotesWindowManagerPreview {
     #[inline] pub fn get_for_current_app() -> Result<Option<ComPtr<NotesWindowManagerPreview>>> {
@@ -21913,7 +21913,7 @@ impl INotesWindowManagerPreviewShowNoteOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NotesWindowManagerPreviewShowNoteOptions: INotesWindowManagerPreviewShowNoteOptions}
+RT_CLASS!{class NotesWindowManagerPreviewShowNoteOptions: INotesWindowManagerPreviewShowNoteOptions ["Windows.ApplicationModel.Preview.Notes.NotesWindowManagerPreviewShowNoteOptions"]}
 impl RtActivatable<IActivationFactory> for NotesWindowManagerPreviewShowNoteOptions {}
 DEFINE_CLSID!(NotesWindowManagerPreviewShowNoteOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,80,114,101,118,105,101,119,46,78,111,116,101,115,46,78,111,116,101,115,87,105,110,100,111,119,77,97,110,97,103,101,114,80,114,101,118,105,101,119,83,104,111,119,78,111,116,101,79,112,116,105,111,110,115,0]) [CLSID_NotesWindowManagerPreviewShowNoteOptions]);
 DEFINE_IID!(IID_INotesWindowManagerPreviewStatics, 1718144136, 2702, 16679, 163, 142, 153, 84, 69, 134, 138, 120);
@@ -21944,7 +21944,7 @@ impl INoteVisibilityChangedPreviewEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NoteVisibilityChangedPreviewEventArgs: INoteVisibilityChangedPreviewEventArgs}
+RT_CLASS!{class NoteVisibilityChangedPreviewEventArgs: INoteVisibilityChangedPreviewEventArgs ["Windows.ApplicationModel.Preview.Notes.NoteVisibilityChangedPreviewEventArgs"]}
 } // Windows.ApplicationModel.Preview.Notes
 } // Windows.ApplicationModel.Preview
 pub mod resources { // Windows.ApplicationModel.Resources
@@ -21960,7 +21960,7 @@ impl IResourceLoader {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceLoader: IResourceLoader}
+RT_CLASS!{class ResourceLoader: IResourceLoader ["Windows.ApplicationModel.Resources.ResourceLoader"]}
 impl RtActivatable<IResourceLoaderFactory> for ResourceLoader {}
 impl RtActivatable<IResourceLoaderStatics> for ResourceLoader {}
 impl RtActivatable<IResourceLoaderStatics2> for ResourceLoader {}
@@ -22091,7 +22091,7 @@ impl INamedResource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NamedResource: INamedResource}
+RT_CLASS!{class NamedResource: INamedResource ["Windows.ApplicationModel.Resources.Core.NamedResource"]}
 DEFINE_IID!(IID_IResourceCandidate, 2941388761, 50227, 18276, 179, 253, 143, 166, 191, 188, 186, 220);
 RT_INTERFACE!{interface IResourceCandidate(IResourceCandidateVtbl): IInspectable(IInspectableVtbl) [IID_IResourceCandidate] {
     fn get_Qualifiers(&self, out: *mut *mut foundation::collections::IVectorView<ResourceQualifier>) -> HRESULT,
@@ -22140,7 +22140,7 @@ impl IResourceCandidate {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceCandidate: IResourceCandidate}
+RT_CLASS!{class ResourceCandidate: IResourceCandidate ["Windows.ApplicationModel.Resources.Core.ResourceCandidate"]}
 DEFINE_IID!(IID_IResourceCandidate2, 1776661608, 63228, 16403, 170, 162, 213, 63, 23, 87, 211, 181);
 RT_INTERFACE!{interface IResourceCandidate2(IResourceCandidate2Vtbl): IInspectable(IInspectableVtbl) [IID_IResourceCandidate2] {
     #[cfg(feature="windows-storage")] fn GetValueAsStreamAsync(&self, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStream>) -> HRESULT
@@ -22152,7 +22152,7 @@ impl IResourceCandidate2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceCandidateVectorView: foundation::collections::IVectorView<ResourceCandidate>}
+RT_CLASS!{class ResourceCandidateVectorView: foundation::collections::IVectorView<ResourceCandidate> ["Windows.ApplicationModel.Resources.Core.ResourceCandidateVectorView"]}
 DEFINE_IID!(IID_IResourceContext, 799158091, 28798, 19239, 173, 13, 208, 216, 205, 70, 143, 210);
 RT_INTERFACE!{interface IResourceContext(IResourceContextVtbl): IInspectable(IInspectableVtbl) [IID_IResourceContext] {
     fn get_QualifierValues(&self, out: *mut *mut foundation::collections::IObservableMap<HString, HString>) -> HRESULT,
@@ -22196,7 +22196,7 @@ impl IResourceContext {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceContext: IResourceContext}
+RT_CLASS!{class ResourceContext: IResourceContext ["Windows.ApplicationModel.Resources.Core.ResourceContext"]}
 impl RtActivatable<IResourceContextStatics> for ResourceContext {}
 impl RtActivatable<IResourceContextStatics2> for ResourceContext {}
 impl RtActivatable<IResourceContextStatics3> for ResourceContext {}
@@ -22225,7 +22225,7 @@ impl ResourceContext {
     }
 }
 DEFINE_CLSID!(ResourceContext(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,82,101,115,111,117,114,99,101,115,46,67,111,114,101,46,82,101,115,111,117,114,99,101,67,111,110,116,101,120,116,0]) [CLSID_ResourceContext]);
-RT_CLASS!{class ResourceContextLanguagesVectorView: foundation::collections::IVectorView<HString>}
+RT_CLASS!{class ResourceContextLanguagesVectorView: foundation::collections::IVectorView<HString> ["Windows.ApplicationModel.Resources.Core.ResourceContextLanguagesVectorView"]}
 DEFINE_IID!(IID_IResourceContextStatics, 2562628972, 25400, 19249, 153, 223, 178, 180, 66, 241, 113, 73);
 RT_INTERFACE!{static interface IResourceContextStatics(IResourceContextStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IResourceContextStatics] {
     fn CreateMatchingContext(&self, result: *mut foundation::collections::IIterable<ResourceQualifier>, out: *mut *mut ResourceContext) -> HRESULT
@@ -22279,7 +22279,7 @@ impl IResourceContextStatics3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct ResourceLayoutInfo {
+RT_STRUCT! { struct ResourceLayoutInfo ["Windows.ApplicationModel.Resources.Core.ResourceLayoutInfo"] {
     MajorVersion: u32, MinorVersion: u32, ResourceSubtreeCount: u32, NamedResourceCount: u32, Checksum: i32,
 }}
 DEFINE_IID!(IID_IResourceManager, 4148484475, 39304, 17659, 171, 214, 83, 120, 132, 76, 250, 139);
@@ -22315,7 +22315,7 @@ impl IResourceManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceManager: IResourceManager}
+RT_CLASS!{class ResourceManager: IResourceManager ["Windows.ApplicationModel.Resources.Core.ResourceManager"]}
 impl RtActivatable<IResourceManagerStatics> for ResourceManager {}
 impl ResourceManager {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<ResourceManager>>> {
@@ -22389,10 +22389,10 @@ impl IResourceMap {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceMap: IResourceMap}
-RT_CLASS!{class ResourceMapIterator: foundation::collections::IIterator<foundation::collections::IKeyValuePair<HString, NamedResource>>}
-RT_CLASS!{class ResourceMapMapView: foundation::collections::IMapView<HString, ResourceMap>}
-RT_CLASS!{class ResourceMapMapViewIterator: foundation::collections::IIterator<foundation::collections::IKeyValuePair<HString, ResourceMap>>}
+RT_CLASS!{class ResourceMap: IResourceMap ["Windows.ApplicationModel.Resources.Core.ResourceMap"]}
+RT_CLASS!{class ResourceMapIterator: foundation::collections::IIterator<foundation::collections::IKeyValuePair<HString, NamedResource>> ["Windows.ApplicationModel.Resources.Core.ResourceMapIterator"]}
+RT_CLASS!{class ResourceMapMapView: foundation::collections::IMapView<HString, ResourceMap> ["Windows.ApplicationModel.Resources.Core.ResourceMapMapView"]}
+RT_CLASS!{class ResourceMapMapViewIterator: foundation::collections::IIterator<foundation::collections::IKeyValuePair<HString, ResourceMap>> ["Windows.ApplicationModel.Resources.Core.ResourceMapMapViewIterator"]}
 DEFINE_IID!(IID_IResourceQualifier, 2019403186, 19197, 17270, 168, 136, 197, 249, 166, 183, 160, 92);
 RT_INTERFACE!{interface IResourceQualifier(IResourceQualifierVtbl): IInspectable(IInspectableVtbl) [IID_IResourceQualifier] {
     fn get_QualifierName(&self, out: *mut HSTRING) -> HRESULT,
@@ -22428,13 +22428,13 @@ impl IResourceQualifier {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceQualifier: IResourceQualifier}
-RT_CLASS!{class ResourceQualifierMapView: foundation::collections::IMapView<HString, HString>}
-RT_CLASS!{class ResourceQualifierObservableMap: foundation::collections::IObservableMap<HString, HString>}
-RT_ENUM! { enum ResourceQualifierPersistence: i32 {
+RT_CLASS!{class ResourceQualifier: IResourceQualifier ["Windows.ApplicationModel.Resources.Core.ResourceQualifier"]}
+RT_CLASS!{class ResourceQualifierMapView: foundation::collections::IMapView<HString, HString> ["Windows.ApplicationModel.Resources.Core.ResourceQualifierMapView"]}
+RT_CLASS!{class ResourceQualifierObservableMap: foundation::collections::IObservableMap<HString, HString> ["Windows.ApplicationModel.Resources.Core.ResourceQualifierObservableMap"]}
+RT_ENUM! { enum ResourceQualifierPersistence: i32 ["Windows.ApplicationModel.Resources.Core.ResourceQualifierPersistence"] {
     None (ResourceQualifierPersistence_None) = 0, LocalMachine (ResourceQualifierPersistence_LocalMachine) = 1,
 }}
-RT_CLASS!{class ResourceQualifierVectorView: foundation::collections::IVectorView<ResourceQualifier>}
+RT_CLASS!{class ResourceQualifierVectorView: foundation::collections::IVectorView<ResourceQualifier> ["Windows.ApplicationModel.Resources.Core.ResourceQualifierVectorView"]}
 } // Windows.ApplicationModel.Resources.Core
 pub mod management { // Windows.ApplicationModel.Resources.Management
 use ::prelude::*;
@@ -22479,7 +22479,7 @@ impl IIndexedResourceCandidate {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class IndexedResourceCandidate: IIndexedResourceCandidate}
+RT_CLASS!{class IndexedResourceCandidate: IIndexedResourceCandidate ["Windows.ApplicationModel.Resources.Management.IndexedResourceCandidate"]}
 DEFINE_IID!(IID_IIndexedResourceQualifier, 3672357787, 54020, 18815, 161, 104, 163, 64, 4, 44, 138, 219);
 RT_INTERFACE!{interface IIndexedResourceQualifier(IIndexedResourceQualifierVtbl): IInspectable(IInspectableVtbl) [IID_IIndexedResourceQualifier] {
     fn get_QualifierName(&self, out: *mut HSTRING) -> HRESULT,
@@ -22497,8 +22497,8 @@ impl IIndexedResourceQualifier {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class IndexedResourceQualifier: IIndexedResourceQualifier}
-RT_ENUM! { enum IndexedResourceType: i32 {
+RT_CLASS!{class IndexedResourceQualifier: IIndexedResourceQualifier ["Windows.ApplicationModel.Resources.Management.IndexedResourceQualifier"]}
+RT_ENUM! { enum IndexedResourceType: i32 ["Windows.ApplicationModel.Resources.Management.IndexedResourceType"] {
     String (IndexedResourceType_String) = 0, Path (IndexedResourceType_Path) = 1, EmbeddedData (IndexedResourceType_EmbeddedData) = 2,
 }}
 DEFINE_IID!(IID_IResourceIndexer, 760019365, 58159, 19122, 135, 72, 150, 53, 10, 1, 109, 163);
@@ -22518,7 +22518,7 @@ impl IResourceIndexer {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceIndexer: IResourceIndexer}
+RT_CLASS!{class ResourceIndexer: IResourceIndexer ["Windows.ApplicationModel.Resources.Management.ResourceIndexer"]}
 impl RtActivatable<IResourceIndexerFactory> for ResourceIndexer {}
 impl RtActivatable<IResourceIndexerFactory2> for ResourceIndexer {}
 impl ResourceIndexer {
@@ -22596,7 +22596,7 @@ impl ILocalContentSuggestionSettings {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LocalContentSuggestionSettings: ILocalContentSuggestionSettings}
+RT_CLASS!{class LocalContentSuggestionSettings: ILocalContentSuggestionSettings ["Windows.ApplicationModel.Search.LocalContentSuggestionSettings"]}
 impl RtActivatable<IActivationFactory> for LocalContentSuggestionSettings {}
 DEFINE_CLSID!(LocalContentSuggestionSettings(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,101,97,114,99,104,46,76,111,99,97,108,67,111,110,116,101,110,116,83,117,103,103,101,115,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_LocalContentSuggestionSettings]);
 DEFINE_IID!(IID_ISearchPane, 4255968312, 14080, 19827, 145, 161, 47, 153, 134, 116, 35, 138);
@@ -22742,7 +22742,7 @@ impl ISearchPane {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPane: ISearchPane}
+RT_CLASS!{class SearchPane: ISearchPane ["Windows.ApplicationModel.Search.SearchPane"]}
 impl RtActivatable<ISearchPaneStatics> for SearchPane {}
 impl RtActivatable<ISearchPaneStaticsWithHideThisApplication> for SearchPane {}
 impl SearchPane {
@@ -22777,7 +22777,7 @@ impl ISearchPaneQueryChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneQueryChangedEventArgs: ISearchPaneQueryChangedEventArgs}
+RT_CLASS!{class SearchPaneQueryChangedEventArgs: ISearchPaneQueryChangedEventArgs ["Windows.ApplicationModel.Search.SearchPaneQueryChangedEventArgs"]}
 DEFINE_IID!(IID_ISearchPaneQueryLinguisticDetails, 2197505550, 2368, 19309, 184, 208, 100, 43, 48, 152, 158, 21);
 RT_INTERFACE!{interface ISearchPaneQueryLinguisticDetails(ISearchPaneQueryLinguisticDetailsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneQueryLinguisticDetails] {
     fn get_QueryTextAlternatives(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -22801,7 +22801,7 @@ impl ISearchPaneQueryLinguisticDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneQueryLinguisticDetails: ISearchPaneQueryLinguisticDetails}
+RT_CLASS!{class SearchPaneQueryLinguisticDetails: ISearchPaneQueryLinguisticDetails ["Windows.ApplicationModel.Search.SearchPaneQueryLinguisticDetails"]}
 DEFINE_IID!(IID_ISearchPaneQuerySubmittedEventArgs, 339453180, 59845, 18230, 145, 178, 232, 235, 156, 184, 131, 86);
 RT_INTERFACE!{interface ISearchPaneQuerySubmittedEventArgs(ISearchPaneQuerySubmittedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneQuerySubmittedEventArgs] {
     fn get_QueryText(&self, out: *mut HSTRING) -> HRESULT,
@@ -22819,7 +22819,7 @@ impl ISearchPaneQuerySubmittedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneQuerySubmittedEventArgs: ISearchPaneQuerySubmittedEventArgs}
+RT_CLASS!{class SearchPaneQuerySubmittedEventArgs: ISearchPaneQuerySubmittedEventArgs ["Windows.ApplicationModel.Search.SearchPaneQuerySubmittedEventArgs"]}
 DEFINE_IID!(IID_ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails, 1175229157, 19506, 17720, 164, 212, 182, 180, 64, 13, 20, 15);
 RT_INTERFACE!{interface ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails(ISearchPaneQuerySubmittedEventArgsWithLinguisticDetailsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails] {
     fn get_LinguisticDetails(&self, out: *mut *mut SearchPaneQueryLinguisticDetails) -> HRESULT
@@ -22842,7 +22842,7 @@ impl ISearchPaneResultSuggestionChosenEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneResultSuggestionChosenEventArgs: ISearchPaneResultSuggestionChosenEventArgs}
+RT_CLASS!{class SearchPaneResultSuggestionChosenEventArgs: ISearchPaneResultSuggestionChosenEventArgs ["Windows.ApplicationModel.Search.SearchPaneResultSuggestionChosenEventArgs"]}
 DEFINE_IID!(IID_ISearchPaneStatics, 2507320817, 36637, 18463, 161, 91, 198, 22, 85, 241, 106, 14);
 RT_INTERFACE!{static interface ISearchPaneStatics(ISearchPaneStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneStatics] {
     fn GetForCurrentView(&self, out: *mut *mut SearchPane) -> HRESULT
@@ -22887,7 +22887,7 @@ impl ISearchPaneSuggestionsRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneSuggestionsRequest: ISearchPaneSuggestionsRequest}
+RT_CLASS!{class SearchPaneSuggestionsRequest: ISearchPaneSuggestionsRequest ["Windows.ApplicationModel.Search.SearchPaneSuggestionsRequest"]}
 DEFINE_IID!(IID_ISearchPaneSuggestionsRequestDeferral, 2697988599, 34632, 20194, 173, 68, 175, 166, 190, 153, 124, 81);
 RT_INTERFACE!{interface ISearchPaneSuggestionsRequestDeferral(ISearchPaneSuggestionsRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneSuggestionsRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -22898,7 +22898,7 @@ impl ISearchPaneSuggestionsRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneSuggestionsRequestDeferral: ISearchPaneSuggestionsRequestDeferral}
+RT_CLASS!{class SearchPaneSuggestionsRequestDeferral: ISearchPaneSuggestionsRequestDeferral ["Windows.ApplicationModel.Search.SearchPaneSuggestionsRequestDeferral"]}
 DEFINE_IID!(IID_ISearchPaneSuggestionsRequestedEventArgs, 3365636655, 44118, 17504, 141, 47, 128, 2, 59, 236, 79, 197);
 RT_INTERFACE!{interface ISearchPaneSuggestionsRequestedEventArgs(ISearchPaneSuggestionsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneSuggestionsRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut SearchPaneSuggestionsRequest) -> HRESULT
@@ -22910,7 +22910,7 @@ impl ISearchPaneSuggestionsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneSuggestionsRequestedEventArgs: ISearchPaneSuggestionsRequestedEventArgs}
+RT_CLASS!{class SearchPaneSuggestionsRequestedEventArgs: ISearchPaneSuggestionsRequestedEventArgs ["Windows.ApplicationModel.Search.SearchPaneSuggestionsRequestedEventArgs"]}
 DEFINE_IID!(IID_ISearchPaneVisibilityChangedEventArgs, 1011691590, 44107, 18930, 151, 214, 2, 14, 97, 130, 203, 156);
 RT_INTERFACE!{interface ISearchPaneVisibilityChangedEventArgs(ISearchPaneVisibilityChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchPaneVisibilityChangedEventArgs] {
     fn get_Visible(&self, out: *mut bool) -> HRESULT
@@ -22922,7 +22922,7 @@ impl ISearchPaneVisibilityChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchPaneVisibilityChangedEventArgs: ISearchPaneVisibilityChangedEventArgs}
+RT_CLASS!{class SearchPaneVisibilityChangedEventArgs: ISearchPaneVisibilityChangedEventArgs ["Windows.ApplicationModel.Search.SearchPaneVisibilityChangedEventArgs"]}
 DEFINE_IID!(IID_ISearchQueryLinguisticDetails, 1184964699, 27081, 18245, 183, 47, 168, 164, 252, 143, 36, 174);
 RT_INTERFACE!{interface ISearchQueryLinguisticDetails(ISearchQueryLinguisticDetailsVtbl): IInspectable(IInspectableVtbl) [IID_ISearchQueryLinguisticDetails] {
     fn get_QueryTextAlternatives(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -22946,7 +22946,7 @@ impl ISearchQueryLinguisticDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchQueryLinguisticDetails: ISearchQueryLinguisticDetails}
+RT_CLASS!{class SearchQueryLinguisticDetails: ISearchQueryLinguisticDetails ["Windows.ApplicationModel.Search.SearchQueryLinguisticDetails"]}
 impl RtActivatable<ISearchQueryLinguisticDetailsFactory> for SearchQueryLinguisticDetails {}
 impl SearchQueryLinguisticDetails {
     #[inline] pub fn create_instance(queryTextAlternatives: &foundation::collections::IIterable<HString>, queryTextCompositionStart: u32, queryTextCompositionLength: u32) -> Result<ComPtr<SearchQueryLinguisticDetails>> {
@@ -22997,7 +22997,7 @@ impl ISearchSuggestionCollection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchSuggestionCollection: ISearchSuggestionCollection}
+RT_CLASS!{class SearchSuggestionCollection: ISearchSuggestionCollection ["Windows.ApplicationModel.Search.SearchSuggestionCollection"]}
 DEFINE_IID!(IID_ISearchSuggestionsRequest, 1313744551, 17637, 16441, 144, 153, 96, 0, 234, 209, 240, 198);
 RT_INTERFACE!{interface ISearchSuggestionsRequest(ISearchSuggestionsRequestVtbl): IInspectable(IInspectableVtbl) [IID_ISearchSuggestionsRequest] {
     fn get_IsCanceled(&self, out: *mut bool) -> HRESULT,
@@ -23021,7 +23021,7 @@ impl ISearchSuggestionsRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchSuggestionsRequest: ISearchSuggestionsRequest}
+RT_CLASS!{class SearchSuggestionsRequest: ISearchSuggestionsRequest ["Windows.ApplicationModel.Search.SearchSuggestionsRequest"]}
 DEFINE_IID!(IID_ISearchSuggestionsRequestDeferral, 3071645865, 49253, 17773, 168, 69, 30, 204, 236, 93, 194, 139);
 RT_INTERFACE!{interface ISearchSuggestionsRequestDeferral(ISearchSuggestionsRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_ISearchSuggestionsRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -23032,14 +23032,14 @@ impl ISearchSuggestionsRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchSuggestionsRequestDeferral: ISearchSuggestionsRequestDeferral}
+RT_CLASS!{class SearchSuggestionsRequestDeferral: ISearchSuggestionsRequestDeferral ["Windows.ApplicationModel.Search.SearchSuggestionsRequestDeferral"]}
 pub mod core { // Windows.ApplicationModel.Search.Core
 use ::prelude::*;
 DEFINE_IID!(IID_IRequestingFocusOnKeyboardInputEventArgs, 2702794535, 45479, 16802, 135, 157, 106, 104, 104, 126, 89, 133);
 RT_INTERFACE!{interface IRequestingFocusOnKeyboardInputEventArgs(IRequestingFocusOnKeyboardInputEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRequestingFocusOnKeyboardInputEventArgs] {
     
 }}
-RT_CLASS!{class RequestingFocusOnKeyboardInputEventArgs: IRequestingFocusOnKeyboardInputEventArgs}
+RT_CLASS!{class RequestingFocusOnKeyboardInputEventArgs: IRequestingFocusOnKeyboardInputEventArgs ["Windows.ApplicationModel.Search.Core.RequestingFocusOnKeyboardInputEventArgs"]}
 DEFINE_IID!(IID_ISearchSuggestion, 1532318896, 5415, 17275, 149, 197, 141, 24, 210, 184, 175, 85);
 RT_INTERFACE!{interface ISearchSuggestion(ISearchSuggestionVtbl): IInspectable(IInspectableVtbl) [IID_ISearchSuggestion] {
     fn get_Kind(&self, out: *mut SearchSuggestionKind) -> HRESULT,
@@ -23082,8 +23082,8 @@ impl ISearchSuggestion {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchSuggestion: ISearchSuggestion}
-RT_ENUM! { enum SearchSuggestionKind: i32 {
+RT_CLASS!{class SearchSuggestion: ISearchSuggestion ["Windows.ApplicationModel.Search.Core.SearchSuggestion"]}
+RT_ENUM! { enum SearchSuggestionKind: i32 ["Windows.ApplicationModel.Search.Core.SearchSuggestionKind"] {
     Query (SearchSuggestionKind_Query) = 0, Result (SearchSuggestionKind_Result) = 1, Separator (SearchSuggestionKind_Separator) = 2,
 }}
 DEFINE_IID!(IID_ISearchSuggestionManager, 1057771681, 52125, 18811, 181, 0, 60, 4, 172, 149, 154, 210);
@@ -23176,7 +23176,7 @@ impl ISearchSuggestionManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchSuggestionManager: ISearchSuggestionManager}
+RT_CLASS!{class SearchSuggestionManager: ISearchSuggestionManager ["Windows.ApplicationModel.Search.Core.SearchSuggestionManager"]}
 impl RtActivatable<IActivationFactory> for SearchSuggestionManager {}
 DEFINE_CLSID!(SearchSuggestionManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,101,97,114,99,104,46,67,111,114,101,46,83,101,97,114,99,104,83,117,103,103,101,115,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_SearchSuggestionManager]);
 DEFINE_IID!(IID_ISearchSuggestionsRequestedEventArgs, 1876236773, 40574, 19124, 139, 227, 199, 107, 27, 212, 52, 74);
@@ -23208,7 +23208,7 @@ impl ISearchSuggestionsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SearchSuggestionsRequestedEventArgs: ISearchSuggestionsRequestedEventArgs}
+RT_CLASS!{class SearchSuggestionsRequestedEventArgs: ISearchSuggestionsRequestedEventArgs ["Windows.ApplicationModel.Search.Core.SearchSuggestionsRequestedEventArgs"]}
 } // Windows.ApplicationModel.Search.Core
 } // Windows.ApplicationModel.Search
 pub mod socialinfo { // Windows.ApplicationModel.SocialInfo
@@ -23275,7 +23275,7 @@ impl ISocialFeedChildItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialFeedChildItem: ISocialFeedChildItem}
+RT_CLASS!{class SocialFeedChildItem: ISocialFeedChildItem ["Windows.ApplicationModel.SocialInfo.SocialFeedChildItem"]}
 impl RtActivatable<IActivationFactory> for SocialFeedChildItem {}
 DEFINE_CLSID!(SocialFeedChildItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,70,101,101,100,67,104,105,108,100,73,116,101,109,0]) [CLSID_SocialFeedChildItem]);
 DEFINE_IID!(IID_ISocialFeedContent, 2721375273, 15929, 18765, 163, 124, 244, 98, 162, 73, 69, 20);
@@ -23316,7 +23316,7 @@ impl ISocialFeedContent {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialFeedContent: ISocialFeedContent}
+RT_CLASS!{class SocialFeedContent: ISocialFeedContent ["Windows.ApplicationModel.SocialInfo.SocialFeedContent"]}
 DEFINE_IID!(IID_ISocialFeedItem, 1326682795, 8050, 19763, 182, 149, 222, 62, 29, 182, 3, 23);
 RT_INTERFACE!{interface ISocialFeedItem(ISocialFeedItemVtbl): IInspectable(IInspectableVtbl) [IID_ISocialFeedItem] {
     fn get_Author(&self, out: *mut *mut SocialUserInfo) -> HRESULT,
@@ -23434,13 +23434,13 @@ impl ISocialFeedItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialFeedItem: ISocialFeedItem}
+RT_CLASS!{class SocialFeedItem: ISocialFeedItem ["Windows.ApplicationModel.SocialInfo.SocialFeedItem"]}
 impl RtActivatable<IActivationFactory> for SocialFeedItem {}
 DEFINE_CLSID!(SocialFeedItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,70,101,101,100,73,116,101,109,0]) [CLSID_SocialFeedItem]);
-RT_ENUM! { enum SocialFeedItemStyle: i32 {
+RT_ENUM! { enum SocialFeedItemStyle: i32 ["Windows.ApplicationModel.SocialInfo.SocialFeedItemStyle"] {
     Default (SocialFeedItemStyle_Default) = 0, Photo (SocialFeedItemStyle_Photo) = 1,
 }}
-RT_ENUM! { enum SocialFeedKind: i32 {
+RT_ENUM! { enum SocialFeedKind: i32 ["Windows.ApplicationModel.SocialInfo.SocialFeedKind"] {
     HomeFeed (SocialFeedKind_HomeFeed) = 0, ContactFeed (SocialFeedKind_ContactFeed) = 1, Dashboard (SocialFeedKind_Dashboard) = 2,
 }}
 DEFINE_IID!(IID_ISocialFeedSharedItem, 2080087616, 42666, 17831, 159, 246, 84, 196, 33, 5, 221, 31);
@@ -23498,13 +23498,13 @@ impl ISocialFeedSharedItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialFeedSharedItem: ISocialFeedSharedItem}
+RT_CLASS!{class SocialFeedSharedItem: ISocialFeedSharedItem ["Windows.ApplicationModel.SocialInfo.SocialFeedSharedItem"]}
 impl RtActivatable<IActivationFactory> for SocialFeedSharedItem {}
 DEFINE_CLSID!(SocialFeedSharedItem(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,70,101,101,100,83,104,97,114,101,100,73,116,101,109,0]) [CLSID_SocialFeedSharedItem]);
-RT_ENUM! { enum SocialFeedUpdateMode: i32 {
+RT_ENUM! { enum SocialFeedUpdateMode: i32 ["Windows.ApplicationModel.SocialInfo.SocialFeedUpdateMode"] {
     Append (SocialFeedUpdateMode_Append) = 0, Replace (SocialFeedUpdateMode_Replace) = 1,
 }}
-RT_ENUM! { enum SocialItemBadgeStyle: i32 {
+RT_ENUM! { enum SocialItemBadgeStyle: i32 ["Windows.ApplicationModel.SocialInfo.SocialItemBadgeStyle"] {
     Hidden (SocialItemBadgeStyle_Hidden) = 0, Visible (SocialItemBadgeStyle_Visible) = 1, VisibleWithCount (SocialItemBadgeStyle_VisibleWithCount) = 2,
 }}
 DEFINE_IID!(IID_ISocialItemThumbnail, 1556054810, 16136, 18815, 145, 127, 87, 224, 157, 132, 177, 65);
@@ -23553,7 +23553,7 @@ impl ISocialItemThumbnail {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialItemThumbnail: ISocialItemThumbnail}
+RT_CLASS!{class SocialItemThumbnail: ISocialItemThumbnail ["Windows.ApplicationModel.SocialInfo.SocialItemThumbnail"]}
 impl RtActivatable<IActivationFactory> for SocialItemThumbnail {}
 DEFINE_CLSID!(SocialItemThumbnail(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,111,99,105,97,108,73,110,102,111,46,83,111,99,105,97,108,73,116,101,109,84,104,117,109,98,110,97,105,108,0]) [CLSID_SocialItemThumbnail]);
 DEFINE_IID!(IID_ISocialUserInfo, 2656967633, 37072, 19997, 149, 84, 132, 77, 70, 96, 127, 97);
@@ -23605,7 +23605,7 @@ impl ISocialUserInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialUserInfo: ISocialUserInfo}
+RT_CLASS!{class SocialUserInfo: ISocialUserInfo ["Windows.ApplicationModel.SocialInfo.SocialUserInfo"]}
 pub mod provider { // Windows.ApplicationModel.SocialInfo.Provider
 use ::prelude::*;
 DEFINE_IID!(IID_ISocialDashboardItemUpdater, 1021222345, 18432, 18125, 134, 155, 25, 115, 236, 104, 91, 222);
@@ -23664,7 +23664,7 @@ impl ISocialDashboardItemUpdater {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialDashboardItemUpdater: ISocialDashboardItemUpdater}
+RT_CLASS!{class SocialDashboardItemUpdater: ISocialDashboardItemUpdater ["Windows.ApplicationModel.SocialInfo.Provider.SocialDashboardItemUpdater"]}
 DEFINE_IID!(IID_ISocialFeedUpdater, 2047609511, 60809, 19413, 168, 217, 21, 244, 217, 134, 28, 16);
 RT_INTERFACE!{interface ISocialFeedUpdater(ISocialFeedUpdaterVtbl): IInspectable(IInspectableVtbl) [IID_ISocialFeedUpdater] {
     fn get_OwnerRemoteId(&self, out: *mut HSTRING) -> HRESULT,
@@ -23694,7 +23694,7 @@ impl ISocialFeedUpdater {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocialFeedUpdater: ISocialFeedUpdater}
+RT_CLASS!{class SocialFeedUpdater: ISocialFeedUpdater ["Windows.ApplicationModel.SocialInfo.Provider.SocialFeedUpdater"]}
 RT_CLASS!{static class SocialInfoProviderManager}
 impl RtActivatable<ISocialInfoProviderManagerStatics> for SocialInfoProviderManager {}
 impl SocialInfoProviderManager {
@@ -24128,7 +24128,7 @@ impl ICurrentAppWithConsumables {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum FulfillmentResult: i32 {
+RT_ENUM! { enum FulfillmentResult: i32 ["Windows.ApplicationModel.Store.FulfillmentResult"] {
     Succeeded (FulfillmentResult_Succeeded) = 0, NothingToFulfill (FulfillmentResult_NothingToFulfill) = 1, PurchasePending (FulfillmentResult_PurchasePending) = 2, PurchaseReverted (FulfillmentResult_PurchaseReverted) = 3, ServerError (FulfillmentResult_ServerError) = 4,
 }}
 DEFINE_IID!(IID_LicenseChangedEventHandler, 3567583829, 4969, 19510, 131, 47, 111, 45, 136, 227, 101, 155);
@@ -24181,7 +24181,7 @@ impl ILicenseInformation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LicenseInformation: ILicenseInformation}
+RT_CLASS!{class LicenseInformation: ILicenseInformation ["Windows.ApplicationModel.Store.LicenseInformation"]}
 DEFINE_IID!(IID_IListingInformation, 1485523647, 48244, 17283, 183, 140, 153, 96, 99, 35, 222, 206);
 RT_INTERFACE!{interface IListingInformation(IListingInformationVtbl): IInspectable(IInspectableVtbl) [IID_IListingInformation] {
     fn get_CurrentMarket(&self, out: *mut HSTRING) -> HRESULT,
@@ -24223,7 +24223,7 @@ impl IListingInformation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ListingInformation: IListingInformation}
+RT_CLASS!{class ListingInformation: IListingInformation ["Windows.ApplicationModel.Store.ListingInformation"]}
 DEFINE_IID!(IID_IListingInformation2, 3237817373, 45838, 17284, 132, 234, 114, 254, 250, 130, 34, 62);
 RT_INTERFACE!{interface IListingInformation2(IListingInformation2Vtbl): IInspectable(IInspectableVtbl) [IID_IListingInformation2] {
     fn get_FormattedBasePrice(&self, out: *mut HSTRING) -> HRESULT,
@@ -24276,7 +24276,7 @@ impl IProductLicense {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProductLicense: IProductLicense}
+RT_CLASS!{class ProductLicense: IProductLicense ["Windows.ApplicationModel.Store.ProductLicense"]}
 DEFINE_IID!(IID_IProductLicenseWithFulfillment, 4233321610, 63079, 16627, 186, 60, 4, 90, 99, 171, 179, 172);
 RT_INTERFACE!{interface IProductLicenseWithFulfillment(IProductLicenseWithFulfillmentVtbl): IInspectable(IInspectableVtbl) [IID_IProductLicenseWithFulfillment] {
     fn get_IsConsumable(&self, out: *mut bool) -> HRESULT
@@ -24311,7 +24311,7 @@ impl IProductListing {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProductListing: IProductListing}
+RT_CLASS!{class ProductListing: IProductListing ["Windows.ApplicationModel.Store.ProductListing"]}
 DEFINE_IID!(IID_IProductListing2, 4171114767, 29694, 18765, 169, 57, 8, 169, 178, 73, 90, 190);
 RT_INTERFACE!{interface IProductListing2(IProductListing2Vtbl): IInspectable(IInspectableVtbl) [IID_IProductListing2] {
     fn get_FormattedBasePrice(&self, out: *mut HSTRING) -> HRESULT,
@@ -24425,7 +24425,7 @@ impl IProductPurchaseDisplayProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProductPurchaseDisplayProperties: IProductPurchaseDisplayProperties}
+RT_CLASS!{class ProductPurchaseDisplayProperties: IProductPurchaseDisplayProperties ["Windows.ApplicationModel.Store.ProductPurchaseDisplayProperties"]}
 impl RtActivatable<IProductPurchaseDisplayPropertiesFactory> for ProductPurchaseDisplayProperties {}
 impl RtActivatable<IActivationFactory> for ProductPurchaseDisplayProperties {}
 impl ProductPurchaseDisplayProperties {
@@ -24445,10 +24445,10 @@ impl IProductPurchaseDisplayPropertiesFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProductPurchaseStatus: i32 {
+RT_ENUM! { enum ProductPurchaseStatus: i32 ["Windows.ApplicationModel.Store.ProductPurchaseStatus"] {
     Succeeded (ProductPurchaseStatus_Succeeded) = 0, AlreadyPurchased (ProductPurchaseStatus_AlreadyPurchased) = 1, NotFulfilled (ProductPurchaseStatus_NotFulfilled) = 2, NotPurchased (ProductPurchaseStatus_NotPurchased) = 3,
 }}
-RT_ENUM! { enum ProductType: i32 {
+RT_ENUM! { enum ProductType: i32 ["Windows.ApplicationModel.Store.ProductType"] {
     Unknown (ProductType_Unknown) = 0, Durable (ProductType_Durable) = 1, Consumable (ProductType_Consumable) = 2,
 }}
 DEFINE_IID!(IID_IPurchaseResults, 3981489022, 34390, 20325, 184, 200, 172, 126, 12, 177, 161, 194);
@@ -24480,7 +24480,7 @@ impl IPurchaseResults {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PurchaseResults: IPurchaseResults}
+RT_CLASS!{class PurchaseResults: IPurchaseResults ["Windows.ApplicationModel.Store.PurchaseResults"]}
 DEFINE_IID!(IID_IUnfulfilledConsumable, 771226555, 7389, 19640, 160, 20, 123, 156, 248, 152, 105, 39);
 RT_INTERFACE!{interface IUnfulfilledConsumable(IUnfulfilledConsumableVtbl): IInspectable(IInspectableVtbl) [IID_IUnfulfilledConsumable] {
     fn get_ProductId(&self, out: *mut HSTRING) -> HRESULT,
@@ -24504,7 +24504,7 @@ impl IUnfulfilledConsumable {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UnfulfilledConsumable: IUnfulfilledConsumable}
+RT_CLASS!{class UnfulfilledConsumable: IUnfulfilledConsumable ["Windows.ApplicationModel.Store.UnfulfilledConsumable"]}
 pub mod licensemanagement { // Windows.ApplicationModel.Store.LicenseManagement
 use ::prelude::*;
 RT_CLASS!{static class LicenseManager}
@@ -24551,7 +24551,7 @@ impl ILicenseManagerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LicenseRefreshOption: i32 {
+RT_ENUM! { enum LicenseRefreshOption: i32 ["Windows.ApplicationModel.Store.LicenseManagement.LicenseRefreshOption"] {
     RunningLicenses (LicenseRefreshOption_RunningLicenses) = 0, AllLicenses (LicenseRefreshOption_AllLicenses) = 1,
 }}
 DEFINE_IID!(IID_ILicenseSatisfactionInfo, 1019981967, 56113, 18645, 131, 132, 250, 23, 200, 20, 116, 226);
@@ -24601,7 +24601,7 @@ impl ILicenseSatisfactionInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LicenseSatisfactionInfo: ILicenseSatisfactionInfo}
+RT_CLASS!{class LicenseSatisfactionInfo: ILicenseSatisfactionInfo ["Windows.ApplicationModel.Store.LicenseManagement.LicenseSatisfactionInfo"]}
 DEFINE_IID!(IID_ILicenseSatisfactionResult, 1013403507, 15495, 20193, 130, 1, 244, 40, 53, 155, 211, 175);
 RT_INTERFACE!{interface ILicenseSatisfactionResult(ILicenseSatisfactionResultVtbl): IInspectable(IInspectableVtbl) [IID_ILicenseSatisfactionResult] {
     fn get_LicenseSatisfactionInfos(&self, out: *mut *mut foundation::collections::IMapView<HString, LicenseSatisfactionInfo>) -> HRESULT,
@@ -24619,14 +24619,14 @@ impl ILicenseSatisfactionResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LicenseSatisfactionResult: ILicenseSatisfactionResult}
+RT_CLASS!{class LicenseSatisfactionResult: ILicenseSatisfactionResult ["Windows.ApplicationModel.Store.LicenseManagement.LicenseSatisfactionResult"]}
 } // Windows.ApplicationModel.Store.LicenseManagement
 pub mod preview { // Windows.ApplicationModel.Store.Preview
 use ::prelude::*;
-RT_ENUM! { enum DeliveryOptimizationDownloadMode: i32 {
+RT_ENUM! { enum DeliveryOptimizationDownloadMode: i32 ["Windows.ApplicationModel.Store.Preview.DeliveryOptimizationDownloadMode"] {
     Simple (DeliveryOptimizationDownloadMode_Simple) = 0, HttpOnly (DeliveryOptimizationDownloadMode_HttpOnly) = 1, Lan (DeliveryOptimizationDownloadMode_Lan) = 2, Group (DeliveryOptimizationDownloadMode_Group) = 3, Internet (DeliveryOptimizationDownloadMode_Internet) = 4, Bypass (DeliveryOptimizationDownloadMode_Bypass) = 5,
 }}
-RT_ENUM! { enum DeliveryOptimizationDownloadModeSource: i32 {
+RT_ENUM! { enum DeliveryOptimizationDownloadModeSource: i32 ["Windows.ApplicationModel.Store.Preview.DeliveryOptimizationDownloadModeSource"] {
     Default (DeliveryOptimizationDownloadModeSource_Default) = 0, Policy (DeliveryOptimizationDownloadModeSource_Policy) = 1,
 }}
 DEFINE_IID!(IID_IDeliveryOptimizationSettings, 403766688, 59475, 22110, 184, 116, 122, 138, 123, 154, 14, 15);
@@ -24646,7 +24646,7 @@ impl IDeliveryOptimizationSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeliveryOptimizationSettings: IDeliveryOptimizationSettings}
+RT_CLASS!{class DeliveryOptimizationSettings: IDeliveryOptimizationSettings ["Windows.ApplicationModel.Store.Preview.DeliveryOptimizationSettings"]}
 impl RtActivatable<IDeliveryOptimizationSettingsStatics> for DeliveryOptimizationSettings {}
 impl DeliveryOptimizationSettings {
     #[inline] pub fn get_current_settings() -> Result<Option<ComPtr<DeliveryOptimizationSettings>>> {
@@ -24971,8 +24971,8 @@ impl IStoreHardwareManufacturerInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreHardwareManufacturerInfo: IStoreHardwareManufacturerInfo}
-RT_ENUM! { enum StoreLogOptions: u32 {
+RT_CLASS!{class StoreHardwareManufacturerInfo: IStoreHardwareManufacturerInfo ["Windows.ApplicationModel.Store.Preview.StoreHardwareManufacturerInfo"]}
+RT_ENUM! { enum StoreLogOptions: u32 ["Windows.ApplicationModel.Store.Preview.StoreLogOptions"] {
     None (StoreLogOptions_None) = 0, TryElevate (StoreLogOptions_TryElevate) = 1,
 }}
 DEFINE_IID!(IID_IStorePreview, 2316661313, 33806, 18857, 188, 1, 93, 91, 1, 251, 200, 233);
@@ -25038,8 +25038,8 @@ impl IStorePreviewProductInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePreviewProductInfo: IStorePreviewProductInfo}
-RT_ENUM! { enum StorePreviewProductPurchaseStatus: i32 {
+RT_CLASS!{class StorePreviewProductInfo: IStorePreviewProductInfo ["Windows.ApplicationModel.Store.Preview.StorePreviewProductInfo"]}
+RT_ENUM! { enum StorePreviewProductPurchaseStatus: i32 ["Windows.ApplicationModel.Store.Preview.StorePreviewProductPurchaseStatus"] {
     Succeeded (StorePreviewProductPurchaseStatus_Succeeded) = 0, AlreadyPurchased (StorePreviewProductPurchaseStatus_AlreadyPurchased) = 1, NotFulfilled (StorePreviewProductPurchaseStatus_NotFulfilled) = 2, NotPurchased (StorePreviewProductPurchaseStatus_NotPurchased) = 3,
 }}
 DEFINE_IID!(IID_IStorePreviewPurchaseResults, 2967121617, 54981, 20051, 160, 67, 251, 160, 216, 230, 18, 49);
@@ -25053,7 +25053,7 @@ impl IStorePreviewPurchaseResults {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePreviewPurchaseResults: IStorePreviewPurchaseResults}
+RT_CLASS!{class StorePreviewPurchaseResults: IStorePreviewPurchaseResults ["Windows.ApplicationModel.Store.Preview.StorePreviewPurchaseResults"]}
 DEFINE_IID!(IID_IStorePreviewSkuInfo, 2180871906, 2854, 18649, 152, 206, 39, 70, 28, 102, 157, 108);
 RT_INTERFACE!{interface IStorePreviewSkuInfo(IStorePreviewSkuInfoVtbl): IInspectable(IInspectableVtbl) [IID_IStorePreviewSkuInfo] {
     fn get_ProductId(&self, out: *mut HSTRING) -> HRESULT,
@@ -25113,8 +25113,8 @@ impl IStorePreviewSkuInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePreviewSkuInfo: IStorePreviewSkuInfo}
-RT_ENUM! { enum StoreSystemFeature: i32 {
+RT_CLASS!{class StorePreviewSkuInfo: IStorePreviewSkuInfo ["Windows.ApplicationModel.Store.Preview.StorePreviewSkuInfo"]}
+RT_ENUM! { enum StoreSystemFeature: i32 ["Windows.ApplicationModel.Store.Preview.StoreSystemFeature"] {
     ArchitectureX86 (StoreSystemFeature_ArchitectureX86) = 0, ArchitectureX64 (StoreSystemFeature_ArchitectureX64) = 1, ArchitectureArm (StoreSystemFeature_ArchitectureArm) = 2, DirectX9 (StoreSystemFeature_DirectX9) = 3, DirectX10 (StoreSystemFeature_DirectX10) = 4, DirectX11 (StoreSystemFeature_DirectX11) = 5, D3D12HardwareFL11 (StoreSystemFeature_D3D12HardwareFL11) = 6, D3D12HardwareFL12 (StoreSystemFeature_D3D12HardwareFL12) = 7, Memory300MB (StoreSystemFeature_Memory300MB) = 8, Memory750MB (StoreSystemFeature_Memory750MB) = 9, Memory1GB (StoreSystemFeature_Memory1GB) = 10, Memory2GB (StoreSystemFeature_Memory2GB) = 11, CameraFront (StoreSystemFeature_CameraFront) = 12, CameraRear (StoreSystemFeature_CameraRear) = 13, Gyroscope (StoreSystemFeature_Gyroscope) = 14, Hover (StoreSystemFeature_Hover) = 15, Magnetometer (StoreSystemFeature_Magnetometer) = 16, Nfc (StoreSystemFeature_Nfc) = 17, Resolution720P (StoreSystemFeature_Resolution720P) = 18, ResolutionWvga (StoreSystemFeature_ResolutionWvga) = 19, ResolutionWvgaOr720P (StoreSystemFeature_ResolutionWvgaOr720P) = 20, ResolutionWxga (StoreSystemFeature_ResolutionWxga) = 21, ResolutionWvgaOrWxga (StoreSystemFeature_ResolutionWvgaOrWxga) = 22, ResolutionWxgaOr720P (StoreSystemFeature_ResolutionWxgaOr720P) = 23, Memory4GB (StoreSystemFeature_Memory4GB) = 24, Memory6GB (StoreSystemFeature_Memory6GB) = 25, Memory8GB (StoreSystemFeature_Memory8GB) = 26, Memory12GB (StoreSystemFeature_Memory12GB) = 27, Memory16GB (StoreSystemFeature_Memory16GB) = 28, Memory20GB (StoreSystemFeature_Memory20GB) = 29, VideoMemory2GB (StoreSystemFeature_VideoMemory2GB) = 30, VideoMemory4GB (StoreSystemFeature_VideoMemory4GB) = 31, VideoMemory6GB (StoreSystemFeature_VideoMemory6GB) = 32, VideoMemory1GB (StoreSystemFeature_VideoMemory1GB) = 33, ArchitectureArm64 (StoreSystemFeature_ArchitectureArm64) = 34,
 }}
 DEFINE_IID!(IID_IWebAuthenticationCoreManagerHelper, 111478053, 59157, 16675, 146, 118, 157, 111, 134, 91, 165, 95);
@@ -25147,7 +25147,7 @@ impl WebAuthenticationCoreManagerHelper {
 DEFINE_CLSID!(WebAuthenticationCoreManagerHelper(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,87,101,98,65,117,116,104,101,110,116,105,99,97,116,105,111,110,67,111,114,101,77,97,110,97,103,101,114,72,101,108,112,101,114,0]) [CLSID_WebAuthenticationCoreManagerHelper]);
 pub mod installcontrol { // Windows.ApplicationModel.Store.Preview.InstallControl
 use ::prelude::*;
-RT_ENUM! { enum AppInstallationToastNotificationMode: i32 {
+RT_ENUM! { enum AppInstallationToastNotificationMode: i32 ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallationToastNotificationMode"] {
     Default (AppInstallationToastNotificationMode_Default) = 0, Toast (AppInstallationToastNotificationMode_Toast) = 1, ToastWithoutPopup (AppInstallationToastNotificationMode_ToastWithoutPopup) = 2, NoToast (AppInstallationToastNotificationMode_NoToast) = 3,
 }}
 DEFINE_IID!(IID_IAppInstallItem, 1238622123, 5770, 19647, 169, 58, 158, 68, 140, 130, 115, 125);
@@ -25222,7 +25222,7 @@ impl IAppInstallItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstallItem: IAppInstallItem}
+RT_CLASS!{class AppInstallItem: IAppInstallItem ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallItem"]}
 DEFINE_IID!(IID_IAppInstallItem2, 3549899512, 16576, 20439, 170, 108, 10, 161, 60, 166, 24, 140);
 RT_INTERFACE!{interface IAppInstallItem2(IAppInstallItem2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallItem2] {
     fn CancelWithTelemetry(&self, correlationVector: HSTRING) -> HRESULT,
@@ -25448,7 +25448,7 @@ impl IAppInstallManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstallManager: IAppInstallManager}
+RT_CLASS!{class AppInstallManager: IAppInstallManager ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallManager"]}
 impl RtActivatable<IActivationFactory> for AppInstallManager {}
 DEFINE_CLSID!(AppInstallManager(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,73,110,115,116,97,108,108,67,111,110,116,114,111,108,46,65,112,112,73,110,115,116,97,108,108,77,97,110,97,103,101,114,0]) [CLSID_AppInstallManager]);
 DEFINE_IID!(IID_IAppInstallManager2, 378763345, 60727, 18445, 131, 20, 82, 226, 124, 3, 240, 74);
@@ -25670,7 +25670,7 @@ impl IAppInstallManagerItemEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstallManagerItemEventArgs: IAppInstallManagerItemEventArgs}
+RT_CLASS!{class AppInstallManagerItemEventArgs: IAppInstallManagerItemEventArgs ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallManagerItemEventArgs"]}
 DEFINE_IID!(IID_IAppInstallOptions, 3380642560, 7352, 20150, 140, 159, 106, 48, 198, 74, 91, 81);
 RT_INTERFACE!{interface IAppInstallOptions(IAppInstallOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallOptions] {
     fn get_CatalogId(&self, out: *mut HSTRING) -> HRESULT,
@@ -25744,7 +25744,7 @@ impl IAppInstallOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstallOptions: IAppInstallOptions}
+RT_CLASS!{class AppInstallOptions: IAppInstallOptions ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallOptions"]}
 impl RtActivatable<IActivationFactory> for AppInstallOptions {}
 DEFINE_CLSID!(AppInstallOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,73,110,115,116,97,108,108,67,111,110,116,114,111,108,46,65,112,112,73,110,115,116,97,108,108,79,112,116,105,111,110,115,0]) [CLSID_AppInstallOptions]);
 DEFINE_IID!(IID_IAppInstallOptions2, 2315567319, 51531, 16990, 149, 180, 191, 39, 250, 234, 238, 137);
@@ -25851,7 +25851,7 @@ impl IAppInstallOptions2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppInstallState: i32 {
+RT_ENUM! { enum AppInstallState: i32 ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallState"] {
     Pending (AppInstallState_Pending) = 0, Starting (AppInstallState_Starting) = 1, AcquiringLicense (AppInstallState_AcquiringLicense) = 2, Downloading (AppInstallState_Downloading) = 3, RestoringData (AppInstallState_RestoringData) = 4, Installing (AppInstallState_Installing) = 5, Completed (AppInstallState_Completed) = 6, Canceled (AppInstallState_Canceled) = 7, Paused (AppInstallState_Paused) = 8, Error (AppInstallState_Error) = 9, PausedLowBattery (AppInstallState_PausedLowBattery) = 10, PausedWiFiRecommended (AppInstallState_PausedWiFiRecommended) = 11, PausedWiFiRequired (AppInstallState_PausedWiFiRequired) = 12, ReadyToDownload (AppInstallState_ReadyToDownload) = 13,
 }}
 DEFINE_IID!(IID_IAppInstallStatus, 2473446650, 9296, 16678, 136, 177, 97, 39, 166, 68, 221, 92);
@@ -25889,7 +25889,7 @@ impl IAppInstallStatus {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppInstallStatus: IAppInstallStatus}
+RT_CLASS!{class AppInstallStatus: IAppInstallStatus ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallStatus"]}
 DEFINE_IID!(IID_IAppInstallStatus2, 2531754378, 24210, 19113, 142, 220, 88, 254, 212, 184, 126, 0);
 RT_INTERFACE!{interface IAppInstallStatus2(IAppInstallStatus2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppInstallStatus2] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -25919,7 +25919,7 @@ impl IAppInstallStatus3 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppInstallType: i32 {
+RT_ENUM! { enum AppInstallType: i32 ["Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallType"] {
     Install (AppInstallType_Install) = 0, Update (AppInstallType_Update) = 1, Repair (AppInstallType_Repair) = 2,
 }}
 DEFINE_IID!(IID_IAppUpdateOptions, 653307951, 49907, 19178, 175, 140, 99, 8, 221, 157, 184, 95);
@@ -25949,7 +25949,7 @@ impl IAppUpdateOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppUpdateOptions: IAppUpdateOptions}
+RT_CLASS!{class AppUpdateOptions: IAppUpdateOptions ["Windows.ApplicationModel.Store.Preview.InstallControl.AppUpdateOptions"]}
 impl RtActivatable<IActivationFactory> for AppUpdateOptions {}
 DEFINE_CLSID!(AppUpdateOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,83,116,111,114,101,46,80,114,101,118,105,101,119,46,73,110,115,116,97,108,108,67,111,110,116,114,111,108,46,65,112,112,85,112,100,97,116,101,79,112,116,105,111,110,115,0]) [CLSID_AppUpdateOptions]);
 DEFINE_IID!(IID_IAppUpdateOptions2, 4100222472, 60710, 19449, 150, 121, 72, 246, 40, 229, 61, 248);
@@ -25968,7 +25968,7 @@ impl IAppUpdateOptions2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AutoUpdateSetting: i32 {
+RT_ENUM! { enum AutoUpdateSetting: i32 ["Windows.ApplicationModel.Store.Preview.InstallControl.AutoUpdateSetting"] {
     Disabled (AutoUpdateSetting_Disabled) = 0, Enabled (AutoUpdateSetting_Enabled) = 1, DisabledByPolicy (AutoUpdateSetting_DisabledByPolicy) = 2, EnabledByPolicy (AutoUpdateSetting_EnabledByPolicy) = 3,
 }}
 DEFINE_IID!(IID_IGetEntitlementResult, 1962705983, 6814, 17929, 142, 77, 129, 144, 134, 208, 138, 61);
@@ -25982,8 +25982,8 @@ impl IGetEntitlementResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GetEntitlementResult: IGetEntitlementResult}
-RT_ENUM! { enum GetEntitlementStatus: i32 {
+RT_CLASS!{class GetEntitlementResult: IGetEntitlementResult ["Windows.ApplicationModel.Store.Preview.InstallControl.GetEntitlementResult"]}
+RT_ENUM! { enum GetEntitlementStatus: i32 ["Windows.ApplicationModel.Store.Preview.InstallControl.GetEntitlementStatus"] {
     Succeeded (GetEntitlementStatus_Succeeded) = 0, NoStoreAccount (GetEntitlementStatus_NoStoreAccount) = 1, NetworkError (GetEntitlementStatus_NetworkError) = 2, ServerError (GetEntitlementStatus_ServerError) = 3,
 }}
 } // Windows.ApplicationModel.Store.Preview.InstallControl
@@ -26081,7 +26081,7 @@ impl IUserActivity {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivity: IUserActivity}
+RT_CLASS!{class UserActivity: IUserActivity ["Windows.ApplicationModel.UserActivities.UserActivity"]}
 impl RtActivatable<IUserActivityFactory> for UserActivity {}
 impl RtActivatable<IUserActivityStatics> for UserActivity {}
 impl UserActivity {
@@ -26164,7 +26164,7 @@ impl IUserActivityAttribution {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityAttribution: IUserActivityAttribution}
+RT_CLASS!{class UserActivityAttribution: IUserActivityAttribution ["Windows.ApplicationModel.UserActivities.UserActivityAttribution"]}
 impl RtActivatable<IUserActivityAttributionFactory> for UserActivityAttribution {}
 impl RtActivatable<IActivationFactory> for UserActivityAttribution {}
 impl UserActivityAttribution {
@@ -26207,7 +26207,7 @@ impl IUserActivityChannel {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityChannel: IUserActivityChannel}
+RT_CLASS!{class UserActivityChannel: IUserActivityChannel ["Windows.ApplicationModel.UserActivities.UserActivityChannel"]}
 impl RtActivatable<IUserActivityChannelStatics> for UserActivityChannel {}
 impl RtActivatable<IUserActivityChannelStatics2> for UserActivityChannel {}
 impl UserActivityChannel {
@@ -26277,7 +26277,7 @@ impl IUserActivityContentInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityContentInfo: IUserActivityContentInfo}
+RT_CLASS!{class UserActivityContentInfo: IUserActivityContentInfo ["Windows.ApplicationModel.UserActivities.UserActivityContentInfo"]}
 impl RtActivatable<IUserActivityContentInfoStatics> for UserActivityContentInfo {}
 impl UserActivityContentInfo {
     #[inline] pub fn from_json(value: &HStringArg) -> Result<Option<ComPtr<UserActivityContentInfo>>> {
@@ -26317,7 +26317,7 @@ impl IUserActivityRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityRequest: IUserActivityRequest}
+RT_CLASS!{class UserActivityRequest: IUserActivityRequest ["Windows.ApplicationModel.UserActivities.UserActivityRequest"]}
 DEFINE_IID!(IID_IUserActivityRequestedEventArgs, 2764864076, 33321, 19709, 163, 188, 198, 29, 49, 133, 117, 164);
 RT_INTERFACE!{interface IUserActivityRequestedEventArgs(IUserActivityRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivityRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut UserActivityRequest) -> HRESULT,
@@ -26335,7 +26335,7 @@ impl IUserActivityRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityRequestedEventArgs: IUserActivityRequestedEventArgs}
+RT_CLASS!{class UserActivityRequestedEventArgs: IUserActivityRequestedEventArgs ["Windows.ApplicationModel.UserActivities.UserActivityRequestedEventArgs"]}
 DEFINE_IID!(IID_IUserActivityRequestManager, 204521038, 36925, 18646, 130, 212, 64, 67, 237, 87, 121, 27);
 RT_INTERFACE!{interface IUserActivityRequestManager(IUserActivityRequestManagerVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivityRequestManager] {
     fn add_UserActivityRequested(&self, handler: *mut foundation::TypedEventHandler<UserActivityRequestManager, UserActivityRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -26352,7 +26352,7 @@ impl IUserActivityRequestManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityRequestManager: IUserActivityRequestManager}
+RT_CLASS!{class UserActivityRequestManager: IUserActivityRequestManager ["Windows.ApplicationModel.UserActivities.UserActivityRequestManager"]}
 impl RtActivatable<IUserActivityRequestManagerStatics> for UserActivityRequestManager {}
 impl UserActivityRequestManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<UserActivityRequestManager>>> {
@@ -26382,7 +26382,7 @@ impl IUserActivitySession {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivitySession: IUserActivitySession}
+RT_CLASS!{class UserActivitySession: IUserActivitySession ["Windows.ApplicationModel.UserActivities.UserActivitySession"]}
 DEFINE_IID!(IID_IUserActivitySessionHistoryItem, 3906313171, 15965, 18941, 152, 215, 109, 169, 117, 33, 226, 85);
 RT_INTERFACE!{interface IUserActivitySessionHistoryItem(IUserActivitySessionHistoryItemVtbl): IInspectable(IInspectableVtbl) [IID_IUserActivitySessionHistoryItem] {
     fn get_UserActivity(&self, out: *mut *mut UserActivity) -> HRESULT,
@@ -26406,8 +26406,8 @@ impl IUserActivitySessionHistoryItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivitySessionHistoryItem: IUserActivitySessionHistoryItem}
-RT_ENUM! { enum UserActivityState: i32 {
+RT_CLASS!{class UserActivitySessionHistoryItem: IUserActivitySessionHistoryItem ["Windows.ApplicationModel.UserActivities.UserActivitySessionHistoryItem"]}
+RT_ENUM! { enum UserActivityState: i32 ["Windows.ApplicationModel.UserActivities.UserActivityState"] {
     New (UserActivityState_New) = 0, Published (UserActivityState_Published) = 1,
 }}
 DEFINE_IID!(IID_IUserActivityStatics, 2358235955, 3593, 18422, 154, 199, 149, 207, 92, 57, 54, 123);
@@ -26493,7 +26493,7 @@ impl IUserActivityVisualElements {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserActivityVisualElements: IUserActivityVisualElements}
+RT_CLASS!{class UserActivityVisualElements: IUserActivityVisualElements ["Windows.ApplicationModel.UserActivities.UserActivityVisualElements"]}
 DEFINE_IID!(IID_IUserActivityVisualElements2, 3400433607, 16111, 17241, 130, 92, 157, 81, 185, 34, 13, 227);
 RT_INTERFACE!{interface IUserActivityVisualElements2(IUserActivityVisualElements2Vtbl): IInspectable(IInspectableVtbl) [IID_IUserActivityVisualElements2] {
     fn get_AttributionDisplayText(&self, out: *mut HSTRING) -> HRESULT,
@@ -26632,7 +26632,7 @@ impl IUserDataAccount {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccount: IUserDataAccount}
+RT_CLASS!{class UserDataAccount: IUserDataAccount ["Windows.ApplicationModel.UserDataAccounts.UserDataAccount"]}
 DEFINE_IID!(IID_IUserDataAccount2, 126671007, 56962, 16459, 129, 149, 200, 163, 172, 25, 143, 96);
 RT_INTERFACE!{interface IUserDataAccount2(IUserDataAccount2Vtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccount2] {
     fn get_EnterpriseId(&self, out: *mut HSTRING) -> HRESULT,
@@ -26722,7 +26722,7 @@ impl IUserDataAccount4 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserDataAccountContentKinds: u32 {
+RT_ENUM! { enum UserDataAccountContentKinds: u32 ["Windows.ApplicationModel.UserDataAccounts.UserDataAccountContentKinds"] {
     Email (UserDataAccountContentKinds_Email) = 1, Contact (UserDataAccountContentKinds_Contact) = 2, Appointment (UserDataAccountContentKinds_Appointment) = 4,
 }}
 RT_CLASS!{static class UserDataAccountManager}
@@ -26763,7 +26763,7 @@ impl IUserDataAccountManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountManagerForUser: IUserDataAccountManagerForUser}
+RT_CLASS!{class UserDataAccountManagerForUser: IUserDataAccountManagerForUser ["Windows.ApplicationModel.UserDataAccounts.UserDataAccountManagerForUser"]}
 DEFINE_IID!(IID_IUserDataAccountManagerStatics, 228297194, 6440, 18976, 134, 213, 60, 115, 127, 125, 195, 176);
 RT_INTERFACE!{static interface IUserDataAccountManagerStatics(IUserDataAccountManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountManagerStatics] {
     fn RequestStoreAsync(&self, storeAccessType: UserDataAccountStoreAccessType, out: *mut *mut foundation::IAsyncOperation<UserDataAccountStore>) -> HRESULT,
@@ -26804,7 +26804,7 @@ impl IUserDataAccountManagerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserDataAccountOtherAppReadAccess: i32 {
+RT_ENUM! { enum UserDataAccountOtherAppReadAccess: i32 ["Windows.ApplicationModel.UserDataAccounts.UserDataAccountOtherAppReadAccess"] {
     SystemOnly (UserDataAccountOtherAppReadAccess_SystemOnly) = 0, Full (UserDataAccountOtherAppReadAccess_Full) = 1, None (UserDataAccountOtherAppReadAccess_None) = 2,
 }}
 DEFINE_IID!(IID_IUserDataAccountStore, 544452781, 32010, 20086, 191, 69, 35, 104, 249, 120, 165, 154);
@@ -26830,7 +26830,7 @@ impl IUserDataAccountStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountStore: IUserDataAccountStore}
+RT_CLASS!{class UserDataAccountStore: IUserDataAccountStore ["Windows.ApplicationModel.UserDataAccounts.UserDataAccountStore"]}
 DEFINE_IID!(IID_IUserDataAccountStore2, 2984292087, 38240, 17969, 138, 240, 6, 29, 48, 22, 20, 105);
 RT_INTERFACE!{interface IUserDataAccountStore2(IUserDataAccountStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountStore2] {
     fn CreateAccountWithPackageRelativeAppIdAsync(&self, userDisplayName: HSTRING, packageRelativeAppId: HSTRING, out: *mut *mut foundation::IAsyncOperation<UserDataAccount>) -> HRESULT,
@@ -26864,7 +26864,7 @@ impl IUserDataAccountStore3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserDataAccountStoreAccessType: i32 {
+RT_ENUM! { enum UserDataAccountStoreAccessType: i32 ["Windows.ApplicationModel.UserDataAccounts.UserDataAccountStoreAccessType"] {
     AllAccountsReadOnly (UserDataAccountStoreAccessType_AllAccountsReadOnly) = 0, AppAccountsReadWrite (UserDataAccountStoreAccessType_AppAccountsReadWrite) = 1,
 }}
 DEFINE_IID!(IID_IUserDataAccountStoreChangedEventArgs, 2229527269, 34848, 17682, 177, 246, 46, 3, 91, 225, 7, 44);
@@ -26878,7 +26878,7 @@ impl IUserDataAccountStoreChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountStoreChangedEventArgs: IUserDataAccountStoreChangedEventArgs}
+RT_CLASS!{class UserDataAccountStoreChangedEventArgs: IUserDataAccountStoreChangedEventArgs ["Windows.ApplicationModel.UserDataAccounts.UserDataAccountStoreChangedEventArgs"]}
 pub mod provider { // Windows.ApplicationModel.UserDataAccounts.Provider
 use ::prelude::*;
 DEFINE_IID!(IID_IUserDataAccountPartnerAccountInfo, 1595932727, 63215, 20163, 134, 48, 1, 44, 89, 193, 20, 159);
@@ -26904,7 +26904,7 @@ impl IUserDataAccountPartnerAccountInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountPartnerAccountInfo: IUserDataAccountPartnerAccountInfo}
+RT_CLASS!{class UserDataAccountPartnerAccountInfo: IUserDataAccountPartnerAccountInfo ["Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountPartnerAccountInfo"]}
 DEFINE_IID!(IID_IUserDataAccountProviderAddAccountOperation, 3116836144, 16260, 19293, 142, 170, 69, 233, 122, 168, 66, 237);
 RT_INTERFACE!{interface IUserDataAccountProviderAddAccountOperation(IUserDataAccountProviderAddAccountOperationVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountProviderAddAccountOperation] {
     fn get_ContentKinds(&self, out: *mut super::UserDataAccountContentKinds) -> HRESULT,
@@ -26927,7 +26927,7 @@ impl IUserDataAccountProviderAddAccountOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountProviderAddAccountOperation: IUserDataAccountProviderAddAccountOperation}
+RT_CLASS!{class UserDataAccountProviderAddAccountOperation: IUserDataAccountProviderAddAccountOperation ["Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderAddAccountOperation"]}
 DEFINE_IID!(IID_IUserDataAccountProviderOperation, 2718608739, 34956, 19042, 163, 221, 52, 208, 122, 128, 43, 43);
 RT_INTERFACE!{interface IUserDataAccountProviderOperation(IUserDataAccountProviderOperationVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountProviderOperation] {
     fn get_Kind(&self, out: *mut UserDataAccountProviderOperationKind) -> HRESULT
@@ -26939,10 +26939,10 @@ impl IUserDataAccountProviderOperation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserDataAccountProviderOperationKind: i32 {
+RT_ENUM! { enum UserDataAccountProviderOperationKind: i32 ["Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderOperationKind"] {
     AddAccount (UserDataAccountProviderOperationKind_AddAccount) = 0, Settings (UserDataAccountProviderOperationKind_Settings) = 1, ResolveErrors (UserDataAccountProviderOperationKind_ResolveErrors) = 2,
 }}
-RT_ENUM! { enum UserDataAccountProviderPartnerAccountKind: i32 {
+RT_ENUM! { enum UserDataAccountProviderPartnerAccountKind: i32 ["Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderPartnerAccountKind"] {
     Exchange (UserDataAccountProviderPartnerAccountKind_Exchange) = 0, PopOrImap (UserDataAccountProviderPartnerAccountKind_PopOrImap) = 1,
 }}
 DEFINE_IID!(IID_IUserDataAccountProviderResolveErrorsOperation, 1647696917, 49099, 16865, 153, 87, 151, 89, 162, 136, 70, 204);
@@ -26961,7 +26961,7 @@ impl IUserDataAccountProviderResolveErrorsOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountProviderResolveErrorsOperation: IUserDataAccountProviderResolveErrorsOperation}
+RT_CLASS!{class UserDataAccountProviderResolveErrorsOperation: IUserDataAccountProviderResolveErrorsOperation ["Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderResolveErrorsOperation"]}
 DEFINE_IID!(IID_IUserDataAccountProviderSettingsOperation, 2449690039, 34376, 20272, 172, 250, 48, 2, 101, 140, 168, 13);
 RT_INTERFACE!{interface IUserDataAccountProviderSettingsOperation(IUserDataAccountProviderSettingsOperationVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataAccountProviderSettingsOperation] {
     fn get_UserDataAccountId(&self, out: *mut HSTRING) -> HRESULT,
@@ -26978,11 +26978,11 @@ impl IUserDataAccountProviderSettingsOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataAccountProviderSettingsOperation: IUserDataAccountProviderSettingsOperation}
+RT_CLASS!{class UserDataAccountProviderSettingsOperation: IUserDataAccountProviderSettingsOperation ["Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderSettingsOperation"]}
 } // Windows.ApplicationModel.UserDataAccounts.Provider
 pub mod systemaccess { // Windows.ApplicationModel.UserDataAccounts.SystemAccess
 use ::prelude::*;
-RT_ENUM! { enum DeviceAccountAuthenticationType: i32 {
+RT_ENUM! { enum DeviceAccountAuthenticationType: i32 ["Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountAuthenticationType"] {
     Basic (DeviceAccountAuthenticationType_Basic) = 0, OAuth (DeviceAccountAuthenticationType_OAuth) = 1, SingleSignOn (DeviceAccountAuthenticationType_SingleSignOn) = 2,
 }}
 DEFINE_IID!(IID_IDeviceAccountConfiguration, 2902533027, 64476, 19739, 190, 67, 90, 39, 234, 74, 27, 99);
@@ -27166,7 +27166,7 @@ impl IDeviceAccountConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceAccountConfiguration: IDeviceAccountConfiguration}
+RT_CLASS!{class DeviceAccountConfiguration: IDeviceAccountConfiguration ["Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountConfiguration"]}
 impl RtActivatable<IActivationFactory> for DeviceAccountConfiguration {}
 DEFINE_CLSID!(DeviceAccountConfiguration(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,65,99,99,111,117,110,116,115,46,83,121,115,116,101,109,65,99,99,101,115,115,46,68,101,118,105,99,101,65,99,99,111,117,110,116,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_DeviceAccountConfiguration]);
 DEFINE_IID!(IID_IDeviceAccountConfiguration2, 4071810470, 29325, 19018, 137, 69, 43, 248, 88, 1, 54, 222);
@@ -27487,16 +27487,16 @@ impl IDeviceAccountConfiguration2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DeviceAccountIconId: i32 {
+RT_ENUM! { enum DeviceAccountIconId: i32 ["Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountIconId"] {
     Exchange (DeviceAccountIconId_Exchange) = 0, Msa (DeviceAccountIconId_Msa) = 1, Outlook (DeviceAccountIconId_Outlook) = 2, Generic (DeviceAccountIconId_Generic) = 3,
 }}
-RT_ENUM! { enum DeviceAccountMailAgeFilter: i32 {
+RT_ENUM! { enum DeviceAccountMailAgeFilter: i32 ["Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountMailAgeFilter"] {
     All (DeviceAccountMailAgeFilter_All) = 0, Last1Day (DeviceAccountMailAgeFilter_Last1Day) = 1, Last3Days (DeviceAccountMailAgeFilter_Last3Days) = 2, Last7Days (DeviceAccountMailAgeFilter_Last7Days) = 3, Last14Days (DeviceAccountMailAgeFilter_Last14Days) = 4, Last30Days (DeviceAccountMailAgeFilter_Last30Days) = 5, Last90Days (DeviceAccountMailAgeFilter_Last90Days) = 6,
 }}
-RT_ENUM! { enum DeviceAccountServerType: i32 {
+RT_ENUM! { enum DeviceAccountServerType: i32 ["Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountServerType"] {
     Exchange (DeviceAccountServerType_Exchange) = 0, Pop (DeviceAccountServerType_Pop) = 1, Imap (DeviceAccountServerType_Imap) = 2,
 }}
-RT_ENUM! { enum DeviceAccountSyncScheduleKind: i32 {
+RT_ENUM! { enum DeviceAccountSyncScheduleKind: i32 ["Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountSyncScheduleKind"] {
     Manual (DeviceAccountSyncScheduleKind_Manual) = 0, Every15Minutes (DeviceAccountSyncScheduleKind_Every15Minutes) = 1, Every30Minutes (DeviceAccountSyncScheduleKind_Every30Minutes) = 2, Every60Minutes (DeviceAccountSyncScheduleKind_Every60Minutes) = 3, Every2Hours (DeviceAccountSyncScheduleKind_Every2Hours) = 4, Daily (DeviceAccountSyncScheduleKind_Daily) = 5, AsItemsArrive (DeviceAccountSyncScheduleKind_AsItemsArrive) = 6,
 }}
 RT_CLASS!{static class UserDataAccountSystemAccessManager}
@@ -27719,7 +27719,7 @@ impl IUserDataTask {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTask: IUserDataTask}
+RT_CLASS!{class UserDataTask: IUserDataTask ["Windows.ApplicationModel.UserDataTasks.UserDataTask"]}
 impl RtActivatable<IActivationFactory> for UserDataTask {}
 DEFINE_CLSID!(UserDataTask(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,0]) [CLSID_UserDataTask]);
 DEFINE_IID!(IID_IUserDataTaskBatch, 942515710, 8373, 17180, 143, 66, 165, 210, 146, 236, 147, 12);
@@ -27733,14 +27733,14 @@ impl IUserDataTaskBatch {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskBatch: IUserDataTaskBatch}
-RT_ENUM! { enum UserDataTaskDaysOfWeek: u32 {
+RT_CLASS!{class UserDataTaskBatch: IUserDataTaskBatch ["Windows.ApplicationModel.UserDataTasks.UserDataTaskBatch"]}
+RT_ENUM! { enum UserDataTaskDaysOfWeek: u32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskDaysOfWeek"] {
     None (UserDataTaskDaysOfWeek_None) = 0, Sunday (UserDataTaskDaysOfWeek_Sunday) = 1, Monday (UserDataTaskDaysOfWeek_Monday) = 2, Tuesday (UserDataTaskDaysOfWeek_Tuesday) = 4, Wednesday (UserDataTaskDaysOfWeek_Wednesday) = 8, Thursday (UserDataTaskDaysOfWeek_Thursday) = 16, Friday (UserDataTaskDaysOfWeek_Friday) = 32, Saturday (UserDataTaskDaysOfWeek_Saturday) = 64,
 }}
-RT_ENUM! { enum UserDataTaskDetailsKind: i32 {
+RT_ENUM! { enum UserDataTaskDetailsKind: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskDetailsKind"] {
     PlainText (UserDataTaskDetailsKind_PlainText) = 0, Html (UserDataTaskDetailsKind_Html) = 1,
 }}
-RT_ENUM! { enum UserDataTaskKind: i32 {
+RT_ENUM! { enum UserDataTaskKind: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskKind"] {
     Single (UserDataTaskKind_Single) = 0, Recurring (UserDataTaskKind_Recurring) = 1, Regenerating (UserDataTaskKind_Regenerating) = 2,
 }}
 DEFINE_IID!(IID_IUserDataTaskList, 1229008441, 31773, 19953, 190, 211, 49, 75, 124, 191, 94, 78);
@@ -27859,7 +27859,7 @@ impl IUserDataTaskList {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskList: IUserDataTaskList}
+RT_CLASS!{class UserDataTaskList: IUserDataTaskList ["Windows.ApplicationModel.UserDataTasks.UserDataTaskList"]}
 DEFINE_IID!(IID_IUserDataTaskListLimitedWriteOperations, 2057463794, 24696, 16771, 145, 158, 79, 41, 241, 156, 250, 233);
 RT_INTERFACE!{interface IUserDataTaskListLimitedWriteOperations(IUserDataTaskListLimitedWriteOperationsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListLimitedWriteOperations] {
     fn TryCompleteTaskAsync(&self, userDataTaskId: HSTRING, out: *mut *mut foundation::IAsyncOperation<HString>) -> HRESULT,
@@ -27889,11 +27889,11 @@ impl IUserDataTaskListLimitedWriteOperations {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListLimitedWriteOperations: IUserDataTaskListLimitedWriteOperations}
-RT_ENUM! { enum UserDataTaskListOtherAppReadAccess: i32 {
+RT_CLASS!{class UserDataTaskListLimitedWriteOperations: IUserDataTaskListLimitedWriteOperations ["Windows.ApplicationModel.UserDataTasks.UserDataTaskListLimitedWriteOperations"]}
+RT_ENUM! { enum UserDataTaskListOtherAppReadAccess: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskListOtherAppReadAccess"] {
     Full (UserDataTaskListOtherAppReadAccess_Full) = 0, SystemOnly (UserDataTaskListOtherAppReadAccess_SystemOnly) = 1, None (UserDataTaskListOtherAppReadAccess_None) = 2,
 }}
-RT_ENUM! { enum UserDataTaskListOtherAppWriteAccess: i32 {
+RT_ENUM! { enum UserDataTaskListOtherAppWriteAccess: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskListOtherAppWriteAccess"] {
     Limited (UserDataTaskListOtherAppWriteAccess_Limited) = 0, None (UserDataTaskListOtherAppWriteAccess_None) = 1,
 }}
 DEFINE_IID!(IID_IUserDataTaskListSyncManager, 2388204181, 7631, 18079, 147, 236, 186, 72, 187, 85, 60, 107);
@@ -27951,8 +27951,8 @@ impl IUserDataTaskListSyncManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListSyncManager: IUserDataTaskListSyncManager}
-RT_ENUM! { enum UserDataTaskListSyncStatus: i32 {
+RT_CLASS!{class UserDataTaskListSyncManager: IUserDataTaskListSyncManager ["Windows.ApplicationModel.UserDataTasks.UserDataTaskListSyncManager"]}
+RT_ENUM! { enum UserDataTaskListSyncStatus: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskListSyncStatus"] {
     Idle (UserDataTaskListSyncStatus_Idle) = 0, Syncing (UserDataTaskListSyncStatus_Syncing) = 1, UpToDate (UserDataTaskListSyncStatus_UpToDate) = 2, AuthenticationError (UserDataTaskListSyncStatus_AuthenticationError) = 3, PolicyError (UserDataTaskListSyncStatus_PolicyError) = 4, UnknownError (UserDataTaskListSyncStatus_UnknownError) = 5,
 }}
 DEFINE_IID!(IID_IUserDataTaskManager, 2219952404, 58891, 18601, 146, 17, 127, 184, 165, 108, 184, 76);
@@ -27972,7 +27972,7 @@ impl IUserDataTaskManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskManager: IUserDataTaskManager}
+RT_CLASS!{class UserDataTaskManager: IUserDataTaskManager ["Windows.ApplicationModel.UserDataTasks.UserDataTaskManager"]}
 impl RtActivatable<IUserDataTaskManagerStatics> for UserDataTaskManager {}
 impl UserDataTaskManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<UserDataTaskManager>>> {
@@ -28000,10 +28000,10 @@ impl IUserDataTaskManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserDataTaskPriority: i32 {
+RT_ENUM! { enum UserDataTaskPriority: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskPriority"] {
     Normal (UserDataTaskPriority_Normal) = 0, Low (UserDataTaskPriority_Low) = -1, High (UserDataTaskPriority_High) = 1,
 }}
-RT_ENUM! { enum UserDataTaskQueryKind: i32 {
+RT_ENUM! { enum UserDataTaskQueryKind: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskQueryKind"] {
     All (UserDataTaskQueryKind_All) = 0, Incomplete (UserDataTaskQueryKind_Incomplete) = 1, Complete (UserDataTaskQueryKind_Complete) = 2,
 }}
 DEFINE_IID!(IID_IUserDataTaskQueryOptions, 2510235629, 37018, 19760, 140, 27, 51, 29, 143, 230, 103, 226);
@@ -28033,10 +28033,10 @@ impl IUserDataTaskQueryOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskQueryOptions: IUserDataTaskQueryOptions}
+RT_CLASS!{class UserDataTaskQueryOptions: IUserDataTaskQueryOptions ["Windows.ApplicationModel.UserDataTasks.UserDataTaskQueryOptions"]}
 impl RtActivatable<IActivationFactory> for UserDataTaskQueryOptions {}
 DEFINE_CLSID!(UserDataTaskQueryOptions(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,81,117,101,114,121,79,112,116,105,111,110,115,0]) [CLSID_UserDataTaskQueryOptions]);
-RT_ENUM! { enum UserDataTaskQuerySortProperty: i32 {
+RT_ENUM! { enum UserDataTaskQuerySortProperty: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskQuerySortProperty"] {
     DueDate (UserDataTaskQuerySortProperty_DueDate) = 0,
 }}
 DEFINE_IID!(IID_IUserDataTaskReader, 65439921, 19663, 17664, 136, 59, 231, 98, 144, 207, 237, 99);
@@ -28050,7 +28050,7 @@ impl IUserDataTaskReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskReader: IUserDataTaskReader}
+RT_CLASS!{class UserDataTaskReader: IUserDataTaskReader ["Windows.ApplicationModel.UserDataTasks.UserDataTaskReader"]}
 DEFINE_IID!(IID_IUserDataTaskRecurrenceProperties, 1944027312, 10182, 16590, 177, 73, 156, 212, 20, 133, 166, 158);
 RT_INTERFACE!{interface IUserDataTaskRecurrenceProperties(IUserDataTaskRecurrencePropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskRecurrenceProperties] {
     fn get_Unit(&self, out: *mut UserDataTaskRecurrenceUnit) -> HRESULT,
@@ -28144,10 +28144,10 @@ impl IUserDataTaskRecurrenceProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskRecurrenceProperties: IUserDataTaskRecurrenceProperties}
+RT_CLASS!{class UserDataTaskRecurrenceProperties: IUserDataTaskRecurrenceProperties ["Windows.ApplicationModel.UserDataTasks.UserDataTaskRecurrenceProperties"]}
 impl RtActivatable<IActivationFactory> for UserDataTaskRecurrenceProperties {}
 DEFINE_CLSID!(UserDataTaskRecurrenceProperties(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,82,101,99,117,114,114,101,110,99,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_UserDataTaskRecurrenceProperties]);
-RT_ENUM! { enum UserDataTaskRecurrenceUnit: i32 {
+RT_ENUM! { enum UserDataTaskRecurrenceUnit: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskRecurrenceUnit"] {
     Daily (UserDataTaskRecurrenceUnit_Daily) = 0, Weekly (UserDataTaskRecurrenceUnit_Weekly) = 1, Monthly (UserDataTaskRecurrenceUnit_Monthly) = 2, MonthlyOnDay (UserDataTaskRecurrenceUnit_MonthlyOnDay) = 3, Yearly (UserDataTaskRecurrenceUnit_Yearly) = 4, YearlyOnDay (UserDataTaskRecurrenceUnit_YearlyOnDay) = 5,
 }}
 DEFINE_IID!(IID_IUserDataTaskRegenerationProperties, 2460680199, 2318, 18180, 187, 92, 132, 252, 11, 13, 156, 49);
@@ -28199,13 +28199,13 @@ impl IUserDataTaskRegenerationProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskRegenerationProperties: IUserDataTaskRegenerationProperties}
+RT_CLASS!{class UserDataTaskRegenerationProperties: IUserDataTaskRegenerationProperties ["Windows.ApplicationModel.UserDataTasks.UserDataTaskRegenerationProperties"]}
 impl RtActivatable<IActivationFactory> for UserDataTaskRegenerationProperties {}
 DEFINE_CLSID!(UserDataTaskRegenerationProperties(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,85,115,101,114,68,97,116,97,84,97,115,107,115,46,85,115,101,114,68,97,116,97,84,97,115,107,82,101,103,101,110,101,114,97,116,105,111,110,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_UserDataTaskRegenerationProperties]);
-RT_ENUM! { enum UserDataTaskRegenerationUnit: i32 {
+RT_ENUM! { enum UserDataTaskRegenerationUnit: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskRegenerationUnit"] {
     Daily (UserDataTaskRegenerationUnit_Daily) = 0, Weekly (UserDataTaskRegenerationUnit_Weekly) = 1, Monthly (UserDataTaskRegenerationUnit_Monthly) = 2, Yearly (UserDataTaskRegenerationUnit_Yearly) = 4,
 }}
-RT_ENUM! { enum UserDataTaskSensitivity: i32 {
+RT_ENUM! { enum UserDataTaskSensitivity: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskSensitivity"] {
     Public (UserDataTaskSensitivity_Public) = 0, Private (UserDataTaskSensitivity_Private) = 1,
 }}
 DEFINE_IID!(IID_IUserDataTaskStore, 4033518768, 61915, 17850, 138, 98, 8, 96, 4, 192, 33, 61);
@@ -28237,11 +28237,11 @@ impl IUserDataTaskStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskStore: IUserDataTaskStore}
-RT_ENUM! { enum UserDataTaskStoreAccessType: i32 {
+RT_CLASS!{class UserDataTaskStore: IUserDataTaskStore ["Windows.ApplicationModel.UserDataTasks.UserDataTaskStore"]}
+RT_ENUM! { enum UserDataTaskStoreAccessType: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskStoreAccessType"] {
     AppTasksReadWrite (UserDataTaskStoreAccessType_AppTasksReadWrite) = 0, AllTasksLimitedReadWrite (UserDataTaskStoreAccessType_AllTasksLimitedReadWrite) = 1,
 }}
-RT_ENUM! { enum UserDataTaskWeekOfMonth: i32 {
+RT_ENUM! { enum UserDataTaskWeekOfMonth: i32 ["Windows.ApplicationModel.UserDataTasks.UserDataTaskWeekOfMonth"] {
     First (UserDataTaskWeekOfMonth_First) = 0, Second (UserDataTaskWeekOfMonth_Second) = 1, Third (UserDataTaskWeekOfMonth_Third) = 2, Fourth (UserDataTaskWeekOfMonth_Fourth) = 3, Last (UserDataTaskWeekOfMonth_Last) = 4,
 }}
 pub mod dataprovider { // Windows.ApplicationModel.UserDataTasks.DataProvider
@@ -28311,7 +28311,7 @@ impl IUserDataTaskDataProviderConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskDataProviderConnection: IUserDataTaskDataProviderConnection}
+RT_CLASS!{class UserDataTaskDataProviderConnection: IUserDataTaskDataProviderConnection ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskDataProviderConnection"]}
 DEFINE_IID!(IID_IUserDataTaskDataProviderTriggerDetails, 2921804290, 45513, 17726, 175, 197, 179, 10, 243, 189, 33, 125);
 RT_INTERFACE!{interface IUserDataTaskDataProviderTriggerDetails(IUserDataTaskDataProviderTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskDataProviderTriggerDetails] {
     fn get_Connection(&self, out: *mut *mut UserDataTaskDataProviderConnection) -> HRESULT
@@ -28323,7 +28323,7 @@ impl IUserDataTaskDataProviderTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskDataProviderTriggerDetails: IUserDataTaskDataProviderTriggerDetails}
+RT_CLASS!{class UserDataTaskDataProviderTriggerDetails: IUserDataTaskDataProviderTriggerDetails ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskDataProviderTriggerDetails"]}
 DEFINE_IID!(IID_IUserDataTaskListCompleteTaskRequest, 4133360803, 6722, 18906, 133, 82, 40, 115, 229, 44, 85, 235);
 RT_INTERFACE!{interface IUserDataTaskListCompleteTaskRequest(IUserDataTaskListCompleteTaskRequestVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListCompleteTaskRequest] {
     fn get_TaskListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -28353,7 +28353,7 @@ impl IUserDataTaskListCompleteTaskRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListCompleteTaskRequest: IUserDataTaskListCompleteTaskRequest}
+RT_CLASS!{class UserDataTaskListCompleteTaskRequest: IUserDataTaskListCompleteTaskRequest ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCompleteTaskRequest"]}
 DEFINE_IID!(IID_IUserDataTaskListCompleteTaskRequestEventArgs, 3615242557, 19698, 18605, 135, 253, 150, 63, 14, 170, 122, 149);
 RT_INTERFACE!{interface IUserDataTaskListCompleteTaskRequestEventArgs(IUserDataTaskListCompleteTaskRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListCompleteTaskRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut UserDataTaskListCompleteTaskRequest) -> HRESULT,
@@ -28371,7 +28371,7 @@ impl IUserDataTaskListCompleteTaskRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListCompleteTaskRequestEventArgs: IUserDataTaskListCompleteTaskRequestEventArgs}
+RT_CLASS!{class UserDataTaskListCompleteTaskRequestEventArgs: IUserDataTaskListCompleteTaskRequestEventArgs ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCompleteTaskRequestEventArgs"]}
 DEFINE_IID!(IID_IUserDataTaskListCreateOrUpdateTaskRequest, 557020972, 21954, 17152, 130, 121, 4, 50, 110, 7, 204, 228);
 RT_INTERFACE!{interface IUserDataTaskListCreateOrUpdateTaskRequest(IUserDataTaskListCreateOrUpdateTaskRequestVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListCreateOrUpdateTaskRequest] {
     fn get_TaskListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -28401,7 +28401,7 @@ impl IUserDataTaskListCreateOrUpdateTaskRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListCreateOrUpdateTaskRequest: IUserDataTaskListCreateOrUpdateTaskRequest}
+RT_CLASS!{class UserDataTaskListCreateOrUpdateTaskRequest: IUserDataTaskListCreateOrUpdateTaskRequest ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCreateOrUpdateTaskRequest"]}
 DEFINE_IID!(IID_IUserDataTaskListCreateOrUpdateTaskRequestEventArgs, 314923602, 58232, 16795, 174, 56, 165, 233, 230, 4, 71, 110);
 RT_INTERFACE!{interface IUserDataTaskListCreateOrUpdateTaskRequestEventArgs(IUserDataTaskListCreateOrUpdateTaskRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListCreateOrUpdateTaskRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut UserDataTaskListCreateOrUpdateTaskRequest) -> HRESULT,
@@ -28419,7 +28419,7 @@ impl IUserDataTaskListCreateOrUpdateTaskRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListCreateOrUpdateTaskRequestEventArgs: IUserDataTaskListCreateOrUpdateTaskRequestEventArgs}
+RT_CLASS!{class UserDataTaskListCreateOrUpdateTaskRequestEventArgs: IUserDataTaskListCreateOrUpdateTaskRequestEventArgs ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCreateOrUpdateTaskRequestEventArgs"]}
 DEFINE_IID!(IID_IUserDataTaskListDeleteTaskRequest, 1267088488, 30295, 20285, 176, 116, 212, 126, 200, 223, 7, 231);
 RT_INTERFACE!{interface IUserDataTaskListDeleteTaskRequest(IUserDataTaskListDeleteTaskRequestVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListDeleteTaskRequest] {
     fn get_TaskListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -28449,7 +28449,7 @@ impl IUserDataTaskListDeleteTaskRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListDeleteTaskRequest: IUserDataTaskListDeleteTaskRequest}
+RT_CLASS!{class UserDataTaskListDeleteTaskRequest: IUserDataTaskListDeleteTaskRequest ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListDeleteTaskRequest"]}
 DEFINE_IID!(IID_IUserDataTaskListDeleteTaskRequestEventArgs, 1617156825, 62818, 16709, 142, 254, 213, 0, 120, 201, 43, 127);
 RT_INTERFACE!{interface IUserDataTaskListDeleteTaskRequestEventArgs(IUserDataTaskListDeleteTaskRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListDeleteTaskRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut UserDataTaskListDeleteTaskRequest) -> HRESULT,
@@ -28467,7 +28467,7 @@ impl IUserDataTaskListDeleteTaskRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListDeleteTaskRequestEventArgs: IUserDataTaskListDeleteTaskRequestEventArgs}
+RT_CLASS!{class UserDataTaskListDeleteTaskRequestEventArgs: IUserDataTaskListDeleteTaskRequestEventArgs ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListDeleteTaskRequestEventArgs"]}
 DEFINE_IID!(IID_IUserDataTaskListSkipOccurrenceRequest, 2877809485, 7379, 17180, 159, 88, 8, 154, 164, 51, 141, 133);
 RT_INTERFACE!{interface IUserDataTaskListSkipOccurrenceRequest(IUserDataTaskListSkipOccurrenceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListSkipOccurrenceRequest] {
     fn get_TaskListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -28497,7 +28497,7 @@ impl IUserDataTaskListSkipOccurrenceRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListSkipOccurrenceRequest: IUserDataTaskListSkipOccurrenceRequest}
+RT_CLASS!{class UserDataTaskListSkipOccurrenceRequest: IUserDataTaskListSkipOccurrenceRequest ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSkipOccurrenceRequest"]}
 DEFINE_IID!(IID_IUserDataTaskListSkipOccurrenceRequestEventArgs, 2050724426, 52271, 20091, 170, 205, 165, 185, 210, 156, 250, 78);
 RT_INTERFACE!{interface IUserDataTaskListSkipOccurrenceRequestEventArgs(IUserDataTaskListSkipOccurrenceRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListSkipOccurrenceRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut UserDataTaskListSkipOccurrenceRequest) -> HRESULT,
@@ -28515,7 +28515,7 @@ impl IUserDataTaskListSkipOccurrenceRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListSkipOccurrenceRequestEventArgs: IUserDataTaskListSkipOccurrenceRequestEventArgs}
+RT_CLASS!{class UserDataTaskListSkipOccurrenceRequestEventArgs: IUserDataTaskListSkipOccurrenceRequestEventArgs ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSkipOccurrenceRequestEventArgs"]}
 DEFINE_IID!(IID_IUserDataTaskListSyncManagerSyncRequest, 1084700679, 30096, 16713, 174, 25, 178, 17, 67, 26, 159, 72);
 RT_INTERFACE!{interface IUserDataTaskListSyncManagerSyncRequest(IUserDataTaskListSyncManagerSyncRequestVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListSyncManagerSyncRequest] {
     fn get_TaskListId(&self, out: *mut HSTRING) -> HRESULT,
@@ -28539,7 +28539,7 @@ impl IUserDataTaskListSyncManagerSyncRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListSyncManagerSyncRequest: IUserDataTaskListSyncManagerSyncRequest}
+RT_CLASS!{class UserDataTaskListSyncManagerSyncRequest: IUserDataTaskListSyncManagerSyncRequest ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSyncManagerSyncRequest"]}
 DEFINE_IID!(IID_IUserDataTaskListSyncManagerSyncRequestEventArgs, 2393709586, 30350, 17341, 131, 133, 92, 220, 53, 31, 253, 234);
 RT_INTERFACE!{interface IUserDataTaskListSyncManagerSyncRequestEventArgs(IUserDataTaskListSyncManagerSyncRequestEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataTaskListSyncManagerSyncRequestEventArgs] {
     fn get_Request(&self, out: *mut *mut UserDataTaskListSyncManagerSyncRequest) -> HRESULT,
@@ -28557,7 +28557,7 @@ impl IUserDataTaskListSyncManagerSyncRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataTaskListSyncManagerSyncRequestEventArgs: IUserDataTaskListSyncManagerSyncRequestEventArgs}
+RT_CLASS!{class UserDataTaskListSyncManagerSyncRequestEventArgs: IUserDataTaskListSyncManagerSyncRequestEventArgs ["Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSyncManagerSyncRequestEventArgs"]}
 } // Windows.ApplicationModel.UserDataTasks.DataProvider
 } // Windows.ApplicationModel.UserDataTasks
 pub mod voicecommands { // Windows.ApplicationModel.VoiceCommands
@@ -28585,7 +28585,7 @@ impl IVoiceCommand {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommand: IVoiceCommand}
+RT_CLASS!{class VoiceCommand: IVoiceCommand ["Windows.ApplicationModel.VoiceCommands.VoiceCommand"]}
 DEFINE_IID!(IID_IVoiceCommandCompletedEventArgs, 3361630045, 65090, 17196, 153, 7, 9, 223, 159, 207, 100, 232);
 RT_INTERFACE!{interface IVoiceCommandCompletedEventArgs(IVoiceCommandCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommandCompletedEventArgs] {
     fn get_Reason(&self, out: *mut VoiceCommandCompletionReason) -> HRESULT
@@ -28597,8 +28597,8 @@ impl IVoiceCommandCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandCompletedEventArgs: IVoiceCommandCompletedEventArgs}
-RT_ENUM! { enum VoiceCommandCompletionReason: i32 {
+RT_CLASS!{class VoiceCommandCompletedEventArgs: IVoiceCommandCompletedEventArgs ["Windows.ApplicationModel.VoiceCommands.VoiceCommandCompletedEventArgs"]}
+RT_ENUM! { enum VoiceCommandCompletionReason: i32 ["Windows.ApplicationModel.VoiceCommands.VoiceCommandCompletionReason"] {
     Unknown (VoiceCommandCompletionReason_Unknown) = 0, CommunicationFailed (VoiceCommandCompletionReason_CommunicationFailed) = 1, ResourceLimitsExceeded (VoiceCommandCompletionReason_ResourceLimitsExceeded) = 2, Canceled (VoiceCommandCompletionReason_Canceled) = 3, TimeoutExceeded (VoiceCommandCompletionReason_TimeoutExceeded) = 4, AppLaunched (VoiceCommandCompletionReason_AppLaunched) = 5, Completed (VoiceCommandCompletionReason_Completed) = 6,
 }}
 DEFINE_IID!(IID_IVoiceCommandConfirmationResult, 2686605630, 33313, 17702, 176, 131, 132, 9, 114, 38, 34, 71);
@@ -28612,7 +28612,7 @@ impl IVoiceCommandConfirmationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandConfirmationResult: IVoiceCommandConfirmationResult}
+RT_CLASS!{class VoiceCommandConfirmationResult: IVoiceCommandConfirmationResult ["Windows.ApplicationModel.VoiceCommands.VoiceCommandConfirmationResult"]}
 DEFINE_IID!(IID_IVoiceCommandContentTile, 1055910384, 47303, 19574, 160, 222, 22, 7, 137, 94, 227, 39);
 RT_INTERFACE!{interface IVoiceCommandContentTile(IVoiceCommandContentTileVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommandContentTile] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -28708,10 +28708,10 @@ impl IVoiceCommandContentTile {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandContentTile: IVoiceCommandContentTile}
+RT_CLASS!{class VoiceCommandContentTile: IVoiceCommandContentTile ["Windows.ApplicationModel.VoiceCommands.VoiceCommandContentTile"]}
 impl RtActivatable<IActivationFactory> for VoiceCommandContentTile {}
 DEFINE_CLSID!(VoiceCommandContentTile(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,67,111,110,116,101,110,116,84,105,108,101,0]) [CLSID_VoiceCommandContentTile]);
-RT_ENUM! { enum VoiceCommandContentTileType: i32 {
+RT_ENUM! { enum VoiceCommandContentTileType: i32 ["Windows.ApplicationModel.VoiceCommands.VoiceCommandContentTileType"] {
     TitleOnly (VoiceCommandContentTileType_TitleOnly) = 0, TitleWithText (VoiceCommandContentTileType_TitleWithText) = 1, TitleWith68x68Icon (VoiceCommandContentTileType_TitleWith68x68Icon) = 2, TitleWith68x68IconAndText (VoiceCommandContentTileType_TitleWith68x68IconAndText) = 3, TitleWith68x92Icon (VoiceCommandContentTileType_TitleWith68x92Icon) = 4, TitleWith68x92IconAndText (VoiceCommandContentTileType_TitleWith68x92IconAndText) = 5, TitleWith280x140Icon (VoiceCommandContentTileType_TitleWith280x140Icon) = 6, TitleWith280x140IconAndText (VoiceCommandContentTileType_TitleWith280x140IconAndText) = 7,
 }}
 DEFINE_IID!(IID_IVoiceCommandDefinition, 2037557968, 2420, 18809, 152, 75, 203, 137, 89, 205, 97, 174);
@@ -28737,7 +28737,7 @@ impl IVoiceCommandDefinition {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandDefinition: IVoiceCommandDefinition}
+RT_CLASS!{class VoiceCommandDefinition: IVoiceCommandDefinition ["Windows.ApplicationModel.VoiceCommands.VoiceCommandDefinition"]}
 RT_CLASS!{static class VoiceCommandDefinitionManager}
 impl RtActivatable<IVoiceCommandDefinitionManagerStatics> for VoiceCommandDefinitionManager {}
 impl VoiceCommandDefinitionManager {
@@ -28778,7 +28778,7 @@ impl IVoiceCommandDisambiguationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandDisambiguationResult: IVoiceCommandDisambiguationResult}
+RT_CLASS!{class VoiceCommandDisambiguationResult: IVoiceCommandDisambiguationResult ["Windows.ApplicationModel.VoiceCommands.VoiceCommandDisambiguationResult"]}
 DEFINE_IID!(IID_IVoiceCommandResponse, 42251022, 35387, 19652, 166, 161, 202, 213, 190, 39, 22, 181);
 RT_INTERFACE!{interface IVoiceCommandResponse(IVoiceCommandResponseVtbl): IInspectable(IInspectableVtbl) [IID_IVoiceCommandResponse] {
     fn get_Message(&self, out: *mut *mut VoiceCommandUserMessage) -> HRESULT,
@@ -28823,7 +28823,7 @@ impl IVoiceCommandResponse {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandResponse: IVoiceCommandResponse}
+RT_CLASS!{class VoiceCommandResponse: IVoiceCommandResponse ["Windows.ApplicationModel.VoiceCommands.VoiceCommandResponse"]}
 impl RtActivatable<IVoiceCommandResponseStatics> for VoiceCommandResponse {}
 impl VoiceCommandResponse {
     #[inline] pub fn get_max_supported_voice_command_content_tiles() -> Result<u32> {
@@ -28943,7 +28943,7 @@ impl IVoiceCommandServiceConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandServiceConnection: IVoiceCommandServiceConnection}
+RT_CLASS!{class VoiceCommandServiceConnection: IVoiceCommandServiceConnection ["Windows.ApplicationModel.VoiceCommands.VoiceCommandServiceConnection"]}
 impl RtActivatable<IVoiceCommandServiceConnectionStatics> for VoiceCommandServiceConnection {}
 impl VoiceCommandServiceConnection {
     #[inline] pub fn from_app_service_trigger_details(triggerDetails: &super::appservice::AppServiceTriggerDetails) -> Result<Option<ComPtr<VoiceCommandServiceConnection>>> {
@@ -28989,13 +28989,13 @@ impl IVoiceCommandUserMessage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceCommandUserMessage: IVoiceCommandUserMessage}
+RT_CLASS!{class VoiceCommandUserMessage: IVoiceCommandUserMessage ["Windows.ApplicationModel.VoiceCommands.VoiceCommandUserMessage"]}
 impl RtActivatable<IActivationFactory> for VoiceCommandUserMessage {}
 DEFINE_CLSID!(VoiceCommandUserMessage(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,86,111,105,99,101,67,111,109,109,97,110,100,115,46,86,111,105,99,101,67,111,109,109,97,110,100,85,115,101,114,77,101,115,115,97,103,101,0]) [CLSID_VoiceCommandUserMessage]);
 } // Windows.ApplicationModel.VoiceCommands
 pub mod wallet { // Windows.ApplicationModel.Wallet
 use ::prelude::*;
-RT_ENUM! { enum WalletActionKind: i32 {
+RT_ENUM! { enum WalletActionKind: i32 ["Windows.ApplicationModel.Wallet.WalletActionKind"] {
     OpenItem (WalletActionKind_OpenItem) = 0, Transaction (WalletActionKind_Transaction) = 1, MoreTransactions (WalletActionKind_MoreTransactions) = 2, Message (WalletActionKind_Message) = 3, Verb (WalletActionKind_Verb) = 4,
 }}
 DEFINE_IID!(IID_IWalletBarcode, 1334147881, 56960, 20132, 161, 205, 129, 205, 8, 77, 172, 39);
@@ -29021,7 +29021,7 @@ impl IWalletBarcode {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletBarcode: IWalletBarcode}
+RT_CLASS!{class WalletBarcode: IWalletBarcode ["Windows.ApplicationModel.Wallet.WalletBarcode"]}
 impl RtActivatable<IWalletBarcodeFactory> for WalletBarcode {}
 impl WalletBarcode {
     #[inline] pub fn create_wallet_barcode(symbology: WalletBarcodeSymbology, value: &HStringArg) -> Result<ComPtr<WalletBarcode>> {
@@ -29049,10 +29049,10 @@ impl IWalletBarcodeFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WalletBarcodeSymbology: i32 {
+RT_ENUM! { enum WalletBarcodeSymbology: i32 ["Windows.ApplicationModel.Wallet.WalletBarcodeSymbology"] {
     Invalid (WalletBarcodeSymbology_Invalid) = 0, Upca (WalletBarcodeSymbology_Upca) = 1, Upce (WalletBarcodeSymbology_Upce) = 2, Ean13 (WalletBarcodeSymbology_Ean13) = 3, Ean8 (WalletBarcodeSymbology_Ean8) = 4, Itf (WalletBarcodeSymbology_Itf) = 5, Code39 (WalletBarcodeSymbology_Code39) = 6, Code128 (WalletBarcodeSymbology_Code128) = 7, Qr (WalletBarcodeSymbology_Qr) = 8, Pdf417 (WalletBarcodeSymbology_Pdf417) = 9, Aztec (WalletBarcodeSymbology_Aztec) = 10, Custom (WalletBarcodeSymbology_Custom) = 100000,
 }}
-RT_ENUM! { enum WalletDetailViewPosition: i32 {
+RT_ENUM! { enum WalletDetailViewPosition: i32 ["Windows.ApplicationModel.Wallet.WalletDetailViewPosition"] {
     Hidden (WalletDetailViewPosition_Hidden) = 0, HeaderField1 (WalletDetailViewPosition_HeaderField1) = 1, HeaderField2 (WalletDetailViewPosition_HeaderField2) = 2, PrimaryField1 (WalletDetailViewPosition_PrimaryField1) = 3, PrimaryField2 (WalletDetailViewPosition_PrimaryField2) = 4, SecondaryField1 (WalletDetailViewPosition_SecondaryField1) = 5, SecondaryField2 (WalletDetailViewPosition_SecondaryField2) = 6, SecondaryField3 (WalletDetailViewPosition_SecondaryField3) = 7, SecondaryField4 (WalletDetailViewPosition_SecondaryField4) = 8, SecondaryField5 (WalletDetailViewPosition_SecondaryField5) = 9, CenterField1 (WalletDetailViewPosition_CenterField1) = 10, FooterField1 (WalletDetailViewPosition_FooterField1) = 11, FooterField2 (WalletDetailViewPosition_FooterField2) = 12, FooterField3 (WalletDetailViewPosition_FooterField3) = 13, FooterField4 (WalletDetailViewPosition_FooterField4) = 14,
 }}
 DEFINE_IID!(IID_IWalletItem, 548752360, 4493, 20164, 153, 108, 185, 99, 231, 189, 62, 116);
@@ -29371,7 +29371,7 @@ impl IWalletItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletItem: IWalletItem}
+RT_CLASS!{class WalletItem: IWalletItem ["Windows.ApplicationModel.Wallet.WalletItem"]}
 impl RtActivatable<IWalletItemFactory> for WalletItem {}
 impl WalletItem {
     #[inline] pub fn create_wallet_item(kind: WalletItemKind, displayName: &HStringArg) -> Result<ComPtr<WalletItem>> {
@@ -29439,7 +29439,7 @@ impl IWalletItemCustomProperty {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletItemCustomProperty: IWalletItemCustomProperty}
+RT_CLASS!{class WalletItemCustomProperty: IWalletItemCustomProperty ["Windows.ApplicationModel.Wallet.WalletItemCustomProperty"]}
 impl RtActivatable<IWalletItemCustomPropertyFactory> for WalletItemCustomProperty {}
 impl WalletItemCustomProperty {
     #[inline] pub fn create_wallet_item_custom_property(name: &HStringArg, value: &HStringArg) -> Result<ComPtr<WalletItemCustomProperty>> {
@@ -29469,7 +29469,7 @@ impl IWalletItemFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WalletItemKind: i32 {
+RT_ENUM! { enum WalletItemKind: i32 ["Windows.ApplicationModel.Wallet.WalletItemKind"] {
     Invalid (WalletItemKind_Invalid) = 0, Deal (WalletItemKind_Deal) = 1, General (WalletItemKind_General) = 2, PaymentInstrument (WalletItemKind_PaymentInstrument) = 3, Ticket (WalletItemKind_Ticket) = 4, BoardingPass (WalletItemKind_BoardingPass) = 5, MembershipCard (WalletItemKind_MembershipCard) = 6,
 }}
 DEFINE_IID!(IID_IWalletItemStore, 1902135371, 27977, 18680, 145, 169, 64, 161, 208, 241, 62, 244);
@@ -29538,7 +29538,7 @@ impl IWalletItemStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletItemStore: IWalletItemStore}
+RT_CLASS!{class WalletItemStore: IWalletItemStore ["Windows.ApplicationModel.Wallet.WalletItemStore"]}
 DEFINE_IID!(IID_IWalletItemStore2, 1709605616, 28681, 18965, 189, 84, 79, 255, 55, 155, 255, 226);
 RT_INTERFACE!{interface IWalletItemStore2(IWalletItemStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IWalletItemStore2] {
     fn add_ItemsChanged(&self, handler: *mut foundation::TypedEventHandler<WalletItemStore, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -29603,10 +29603,10 @@ impl IWalletRelevantLocation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletRelevantLocation: IWalletRelevantLocation}
+RT_CLASS!{class WalletRelevantLocation: IWalletRelevantLocation ["Windows.ApplicationModel.Wallet.WalletRelevantLocation"]}
 impl RtActivatable<IActivationFactory> for WalletRelevantLocation {}
 DEFINE_CLSID!(WalletRelevantLocation(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,82,101,108,101,118,97,110,116,76,111,99,97,116,105,111,110,0]) [CLSID_WalletRelevantLocation]);
-RT_ENUM! { enum WalletSummaryViewPosition: i32 {
+RT_ENUM! { enum WalletSummaryViewPosition: i32 ["Windows.ApplicationModel.Wallet.WalletSummaryViewPosition"] {
     Hidden (WalletSummaryViewPosition_Hidden) = 0, Field1 (WalletSummaryViewPosition_Field1) = 1, Field2 (WalletSummaryViewPosition_Field2) = 2,
 }}
 DEFINE_IID!(IID_IWalletTransaction, 1088547136, 9734, 17689, 129, 203, 191, 241, 198, 13, 31, 121);
@@ -29680,7 +29680,7 @@ impl IWalletTransaction {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletTransaction: IWalletTransaction}
+RT_CLASS!{class WalletTransaction: IWalletTransaction ["Windows.ApplicationModel.Wallet.WalletTransaction"]}
 impl RtActivatable<IActivationFactory> for WalletTransaction {}
 DEFINE_CLSID!(WalletTransaction(&[87,105,110,100,111,119,115,46,65,112,112,108,105,99,97,116,105,111,110,77,111,100,101,108,46,87,97,108,108,101,116,46,87,97,108,108,101,116,84,114,97,110,115,97,99,116,105,111,110,0]) [CLSID_WalletTransaction]);
 DEFINE_IID!(IID_IWalletVerb, 397944534, 58305, 19572, 138, 148, 33, 122, 173, 188, 72, 132);
@@ -29699,7 +29699,7 @@ impl IWalletVerb {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletVerb: IWalletVerb}
+RT_CLASS!{class WalletVerb: IWalletVerb ["Windows.ApplicationModel.Wallet.WalletVerb"]}
 impl RtActivatable<IWalletVerbFactory> for WalletVerb {}
 impl WalletVerb {
     #[inline] pub fn create_wallet_verb(name: &HStringArg) -> Result<ComPtr<WalletVerb>> {
@@ -29720,7 +29720,7 @@ impl IWalletVerbFactory {
 }
 pub mod system { // Windows.ApplicationModel.Wallet.System
 use ::prelude::*;
-RT_ENUM! { enum WalletItemAppAssociation: i32 {
+RT_ENUM! { enum WalletItemAppAssociation: i32 ["Windows.ApplicationModel.Wallet.System.WalletItemAppAssociation"] {
     None (WalletItemAppAssociation_None) = 0, AppInstalled (WalletItemAppAssociation_AppInstalled) = 1, AppNotInstalled (WalletItemAppAssociation_AppNotInstalled) = 2,
 }}
 DEFINE_IID!(IID_IWalletItemSystemStore, 1378757631, 38562, 18967, 141, 25, 254, 29, 159, 131, 117, 97);
@@ -29759,7 +29759,7 @@ impl IWalletItemSystemStore {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WalletItemSystemStore: IWalletItemSystemStore}
+RT_CLASS!{class WalletItemSystemStore: IWalletItemSystemStore ["Windows.ApplicationModel.Wallet.System.WalletItemSystemStore"]}
 DEFINE_IID!(IID_IWalletItemSystemStore2, 4186782286, 48640, 20445, 151, 52, 108, 17, 60, 26, 193, 203);
 RT_INTERFACE!{interface IWalletItemSystemStore2(IWalletItemSystemStore2Vtbl): IInspectable(IInspectableVtbl) [IID_IWalletItemSystemStore2] {
     fn add_ItemsChanged(&self, handler: *mut foundation::TypedEventHandler<WalletItemSystemStore, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,

--- a/src/rt/gen/windows/data.rs
+++ b/src/rt/gen/windows/data.rs
@@ -57,7 +57,7 @@ impl IJsonArray {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class JsonArray: IJsonArray}
+RT_CLASS!{class JsonArray: IJsonArray ["Windows.Data.Json.JsonArray"]}
 impl RtActivatable<IJsonArrayStatics> for JsonArray {}
 impl RtActivatable<IActivationFactory> for JsonArray {}
 impl JsonArray {
@@ -105,7 +105,7 @@ impl IJsonErrorStatics2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum JsonErrorStatus: i32 {
+RT_ENUM! { enum JsonErrorStatus: i32 ["Windows.Data.Json.JsonErrorStatus"] {
     Unknown (JsonErrorStatus_Unknown) = 0, InvalidJsonString (JsonErrorStatus_InvalidJsonString) = 1, InvalidJsonNumber (JsonErrorStatus_InvalidJsonNumber) = 2, JsonValueNotFound (JsonErrorStatus_JsonValueNotFound) = 3, ImplementationLimit (JsonErrorStatus_ImplementationLimit) = 4,
 }}
 DEFINE_IID!(IID_IJsonObject, 105784541, 10690, 20355, 154, 193, 158, 225, 21, 120, 190, 179);
@@ -154,7 +154,7 @@ impl IJsonObject {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class JsonObject: IJsonObject}
+RT_CLASS!{class JsonObject: IJsonObject ["Windows.Data.Json.JsonObject"]}
 impl RtActivatable<IJsonObjectStatics> for JsonObject {}
 impl RtActivatable<IActivationFactory> for JsonObject {}
 impl JsonObject {
@@ -271,7 +271,7 @@ impl IJsonValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class JsonValue: IJsonValue}
+RT_CLASS!{class JsonValue: IJsonValue ["Windows.Data.Json.JsonValue"]}
 impl RtActivatable<IJsonValueStatics> for JsonValue {}
 impl RtActivatable<IJsonValueStatics2> for JsonValue {}
 impl JsonValue {
@@ -341,7 +341,7 @@ impl IJsonValueStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum JsonValueType: i32 {
+RT_ENUM! { enum JsonValueType: i32 ["Windows.Data.Json.JsonValueType"] {
     Null (JsonValueType_Null) = 0, Boolean (JsonValueType_Boolean) = 1, Number (JsonValueType_Number) = 2, String (JsonValueType_String) = 3, Array (JsonValueType_Array) = 4, Object (JsonValueType_Object) = 5,
 }}
 } // Windows.Data.Json
@@ -370,7 +370,7 @@ impl IPdfDocument {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PdfDocument: IPdfDocument}
+RT_CLASS!{class PdfDocument: IPdfDocument ["Windows.Data.Pdf.PdfDocument"]}
 impl RtActivatable<IPdfDocumentStatics> for PdfDocument {}
 impl PdfDocument {
     #[cfg(feature="windows-storage")] #[inline] pub fn load_from_file_async(file: &super::super::storage::IStorageFile) -> Result<ComPtr<foundation::IAsyncOperation<PdfDocument>>> {
@@ -471,7 +471,7 @@ impl IPdfPage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PdfPage: IPdfPage}
+RT_CLASS!{class PdfPage: IPdfPage ["Windows.Data.Pdf.PdfPage"]}
 DEFINE_IID!(IID_IPdfPageDimensions, 571933809, 12606, 17640, 131, 93, 99, 163, 231, 98, 74, 16);
 RT_INTERFACE!{interface IPdfPageDimensions(IPdfPageDimensionsVtbl): IInspectable(IInspectableVtbl) [IID_IPdfPageDimensions] {
     fn get_MediaBox(&self, out: *mut foundation::Rect) -> HRESULT,
@@ -507,7 +507,7 @@ impl IPdfPageDimensions {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PdfPageDimensions: IPdfPageDimensions}
+RT_CLASS!{class PdfPageDimensions: IPdfPageDimensions ["Windows.Data.Pdf.PdfPageDimensions"]}
 DEFINE_IID!(IID_IPdfPageRenderOptions, 1016595823, 47055, 19497, 154, 4, 82, 217, 2, 103, 244, 37);
 RT_INTERFACE!{interface IPdfPageRenderOptions(IPdfPageRenderOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IPdfPageRenderOptions] {
     fn get_SourceRect(&self, out: *mut foundation::Rect) -> HRESULT,
@@ -581,16 +581,16 @@ impl IPdfPageRenderOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PdfPageRenderOptions: IPdfPageRenderOptions}
+RT_CLASS!{class PdfPageRenderOptions: IPdfPageRenderOptions ["Windows.Data.Pdf.PdfPageRenderOptions"]}
 impl RtActivatable<IActivationFactory> for PdfPageRenderOptions {}
 DEFINE_CLSID!(PdfPageRenderOptions(&[87,105,110,100,111,119,115,46,68,97,116,97,46,80,100,102,46,80,100,102,80,97,103,101,82,101,110,100,101,114,79,112,116,105,111,110,115,0]) [CLSID_PdfPageRenderOptions]);
-RT_ENUM! { enum PdfPageRotation: i32 {
+RT_ENUM! { enum PdfPageRotation: i32 ["Windows.Data.Pdf.PdfPageRotation"] {
     Normal (PdfPageRotation_Normal) = 0, Rotate90 (PdfPageRotation_Rotate90) = 1, Rotate180 (PdfPageRotation_Rotate180) = 2, Rotate270 (PdfPageRotation_Rotate270) = 3,
 }}
 } // Windows.Data.Pdf
 pub mod text { // Windows.Data.Text
 use ::prelude::*;
-RT_ENUM! { enum AlternateNormalizationFormat: i32 {
+RT_ENUM! { enum AlternateNormalizationFormat: i32 ["Windows.Data.Text.AlternateNormalizationFormat"] {
     NotNormalized (AlternateNormalizationFormat_NotNormalized) = 0, Number (AlternateNormalizationFormat_Number) = 1, Currency (AlternateNormalizationFormat_Currency) = 3, Date (AlternateNormalizationFormat_Date) = 4, Time (AlternateNormalizationFormat_Time) = 5,
 }}
 DEFINE_IID!(IID_IAlternateWordForm, 1194945566, 20921, 16903, 145, 70, 36, 142, 99, 106, 29, 29);
@@ -616,7 +616,7 @@ impl IAlternateWordForm {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AlternateWordForm: IAlternateWordForm}
+RT_CLASS!{class AlternateWordForm: IAlternateWordForm ["Windows.Data.Text.AlternateWordForm"]}
 DEFINE_IID!(IID_ISelectableWordSegment, 2439662775, 35495, 19576, 179, 116, 93, 237, 183, 82, 230, 11);
 RT_INTERFACE!{interface ISelectableWordSegment(ISelectableWordSegmentVtbl): IInspectable(IInspectableVtbl) [IID_ISelectableWordSegment] {
     fn get_Text(&self, out: *mut HSTRING) -> HRESULT,
@@ -634,7 +634,7 @@ impl ISelectableWordSegment {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SelectableWordSegment: ISelectableWordSegment}
+RT_CLASS!{class SelectableWordSegment: ISelectableWordSegment ["Windows.Data.Text.SelectableWordSegment"]}
 DEFINE_IID!(IID_SelectableWordSegmentsTokenizingHandler, 977140892, 44766, 19911, 158, 108, 65, 192, 68, 189, 53, 146);
 RT_DELEGATE!{delegate SelectableWordSegmentsTokenizingHandler(SelectableWordSegmentsTokenizingHandlerVtbl, SelectableWordSegmentsTokenizingHandlerImpl) [IID_SelectableWordSegmentsTokenizingHandler] {
     fn Invoke(&self, precedingWords: *mut foundation::collections::IIterable<SelectableWordSegment>, words: *mut foundation::collections::IIterable<SelectableWordSegment>) -> HRESULT
@@ -673,7 +673,7 @@ impl ISelectableWordsSegmenter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SelectableWordsSegmenter: ISelectableWordsSegmenter}
+RT_CLASS!{class SelectableWordsSegmenter: ISelectableWordsSegmenter ["Windows.Data.Text.SelectableWordsSegmenter"]}
 impl RtActivatable<ISelectableWordsSegmenterFactory> for SelectableWordsSegmenter {}
 impl SelectableWordsSegmenter {
     #[inline] pub fn create_with_language(language: &HStringArg) -> Result<ComPtr<SelectableWordsSegmenter>> {
@@ -709,7 +709,7 @@ impl ISemanticTextQuery {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SemanticTextQuery: ISemanticTextQuery}
+RT_CLASS!{class SemanticTextQuery: ISemanticTextQuery ["Windows.Data.Text.SemanticTextQuery"]}
 impl RtActivatable<ISemanticTextQueryFactory> for SemanticTextQuery {}
 impl SemanticTextQuery {
     #[inline] pub fn create(aqsFilter: &HStringArg) -> Result<ComPtr<SemanticTextQuery>> {
@@ -766,7 +766,7 @@ impl ITextConversionGenerator {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TextConversionGenerator: ITextConversionGenerator}
+RT_CLASS!{class TextConversionGenerator: ITextConversionGenerator ["Windows.Data.Text.TextConversionGenerator"]}
 impl RtActivatable<ITextConversionGeneratorFactory> for TextConversionGenerator {}
 impl TextConversionGenerator {
     #[inline] pub fn create(languageTag: &HStringArg) -> Result<ComPtr<TextConversionGenerator>> {
@@ -802,7 +802,7 @@ impl ITextPhoneme {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TextPhoneme: ITextPhoneme}
+RT_CLASS!{class TextPhoneme: ITextPhoneme ["Windows.Data.Text.TextPhoneme"]}
 DEFINE_IID!(IID_ITextPredictionGenerator, 1588374279, 44017, 19638, 157, 158, 50, 111, 43, 70, 135, 86);
 RT_INTERFACE!{interface ITextPredictionGenerator(ITextPredictionGeneratorVtbl): IInspectable(IInspectableVtbl) [IID_ITextPredictionGenerator] {
     fn get_ResolvedLanguage(&self, out: *mut HSTRING) -> HRESULT,
@@ -832,7 +832,7 @@ impl ITextPredictionGenerator {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TextPredictionGenerator: ITextPredictionGenerator}
+RT_CLASS!{class TextPredictionGenerator: ITextPredictionGenerator ["Windows.Data.Text.TextPredictionGenerator"]}
 impl RtActivatable<ITextPredictionGeneratorFactory> for TextPredictionGenerator {}
 impl TextPredictionGenerator {
     #[inline] pub fn create(languageTag: &HStringArg) -> Result<ComPtr<TextPredictionGenerator>> {
@@ -879,7 +879,7 @@ impl ITextPredictionGeneratorFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TextPredictionOptions: u32 {
+RT_ENUM! { enum TextPredictionOptions: u32 ["Windows.Data.Text.TextPredictionOptions"] {
     None (TextPredictionOptions_None) = 0, Predictions (TextPredictionOptions_Predictions) = 1, Corrections (TextPredictionOptions_Corrections) = 2,
 }}
 DEFINE_IID!(IID_ITextReverseConversionGenerator, 1374156052, 40017, 19846, 174, 27, 180, 152, 251, 173, 131, 19);
@@ -905,7 +905,7 @@ impl ITextReverseConversionGenerator {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TextReverseConversionGenerator: ITextReverseConversionGenerator}
+RT_CLASS!{class TextReverseConversionGenerator: ITextReverseConversionGenerator ["Windows.Data.Text.TextReverseConversionGenerator"]}
 impl RtActivatable<ITextReverseConversionGeneratorFactory> for TextReverseConversionGenerator {}
 impl TextReverseConversionGenerator {
     #[inline] pub fn create(languageTag: &HStringArg) -> Result<ComPtr<TextReverseConversionGenerator>> {
@@ -935,7 +935,7 @@ impl ITextReverseConversionGeneratorFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct TextSegment {
+RT_STRUCT! { struct TextSegment ["Windows.Data.Text.TextSegment"] {
     StartPosition: u32, Length: u32,
 }}
 RT_CLASS!{static class UnicodeCharacters}
@@ -1101,10 +1101,10 @@ impl IUnicodeCharactersStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UnicodeGeneralCategory: i32 {
+RT_ENUM! { enum UnicodeGeneralCategory: i32 ["Windows.Data.Text.UnicodeGeneralCategory"] {
     UppercaseLetter (UnicodeGeneralCategory_UppercaseLetter) = 0, LowercaseLetter (UnicodeGeneralCategory_LowercaseLetter) = 1, TitlecaseLetter (UnicodeGeneralCategory_TitlecaseLetter) = 2, ModifierLetter (UnicodeGeneralCategory_ModifierLetter) = 3, OtherLetter (UnicodeGeneralCategory_OtherLetter) = 4, NonspacingMark (UnicodeGeneralCategory_NonspacingMark) = 5, SpacingCombiningMark (UnicodeGeneralCategory_SpacingCombiningMark) = 6, EnclosingMark (UnicodeGeneralCategory_EnclosingMark) = 7, DecimalDigitNumber (UnicodeGeneralCategory_DecimalDigitNumber) = 8, LetterNumber (UnicodeGeneralCategory_LetterNumber) = 9, OtherNumber (UnicodeGeneralCategory_OtherNumber) = 10, SpaceSeparator (UnicodeGeneralCategory_SpaceSeparator) = 11, LineSeparator (UnicodeGeneralCategory_LineSeparator) = 12, ParagraphSeparator (UnicodeGeneralCategory_ParagraphSeparator) = 13, Control (UnicodeGeneralCategory_Control) = 14, Format (UnicodeGeneralCategory_Format) = 15, Surrogate (UnicodeGeneralCategory_Surrogate) = 16, PrivateUse (UnicodeGeneralCategory_PrivateUse) = 17, ConnectorPunctuation (UnicodeGeneralCategory_ConnectorPunctuation) = 18, DashPunctuation (UnicodeGeneralCategory_DashPunctuation) = 19, OpenPunctuation (UnicodeGeneralCategory_OpenPunctuation) = 20, ClosePunctuation (UnicodeGeneralCategory_ClosePunctuation) = 21, InitialQuotePunctuation (UnicodeGeneralCategory_InitialQuotePunctuation) = 22, FinalQuotePunctuation (UnicodeGeneralCategory_FinalQuotePunctuation) = 23, OtherPunctuation (UnicodeGeneralCategory_OtherPunctuation) = 24, MathSymbol (UnicodeGeneralCategory_MathSymbol) = 25, CurrencySymbol (UnicodeGeneralCategory_CurrencySymbol) = 26, ModifierSymbol (UnicodeGeneralCategory_ModifierSymbol) = 27, OtherSymbol (UnicodeGeneralCategory_OtherSymbol) = 28, NotAssigned (UnicodeGeneralCategory_NotAssigned) = 29,
 }}
-RT_ENUM! { enum UnicodeNumericType: i32 {
+RT_ENUM! { enum UnicodeNumericType: i32 ["Windows.Data.Text.UnicodeNumericType"] {
     None (UnicodeNumericType_None) = 0, Decimal (UnicodeNumericType_Decimal) = 1, Digit (UnicodeNumericType_Digit) = 2, Numeric (UnicodeNumericType_Numeric) = 3,
 }}
 DEFINE_IID!(IID_IWordSegment, 3537156717, 39036, 19648, 182, 189, 212, 154, 17, 179, 143, 154);
@@ -1130,7 +1130,7 @@ impl IWordSegment {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WordSegment: IWordSegment}
+RT_CLASS!{class WordSegment: IWordSegment ["Windows.Data.Text.WordSegment"]}
 DEFINE_IID!(IID_WordSegmentsTokenizingHandler, 2782749527, 48938, 19535, 163, 31, 41, 231, 28, 111, 139, 53);
 RT_DELEGATE!{delegate WordSegmentsTokenizingHandler(WordSegmentsTokenizingHandlerVtbl, WordSegmentsTokenizingHandlerImpl) [IID_WordSegmentsTokenizingHandler] {
     fn Invoke(&self, precedingWords: *mut foundation::collections::IIterable<WordSegment>, words: *mut foundation::collections::IIterable<WordSegment>) -> HRESULT
@@ -1169,7 +1169,7 @@ impl IWordsSegmenter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WordsSegmenter: IWordsSegmenter}
+RT_CLASS!{class WordsSegmenter: IWordsSegmenter ["Windows.Data.Text.WordsSegmenter"]}
 impl RtActivatable<IWordsSegmenterFactory> for WordsSegmenter {}
 impl WordsSegmenter {
     #[inline] pub fn create_with_language(language: &HStringArg) -> Result<ComPtr<WordsSegmenter>> {
@@ -1215,7 +1215,7 @@ impl IDtdEntity {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DtdEntity: IDtdEntity}
+RT_CLASS!{class DtdEntity: IDtdEntity ["Windows.Data.Xml.Dom.DtdEntity"]}
 DEFINE_IID!(IID_IDtdNotation, 2360664141, 27974, 20187, 171, 115, 223, 131, 197, 26, 211, 151);
 RT_INTERFACE!{interface IDtdNotation(IDtdNotationVtbl): IInspectable(IInspectableVtbl) [IID_IDtdNotation] {
     fn get_PublicId(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -1233,8 +1233,8 @@ impl IDtdNotation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DtdNotation: IDtdNotation}
-RT_ENUM! { enum NodeType: i32 {
+RT_CLASS!{class DtdNotation: IDtdNotation ["Windows.Data.Xml.Dom.DtdNotation"]}
+RT_ENUM! { enum NodeType: i32 ["Windows.Data.Xml.Dom.NodeType"] {
     Invalid (NodeType_Invalid) = 0, ElementNode (NodeType_ElementNode) = 1, AttributeNode (NodeType_AttributeNode) = 2, TextNode (NodeType_TextNode) = 3, DataSectionNode (NodeType_DataSectionNode) = 4, EntityReferenceNode (NodeType_EntityReferenceNode) = 5, EntityNode (NodeType_EntityNode) = 6, ProcessingInstructionNode (NodeType_ProcessingInstructionNode) = 7, CommentNode (NodeType_CommentNode) = 8, DocumentNode (NodeType_DocumentNode) = 9, DocumentTypeNode (NodeType_DocumentTypeNode) = 10, DocumentFragmentNode (NodeType_DocumentFragmentNode) = 11, NotationNode (NodeType_NotationNode) = 12,
 }}
 DEFINE_IID!(IID_IXmlAttribute, 2887010980, 46321, 19894, 178, 6, 138, 34, 195, 8, 219, 10);
@@ -1265,12 +1265,12 @@ impl IXmlAttribute {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlAttribute: IXmlAttribute}
+RT_CLASS!{class XmlAttribute: IXmlAttribute ["Windows.Data.Xml.Dom.XmlAttribute"]}
 DEFINE_IID!(IID_IXmlCDataSection, 1292153967, 51389, 17844, 136, 153, 4, 0, 215, 194, 198, 15);
 RT_INTERFACE!{interface IXmlCDataSection(IXmlCDataSectionVtbl): IInspectable(IInspectableVtbl) [IID_IXmlCDataSection] {
     
 }}
-RT_CLASS!{class XmlCDataSection: IXmlCDataSection}
+RT_CLASS!{class XmlCDataSection: IXmlCDataSection ["Windows.Data.Xml.Dom.XmlCDataSection"]}
 DEFINE_IID!(IID_IXmlCharacterData, 321798827, 20022, 19958, 177, 200, 12, 230, 47, 216, 139, 38);
 RT_INTERFACE!{interface IXmlCharacterData(IXmlCharacterDataVtbl): IInspectable(IInspectableVtbl) [IID_IXmlCharacterData] {
     fn get_Data(&self, out: *mut HSTRING) -> HRESULT,
@@ -1323,7 +1323,7 @@ DEFINE_IID!(IID_IXmlComment, 3164894421, 46623, 17937, 156, 172, 46, 146, 227, 7
 RT_INTERFACE!{interface IXmlComment(IXmlCommentVtbl): IInspectable(IInspectableVtbl) [IID_IXmlComment] {
     
 }}
-RT_CLASS!{class XmlComment: IXmlComment}
+RT_CLASS!{class XmlComment: IXmlComment ["Windows.Data.Xml.Dom.XmlComment"]}
 DEFINE_IID!(IID_IXmlDocument, 4159939846, 7815, 17110, 188, 251, 184, 200, 9, 250, 84, 148);
 RT_INTERFACE!{interface IXmlDocument(IXmlDocumentVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocument] {
     fn get_Doctype(&self, out: *mut *mut XmlDocumentType) -> HRESULT,
@@ -1431,7 +1431,7 @@ impl IXmlDocument {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlDocument: IXmlDocument}
+RT_CLASS!{class XmlDocument: IXmlDocument ["Windows.Data.Xml.Dom.XmlDocument"]}
 impl RtActivatable<IXmlDocumentStatics> for XmlDocument {}
 impl RtActivatable<IActivationFactory> for XmlDocument {}
 impl XmlDocument {
@@ -1453,7 +1453,7 @@ DEFINE_IID!(IID_IXmlDocumentFragment, 3807013526, 3105, 17573, 139, 201, 158, 74
 RT_INTERFACE!{interface IXmlDocumentFragment(IXmlDocumentFragmentVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocumentFragment] {
     
 }}
-RT_CLASS!{class XmlDocumentFragment: IXmlDocumentFragment}
+RT_CLASS!{class XmlDocumentFragment: IXmlDocumentFragment ["Windows.Data.Xml.Dom.XmlDocumentFragment"]}
 DEFINE_IID!(IID_IXmlDocumentIO, 1825630030, 61029, 17545, 158, 191, 202, 67, 232, 123, 166, 55);
 RT_INTERFACE!{interface IXmlDocumentIO(IXmlDocumentIOVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDocumentIO] {
     fn LoadXml(&self, xml: HSTRING) -> HRESULT,
@@ -1542,7 +1542,7 @@ impl IXmlDocumentType {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlDocumentType: IXmlDocumentType}
+RT_CLASS!{class XmlDocumentType: IXmlDocumentType ["Windows.Data.Xml.Dom.XmlDocumentType"]}
 DEFINE_IID!(IID_IXmlDomImplementation, 1843757362, 61725, 20411, 140, 198, 88, 60, 186, 147, 17, 47);
 RT_INTERFACE!{interface IXmlDomImplementation(IXmlDomImplementationVtbl): IInspectable(IInspectableVtbl) [IID_IXmlDomImplementation] {
     fn HasFeature(&self, feature: HSTRING, version: *mut IInspectable, out: *mut bool) -> HRESULT
@@ -1554,7 +1554,7 @@ impl IXmlDomImplementation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlDomImplementation: IXmlDomImplementation}
+RT_CLASS!{class XmlDomImplementation: IXmlDomImplementation ["Windows.Data.Xml.Dom.XmlDomImplementation"]}
 DEFINE_IID!(IID_IXmlElement, 771459615, 27408, 20216, 159, 131, 239, 204, 232, 250, 236, 55);
 RT_INTERFACE!{interface IXmlElement(IXmlElementVtbl): IInspectable(IInspectableVtbl) [IID_IXmlElement] {
     fn get_TagName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1634,12 +1634,12 @@ impl IXmlElement {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlElement: IXmlElement}
+RT_CLASS!{class XmlElement: IXmlElement ["Windows.Data.Xml.Dom.XmlElement"]}
 DEFINE_IID!(IID_IXmlEntityReference, 774850492, 50128, 19663, 187, 134, 10, 184, 195, 106, 97, 207);
 RT_INTERFACE!{interface IXmlEntityReference(IXmlEntityReferenceVtbl): IInspectable(IInspectableVtbl) [IID_IXmlEntityReference] {
     
 }}
-RT_CLASS!{class XmlEntityReference: IXmlEntityReference}
+RT_CLASS!{class XmlEntityReference: IXmlEntityReference ["Windows.Data.Xml.Dom.XmlEntityReference"]}
 DEFINE_IID!(IID_IXmlLoadSettings, 1487538088, 65238, 18167, 180, 197, 251, 27, 167, 33, 8, 214);
 RT_INTERFACE!{interface IXmlLoadSettings(IXmlLoadSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IXmlLoadSettings] {
     fn get_MaxElementDepth(&self, out: *mut u32) -> HRESULT,
@@ -1700,7 +1700,7 @@ impl IXmlLoadSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlLoadSettings: IXmlLoadSettings}
+RT_CLASS!{class XmlLoadSettings: IXmlLoadSettings ["Windows.Data.Xml.Dom.XmlLoadSettings"]}
 impl RtActivatable<IActivationFactory> for XmlLoadSettings {}
 DEFINE_CLSID!(XmlLoadSettings(&[87,105,110,100,111,119,115,46,68,97,116,97,46,88,109,108,46,68,111,109,46,88,109,108,76,111,97,100,83,101,116,116,105,110,103,115,0]) [CLSID_XmlLoadSettings]);
 DEFINE_IID!(IID_IXmlNamedNodeMap, 3014041264, 43696, 19330, 166, 250, 177, 69, 63, 124, 2, 27);
@@ -1756,7 +1756,7 @@ impl IXmlNamedNodeMap {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlNamedNodeMap: IXmlNamedNodeMap}
+RT_CLASS!{class XmlNamedNodeMap: IXmlNamedNodeMap ["Windows.Data.Xml.Dom.XmlNamedNodeMap"]}
 DEFINE_IID!(IID_IXmlNode, 477371737, 8482, 18389, 168, 86, 131, 243, 212, 33, 72, 117);
 RT_INTERFACE!{interface IXmlNode(IXmlNodeVtbl): IInspectable(IInspectableVtbl) [IID_IXmlNode] {
     fn get_NodeValue(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -1914,7 +1914,7 @@ impl IXmlNodeList {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlNodeList: IXmlNodeList}
+RT_CLASS!{class XmlNodeList: IXmlNodeList ["Windows.Data.Xml.Dom.XmlNodeList"]}
 DEFINE_IID!(IID_IXmlNodeSelector, 1675344523, 53467, 20449, 183, 69, 249, 67, 58, 253, 194, 91);
 RT_INTERFACE!{interface IXmlNodeSelector(IXmlNodeSelectorVtbl): IInspectable(IInspectableVtbl) [IID_IXmlNodeSelector] {
     fn SelectSingleNode(&self, xpath: HSTRING, out: *mut *mut IXmlNode) -> HRESULT,
@@ -1988,7 +1988,7 @@ impl IXmlProcessingInstruction {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlProcessingInstruction: IXmlProcessingInstruction}
+RT_CLASS!{class XmlProcessingInstruction: IXmlProcessingInstruction ["Windows.Data.Xml.Dom.XmlProcessingInstruction"]}
 DEFINE_IID!(IID_IXmlText, 4180780235, 12429, 18272, 161, 213, 67, 182, 116, 80, 172, 126);
 RT_INTERFACE!{interface IXmlText(IXmlTextVtbl): IInspectable(IInspectableVtbl) [IID_IXmlText] {
     fn SplitText(&self, offset: u32, out: *mut *mut IXmlText) -> HRESULT
@@ -2000,7 +2000,7 @@ impl IXmlText {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XmlText: IXmlText}
+RT_CLASS!{class XmlText: IXmlText ["Windows.Data.Xml.Dom.XmlText"]}
 } // Windows.Data.Xml.Dom
 pub mod xsl { // Windows.Data.Xml.Xsl
 use ::prelude::*;
@@ -2015,7 +2015,7 @@ impl IXsltProcessor {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XsltProcessor: IXsltProcessor}
+RT_CLASS!{class XsltProcessor: IXsltProcessor ["Windows.Data.Xml.Xsl.XsltProcessor"]}
 impl RtActivatable<IXsltProcessorFactory> for XsltProcessor {}
 impl XsltProcessor {
     #[inline] pub fn create_instance(document: &super::dom::XmlDocument) -> Result<ComPtr<XsltProcessor>> {

--- a/src/rt/gen/windows/devices.rs
+++ b/src/rt/gen/windows/devices.rs
@@ -34,7 +34,7 @@ impl ILowLevelDevicesAggregateProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLevelDevicesAggregateProvider: ILowLevelDevicesAggregateProvider}
+RT_CLASS!{class LowLevelDevicesAggregateProvider: ILowLevelDevicesAggregateProvider ["Windows.Devices.LowLevelDevicesAggregateProvider"]}
 impl RtActivatable<ILowLevelDevicesAggregateProviderFactory> for LowLevelDevicesAggregateProvider {}
 impl LowLevelDevicesAggregateProvider {
     #[inline] pub fn create(adc: &adc::provider::IAdcControllerProvider, pwm: &pwm::provider::IPwmControllerProvider, gpio: &gpio::provider::IGpioControllerProvider, i2c: &i2c::provider::II2cControllerProvider, spi: &spi::provider::ISpiControllerProvider) -> Result<ComPtr<LowLevelDevicesAggregateProvider>> {
@@ -57,7 +57,7 @@ DEFINE_IID!(IID_ILowLevelDevicesController, 784481748, 6043, 17886, 155, 57, 58,
 RT_INTERFACE!{interface ILowLevelDevicesController(ILowLevelDevicesControllerVtbl): IInspectable(IInspectableVtbl) [IID_ILowLevelDevicesController] {
     
 }}
-RT_CLASS!{class LowLevelDevicesController: ILowLevelDevicesController}
+RT_CLASS!{class LowLevelDevicesController: ILowLevelDevicesController ["Windows.Devices.LowLevelDevicesController"]}
 impl RtActivatable<ILowLevelDevicesControllerStatics> for LowLevelDevicesController {}
 impl LowLevelDevicesController {
     #[inline] pub fn get_default_provider() -> Result<Option<ComPtr<ILowLevelDevicesAggregateProvider>>> {
@@ -109,8 +109,8 @@ impl IAdcChannel {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdcChannel: IAdcChannel}
-RT_ENUM! { enum AdcChannelMode: i32 {
+RT_CLASS!{class AdcChannel: IAdcChannel ["Windows.Devices.Adc.AdcChannel"]}
+RT_ENUM! { enum AdcChannelMode: i32 ["Windows.Devices.Adc.AdcChannelMode"] {
     SingleEnded (AdcChannelMode_SingleEnded) = 0, Differential (AdcChannelMode_Differential) = 1,
 }}
 DEFINE_IID!(IID_IAdcController, 712434864, 43158, 16921, 134, 182, 234, 140, 220, 233, 143, 86);
@@ -165,7 +165,7 @@ impl IAdcController {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdcController: IAdcController}
+RT_CLASS!{class AdcController: IAdcController ["Windows.Devices.Adc.AdcController"]}
 impl RtActivatable<IAdcControllerStatics> for AdcController {}
 impl RtActivatable<IAdcControllerStatics2> for AdcController {}
 impl AdcController {
@@ -274,7 +274,7 @@ impl IAdcProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProviderAdcChannelMode: i32 {
+RT_ENUM! { enum ProviderAdcChannelMode: i32 ["Windows.Devices.Adc.Provider.ProviderAdcChannelMode"] {
     SingleEnded (ProviderAdcChannelMode_SingleEnded) = 0, Differential (ProviderAdcChannelMode_Differential) = 1,
 }}
 } // Windows.Devices.Adc.Provider
@@ -403,7 +403,7 @@ impl IAllJoynAboutData {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynAboutData: IAllJoynAboutData}
+RT_CLASS!{class AllJoynAboutData: IAllJoynAboutData ["Windows.Devices.AllJoyn.AllJoynAboutData"]}
 DEFINE_IID!(IID_IAllJoynAboutDataView, 1747128607, 25106, 18740, 156, 72, 225, 156, 164, 152, 66, 136);
 RT_INTERFACE!{interface IAllJoynAboutDataView(IAllJoynAboutDataViewVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynAboutDataView] {
     fn get_Status(&self, out: *mut i32) -> HRESULT,
@@ -507,7 +507,7 @@ impl IAllJoynAboutDataView {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynAboutDataView: IAllJoynAboutDataView}
+RT_CLASS!{class AllJoynAboutDataView: IAllJoynAboutDataView ["Windows.Devices.AllJoyn.AllJoynAboutDataView"]}
 impl RtActivatable<IAllJoynAboutDataViewStatics> for AllJoynAboutDataView {}
 impl AllJoynAboutDataView {
     #[inline] pub fn get_data_by_session_port_async(uniqueName: &HStringArg, busAttachment: &AllJoynBusAttachment, sessionPort: u16) -> Result<ComPtr<foundation::IAsyncOperation<AllJoynAboutDataView>>> {
@@ -585,7 +585,7 @@ impl IAllJoynAcceptSessionJoinerEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynAcceptSessionJoinerEventArgs: IAllJoynAcceptSessionJoinerEventArgs}
+RT_CLASS!{class AllJoynAcceptSessionJoinerEventArgs: IAllJoynAcceptSessionJoinerEventArgs ["Windows.Devices.AllJoyn.AllJoynAcceptSessionJoinerEventArgs"]}
 impl RtActivatable<IAllJoynAcceptSessionJoinerEventArgsFactory> for AllJoynAcceptSessionJoinerEventArgs {}
 impl AllJoynAcceptSessionJoinerEventArgs {
     #[inline] pub fn create(uniqueName: &HStringArg, sessionPort: u16, trafficType: AllJoynTrafficType, proximity: u8, acceptSessionJoiner: &IAllJoynAcceptSessionJoiner) -> Result<ComPtr<AllJoynAcceptSessionJoinerEventArgs>> {
@@ -627,8 +627,8 @@ impl IAllJoynAuthenticationCompleteEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynAuthenticationCompleteEventArgs: IAllJoynAuthenticationCompleteEventArgs}
-RT_ENUM! { enum AllJoynAuthenticationMechanism: i32 {
+RT_CLASS!{class AllJoynAuthenticationCompleteEventArgs: IAllJoynAuthenticationCompleteEventArgs ["Windows.Devices.AllJoyn.AllJoynAuthenticationCompleteEventArgs"]}
+RT_ENUM! { enum AllJoynAuthenticationMechanism: i32 ["Windows.Devices.AllJoyn.AllJoynAuthenticationMechanism"] {
     None (AllJoynAuthenticationMechanism_None) = 0, SrpAnonymous (AllJoynAuthenticationMechanism_SrpAnonymous) = 1, SrpLogon (AllJoynAuthenticationMechanism_SrpLogon) = 2, EcdheNull (AllJoynAuthenticationMechanism_EcdheNull) = 3, EcdhePsk (AllJoynAuthenticationMechanism_EcdhePsk) = 4, EcdheEcdsa (AllJoynAuthenticationMechanism_EcdheEcdsa) = 5, EcdheSpeke (AllJoynAuthenticationMechanism_EcdheSpeke) = 6,
 }}
 DEFINE_IID!(IID_IAllJoynBusAttachment, 4077515091, 7917, 17091, 162, 14, 67, 109, 65, 254, 98, 246);
@@ -726,7 +726,7 @@ impl IAllJoynBusAttachment {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynBusAttachment: IAllJoynBusAttachment}
+RT_CLASS!{class AllJoynBusAttachment: IAllJoynBusAttachment ["Windows.Devices.AllJoyn.AllJoynBusAttachment"]}
 impl RtActivatable<IAllJoynBusAttachmentFactory> for AllJoynBusAttachment {}
 impl RtActivatable<IAllJoynBusAttachmentStatics> for AllJoynBusAttachment {}
 impl RtActivatable<IActivationFactory> for AllJoynBusAttachment {}
@@ -793,7 +793,7 @@ impl IAllJoynBusAttachmentFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AllJoynBusAttachmentState: i32 {
+RT_ENUM! { enum AllJoynBusAttachmentState: i32 ["Windows.Devices.AllJoyn.AllJoynBusAttachmentState"] {
     Disconnected (AllJoynBusAttachmentState_Disconnected) = 0, Connecting (AllJoynBusAttachmentState_Connecting) = 1, Connected (AllJoynBusAttachmentState_Connected) = 2, Disconnecting (AllJoynBusAttachmentState_Disconnecting) = 3,
 }}
 DEFINE_IID!(IID_IAllJoynBusAttachmentStateChangedEventArgs, 3626923508, 49194, 16876, 168, 213, 234, 177, 85, 137, 83, 170);
@@ -813,7 +813,7 @@ impl IAllJoynBusAttachmentStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynBusAttachmentStateChangedEventArgs: IAllJoynBusAttachmentStateChangedEventArgs}
+RT_CLASS!{class AllJoynBusAttachmentStateChangedEventArgs: IAllJoynBusAttachmentStateChangedEventArgs ["Windows.Devices.AllJoyn.AllJoynBusAttachmentStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAllJoynBusAttachmentStatics, 2208124221, 4177, 16599, 135, 42, 141, 1, 65, 17, 91, 31);
 RT_INTERFACE!{static interface IAllJoynBusAttachmentStatics(IAllJoynBusAttachmentStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynBusAttachmentStatics] {
     fn GetDefault(&self, out: *mut *mut AllJoynBusAttachment) -> HRESULT,
@@ -874,7 +874,7 @@ impl IAllJoynBusObject {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynBusObject: IAllJoynBusObject}
+RT_CLASS!{class AllJoynBusObject: IAllJoynBusObject ["Windows.Devices.AllJoyn.AllJoynBusObject"]}
 impl RtActivatable<IAllJoynBusObjectFactory> for AllJoynBusObject {}
 impl RtActivatable<IActivationFactory> for AllJoynBusObject {}
 impl AllJoynBusObject {
@@ -914,7 +914,7 @@ impl IAllJoynBusObjectStoppedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynBusObjectStoppedEventArgs: IAllJoynBusObjectStoppedEventArgs}
+RT_CLASS!{class AllJoynBusObjectStoppedEventArgs: IAllJoynBusObjectStoppedEventArgs ["Windows.Devices.AllJoyn.AllJoynBusObjectStoppedEventArgs"]}
 impl RtActivatable<IAllJoynBusObjectStoppedEventArgsFactory> for AllJoynBusObjectStoppedEventArgs {}
 impl AllJoynBusObjectStoppedEventArgs {
     #[inline] pub fn create(status: i32) -> Result<ComPtr<AllJoynBusObjectStoppedEventArgs>> {
@@ -981,7 +981,7 @@ impl IAllJoynCredentials {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynCredentials: IAllJoynCredentials}
+RT_CLASS!{class AllJoynCredentials: IAllJoynCredentials ["Windows.Devices.AllJoyn.AllJoynCredentials"]}
 DEFINE_IID!(IID_IAllJoynCredentialsRequestedEventArgs, 1787290446, 45161, 19328, 158, 26, 65, 188, 131, 124, 101, 210);
 RT_INTERFACE!{interface IAllJoynCredentialsRequestedEventArgs(IAllJoynCredentialsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynCredentialsRequestedEventArgs] {
     fn get_AttemptCount(&self, out: *mut u16) -> HRESULT,
@@ -1017,7 +1017,7 @@ impl IAllJoynCredentialsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynCredentialsRequestedEventArgs: IAllJoynCredentialsRequestedEventArgs}
+RT_CLASS!{class AllJoynCredentialsRequestedEventArgs: IAllJoynCredentialsRequestedEventArgs ["Windows.Devices.AllJoyn.AllJoynCredentialsRequestedEventArgs"]}
 DEFINE_IID!(IID_IAllJoynCredentialsVerificationRequestedEventArgs, 2148169234, 47109, 17583, 162, 225, 121, 42, 182, 85, 162, 208);
 RT_INTERFACE!{interface IAllJoynCredentialsVerificationRequestedEventArgs(IAllJoynCredentialsVerificationRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynCredentialsVerificationRequestedEventArgs] {
     fn get_AuthenticationMechanism(&self, out: *mut AllJoynAuthenticationMechanism) -> HRESULT,
@@ -1074,7 +1074,7 @@ impl IAllJoynCredentialsVerificationRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynCredentialsVerificationRequestedEventArgs: IAllJoynCredentialsVerificationRequestedEventArgs}
+RT_CLASS!{class AllJoynCredentialsVerificationRequestedEventArgs: IAllJoynCredentialsVerificationRequestedEventArgs ["Windows.Devices.AllJoyn.AllJoynCredentialsVerificationRequestedEventArgs"]}
 DEFINE_IID!(IID_IAllJoynMessageInfo, 4281008423, 11282, 18521, 170, 58, 199, 68, 97, 238, 129, 76);
 RT_INTERFACE!{interface IAllJoynMessageInfo(IAllJoynMessageInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAllJoynMessageInfo] {
     fn get_SenderUniqueName(&self, out: *mut HSTRING) -> HRESULT
@@ -1086,7 +1086,7 @@ impl IAllJoynMessageInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynMessageInfo: IAllJoynMessageInfo}
+RT_CLASS!{class AllJoynMessageInfo: IAllJoynMessageInfo ["Windows.Devices.AllJoyn.AllJoynMessageInfo"]}
 impl RtActivatable<IAllJoynMessageInfoFactory> for AllJoynMessageInfo {}
 impl AllJoynMessageInfo {
     #[inline] pub fn create(senderUniqueName: &HStringArg) -> Result<ComPtr<AllJoynMessageInfo>> {
@@ -1126,7 +1126,7 @@ impl IAllJoynProducerStoppedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynProducerStoppedEventArgs: IAllJoynProducerStoppedEventArgs}
+RT_CLASS!{class AllJoynProducerStoppedEventArgs: IAllJoynProducerStoppedEventArgs ["Windows.Devices.AllJoyn.AllJoynProducerStoppedEventArgs"]}
 impl RtActivatable<IAllJoynProducerStoppedEventArgsFactory> for AllJoynProducerStoppedEventArgs {}
 impl AllJoynProducerStoppedEventArgs {
     #[inline] pub fn create(status: i32) -> Result<ComPtr<AllJoynProducerStoppedEventArgs>> {
@@ -1168,7 +1168,7 @@ impl IAllJoynServiceInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynServiceInfo: IAllJoynServiceInfo}
+RT_CLASS!{class AllJoynServiceInfo: IAllJoynServiceInfo ["Windows.Devices.AllJoyn.AllJoynServiceInfo"]}
 impl RtActivatable<IAllJoynServiceInfoFactory> for AllJoynServiceInfo {}
 impl RtActivatable<IAllJoynServiceInfoStatics> for AllJoynServiceInfo {}
 impl AllJoynServiceInfo {
@@ -1202,7 +1202,7 @@ impl IAllJoynServiceInfoRemovedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynServiceInfoRemovedEventArgs: IAllJoynServiceInfoRemovedEventArgs}
+RT_CLASS!{class AllJoynServiceInfoRemovedEventArgs: IAllJoynServiceInfoRemovedEventArgs ["Windows.Devices.AllJoyn.AllJoynServiceInfoRemovedEventArgs"]}
 impl RtActivatable<IAllJoynServiceInfoRemovedEventArgsFactory> for AllJoynServiceInfoRemovedEventArgs {}
 impl AllJoynServiceInfoRemovedEventArgs {
     #[inline] pub fn create(uniqueName: &HStringArg) -> Result<ComPtr<AllJoynServiceInfoRemovedEventArgs>> {
@@ -1288,7 +1288,7 @@ impl IAllJoynSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynSession: IAllJoynSession}
+RT_CLASS!{class AllJoynSession: IAllJoynSession ["Windows.Devices.AllJoyn.AllJoynSession"]}
 impl RtActivatable<IAllJoynSessionStatics> for AllJoynSession {}
 impl AllJoynSession {
     #[inline] pub fn get_from_service_info_async(serviceInfo: &AllJoynServiceInfo) -> Result<ComPtr<foundation::IAsyncOperation<AllJoynSession>>> {
@@ -1310,7 +1310,7 @@ impl IAllJoynSessionJoinedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynSessionJoinedEventArgs: IAllJoynSessionJoinedEventArgs}
+RT_CLASS!{class AllJoynSessionJoinedEventArgs: IAllJoynSessionJoinedEventArgs ["Windows.Devices.AllJoyn.AllJoynSessionJoinedEventArgs"]}
 impl RtActivatable<IAllJoynSessionJoinedEventArgsFactory> for AllJoynSessionJoinedEventArgs {}
 impl AllJoynSessionJoinedEventArgs {
     #[inline] pub fn create(session: &AllJoynSession) -> Result<ComPtr<AllJoynSessionJoinedEventArgs>> {
@@ -1340,7 +1340,7 @@ impl IAllJoynSessionLostEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynSessionLostEventArgs: IAllJoynSessionLostEventArgs}
+RT_CLASS!{class AllJoynSessionLostEventArgs: IAllJoynSessionLostEventArgs ["Windows.Devices.AllJoyn.AllJoynSessionLostEventArgs"]}
 impl RtActivatable<IAllJoynSessionLostEventArgsFactory> for AllJoynSessionLostEventArgs {}
 impl AllJoynSessionLostEventArgs {
     #[inline] pub fn create(reason: AllJoynSessionLostReason) -> Result<ComPtr<AllJoynSessionLostEventArgs>> {
@@ -1359,7 +1359,7 @@ impl IAllJoynSessionLostEventArgsFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AllJoynSessionLostReason: i32 {
+RT_ENUM! { enum AllJoynSessionLostReason: i32 ["Windows.Devices.AllJoyn.AllJoynSessionLostReason"] {
     None (AllJoynSessionLostReason_None) = 0, ProducerLeftSession (AllJoynSessionLostReason_ProducerLeftSession) = 1, ProducerClosedAbruptly (AllJoynSessionLostReason_ProducerClosedAbruptly) = 2, RemovedByProducer (AllJoynSessionLostReason_RemovedByProducer) = 3, LinkTimeout (AllJoynSessionLostReason_LinkTimeout) = 4, Other (AllJoynSessionLostReason_Other) = 5,
 }}
 DEFINE_IID!(IID_IAllJoynSessionMemberAddedEventArgs, 1235384714, 3537, 18113, 156, 214, 39, 25, 14, 80, 58, 94);
@@ -1373,7 +1373,7 @@ impl IAllJoynSessionMemberAddedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynSessionMemberAddedEventArgs: IAllJoynSessionMemberAddedEventArgs}
+RT_CLASS!{class AllJoynSessionMemberAddedEventArgs: IAllJoynSessionMemberAddedEventArgs ["Windows.Devices.AllJoyn.AllJoynSessionMemberAddedEventArgs"]}
 impl RtActivatable<IAllJoynSessionMemberAddedEventArgsFactory> for AllJoynSessionMemberAddedEventArgs {}
 impl AllJoynSessionMemberAddedEventArgs {
     #[inline] pub fn create(uniqueName: &HStringArg) -> Result<ComPtr<AllJoynSessionMemberAddedEventArgs>> {
@@ -1403,7 +1403,7 @@ impl IAllJoynSessionMemberRemovedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynSessionMemberRemovedEventArgs: IAllJoynSessionMemberRemovedEventArgs}
+RT_CLASS!{class AllJoynSessionMemberRemovedEventArgs: IAllJoynSessionMemberRemovedEventArgs ["Windows.Devices.AllJoyn.AllJoynSessionMemberRemovedEventArgs"]}
 impl RtActivatable<IAllJoynSessionMemberRemovedEventArgsFactory> for AllJoynSessionMemberRemovedEventArgs {}
 impl AllJoynSessionMemberRemovedEventArgs {
     #[inline] pub fn create(uniqueName: &HStringArg) -> Result<ComPtr<AllJoynSessionMemberRemovedEventArgs>> {
@@ -1611,7 +1611,7 @@ impl IAllJoynStatusStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AllJoynTrafficType: i32 {
+RT_ENUM! { enum AllJoynTrafficType: i32 ["Windows.Devices.AllJoyn.AllJoynTrafficType"] {
     Unknown (AllJoynTrafficType_Unknown) = 0, Messages (AllJoynTrafficType_Messages) = 1, RawUnreliable (AllJoynTrafficType_RawUnreliable) = 2, RawReliable (AllJoynTrafficType_RawReliable) = 4,
 }}
 DEFINE_IID!(IID_IAllJoynWatcherStoppedEventArgs, 3388776507, 28701, 19112, 151, 221, 162, 187, 10, 143, 95, 163);
@@ -1625,7 +1625,7 @@ impl IAllJoynWatcherStoppedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AllJoynWatcherStoppedEventArgs: IAllJoynWatcherStoppedEventArgs}
+RT_CLASS!{class AllJoynWatcherStoppedEventArgs: IAllJoynWatcherStoppedEventArgs ["Windows.Devices.AllJoyn.AllJoynWatcherStoppedEventArgs"]}
 impl RtActivatable<IAllJoynWatcherStoppedEventArgsFactory> for AllJoynWatcherStoppedEventArgs {}
 impl AllJoynWatcherStoppedEventArgs {
     #[inline] pub fn create(status: i32) -> Result<ComPtr<AllJoynWatcherStoppedEventArgs>> {
@@ -1670,7 +1670,7 @@ impl IDeviceServicingDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceServicingDetails: IDeviceServicingDetails}
+RT_CLASS!{class DeviceServicingDetails: IDeviceServicingDetails ["Windows.Devices.Background.DeviceServicingDetails"]}
 DEFINE_IID!(IID_IDeviceUseDetails, 2102808897, 21886, 16724, 185, 148, 228, 247, 161, 31, 179, 35);
 RT_INTERFACE!{interface IDeviceUseDetails(IDeviceUseDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceUseDetails] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -1688,7 +1688,7 @@ impl IDeviceUseDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceUseDetails: IDeviceUseDetails}
+RT_CLASS!{class DeviceUseDetails: IDeviceUseDetails ["Windows.Devices.Background.DeviceUseDetails"]}
 } // Windows.Devices.Background
 pub mod bluetooth { // Windows.Devices.Bluetooth
 use ::prelude::*;
@@ -1745,7 +1745,7 @@ impl IBluetoothAdapter {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothAdapter: IBluetoothAdapter}
+RT_CLASS!{class BluetoothAdapter: IBluetoothAdapter ["Windows.Devices.Bluetooth.BluetoothAdapter"]}
 impl RtActivatable<IBluetoothAdapterStatics> for BluetoothAdapter {}
 impl BluetoothAdapter {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -1799,10 +1799,10 @@ impl IBluetoothAdapterStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothAddressType: i32 {
+RT_ENUM! { enum BluetoothAddressType: i32 ["Windows.Devices.Bluetooth.BluetoothAddressType"] {
     Public (BluetoothAddressType_Public) = 0, Random (BluetoothAddressType_Random) = 1, Unspecified (BluetoothAddressType_Unspecified) = 2,
 }}
-RT_ENUM! { enum BluetoothCacheMode: i32 {
+RT_ENUM! { enum BluetoothCacheMode: i32 ["Windows.Devices.Bluetooth.BluetoothCacheMode"] {
     Cached (BluetoothCacheMode_Cached) = 0, Uncached (BluetoothCacheMode_Uncached) = 1,
 }}
 DEFINE_IID!(IID_IBluetoothClassOfDevice, 3594527358, 55255, 18017, 148, 84, 101, 3, 156, 161, 122, 43);
@@ -1834,7 +1834,7 @@ impl IBluetoothClassOfDevice {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothClassOfDevice: IBluetoothClassOfDevice}
+RT_CLASS!{class BluetoothClassOfDevice: IBluetoothClassOfDevice ["Windows.Devices.Bluetooth.BluetoothClassOfDevice"]}
 impl RtActivatable<IBluetoothClassOfDeviceStatics> for BluetoothClassOfDevice {}
 impl BluetoothClassOfDevice {
     #[inline] pub fn from_raw_value(rawValue: u32) -> Result<Option<ComPtr<BluetoothClassOfDevice>>> {
@@ -1862,7 +1862,7 @@ impl IBluetoothClassOfDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothConnectionStatus: i32 {
+RT_ENUM! { enum BluetoothConnectionStatus: i32 ["Windows.Devices.Bluetooth.BluetoothConnectionStatus"] {
     Disconnected (BluetoothConnectionStatus_Disconnected) = 0, Connected (BluetoothConnectionStatus_Connected) = 1,
 }}
 DEFINE_IID!(IID_IBluetoothDevice, 590721366, 37074, 18948, 174, 245, 14, 32, 185, 230, 183, 7);
@@ -1953,7 +1953,7 @@ impl IBluetoothDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothDevice: IBluetoothDevice}
+RT_CLASS!{class BluetoothDevice: IBluetoothDevice ["Windows.Devices.Bluetooth.BluetoothDevice"]}
 impl RtActivatable<IBluetoothDeviceStatics> for BluetoothDevice {}
 impl RtActivatable<IBluetoothDeviceStatics2> for BluetoothDevice {}
 impl BluetoothDevice {
@@ -2083,7 +2083,7 @@ impl IBluetoothDeviceId {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothDeviceId: IBluetoothDeviceId}
+RT_CLASS!{class BluetoothDeviceId: IBluetoothDeviceId ["Windows.Devices.Bluetooth.BluetoothDeviceId"]}
 impl RtActivatable<IBluetoothDeviceIdStatics> for BluetoothDeviceId {}
 impl BluetoothDeviceId {
     #[inline] pub fn from_id(deviceId: &HStringArg) -> Result<Option<ComPtr<BluetoothDeviceId>>> {
@@ -2167,7 +2167,7 @@ impl IBluetoothDeviceStatics2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothError: i32 {
+RT_ENUM! { enum BluetoothError: i32 ["Windows.Devices.Bluetooth.BluetoothError"] {
     Success (BluetoothError_Success) = 0, RadioNotAvailable (BluetoothError_RadioNotAvailable) = 1, ResourceInUse (BluetoothError_ResourceInUse) = 2, DeviceNotConnected (BluetoothError_DeviceNotConnected) = 3, OtherError (BluetoothError_OtherError) = 4, DisabledByPolicy (BluetoothError_DisabledByPolicy) = 5, NotSupported (BluetoothError_NotSupported) = 6, DisabledByUser (BluetoothError_DisabledByUser) = 7, ConsentRequired (BluetoothError_ConsentRequired) = 8, TransportNotSupported (BluetoothError_TransportNotSupported) = 9,
 }}
 DEFINE_IID!(IID_IBluetoothLEAppearance, 1562409458, 26280, 16984, 152, 94, 2, 180, 217, 80, 159, 24);
@@ -2193,7 +2193,7 @@ impl IBluetoothLEAppearance {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAppearance: IBluetoothLEAppearance}
+RT_CLASS!{class BluetoothLEAppearance: IBluetoothLEAppearance ["Windows.Devices.Bluetooth.BluetoothLEAppearance"]}
 impl RtActivatable<IBluetoothLEAppearanceStatics> for BluetoothLEAppearance {}
 impl BluetoothLEAppearance {
     #[inline] pub fn from_raw_value(rawValue: u16) -> Result<Option<ComPtr<BluetoothLEAppearance>>> {
@@ -2765,7 +2765,7 @@ impl IBluetoothLEDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEDevice: IBluetoothLEDevice}
+RT_CLASS!{class BluetoothLEDevice: IBluetoothLEDevice ["Windows.Devices.Bluetooth.BluetoothLEDevice"]}
 impl RtActivatable<IBluetoothLEDeviceStatics> for BluetoothLEDevice {}
 impl RtActivatable<IBluetoothLEDeviceStatics2> for BluetoothLEDevice {}
 impl BluetoothLEDevice {
@@ -2957,13 +2957,13 @@ impl IBluetoothLEDeviceStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothMajorClass: i32 {
+RT_ENUM! { enum BluetoothMajorClass: i32 ["Windows.Devices.Bluetooth.BluetoothMajorClass"] {
     Miscellaneous (BluetoothMajorClass_Miscellaneous) = 0, Computer (BluetoothMajorClass_Computer) = 1, Phone (BluetoothMajorClass_Phone) = 2, NetworkAccessPoint (BluetoothMajorClass_NetworkAccessPoint) = 3, AudioVideo (BluetoothMajorClass_AudioVideo) = 4, Peripheral (BluetoothMajorClass_Peripheral) = 5, Imaging (BluetoothMajorClass_Imaging) = 6, Wearable (BluetoothMajorClass_Wearable) = 7, Toy (BluetoothMajorClass_Toy) = 8, Health (BluetoothMajorClass_Health) = 9,
 }}
-RT_ENUM! { enum BluetoothMinorClass: i32 {
+RT_ENUM! { enum BluetoothMinorClass: i32 ["Windows.Devices.Bluetooth.BluetoothMinorClass"] {
     Uncategorized (BluetoothMinorClass_Uncategorized) = 0, ComputerDesktop (BluetoothMinorClass_ComputerDesktop) = 1, ComputerServer (BluetoothMinorClass_ComputerServer) = 2, ComputerLaptop (BluetoothMinorClass_ComputerLaptop) = 3, ComputerHandheld (BluetoothMinorClass_ComputerHandheld) = 4, ComputerPalmSize (BluetoothMinorClass_ComputerPalmSize) = 5, ComputerWearable (BluetoothMinorClass_ComputerWearable) = 6, ComputerTablet (BluetoothMinorClass_ComputerTablet) = 7, PhoneCellular (BluetoothMinorClass_PhoneCellular) = 1, PhoneCordless (BluetoothMinorClass_PhoneCordless) = 2, PhoneSmartPhone (BluetoothMinorClass_PhoneSmartPhone) = 3, PhoneWired (BluetoothMinorClass_PhoneWired) = 4, PhoneIsdn (BluetoothMinorClass_PhoneIsdn) = 5, NetworkFullyAvailable (BluetoothMinorClass_NetworkFullyAvailable) = 0, NetworkUsed01To17Percent (BluetoothMinorClass_NetworkUsed01To17Percent) = 8, NetworkUsed17To33Percent (BluetoothMinorClass_NetworkUsed17To33Percent) = 16, NetworkUsed33To50Percent (BluetoothMinorClass_NetworkUsed33To50Percent) = 24, NetworkUsed50To67Percent (BluetoothMinorClass_NetworkUsed50To67Percent) = 32, NetworkUsed67To83Percent (BluetoothMinorClass_NetworkUsed67To83Percent) = 40, NetworkUsed83To99Percent (BluetoothMinorClass_NetworkUsed83To99Percent) = 48, NetworkNoServiceAvailable (BluetoothMinorClass_NetworkNoServiceAvailable) = 56, AudioVideoWearableHeadset (BluetoothMinorClass_AudioVideoWearableHeadset) = 1, AudioVideoHandsFree (BluetoothMinorClass_AudioVideoHandsFree) = 2, AudioVideoMicrophone (BluetoothMinorClass_AudioVideoMicrophone) = 4, AudioVideoLoudspeaker (BluetoothMinorClass_AudioVideoLoudspeaker) = 5, AudioVideoHeadphones (BluetoothMinorClass_AudioVideoHeadphones) = 6, AudioVideoPortableAudio (BluetoothMinorClass_AudioVideoPortableAudio) = 7, AudioVideoCarAudio (BluetoothMinorClass_AudioVideoCarAudio) = 8, AudioVideoSetTopBox (BluetoothMinorClass_AudioVideoSetTopBox) = 9, AudioVideoHifiAudioDevice (BluetoothMinorClass_AudioVideoHifiAudioDevice) = 10, AudioVideoVcr (BluetoothMinorClass_AudioVideoVcr) = 11, AudioVideoVideoCamera (BluetoothMinorClass_AudioVideoVideoCamera) = 12, AudioVideoCamcorder (BluetoothMinorClass_AudioVideoCamcorder) = 13, AudioVideoVideoMonitor (BluetoothMinorClass_AudioVideoVideoMonitor) = 14, AudioVideoVideoDisplayAndLoudspeaker (BluetoothMinorClass_AudioVideoVideoDisplayAndLoudspeaker) = 15, AudioVideoVideoConferencing (BluetoothMinorClass_AudioVideoVideoConferencing) = 16, AudioVideoGamingOrToy (BluetoothMinorClass_AudioVideoGamingOrToy) = 18, PeripheralJoystick (BluetoothMinorClass_PeripheralJoystick) = 1, PeripheralGamepad (BluetoothMinorClass_PeripheralGamepad) = 2, PeripheralRemoteControl (BluetoothMinorClass_PeripheralRemoteControl) = 3, PeripheralSensing (BluetoothMinorClass_PeripheralSensing) = 4, PeripheralDigitizerTablet (BluetoothMinorClass_PeripheralDigitizerTablet) = 5, PeripheralCardReader (BluetoothMinorClass_PeripheralCardReader) = 6, PeripheralDigitalPen (BluetoothMinorClass_PeripheralDigitalPen) = 7, PeripheralHandheldScanner (BluetoothMinorClass_PeripheralHandheldScanner) = 8, PeripheralHandheldGesture (BluetoothMinorClass_PeripheralHandheldGesture) = 9, WearableWristwatch (BluetoothMinorClass_WearableWristwatch) = 1, WearablePager (BluetoothMinorClass_WearablePager) = 2, WearableJacket (BluetoothMinorClass_WearableJacket) = 3, WearableHelmet (BluetoothMinorClass_WearableHelmet) = 4, WearableGlasses (BluetoothMinorClass_WearableGlasses) = 5, ToyRobot (BluetoothMinorClass_ToyRobot) = 1, ToyVehicle (BluetoothMinorClass_ToyVehicle) = 2, ToyDoll (BluetoothMinorClass_ToyDoll) = 3, ToyController (BluetoothMinorClass_ToyController) = 4, ToyGame (BluetoothMinorClass_ToyGame) = 5, HealthBloodPressureMonitor (BluetoothMinorClass_HealthBloodPressureMonitor) = 1, HealthThermometer (BluetoothMinorClass_HealthThermometer) = 2, HealthWeighingScale (BluetoothMinorClass_HealthWeighingScale) = 3, HealthGlucoseMeter (BluetoothMinorClass_HealthGlucoseMeter) = 4, HealthPulseOximeter (BluetoothMinorClass_HealthPulseOximeter) = 5, HealthHeartRateMonitor (BluetoothMinorClass_HealthHeartRateMonitor) = 6, HealthHealthDataDisplay (BluetoothMinorClass_HealthHealthDataDisplay) = 7, HealthStepCounter (BluetoothMinorClass_HealthStepCounter) = 8, HealthBodyCompositionAnalyzer (BluetoothMinorClass_HealthBodyCompositionAnalyzer) = 9, HealthPeakFlowMonitor (BluetoothMinorClass_HealthPeakFlowMonitor) = 10, HealthMedicationMonitor (BluetoothMinorClass_HealthMedicationMonitor) = 11, HealthKneeProsthesis (BluetoothMinorClass_HealthKneeProsthesis) = 12, HealthAnkleProsthesis (BluetoothMinorClass_HealthAnkleProsthesis) = 13, HealthGenericHealthManager (BluetoothMinorClass_HealthGenericHealthManager) = 14, HealthPersonalMobilityDevice (BluetoothMinorClass_HealthPersonalMobilityDevice) = 15,
 }}
-RT_ENUM! { enum BluetoothServiceCapabilities: u32 {
+RT_ENUM! { enum BluetoothServiceCapabilities: u32 ["Windows.Devices.Bluetooth.BluetoothServiceCapabilities"] {
     None (BluetoothServiceCapabilities_None) = 0, LimitedDiscoverableMode (BluetoothServiceCapabilities_LimitedDiscoverableMode) = 1, PositioningService (BluetoothServiceCapabilities_PositioningService) = 8, NetworkingService (BluetoothServiceCapabilities_NetworkingService) = 16, RenderingService (BluetoothServiceCapabilities_RenderingService) = 32, CapturingService (BluetoothServiceCapabilities_CapturingService) = 64, ObjectTransferService (BluetoothServiceCapabilities_ObjectTransferService) = 128, AudioService (BluetoothServiceCapabilities_AudioService) = 256, TelephoneService (BluetoothServiceCapabilities_TelephoneService) = 512, InformationService (BluetoothServiceCapabilities_InformationService) = 1024,
 }}
 DEFINE_IID!(IID_IBluetoothSignalStrengthFilter, 3749409681, 27573, 19710, 144, 177, 93, 115, 36, 237, 207, 127);
@@ -3015,7 +3015,7 @@ impl IBluetoothSignalStrengthFilter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothSignalStrengthFilter: IBluetoothSignalStrengthFilter}
+RT_CLASS!{class BluetoothSignalStrengthFilter: IBluetoothSignalStrengthFilter ["Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter"]}
 impl RtActivatable<IActivationFactory> for BluetoothSignalStrengthFilter {}
 DEFINE_CLSID!(BluetoothSignalStrengthFilter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,66,108,117,101,116,111,111,116,104,83,105,103,110,97,108,83,116,114,101,110,103,116,104,70,105,108,116,101,114,0]) [CLSID_BluetoothSignalStrengthFilter]);
 RT_CLASS!{static class BluetoothUuidHelper}
@@ -3105,7 +3105,7 @@ impl IBluetoothLEAdvertisement {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisement: IBluetoothLEAdvertisement}
+RT_CLASS!{class BluetoothLEAdvertisement: IBluetoothLEAdvertisement ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement"]}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisement {}
 DEFINE_CLSID!(BluetoothLEAdvertisement(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,0]) [CLSID_BluetoothLEAdvertisement]);
 DEFINE_IID!(IID_IBluetoothLEAdvertisementBytePattern, 4227520498, 47557, 18952, 188, 81, 80, 47, 142, 246, 138, 121);
@@ -3146,7 +3146,7 @@ impl IBluetoothLEAdvertisementBytePattern {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementBytePattern: IBluetoothLEAdvertisementBytePattern}
+RT_CLASS!{class BluetoothLEAdvertisementBytePattern: IBluetoothLEAdvertisementBytePattern ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementBytePattern"]}
 impl RtActivatable<IBluetoothLEAdvertisementBytePatternFactory> for BluetoothLEAdvertisementBytePattern {}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementBytePattern {}
 impl BluetoothLEAdvertisementBytePattern {
@@ -3193,7 +3193,7 @@ impl IBluetoothLEAdvertisementDataSection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementDataSection: IBluetoothLEAdvertisementDataSection}
+RT_CLASS!{class BluetoothLEAdvertisementDataSection: IBluetoothLEAdvertisementDataSection ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataSection"]}
 impl RtActivatable<IBluetoothLEAdvertisementDataSectionFactory> for BluetoothLEAdvertisementDataSection {}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementDataSection {}
 impl BluetoothLEAdvertisementDataSection {
@@ -3443,10 +3443,10 @@ impl IBluetoothLEAdvertisementFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementFilter: IBluetoothLEAdvertisementFilter}
+RT_CLASS!{class BluetoothLEAdvertisementFilter: IBluetoothLEAdvertisementFilter ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFilter"]}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementFilter {}
 DEFINE_CLSID!(BluetoothLEAdvertisementFilter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,65,100,118,101,114,116,105,115,101,109,101,110,116,46,66,108,117,101,116,111,111,116,104,76,69,65,100,118,101,114,116,105,115,101,109,101,110,116,70,105,108,116,101,114,0]) [CLSID_BluetoothLEAdvertisementFilter]);
-RT_ENUM! { enum BluetoothLEAdvertisementFlags: u32 {
+RT_ENUM! { enum BluetoothLEAdvertisementFlags: u32 ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFlags"] {
     None (BluetoothLEAdvertisementFlags_None) = 0, LimitedDiscoverableMode (BluetoothLEAdvertisementFlags_LimitedDiscoverableMode) = 1, GeneralDiscoverableMode (BluetoothLEAdvertisementFlags_GeneralDiscoverableMode) = 2, ClassicNotSupported (BluetoothLEAdvertisementFlags_ClassicNotSupported) = 4, DualModeControllerCapable (BluetoothLEAdvertisementFlags_DualModeControllerCapable) = 8, DualModeHostCapable (BluetoothLEAdvertisementFlags_DualModeHostCapable) = 16,
 }}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementPublisher, 3454542073, 55802, 17366, 162, 100, 221, 216, 183, 218, 139, 120);
@@ -3487,7 +3487,7 @@ impl IBluetoothLEAdvertisementPublisher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementPublisher: IBluetoothLEAdvertisementPublisher}
+RT_CLASS!{class BluetoothLEAdvertisementPublisher: IBluetoothLEAdvertisementPublisher ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher"]}
 impl RtActivatable<IBluetoothLEAdvertisementPublisherFactory> for BluetoothLEAdvertisementPublisher {}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementPublisher {}
 impl BluetoothLEAdvertisementPublisher {
@@ -3507,7 +3507,7 @@ impl IBluetoothLEAdvertisementPublisherFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothLEAdvertisementPublisherStatus: i32 {
+RT_ENUM! { enum BluetoothLEAdvertisementPublisherStatus: i32 ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisherStatus"] {
     Created (BluetoothLEAdvertisementPublisherStatus_Created) = 0, Waiting (BluetoothLEAdvertisementPublisherStatus_Waiting) = 1, Started (BluetoothLEAdvertisementPublisherStatus_Started) = 2, Stopping (BluetoothLEAdvertisementPublisherStatus_Stopping) = 3, Stopped (BluetoothLEAdvertisementPublisherStatus_Stopped) = 4, Aborted (BluetoothLEAdvertisementPublisherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementPublisherStatusChangedEventArgs, 163757471, 11775, 19235, 134, 238, 13, 20, 251, 148, 174, 174);
@@ -3527,7 +3527,7 @@ impl IBluetoothLEAdvertisementPublisherStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementPublisherStatusChangedEventArgs: IBluetoothLEAdvertisementPublisherStatusChangedEventArgs}
+RT_CLASS!{class BluetoothLEAdvertisementPublisherStatusChangedEventArgs: IBluetoothLEAdvertisementPublisherStatusChangedEventArgs ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisherStatusChangedEventArgs"]}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementReceivedEventArgs, 664305119, 58774, 16830, 141, 67, 158, 103, 49, 212, 169, 19);
 RT_INTERFACE!{interface IBluetoothLEAdvertisementReceivedEventArgs(IBluetoothLEAdvertisementReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementReceivedEventArgs] {
     fn get_RawSignalStrengthInDBm(&self, out: *mut i16) -> HRESULT,
@@ -3563,8 +3563,8 @@ impl IBluetoothLEAdvertisementReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementReceivedEventArgs: IBluetoothLEAdvertisementReceivedEventArgs}
-RT_ENUM! { enum BluetoothLEAdvertisementType: i32 {
+RT_CLASS!{class BluetoothLEAdvertisementReceivedEventArgs: IBluetoothLEAdvertisementReceivedEventArgs ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementReceivedEventArgs"]}
+RT_ENUM! { enum BluetoothLEAdvertisementType: i32 ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementType"] {
     ConnectableUndirected (BluetoothLEAdvertisementType_ConnectableUndirected) = 0, ConnectableDirected (BluetoothLEAdvertisementType_ConnectableDirected) = 1, ScannableUndirected (BluetoothLEAdvertisementType_ScannableUndirected) = 2, NonConnectableUndirected (BluetoothLEAdvertisementType_NonConnectableUndirected) = 3, ScanResponse (BluetoothLEAdvertisementType_ScanResponse) = 4,
 }}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementWatcher, 2796303215, 62419, 17047, 141, 108, 200, 30, 166, 98, 63, 64);
@@ -3667,7 +3667,7 @@ impl IBluetoothLEAdvertisementWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementWatcher: IBluetoothLEAdvertisementWatcher}
+RT_CLASS!{class BluetoothLEAdvertisementWatcher: IBluetoothLEAdvertisementWatcher ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher"]}
 impl RtActivatable<IBluetoothLEAdvertisementWatcherFactory> for BluetoothLEAdvertisementWatcher {}
 impl RtActivatable<IActivationFactory> for BluetoothLEAdvertisementWatcher {}
 impl BluetoothLEAdvertisementWatcher {
@@ -3687,7 +3687,7 @@ impl IBluetoothLEAdvertisementWatcherFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothLEAdvertisementWatcherStatus: i32 {
+RT_ENUM! { enum BluetoothLEAdvertisementWatcherStatus: i32 ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStatus"] {
     Created (BluetoothLEAdvertisementWatcherStatus_Created) = 0, Started (BluetoothLEAdvertisementWatcherStatus_Started) = 1, Stopping (BluetoothLEAdvertisementWatcherStatus_Stopping) = 2, Stopped (BluetoothLEAdvertisementWatcherStatus_Stopped) = 3, Aborted (BluetoothLEAdvertisementWatcherStatus_Aborted) = 4,
 }}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementWatcherStoppedEventArgs, 3712022605, 59321, 17379, 156, 4, 6, 133, 208, 133, 253, 140);
@@ -3701,7 +3701,7 @@ impl IBluetoothLEAdvertisementWatcherStoppedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementWatcherStoppedEventArgs: IBluetoothLEAdvertisementWatcherStoppedEventArgs}
+RT_CLASS!{class BluetoothLEAdvertisementWatcherStoppedEventArgs: IBluetoothLEAdvertisementWatcherStoppedEventArgs ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStoppedEventArgs"]}
 DEFINE_IID!(IID_IBluetoothLEManufacturerData, 2435693080, 26979, 17715, 176, 97, 70, 148, 218, 251, 52, 229);
 RT_INTERFACE!{interface IBluetoothLEManufacturerData(IBluetoothLEManufacturerDataVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEManufacturerData] {
     fn get_CompanyId(&self, out: *mut u16) -> HRESULT,
@@ -3729,7 +3729,7 @@ impl IBluetoothLEManufacturerData {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEManufacturerData: IBluetoothLEManufacturerData}
+RT_CLASS!{class BluetoothLEManufacturerData: IBluetoothLEManufacturerData ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData"]}
 impl RtActivatable<IBluetoothLEManufacturerDataFactory> for BluetoothLEManufacturerData {}
 impl RtActivatable<IActivationFactory> for BluetoothLEManufacturerData {}
 impl BluetoothLEManufacturerData {
@@ -3749,13 +3749,13 @@ impl IBluetoothLEManufacturerDataFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BluetoothLEScanningMode: i32 {
+RT_ENUM! { enum BluetoothLEScanningMode: i32 ["Windows.Devices.Bluetooth.Advertisement.BluetoothLEScanningMode"] {
     Passive (BluetoothLEScanningMode_Passive) = 0, Active (BluetoothLEScanningMode_Active) = 1,
 }}
 } // Windows.Devices.Bluetooth.Advertisement
 pub mod background { // Windows.Devices.Bluetooth.Background
 use ::prelude::*;
-RT_ENUM! { enum BluetoothEventTriggeringMode: i32 {
+RT_ENUM! { enum BluetoothEventTriggeringMode: i32 ["Windows.Devices.Bluetooth.Background.BluetoothEventTriggeringMode"] {
     Serial (BluetoothEventTriggeringMode_Serial) = 0, Batch (BluetoothEventTriggeringMode_Batch) = 1, KeepLatest (BluetoothEventTriggeringMode_KeepLatest) = 2,
 }}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementPublisherTriggerDetails, 1628359302, 13440, 16841, 169, 24, 125, 218, 223, 32, 126, 0);
@@ -3775,7 +3775,7 @@ impl IBluetoothLEAdvertisementPublisherTriggerDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementPublisherTriggerDetails: IBluetoothLEAdvertisementPublisherTriggerDetails}
+RT_CLASS!{class BluetoothLEAdvertisementPublisherTriggerDetails: IBluetoothLEAdvertisementPublisherTriggerDetails ["Windows.Devices.Bluetooth.Background.BluetoothLEAdvertisementPublisherTriggerDetails"]}
 DEFINE_IID!(IID_IBluetoothLEAdvertisementWatcherTriggerDetails, 2816170711, 8791, 20073, 151, 132, 254, 230, 69, 193, 220, 224);
 RT_INTERFACE!{interface IBluetoothLEAdvertisementWatcherTriggerDetails(IBluetoothLEAdvertisementWatcherTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IBluetoothLEAdvertisementWatcherTriggerDetails] {
     fn get_Error(&self, out: *mut super::BluetoothError) -> HRESULT,
@@ -3799,7 +3799,7 @@ impl IBluetoothLEAdvertisementWatcherTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BluetoothLEAdvertisementWatcherTriggerDetails: IBluetoothLEAdvertisementWatcherTriggerDetails}
+RT_CLASS!{class BluetoothLEAdvertisementWatcherTriggerDetails: IBluetoothLEAdvertisementWatcherTriggerDetails ["Windows.Devices.Bluetooth.Background.BluetoothLEAdvertisementWatcherTriggerDetails"]}
 DEFINE_IID!(IID_IGattCharacteristicNotificationTriggerDetails, 2610969368, 4076, 17258, 147, 177, 244, 108, 105, 117, 50, 162);
 RT_INTERFACE!{interface IGattCharacteristicNotificationTriggerDetails(IGattCharacteristicNotificationTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicNotificationTriggerDetails] {
     fn get_Characteristic(&self, out: *mut *mut super::genericattributeprofile::GattCharacteristic) -> HRESULT,
@@ -3817,7 +3817,7 @@ impl IGattCharacteristicNotificationTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattCharacteristicNotificationTriggerDetails: IGattCharacteristicNotificationTriggerDetails}
+RT_CLASS!{class GattCharacteristicNotificationTriggerDetails: IGattCharacteristicNotificationTriggerDetails ["Windows.Devices.Bluetooth.Background.GattCharacteristicNotificationTriggerDetails"]}
 DEFINE_IID!(IID_IGattCharacteristicNotificationTriggerDetails2, 1920618716, 38045, 17738, 177, 146, 152, 52, 103, 227, 213, 15);
 RT_INTERFACE!{interface IGattCharacteristicNotificationTriggerDetails2(IGattCharacteristicNotificationTriggerDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicNotificationTriggerDetails2] {
     fn get_Error(&self, out: *mut super::BluetoothError) -> HRESULT,
@@ -3863,7 +3863,7 @@ impl IGattServiceProviderConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderConnection: IGattServiceProviderConnection}
+RT_CLASS!{class GattServiceProviderConnection: IGattServiceProviderConnection ["Windows.Devices.Bluetooth.Background.GattServiceProviderConnection"]}
 impl RtActivatable<IGattServiceProviderConnectionStatics> for GattServiceProviderConnection {}
 impl GattServiceProviderConnection {
     #[inline] pub fn get_all_services() -> Result<Option<ComPtr<foundation::collections::IMapView<HString, GattServiceProviderConnection>>>> {
@@ -3893,7 +3893,7 @@ impl IGattServiceProviderTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderTriggerDetails: IGattServiceProviderTriggerDetails}
+RT_CLASS!{class GattServiceProviderTriggerDetails: IGattServiceProviderTriggerDetails ["Windows.Devices.Bluetooth.Background.GattServiceProviderTriggerDetails"]}
 DEFINE_IID!(IID_IRfcommConnectionTriggerDetails, 4179784525, 11836, 20220, 171, 89, 252, 92, 249, 111, 151, 227);
 RT_INTERFACE!{interface IRfcommConnectionTriggerDetails(IRfcommConnectionTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommConnectionTriggerDetails] {
     #[cfg(not(feature="windows-networking"))] fn __Dummy0(&self) -> (),
@@ -3918,7 +3918,7 @@ impl IRfcommConnectionTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommConnectionTriggerDetails: IRfcommConnectionTriggerDetails}
+RT_CLASS!{class RfcommConnectionTriggerDetails: IRfcommConnectionTriggerDetails ["Windows.Devices.Bluetooth.Background.RfcommConnectionTriggerDetails"]}
 DEFINE_IID!(IID_IRfcommInboundConnectionInformation, 1832809896, 21545, 16473, 146, 227, 30, 139, 101, 82, 135, 7);
 RT_INTERFACE!{interface IRfcommInboundConnectionInformation(IRfcommInboundConnectionInformationVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommInboundConnectionInformation] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -3959,7 +3959,7 @@ impl IRfcommInboundConnectionInformation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommInboundConnectionInformation: IRfcommInboundConnectionInformation}
+RT_CLASS!{class RfcommInboundConnectionInformation: IRfcommInboundConnectionInformation ["Windows.Devices.Bluetooth.Background.RfcommInboundConnectionInformation"]}
 DEFINE_IID!(IID_IRfcommOutboundConnectionInformation, 2962301563, 62516, 19632, 153, 177, 74, 184, 206, 218, 237, 215);
 RT_INTERFACE!{interface IRfcommOutboundConnectionInformation(IRfcommOutboundConnectionInformationVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommOutboundConnectionInformation] {
     fn get_RemoteServiceId(&self, out: *mut *mut super::rfcomm::RfcommServiceId) -> HRESULT,
@@ -3976,7 +3976,7 @@ impl IRfcommOutboundConnectionInformation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommOutboundConnectionInformation: IRfcommOutboundConnectionInformation}
+RT_CLASS!{class RfcommOutboundConnectionInformation: IRfcommOutboundConnectionInformation ["Windows.Devices.Bluetooth.Background.RfcommOutboundConnectionInformation"]}
 } // Windows.Devices.Bluetooth.Background
 pub mod genericattributeprofile { // Windows.Devices.Bluetooth.GenericAttributeProfile
 use ::prelude::*;
@@ -4081,7 +4081,7 @@ impl IGattCharacteristic {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattCharacteristic: IGattCharacteristic}
+RT_CLASS!{class GattCharacteristic: IGattCharacteristic ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristic"]}
 impl RtActivatable<IGattCharacteristicStatics> for GattCharacteristic {}
 impl GattCharacteristic {
     #[inline] pub fn convert_short_id_to_uuid(shortId: u16) -> Result<Guid> {
@@ -4155,7 +4155,7 @@ impl IGattCharacteristic3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GattCharacteristicProperties: u32 {
+RT_ENUM! { enum GattCharacteristicProperties: u32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicProperties"] {
     None (GattCharacteristicProperties_None) = 0, Broadcast (GattCharacteristicProperties_Broadcast) = 1, Read (GattCharacteristicProperties_Read) = 2, WriteWithoutResponse (GattCharacteristicProperties_WriteWithoutResponse) = 4, Write (GattCharacteristicProperties_Write) = 8, Notify (GattCharacteristicProperties_Notify) = 16, Indicate (GattCharacteristicProperties_Indicate) = 32, AuthenticatedSignedWrites (GattCharacteristicProperties_AuthenticatedSignedWrites) = 64, ExtendedProperties (GattCharacteristicProperties_ExtendedProperties) = 128, ReliableWrites (GattCharacteristicProperties_ReliableWrites) = 256, WritableAuxiliaries (GattCharacteristicProperties_WritableAuxiliaries) = 512,
 }}
 DEFINE_IID!(IID_IGattCharacteristicsResult, 294949980, 45655, 20286, 157, 183, 246, 139, 201, 169, 174, 242);
@@ -4181,7 +4181,7 @@ impl IGattCharacteristicsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattCharacteristicsResult: IGattCharacteristicsResult}
+RT_CLASS!{class GattCharacteristicsResult: IGattCharacteristicsResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicsResult"]}
 DEFINE_IID!(IID_IGattCharacteristicStatics, 1506496707, 22836, 20328, 161, 152, 235, 134, 79, 164, 78, 107);
 RT_INTERFACE!{static interface IGattCharacteristicStatics(IGattCharacteristicStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattCharacteristicStatics] {
     fn ConvertShortIdToUuid(&self, shortId: u16, out: *mut Guid) -> HRESULT
@@ -4938,7 +4938,7 @@ impl IGattCharacteristicUuidsStatics2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GattClientCharacteristicConfigurationDescriptorValue: i32 {
+RT_ENUM! { enum GattClientCharacteristicConfigurationDescriptorValue: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientCharacteristicConfigurationDescriptorValue"] {
     None (GattClientCharacteristicConfigurationDescriptorValue_None) = 0, Notify (GattClientCharacteristicConfigurationDescriptorValue_Notify) = 1, Indicate (GattClientCharacteristicConfigurationDescriptorValue_Indicate) = 2,
 }}
 DEFINE_IID!(IID_IGattClientNotificationResult, 1349342617, 274, 16794, 142, 59, 174, 33, 175, 171, 210, 194);
@@ -4964,7 +4964,7 @@ impl IGattClientNotificationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattClientNotificationResult: IGattClientNotificationResult}
+RT_CLASS!{class GattClientNotificationResult: IGattClientNotificationResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientNotificationResult"]}
 DEFINE_IID!(IID_IGattClientNotificationResult2, 2410595479, 17888, 18814, 149, 130, 41, 161, 254, 40, 26, 213);
 RT_INTERFACE!{interface IGattClientNotificationResult2(IGattClientNotificationResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattClientNotificationResult2] {
     fn get_BytesSent(&self, out: *mut u16) -> HRESULT
@@ -4976,7 +4976,7 @@ impl IGattClientNotificationResult2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GattCommunicationStatus: i32 {
+RT_ENUM! { enum GattCommunicationStatus: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattCommunicationStatus"] {
     Success (GattCommunicationStatus_Success) = 0, Unreachable (GattCommunicationStatus_Unreachable) = 1, ProtocolError (GattCommunicationStatus_ProtocolError) = 2, AccessDenied (GattCommunicationStatus_AccessDenied) = 3,
 }}
 DEFINE_IID!(IID_IGattDescriptor, 2449825579, 32900, 17220, 180, 194, 40, 77, 225, 154, 133, 6);
@@ -5025,7 +5025,7 @@ impl IGattDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattDescriptor: IGattDescriptor}
+RT_CLASS!{class GattDescriptor: IGattDescriptor ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptor"]}
 impl RtActivatable<IGattDescriptorStatics> for GattDescriptor {}
 impl GattDescriptor {
     #[inline] pub fn convert_short_id_to_uuid(shortId: u16) -> Result<Guid> {
@@ -5067,7 +5067,7 @@ impl IGattDescriptorsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattDescriptorsResult: IGattDescriptorsResult}
+RT_CLASS!{class GattDescriptorsResult: IGattDescriptorsResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptorsResult"]}
 DEFINE_IID!(IID_IGattDescriptorStatics, 2449825581, 32900, 17220, 180, 194, 40, 77, 225, 154, 133, 6);
 RT_INTERFACE!{static interface IGattDescriptorStatics(IGattDescriptorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattDescriptorStatics] {
     fn ConvertShortIdToUuid(&self, shortId: u16, out: *mut Guid) -> HRESULT
@@ -5178,7 +5178,7 @@ impl IGattDeviceService {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattDeviceService: IGattDeviceService}
+RT_CLASS!{class GattDeviceService: IGattDeviceService ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceService"]}
 impl RtActivatable<IGattDeviceServiceStatics> for GattDeviceService {}
 impl RtActivatable<IGattDeviceServiceStatics2> for GattDeviceService {}
 impl GattDeviceService {
@@ -5346,7 +5346,7 @@ impl IGattDeviceServicesResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattDeviceServicesResult: IGattDeviceServicesResult}
+RT_CLASS!{class GattDeviceServicesResult: IGattDeviceServicesResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceServicesResult"]}
 DEFINE_IID!(IID_IGattDeviceServiceStatics, 426573858, 64173, 17884, 174, 91, 42, 195, 24, 78, 132, 219);
 RT_INTERFACE!{static interface IGattDeviceServiceStatics(IGattDeviceServiceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattDeviceServiceStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncOperation<GattDeviceService>) -> HRESULT,
@@ -5521,7 +5521,7 @@ impl IGattLocalCharacteristic {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalCharacteristic: IGattLocalCharacteristic}
+RT_CLASS!{class GattLocalCharacteristic: IGattLocalCharacteristic ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristic"]}
 DEFINE_IID!(IID_IGattLocalCharacteristicParameters, 4210507188, 19711, 17607, 132, 69, 4, 14, 110, 173, 0, 99);
 RT_INTERFACE!{interface IGattLocalCharacteristicParameters(IGattLocalCharacteristicParametersVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalCharacteristicParameters] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -5590,7 +5590,7 @@ impl IGattLocalCharacteristicParameters {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalCharacteristicParameters: IGattLocalCharacteristicParameters}
+RT_CLASS!{class GattLocalCharacteristicParameters: IGattLocalCharacteristicParameters ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristicParameters"]}
 impl RtActivatable<IActivationFactory> for GattLocalCharacteristicParameters {}
 DEFINE_CLSID!(GattLocalCharacteristicParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,76,111,99,97,108,67,104,97,114,97,99,116,101,114,105,115,116,105,99,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_GattLocalCharacteristicParameters]);
 DEFINE_IID!(IID_IGattLocalCharacteristicResult, 2037767835, 368, 17303, 150, 102, 146, 248, 99, 241, 46, 230);
@@ -5610,7 +5610,7 @@ impl IGattLocalCharacteristicResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalCharacteristicResult: IGattLocalCharacteristicResult}
+RT_CLASS!{class GattLocalCharacteristicResult: IGattLocalCharacteristicResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristicResult"]}
 DEFINE_IID!(IID_IGattLocalDescriptor, 4102995462, 30877, 19019, 134, 82, 189, 1, 123, 93, 47, 198);
 RT_INTERFACE!{interface IGattLocalDescriptor(IGattLocalDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalDescriptor] {
     fn get_Uuid(&self, out: *mut Guid) -> HRESULT,
@@ -5663,7 +5663,7 @@ impl IGattLocalDescriptor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalDescriptor: IGattLocalDescriptor}
+RT_CLASS!{class GattLocalDescriptor: IGattLocalDescriptor ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptor"]}
 DEFINE_IID!(IID_IGattLocalDescriptorParameters, 1608441450, 62401, 19302, 140, 75, 227, 210, 41, 59, 64, 233);
 RT_INTERFACE!{interface IGattLocalDescriptorParameters(IGattLocalDescriptorParametersVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalDescriptorParameters] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -5704,7 +5704,7 @@ impl IGattLocalDescriptorParameters {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalDescriptorParameters: IGattLocalDescriptorParameters}
+RT_CLASS!{class GattLocalDescriptorParameters: IGattLocalDescriptorParameters ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptorParameters"]}
 impl RtActivatable<IActivationFactory> for GattLocalDescriptorParameters {}
 DEFINE_CLSID!(GattLocalDescriptorParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,76,111,99,97,108,68,101,115,99,114,105,112,116,111,114,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_GattLocalDescriptorParameters]);
 DEFINE_IID!(IID_IGattLocalDescriptorResult, 928485822, 12831, 17254, 191, 193, 59, 198, 184, 44, 121, 248);
@@ -5724,7 +5724,7 @@ impl IGattLocalDescriptorResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalDescriptorResult: IGattLocalDescriptorResult}
+RT_CLASS!{class GattLocalDescriptorResult: IGattLocalDescriptorResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptorResult"]}
 DEFINE_IID!(IID_IGattLocalService, 4111721048, 63479, 18690, 184, 3, 87, 252, 199, 214, 254, 131);
 RT_INTERFACE!{interface IGattLocalService(IGattLocalServiceVtbl): IInspectable(IInspectableVtbl) [IID_IGattLocalService] {
     fn get_Uuid(&self, out: *mut Guid) -> HRESULT,
@@ -5748,8 +5748,8 @@ impl IGattLocalService {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattLocalService: IGattLocalService}
-RT_ENUM! { enum GattOpenStatus: i32 {
+RT_CLASS!{class GattLocalService: IGattLocalService ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalService"]}
+RT_ENUM! { enum GattOpenStatus: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattOpenStatus"] {
     Unspecified (GattOpenStatus_Unspecified) = 0, Success (GattOpenStatus_Success) = 1, AlreadyOpened (GattOpenStatus_AlreadyOpened) = 2, NotFound (GattOpenStatus_NotFound) = 3, SharingViolation (GattOpenStatus_SharingViolation) = 4, AccessDenied (GattOpenStatus_AccessDenied) = 5,
 }}
 DEFINE_IID!(IID_IGattPresentationFormat, 426573857, 64173, 17884, 174, 91, 42, 195, 24, 78, 132, 219);
@@ -5787,7 +5787,7 @@ impl IGattPresentationFormat {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattPresentationFormat: IGattPresentationFormat}
+RT_CLASS!{class GattPresentationFormat: IGattPresentationFormat ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattPresentationFormat"]}
 impl RtActivatable<IGattPresentationFormatStatics> for GattPresentationFormat {}
 impl RtActivatable<IGattPresentationFormatStatics2> for GattPresentationFormat {}
 impl GattPresentationFormat {
@@ -6074,7 +6074,7 @@ impl IGattPresentationFormatTypesStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GattProtectionLevel: i32 {
+RT_ENUM! { enum GattProtectionLevel: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattProtectionLevel"] {
     Plain (GattProtectionLevel_Plain) = 0, AuthenticationRequired (GattProtectionLevel_AuthenticationRequired) = 1, EncryptionRequired (GattProtectionLevel_EncryptionRequired) = 2, EncryptionAndAuthenticationRequired (GattProtectionLevel_EncryptionAndAuthenticationRequired) = 3,
 }}
 RT_CLASS!{static class GattProtocolError}
@@ -6257,7 +6257,7 @@ impl IGattReadClientCharacteristicConfigurationDescriptorResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattReadClientCharacteristicConfigurationDescriptorResult: IGattReadClientCharacteristicConfigurationDescriptorResult}
+RT_CLASS!{class GattReadClientCharacteristicConfigurationDescriptorResult: IGattReadClientCharacteristicConfigurationDescriptorResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadClientCharacteristicConfigurationDescriptorResult"]}
 DEFINE_IID!(IID_IGattReadClientCharacteristicConfigurationDescriptorResult2, 468821405, 47693, 17954, 134, 81, 244, 238, 21, 13, 10, 93);
 RT_INTERFACE!{interface IGattReadClientCharacteristicConfigurationDescriptorResult2(IGattReadClientCharacteristicConfigurationDescriptorResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattReadClientCharacteristicConfigurationDescriptorResult2] {
     fn get_ProtocolError(&self, out: *mut *mut foundation::IReference<u8>) -> HRESULT
@@ -6314,7 +6314,7 @@ impl IGattReadRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattReadRequest: IGattReadRequest}
+RT_CLASS!{class GattReadRequest: IGattReadRequest ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadRequest"]}
 DEFINE_IID!(IID_IGattReadRequestedEventArgs, 2471064131, 62364, 18507, 138, 182, 153, 107, 164, 134, 207, 163);
 RT_INTERFACE!{interface IGattReadRequestedEventArgs(IGattReadRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGattReadRequestedEventArgs] {
     fn get_Session(&self, out: *mut *mut GattSession) -> HRESULT,
@@ -6338,7 +6338,7 @@ impl IGattReadRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattReadRequestedEventArgs: IGattReadRequestedEventArgs}
+RT_CLASS!{class GattReadRequestedEventArgs: IGattReadRequestedEventArgs ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadRequestedEventArgs"]}
 DEFINE_IID!(IID_IGattReadResult, 1671851784, 6890, 19532, 165, 15, 151, 186, 228, 116, 179, 72);
 RT_INTERFACE!{interface IGattReadResult(IGattReadResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattReadResult] {
     fn get_Status(&self, out: *mut GattCommunicationStatus) -> HRESULT,
@@ -6356,7 +6356,7 @@ impl IGattReadResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattReadResult: IGattReadResult}
+RT_CLASS!{class GattReadResult: IGattReadResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadResult"]}
 DEFINE_IID!(IID_IGattReadResult2, 2702135456, 64323, 18607, 186, 170, 99, 138, 92, 99, 41, 254);
 RT_INTERFACE!{interface IGattReadResult2(IGattReadResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IGattReadResult2] {
     fn get_ProtocolError(&self, out: *mut *mut foundation::IReference<u8>) -> HRESULT
@@ -6385,7 +6385,7 @@ impl IGattReliableWriteTransaction {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattReliableWriteTransaction: IGattReliableWriteTransaction}
+RT_CLASS!{class GattReliableWriteTransaction: IGattReliableWriteTransaction ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattReliableWriteTransaction"]}
 impl RtActivatable<IActivationFactory> for GattReliableWriteTransaction {}
 DEFINE_CLSID!(GattReliableWriteTransaction(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,82,101,108,105,97,98,108,101,87,114,105,116,101,84,114,97,110,115,97,99,116,105,111,110,0]) [CLSID_GattReliableWriteTransaction]);
 DEFINE_IID!(IID_IGattReliableWriteTransaction2, 1360083335, 61202, 17967, 159, 178, 161, 164, 58, 103, 148, 22);
@@ -6399,7 +6399,7 @@ impl IGattReliableWriteTransaction2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GattRequestState: i32 {
+RT_ENUM! { enum GattRequestState: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattRequestState"] {
     Pending (GattRequestState_Pending) = 0, Completed (GattRequestState_Completed) = 1, Canceled (GattRequestState_Canceled) = 2,
 }}
 DEFINE_IID!(IID_IGattRequestStateChangedEventArgs, 3895777580, 10174, 17587, 157, 13, 79, 198, 232, 8, 221, 63);
@@ -6419,7 +6419,7 @@ impl IGattRequestStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattRequestStateChangedEventArgs: IGattRequestStateChangedEventArgs}
+RT_CLASS!{class GattRequestStateChangedEventArgs: IGattRequestStateChangedEventArgs ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattRequestStateChangedEventArgs"]}
 DEFINE_IID!(IID_IGattServiceProvider, 2015540173, 10377, 20358, 160, 81, 63, 10, 237, 28, 39, 96);
 RT_INTERFACE!{interface IGattServiceProvider(IGattServiceProviderVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProvider] {
     fn get_Service(&self, out: *mut *mut GattLocalService) -> HRESULT,
@@ -6463,7 +6463,7 @@ impl IGattServiceProvider {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProvider: IGattServiceProvider}
+RT_CLASS!{class GattServiceProvider: IGattServiceProvider ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProvider"]}
 impl RtActivatable<IGattServiceProviderStatics> for GattServiceProvider {}
 impl GattServiceProvider {
     #[inline] pub fn create_async(serviceUuid: Guid) -> Result<ComPtr<foundation::IAsyncOperation<GattServiceProviderResult>>> {
@@ -6471,7 +6471,7 @@ impl GattServiceProvider {
     }
 }
 DEFINE_CLSID!(GattServiceProvider(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,0]) [CLSID_GattServiceProvider]);
-RT_ENUM! { enum GattServiceProviderAdvertisementStatus: i32 {
+RT_ENUM! { enum GattServiceProviderAdvertisementStatus: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderAdvertisementStatus"] {
     Created (GattServiceProviderAdvertisementStatus_Created) = 0, Stopped (GattServiceProviderAdvertisementStatus_Stopped) = 1, Started (GattServiceProviderAdvertisementStatus_Started) = 2, Aborted (GattServiceProviderAdvertisementStatus_Aborted) = 3,
 }}
 DEFINE_IID!(IID_IGattServiceProviderAdvertisementStatusChangedEventArgs, 1504029285, 64033, 20476, 177, 85, 4, 217, 40, 1, 38, 134);
@@ -6491,7 +6491,7 @@ impl IGattServiceProviderAdvertisementStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderAdvertisementStatusChangedEventArgs: IGattServiceProviderAdvertisementStatusChangedEventArgs}
+RT_CLASS!{class GattServiceProviderAdvertisementStatusChangedEventArgs: IGattServiceProviderAdvertisementStatusChangedEventArgs ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderAdvertisementStatusChangedEventArgs"]}
 DEFINE_IID!(IID_IGattServiceProviderAdvertisingParameters, 3805163947, 25365, 19490, 155, 215, 120, 29, 188, 61, 141, 130);
 RT_INTERFACE!{interface IGattServiceProviderAdvertisingParameters(IGattServiceProviderAdvertisingParametersVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProviderAdvertisingParameters] {
     fn put_IsConnectable(&self, value: bool) -> HRESULT,
@@ -6519,7 +6519,7 @@ impl IGattServiceProviderAdvertisingParameters {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderAdvertisingParameters: IGattServiceProviderAdvertisingParameters}
+RT_CLASS!{class GattServiceProviderAdvertisingParameters: IGattServiceProviderAdvertisingParameters ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderAdvertisingParameters"]}
 impl RtActivatable<IActivationFactory> for GattServiceProviderAdvertisingParameters {}
 DEFINE_CLSID!(GattServiceProviderAdvertisingParameters(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,66,108,117,101,116,111,111,116,104,46,71,101,110,101,114,105,99,65,116,116,114,105,98,117,116,101,80,114,111,102,105,108,101,46,71,97,116,116,83,101,114,118,105,99,101,80,114,111,118,105,100,101,114,65,100,118,101,114,116,105,115,105,110,103,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_GattServiceProviderAdvertisingParameters]);
 DEFINE_IID!(IID_IGattServiceProviderResult, 1984337624, 50494, 17036, 138, 72, 103, 175, 224, 44, 58, 230);
@@ -6539,7 +6539,7 @@ impl IGattServiceProviderResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattServiceProviderResult: IGattServiceProviderResult}
+RT_CLASS!{class GattServiceProviderResult: IGattServiceProviderResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderResult"]}
 DEFINE_IID!(IID_IGattServiceProviderStatics, 830029923, 21078, 16468, 164, 244, 123, 190, 119, 85, 165, 126);
 RT_INTERFACE!{static interface IGattServiceProviderStatics(IGattServiceProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGattServiceProviderStatics] {
     fn CreateAsync(&self, serviceUuid: Guid, out: *mut *mut foundation::IAsyncOperation<GattServiceProviderResult>) -> HRESULT
@@ -6827,7 +6827,7 @@ impl IGattSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattSession: IGattSession}
+RT_CLASS!{class GattSession: IGattSession ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattSession"]}
 impl RtActivatable<IGattSessionStatics> for GattSession {}
 impl GattSession {
     #[inline] pub fn from_device_id_async(deviceId: &super::BluetoothDeviceId) -> Result<ComPtr<foundation::IAsyncOperation<GattSession>>> {
@@ -6846,7 +6846,7 @@ impl IGattSessionStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GattSessionStatus: i32 {
+RT_ENUM! { enum GattSessionStatus: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattSessionStatus"] {
     Closed (GattSessionStatus_Closed) = 0, Active (GattSessionStatus_Active) = 1,
 }}
 DEFINE_IID!(IID_IGattSessionStatusChangedEventArgs, 1980086062, 33663, 16460, 171, 52, 49, 99, 243, 157, 223, 50);
@@ -6866,8 +6866,8 @@ impl IGattSessionStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattSessionStatusChangedEventArgs: IGattSessionStatusChangedEventArgs}
-RT_ENUM! { enum GattSharingMode: i32 {
+RT_CLASS!{class GattSessionStatusChangedEventArgs: IGattSessionStatusChangedEventArgs ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattSessionStatusChangedEventArgs"]}
+RT_ENUM! { enum GattSharingMode: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattSharingMode"] {
     Unspecified (GattSharingMode_Unspecified) = 0, Exclusive (GattSharingMode_Exclusive) = 1, SharedReadOnly (GattSharingMode_SharedReadOnly) = 2, SharedReadAndWrite (GattSharingMode_SharedReadAndWrite) = 3,
 }}
 DEFINE_IID!(IID_IGattSubscribedClient, 1936625665, 5540, 20162, 146, 72, 227, 242, 13, 70, 59, 233);
@@ -6898,7 +6898,7 @@ impl IGattSubscribedClient {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattSubscribedClient: IGattSubscribedClient}
+RT_CLASS!{class GattSubscribedClient: IGattSubscribedClient ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattSubscribedClient"]}
 DEFINE_IID!(IID_IGattValueChangedEventArgs, 3525040980, 1763, 20184, 162, 99, 172, 250, 200, 186, 115, 19);
 RT_INTERFACE!{interface IGattValueChangedEventArgs(IGattValueChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGattValueChangedEventArgs] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -6917,8 +6917,8 @@ impl IGattValueChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattValueChangedEventArgs: IGattValueChangedEventArgs}
-RT_ENUM! { enum GattWriteOption: i32 {
+RT_CLASS!{class GattValueChangedEventArgs: IGattValueChangedEventArgs ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattValueChangedEventArgs"]}
+RT_ENUM! { enum GattWriteOption: i32 ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteOption"] {
     WriteWithResponse (GattWriteOption_WriteWithResponse) = 0, WriteWithoutResponse (GattWriteOption_WriteWithoutResponse) = 1,
 }}
 DEFINE_IID!(IID_IGattWriteRequest, 2931206637, 56879, 20418, 169, 168, 148, 234, 120, 68, 241, 61);
@@ -6972,7 +6972,7 @@ impl IGattWriteRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattWriteRequest: IGattWriteRequest}
+RT_CLASS!{class GattWriteRequest: IGattWriteRequest ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteRequest"]}
 DEFINE_IID!(IID_IGattWriteRequestedEventArgs, 770476990, 42810, 18202, 148, 213, 3, 125, 234, 221, 8, 6);
 RT_INTERFACE!{interface IGattWriteRequestedEventArgs(IGattWriteRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGattWriteRequestedEventArgs] {
     fn get_Session(&self, out: *mut *mut GattSession) -> HRESULT,
@@ -6996,7 +6996,7 @@ impl IGattWriteRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattWriteRequestedEventArgs: IGattWriteRequestedEventArgs}
+RT_CLASS!{class GattWriteRequestedEventArgs: IGattWriteRequestedEventArgs ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteRequestedEventArgs"]}
 DEFINE_IID!(IID_IGattWriteResult, 1234296241, 52011, 17655, 153, 252, 210, 154, 40, 113, 220, 155);
 RT_INTERFACE!{interface IGattWriteResult(IGattWriteResultVtbl): IInspectable(IInspectableVtbl) [IID_IGattWriteResult] {
     fn get_Status(&self, out: *mut GattCommunicationStatus) -> HRESULT,
@@ -7014,7 +7014,7 @@ impl IGattWriteResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GattWriteResult: IGattWriteResult}
+RT_CLASS!{class GattWriteResult: IGattWriteResult ["Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteResult"]}
 } // Windows.Devices.Bluetooth.GenericAttributeProfile
 pub mod rfcomm { // Windows.Devices.Bluetooth.Rfcomm
 use ::prelude::*;
@@ -7068,7 +7068,7 @@ impl IRfcommDeviceService {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommDeviceService: IRfcommDeviceService}
+RT_CLASS!{class RfcommDeviceService: IRfcommDeviceService ["Windows.Devices.Bluetooth.Rfcomm.RfcommDeviceService"]}
 impl RtActivatable<IRfcommDeviceServiceStatics> for RfcommDeviceService {}
 impl RtActivatable<IRfcommDeviceServiceStatics2> for RfcommDeviceService {}
 impl RfcommDeviceService {
@@ -7137,7 +7137,7 @@ impl IRfcommDeviceServicesResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommDeviceServicesResult: IRfcommDeviceServicesResult}
+RT_CLASS!{class RfcommDeviceServicesResult: IRfcommDeviceServicesResult ["Windows.Devices.Bluetooth.Rfcomm.RfcommDeviceServicesResult"]}
 DEFINE_IID!(IID_IRfcommDeviceServiceStatics, 2762033647, 25197, 16812, 178, 83, 135, 172, 92, 39, 226, 138);
 RT_INTERFACE!{static interface IRfcommDeviceServiceStatics(IRfcommDeviceServiceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRfcommDeviceServiceStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncOperation<RfcommDeviceService>) -> HRESULT,
@@ -7207,7 +7207,7 @@ impl IRfcommServiceId {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommServiceId: IRfcommServiceId}
+RT_CLASS!{class RfcommServiceId: IRfcommServiceId ["Windows.Devices.Bluetooth.Rfcomm.RfcommServiceId"]}
 impl RtActivatable<IRfcommServiceIdStatics> for RfcommServiceId {}
 impl RfcommServiceId {
     #[inline] pub fn from_uuid(uuid: Guid) -> Result<Option<ComPtr<RfcommServiceId>>> {
@@ -7318,7 +7318,7 @@ impl IRfcommServiceProvider {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RfcommServiceProvider: IRfcommServiceProvider}
+RT_CLASS!{class RfcommServiceProvider: IRfcommServiceProvider ["Windows.Devices.Bluetooth.Rfcomm.RfcommServiceProvider"]}
 impl RtActivatable<IRfcommServiceProviderStatics> for RfcommServiceProvider {}
 impl RfcommServiceProvider {
     #[inline] pub fn create_async(serviceId: &RfcommServiceId) -> Result<ComPtr<foundation::IAsyncOperation<RfcommServiceProvider>>> {
@@ -7380,7 +7380,7 @@ impl ICustomDevice {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CustomDevice: ICustomDevice}
+RT_CLASS!{class CustomDevice: ICustomDevice ["Windows.Devices.Custom.CustomDevice"]}
 impl RtActivatable<ICustomDeviceStatics> for CustomDevice {}
 impl CustomDevice {
     #[inline] pub fn get_device_selector(classGuid: Guid) -> Result<HString> {
@@ -7408,10 +7408,10 @@ impl ICustomDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DeviceAccessMode: i32 {
+RT_ENUM! { enum DeviceAccessMode: i32 ["Windows.Devices.Custom.DeviceAccessMode"] {
     Read (DeviceAccessMode_Read) = 0, Write (DeviceAccessMode_Write) = 1, ReadWrite (DeviceAccessMode_ReadWrite) = 2,
 }}
-RT_ENUM! { enum DeviceSharingMode: i32 {
+RT_ENUM! { enum DeviceSharingMode: i32 ["Windows.Devices.Custom.DeviceSharingMode"] {
     Shared (DeviceSharingMode_Shared) = 0, Exclusive (DeviceSharingMode_Exclusive) = 1,
 }}
 DEFINE_IID!(IID_IIOControlCode, 244668903, 24776, 17269, 167, 97, 127, 136, 8, 6, 108, 96);
@@ -7479,13 +7479,13 @@ impl IKnownDeviceTypesStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum IOControlAccessMode: i32 {
+RT_ENUM! { enum IOControlAccessMode: i32 ["Windows.Devices.Custom.IOControlAccessMode"] {
     Any (IOControlAccessMode_Any) = 0, Read (IOControlAccessMode_Read) = 1, Write (IOControlAccessMode_Write) = 2, ReadWrite (IOControlAccessMode_ReadWrite) = 3,
 }}
-RT_ENUM! { enum IOControlBufferingMethod: i32 {
+RT_ENUM! { enum IOControlBufferingMethod: i32 ["Windows.Devices.Custom.IOControlBufferingMethod"] {
     Buffered (IOControlBufferingMethod_Buffered) = 0, DirectInput (IOControlBufferingMethod_DirectInput) = 1, DirectOutput (IOControlBufferingMethod_DirectOutput) = 2, Neither (IOControlBufferingMethod_Neither) = 3,
 }}
-RT_CLASS!{class IOControlCode: IIOControlCode}
+RT_CLASS!{class IOControlCode: IIOControlCode ["Windows.Devices.Custom.IOControlCode"]}
 impl RtActivatable<IIOControlCodeFactory> for IOControlCode {}
 impl IOControlCode {
     #[inline] pub fn create_io_control_code(deviceType: u16, function: u16, accessMode: IOControlAccessMode, bufferingMethod: IOControlBufferingMethod) -> Result<ComPtr<IOControlCode>> {
@@ -7623,7 +7623,7 @@ impl IDisplayMonitor {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayMonitor: IDisplayMonitor}
+RT_CLASS!{class DisplayMonitor: IDisplayMonitor ["Windows.Devices.Display.DisplayMonitor"]}
 impl RtActivatable<IDisplayMonitorStatics> for DisplayMonitor {}
 impl DisplayMonitor {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -7637,13 +7637,13 @@ impl DisplayMonitor {
     }
 }
 DEFINE_CLSID!(DisplayMonitor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,68,105,115,112,108,97,121,46,68,105,115,112,108,97,121,77,111,110,105,116,111,114,0]) [CLSID_DisplayMonitor]);
-RT_ENUM! { enum DisplayMonitorConnectionKind: i32 {
+RT_ENUM! { enum DisplayMonitorConnectionKind: i32 ["Windows.Devices.Display.DisplayMonitorConnectionKind"] {
     Internal (DisplayMonitorConnectionKind_Internal) = 0, Wired (DisplayMonitorConnectionKind_Wired) = 1, Wireless (DisplayMonitorConnectionKind_Wireless) = 2, Virtual (DisplayMonitorConnectionKind_Virtual) = 3,
 }}
-RT_ENUM! { enum DisplayMonitorDescriptorKind: i32 {
+RT_ENUM! { enum DisplayMonitorDescriptorKind: i32 ["Windows.Devices.Display.DisplayMonitorDescriptorKind"] {
     Edid (DisplayMonitorDescriptorKind_Edid) = 0, DisplayId (DisplayMonitorDescriptorKind_DisplayId) = 1,
 }}
-RT_ENUM! { enum DisplayMonitorPhysicalConnectorKind: i32 {
+RT_ENUM! { enum DisplayMonitorPhysicalConnectorKind: i32 ["Windows.Devices.Display.DisplayMonitorPhysicalConnectorKind"] {
     Unknown (DisplayMonitorPhysicalConnectorKind_Unknown) = 0, HD15 (DisplayMonitorPhysicalConnectorKind_HD15) = 1, AnalogTV (DisplayMonitorPhysicalConnectorKind_AnalogTV) = 2, Dvi (DisplayMonitorPhysicalConnectorKind_Dvi) = 3, Hdmi (DisplayMonitorPhysicalConnectorKind_Hdmi) = 4, Lvds (DisplayMonitorPhysicalConnectorKind_Lvds) = 5, Sdi (DisplayMonitorPhysicalConnectorKind_Sdi) = 6, DisplayPort (DisplayMonitorPhysicalConnectorKind_DisplayPort) = 7,
 }}
 DEFINE_IID!(IID_IDisplayMonitorStatics, 1856924047, 41512, 19461, 130, 29, 182, 149, 214, 103, 222, 142);
@@ -7669,7 +7669,7 @@ impl IDisplayMonitorStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DisplayMonitorUsageKind: i32 {
+RT_ENUM! { enum DisplayMonitorUsageKind: i32 ["Windows.Devices.Display.DisplayMonitorUsageKind"] {
     Standard (DisplayMonitorUsageKind_Standard) = 0, HeadMounted (DisplayMonitorUsageKind_HeadMounted) = 1, SpecialPurpose (DisplayMonitorUsageKind_SpecialPurpose) = 2,
 }}
 pub mod core { // Windows.Devices.Display.Core
@@ -7728,7 +7728,7 @@ impl IDisplayAdapter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayAdapter: IDisplayAdapter}
+RT_CLASS!{class DisplayAdapter: IDisplayAdapter ["Windows.Devices.Display.Core.DisplayAdapter"]}
 impl RtActivatable<IDisplayAdapterStatics> for DisplayAdapter {}
 impl DisplayAdapter {
     #[cfg(feature="windows-graphics")] #[inline] pub fn from_id(id: ::rt::gen::windows::graphics::DisplayAdapterId) -> Result<Option<ComPtr<DisplayAdapter>>> {
@@ -7747,7 +7747,7 @@ impl IDisplayAdapterStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DisplayBitsPerChannel: u32 {
+RT_ENUM! { enum DisplayBitsPerChannel: u32 ["Windows.Devices.Display.Core.DisplayBitsPerChannel"] {
     None (DisplayBitsPerChannel_None) = 0, Bpc6 (DisplayBitsPerChannel_Bpc6) = 1, Bpc8 (DisplayBitsPerChannel_Bpc8) = 2, Bpc10 (DisplayBitsPerChannel_Bpc10) = 4, Bpc12 (DisplayBitsPerChannel_Bpc12) = 8, Bpc14 (DisplayBitsPerChannel_Bpc14) = 16, Bpc16 (DisplayBitsPerChannel_Bpc16) = 32,
 }}
 DEFINE_IID!(IID_IDisplayDevice, 2764682796, 13151, 22321, 140, 180, 193, 204, 212, 115, 16, 112);
@@ -7796,15 +7796,15 @@ impl IDisplayDevice {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayDevice: IDisplayDevice}
-RT_ENUM! { enum DisplayDeviceCapability: i32 {
+RT_CLASS!{class DisplayDevice: IDisplayDevice ["Windows.Devices.Display.Core.DisplayDevice"]}
+RT_ENUM! { enum DisplayDeviceCapability: i32 ["Windows.Devices.Display.Core.DisplayDeviceCapability"] {
     FlipOverride (DisplayDeviceCapability_FlipOverride) = 0,
 }}
 DEFINE_IID!(IID_IDisplayFence, 81590767, 13318, 22272, 143, 236, 119, 235, 164, 197, 167, 75);
 RT_INTERFACE!{interface IDisplayFence(IDisplayFenceVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayFence] {
     
 }}
-RT_CLASS!{class DisplayFence: IDisplayFence}
+RT_CLASS!{class DisplayFence: IDisplayFence ["Windows.Devices.Display.Core.DisplayFence"]}
 DEFINE_IID!(IID_IDisplayManager, 1322853467, 5612, 22242, 144, 114, 127, 229, 8, 74, 49, 167);
 RT_INTERFACE!{interface IDisplayManager(IDisplayManagerVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayManager] {
     fn GetCurrentTargets(&self, out: *mut *mut foundation::collections::IVectorView<DisplayTarget>) -> HRESULT,
@@ -7917,7 +7917,7 @@ impl IDisplayManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayManager: IDisplayManager}
+RT_CLASS!{class DisplayManager: IDisplayManager ["Windows.Devices.Display.Core.DisplayManager"]}
 impl RtActivatable<IDisplayManagerStatics> for DisplayManager {}
 impl DisplayManager {
     #[inline] pub fn create(options: DisplayManagerOptions) -> Result<Option<ComPtr<DisplayManager>>> {
@@ -7947,7 +7947,7 @@ impl IDisplayManagerChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayManagerChangedEventArgs: IDisplayManagerChangedEventArgs}
+RT_CLASS!{class DisplayManagerChangedEventArgs: IDisplayManagerChangedEventArgs ["Windows.Devices.Display.Core.DisplayManagerChangedEventArgs"]}
 DEFINE_IID!(IID_IDisplayManagerDisabledEventArgs, 2267471332, 26515, 22899, 161, 31, 95, 251, 201, 63, 219, 144);
 RT_INTERFACE!{interface IDisplayManagerDisabledEventArgs(IDisplayManagerDisabledEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayManagerDisabledEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -7970,7 +7970,7 @@ impl IDisplayManagerDisabledEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayManagerDisabledEventArgs: IDisplayManagerDisabledEventArgs}
+RT_CLASS!{class DisplayManagerDisabledEventArgs: IDisplayManagerDisabledEventArgs ["Windows.Devices.Display.Core.DisplayManagerDisabledEventArgs"]}
 DEFINE_IID!(IID_IDisplayManagerEnabledEventArgs, 4040114031, 17146, 22946, 178, 151, 38, 225, 113, 61, 232, 72);
 RT_INTERFACE!{interface IDisplayManagerEnabledEventArgs(IDisplayManagerEnabledEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayManagerEnabledEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -7993,8 +7993,8 @@ impl IDisplayManagerEnabledEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayManagerEnabledEventArgs: IDisplayManagerEnabledEventArgs}
-RT_ENUM! { enum DisplayManagerOptions: u32 {
+RT_CLASS!{class DisplayManagerEnabledEventArgs: IDisplayManagerEnabledEventArgs ["Windows.Devices.Display.Core.DisplayManagerEnabledEventArgs"]}
+RT_ENUM! { enum DisplayManagerOptions: u32 ["Windows.Devices.Display.Core.DisplayManagerOptions"] {
     None (DisplayManagerOptions_None) = 0, EnforceSourceOwnership (DisplayManagerOptions_EnforceSourceOwnership) = 1,
 }}
 DEFINE_IID!(IID_IDisplayManagerPathsFailedOrInvalidatedEventArgs, 61232729, 7660, 23573, 178, 162, 143, 233, 18, 152, 105, 254);
@@ -8019,8 +8019,8 @@ impl IDisplayManagerPathsFailedOrInvalidatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayManagerPathsFailedOrInvalidatedEventArgs: IDisplayManagerPathsFailedOrInvalidatedEventArgs}
-RT_ENUM! { enum DisplayManagerResult: i32 {
+RT_CLASS!{class DisplayManagerPathsFailedOrInvalidatedEventArgs: IDisplayManagerPathsFailedOrInvalidatedEventArgs ["Windows.Devices.Display.Core.DisplayManagerPathsFailedOrInvalidatedEventArgs"]}
+RT_ENUM! { enum DisplayManagerResult: i32 ["Windows.Devices.Display.Core.DisplayManagerResult"] {
     Success (DisplayManagerResult_Success) = 0, UnknownFailure (DisplayManagerResult_UnknownFailure) = 1, TargetAccessDenied (DisplayManagerResult_TargetAccessDenied) = 2, TargetStale (DisplayManagerResult_TargetStale) = 3, RemoteSessionNotSupported (DisplayManagerResult_RemoteSessionNotSupported) = 4,
 }}
 DEFINE_IID!(IID_IDisplayManagerResultWithState, 2389011110, 26132, 21694, 191, 239, 73, 148, 84, 127, 123, 225);
@@ -8046,7 +8046,7 @@ impl IDisplayManagerResultWithState {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayManagerResultWithState: IDisplayManagerResultWithState}
+RT_CLASS!{class DisplayManagerResultWithState: IDisplayManagerResultWithState ["Windows.Devices.Display.Core.DisplayManagerResultWithState"]}
 DEFINE_IID!(IID_IDisplayManagerStatics, 728470598, 47513, 21813, 157, 105, 83, 240, 146, 199, 128, 161);
 RT_INTERFACE!{static interface IDisplayManagerStatics(IDisplayManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayManagerStatics] {
     fn Create(&self, options: DisplayManagerOptions, out: *mut *mut DisplayManager) -> HRESULT
@@ -8120,8 +8120,8 @@ impl IDisplayModeInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayModeInfo: IDisplayModeInfo}
-RT_ENUM! { enum DisplayModeQueryOptions: u32 {
+RT_CLASS!{class DisplayModeInfo: IDisplayModeInfo ["Windows.Devices.Display.Core.DisplayModeInfo"]}
+RT_ENUM! { enum DisplayModeQueryOptions: u32 ["Windows.Devices.Display.Core.DisplayModeQueryOptions"] {
     None (DisplayModeQueryOptions_None) = 0, OnlyPreferredResolution (DisplayModeQueryOptions_OnlyPreferredResolution) = 1,
 }}
 DEFINE_IID!(IID_IDisplayPath, 3017791050, 29792, 23774, 129, 27, 213, 174, 159, 61, 159, 132);
@@ -8269,14 +8269,14 @@ impl IDisplayPath {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayPath: IDisplayPath}
-RT_ENUM! { enum DisplayPathScaling: i32 {
+RT_CLASS!{class DisplayPath: IDisplayPath ["Windows.Devices.Display.Core.DisplayPath"]}
+RT_ENUM! { enum DisplayPathScaling: i32 ["Windows.Devices.Display.Core.DisplayPathScaling"] {
     Identity (DisplayPathScaling_Identity) = 0, Centered (DisplayPathScaling_Centered) = 1, Stretched (DisplayPathScaling_Stretched) = 2, AspectRatioStretched (DisplayPathScaling_AspectRatioStretched) = 3, Custom (DisplayPathScaling_Custom) = 4, DriverPreferred (DisplayPathScaling_DriverPreferred) = 5,
 }}
-RT_ENUM! { enum DisplayPathStatus: i32 {
+RT_ENUM! { enum DisplayPathStatus: i32 ["Windows.Devices.Display.Core.DisplayPathStatus"] {
     Unknown (DisplayPathStatus_Unknown) = 0, Succeeded (DisplayPathStatus_Succeeded) = 1, Pending (DisplayPathStatus_Pending) = 2, Failed (DisplayPathStatus_Failed) = 3, FailedAsync (DisplayPathStatus_FailedAsync) = 4, InvalidatedAsync (DisplayPathStatus_InvalidatedAsync) = 5,
 }}
-RT_STRUCT! { struct DisplayPresentationRate {
+RT_STRUCT! { struct DisplayPresentationRate ["Windows.Devices.Display.Core.DisplayPresentationRate"] {
     VerticalSyncRate: foundation::numerics::Rational, VerticalSyncsPerPresentation: i32,
 }}
 DEFINE_IID!(IID_IDisplayPrimaryDescription, 2267386322, 54579, 20735, 168, 94, 6, 105, 97, 148, 183, 124);
@@ -8329,7 +8329,7 @@ impl IDisplayPrimaryDescription {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayPrimaryDescription: IDisplayPrimaryDescription}
+RT_CLASS!{class DisplayPrimaryDescription: IDisplayPrimaryDescription ["Windows.Devices.Display.Core.DisplayPrimaryDescription"]}
 impl RtActivatable<IDisplayPrimaryDescriptionFactory> for DisplayPrimaryDescription {}
 impl RtActivatable<IDisplayPrimaryDescriptionStatics> for DisplayPrimaryDescription {}
 impl DisplayPrimaryDescription {
@@ -8363,14 +8363,14 @@ impl IDisplayPrimaryDescriptionStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DisplayRotation: i32 {
+RT_ENUM! { enum DisplayRotation: i32 ["Windows.Devices.Display.Core.DisplayRotation"] {
     None (DisplayRotation_None) = 0, Clockwise90Degrees (DisplayRotation_Clockwise90Degrees) = 1, Clockwise180Degrees (DisplayRotation_Clockwise180Degrees) = 2, Clockwise270Degrees (DisplayRotation_Clockwise270Degrees) = 3,
 }}
 DEFINE_IID!(IID_IDisplayScanout, 3808761896, 7077, 20711, 138, 57, 187, 31, 210, 244, 248, 185);
 RT_INTERFACE!{interface IDisplayScanout(IDisplayScanoutVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayScanout] {
     
 }}
-RT_CLASS!{class DisplayScanout: IDisplayScanout}
+RT_CLASS!{class DisplayScanout: IDisplayScanout ["Windows.Devices.Display.Core.DisplayScanout"]}
 DEFINE_IID!(IID_IDisplaySource, 3973144513, 60124, 20924, 151, 29, 59, 198, 40, 219, 45, 212);
 RT_INTERFACE!{interface IDisplaySource(IDisplaySourceVtbl): IInspectable(IInspectableVtbl) [IID_IDisplaySource] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -8395,7 +8395,7 @@ impl IDisplaySource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplaySource: IDisplaySource}
+RT_CLASS!{class DisplaySource: IDisplaySource ["Windows.Devices.Display.Core.DisplaySource"]}
 DEFINE_IID!(IID_IDisplayState, 135435041, 4533, 23730, 153, 248, 233, 11, 71, 154, 138, 29);
 RT_INTERFACE!{interface IDisplayState(IDisplayStateVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayState] {
     fn get_IsReadOnly(&self, out: *mut bool) -> HRESULT,
@@ -8484,11 +8484,11 @@ impl IDisplayState {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayState: IDisplayState}
-RT_ENUM! { enum DisplayStateApplyOptions: u32 {
+RT_CLASS!{class DisplayState: IDisplayState ["Windows.Devices.Display.Core.DisplayState"]}
+RT_ENUM! { enum DisplayStateApplyOptions: u32 ["Windows.Devices.Display.Core.DisplayStateApplyOptions"] {
     None (DisplayStateApplyOptions_None) = 0, FailIfStateChanged (DisplayStateApplyOptions_FailIfStateChanged) = 1, ForceReapply (DisplayStateApplyOptions_ForceReapply) = 2, ForceModeEnumeration (DisplayStateApplyOptions_ForceModeEnumeration) = 4,
 }}
-RT_ENUM! { enum DisplayStateFunctionalizeOptions: u32 {
+RT_ENUM! { enum DisplayStateFunctionalizeOptions: u32 ["Windows.Devices.Display.Core.DisplayStateFunctionalizeOptions"] {
     None (DisplayStateFunctionalizeOptions_None) = 0, FailIfStateChanged (DisplayStateFunctionalizeOptions_FailIfStateChanged) = 1, ValidateTopologyOnly (DisplayStateFunctionalizeOptions_ValidateTopologyOnly) = 2,
 }}
 DEFINE_IID!(IID_IDisplayStateOperationResult, 4239245279, 56359, 22072, 183, 242, 235, 223, 164, 247, 234, 147);
@@ -8508,15 +8508,15 @@ impl IDisplayStateOperationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayStateOperationResult: IDisplayStateOperationResult}
-RT_ENUM! { enum DisplayStateOperationStatus: i32 {
+RT_CLASS!{class DisplayStateOperationResult: IDisplayStateOperationResult ["Windows.Devices.Display.Core.DisplayStateOperationResult"]}
+RT_ENUM! { enum DisplayStateOperationStatus: i32 ["Windows.Devices.Display.Core.DisplayStateOperationStatus"] {
     Success (DisplayStateOperationStatus_Success) = 0, PartialFailure (DisplayStateOperationStatus_PartialFailure) = 1, UnknownFailure (DisplayStateOperationStatus_UnknownFailure) = 2, TargetOwnershipLost (DisplayStateOperationStatus_TargetOwnershipLost) = 3, SystemStateChanged (DisplayStateOperationStatus_SystemStateChanged) = 4, TooManyPathsForAdapter (DisplayStateOperationStatus_TooManyPathsForAdapter) = 5, ModesNotSupported (DisplayStateOperationStatus_ModesNotSupported) = 6, RemoteSessionNotSupported (DisplayStateOperationStatus_RemoteSessionNotSupported) = 7,
 }}
 DEFINE_IID!(IID_IDisplaySurface, 1498377414, 5018, 22230, 164, 177, 21, 254, 44, 183, 106, 219);
 RT_INTERFACE!{interface IDisplaySurface(IDisplaySurfaceVtbl): IInspectable(IInspectableVtbl) [IID_IDisplaySurface] {
     
 }}
-RT_CLASS!{class DisplaySurface: IDisplaySurface}
+RT_CLASS!{class DisplaySurface: IDisplaySurface ["Windows.Devices.Display.Core.DisplaySurface"]}
 DEFINE_IID!(IID_IDisplayTarget, 2932178031, 18356, 21611, 152, 124, 231, 63, 167, 145, 254, 58);
 RT_INTERFACE!{interface IDisplayTarget(IDisplayTargetVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayTarget] {
     fn get_Adapter(&self, out: *mut *mut DisplayAdapter) -> HRESULT,
@@ -8606,8 +8606,8 @@ impl IDisplayTarget {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayTarget: IDisplayTarget}
-RT_ENUM! { enum DisplayTargetPersistence: i32 {
+RT_CLASS!{class DisplayTarget: IDisplayTarget ["Windows.Devices.Display.Core.DisplayTarget"]}
+RT_ENUM! { enum DisplayTargetPersistence: i32 ["Windows.Devices.Display.Core.DisplayTargetPersistence"] {
     None (DisplayTargetPersistence_None) = 0, BootPersisted (DisplayTargetPersistence_BootPersisted) = 1, TemporaryPersisted (DisplayTargetPersistence_TemporaryPersisted) = 2, PathPersisted (DisplayTargetPersistence_PathPersisted) = 3,
 }}
 DEFINE_IID!(IID_IDisplayTask, 1577612360, 4955, 23472, 191, 99, 99, 127, 132, 34, 124, 122);
@@ -8625,7 +8625,7 @@ impl IDisplayTask {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayTask: IDisplayTask}
+RT_CLASS!{class DisplayTask: IDisplayTask ["Windows.Devices.Display.Core.DisplayTask"]}
 DEFINE_IID!(IID_IDisplayTaskPool, 3329631549, 9085, 21832, 170, 250, 62, 81, 127, 239, 239, 28);
 RT_INTERFACE!{interface IDisplayTaskPool(IDisplayTaskPoolVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayTaskPool] {
     fn CreateTask(&self, out: *mut *mut DisplayTask) -> HRESULT,
@@ -8642,8 +8642,8 @@ impl IDisplayTaskPool {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayTaskPool: IDisplayTaskPool}
-RT_ENUM! { enum DisplayTaskSignalKind: i32 {
+RT_CLASS!{class DisplayTaskPool: IDisplayTaskPool ["Windows.Devices.Display.Core.DisplayTaskPool"]}
+RT_ENUM! { enum DisplayTaskSignalKind: i32 ["Windows.Devices.Display.Core.DisplayTaskSignalKind"] {
     OnPresentFlipAway (DisplayTaskSignalKind_OnPresentFlipAway) = 0,
 }}
 DEFINE_IID!(IID_IDisplayView, 2965998753, 46937, 23385, 177, 173, 240, 120, 106, 169, 229, 61);
@@ -8681,7 +8681,7 @@ impl IDisplayView {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayView: IDisplayView}
+RT_CLASS!{class DisplayView: IDisplayView ["Windows.Devices.Display.Core.DisplayView"]}
 DEFINE_IID!(IID_IDisplayWireFormat, 449615485, 34604, 23096, 187, 185, 29, 72, 114, 183, 98, 85);
 RT_INTERFACE!{interface IDisplayWireFormat(IDisplayWireFormatVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayWireFormat] {
     fn get_PixelEncoding(&self, out: *mut DisplayWireFormatPixelEncoding) -> HRESULT,
@@ -8723,7 +8723,7 @@ impl IDisplayWireFormat {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayWireFormat: IDisplayWireFormat}
+RT_CLASS!{class DisplayWireFormat: IDisplayWireFormat ["Windows.Devices.Display.Core.DisplayWireFormat"]}
 impl RtActivatable<IDisplayWireFormatFactory> for DisplayWireFormat {}
 impl RtActivatable<IDisplayWireFormatStatics> for DisplayWireFormat {}
 impl DisplayWireFormat {
@@ -8735,10 +8735,10 @@ impl DisplayWireFormat {
     }
 }
 DEFINE_CLSID!(DisplayWireFormat(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,68,105,115,112,108,97,121,46,67,111,114,101,46,68,105,115,112,108,97,121,87,105,114,101,70,111,114,109,97,116,0]) [CLSID_DisplayWireFormat]);
-RT_ENUM! { enum DisplayWireFormatColorSpace: i32 {
+RT_ENUM! { enum DisplayWireFormatColorSpace: i32 ["Windows.Devices.Display.Core.DisplayWireFormatColorSpace"] {
     BT709 (DisplayWireFormatColorSpace_BT709) = 0, BT2020 (DisplayWireFormatColorSpace_BT2020) = 1, ProfileDefinedWideColorGamut (DisplayWireFormatColorSpace_ProfileDefinedWideColorGamut) = 2,
 }}
-RT_ENUM! { enum DisplayWireFormatEotf: i32 {
+RT_ENUM! { enum DisplayWireFormatEotf: i32 ["Windows.Devices.Display.Core.DisplayWireFormatEotf"] {
     Sdr (DisplayWireFormatEotf_Sdr) = 0, HdrSmpte2084 (DisplayWireFormatEotf_HdrSmpte2084) = 1,
 }}
 DEFINE_IID!(IID_IDisplayWireFormatFactory, 3002058965, 2518, 21990, 173, 34, 144, 20, 179, 210, 82, 41);
@@ -8752,10 +8752,10 @@ impl IDisplayWireFormatFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DisplayWireFormatHdrMetadata: i32 {
+RT_ENUM! { enum DisplayWireFormatHdrMetadata: i32 ["Windows.Devices.Display.Core.DisplayWireFormatHdrMetadata"] {
     None (DisplayWireFormatHdrMetadata_None) = 0, Hdr10 (DisplayWireFormatHdrMetadata_Hdr10) = 1, Hdr10Plus (DisplayWireFormatHdrMetadata_Hdr10Plus) = 2, DolbyVisionLowLatency (DisplayWireFormatHdrMetadata_DolbyVisionLowLatency) = 3,
 }}
-RT_ENUM! { enum DisplayWireFormatPixelEncoding: i32 {
+RT_ENUM! { enum DisplayWireFormatPixelEncoding: i32 ["Windows.Devices.Display.Core.DisplayWireFormatPixelEncoding"] {
     Rgb444 (DisplayWireFormatPixelEncoding_Rgb444) = 0, Ycc444 (DisplayWireFormatPixelEncoding_Ycc444) = 1, Ycc422 (DisplayWireFormatPixelEncoding_Ycc422) = 2, Ycc420 (DisplayWireFormatPixelEncoding_Ycc420) = 3, Intensity (DisplayWireFormatPixelEncoding_Intensity) = 4,
 }}
 DEFINE_IID!(IID_IDisplayWireFormatStatics, 3312820781, 50150, 24442, 189, 251, 135, 198, 171, 134, 97, 213);
@@ -8784,7 +8784,7 @@ impl IDeviceAccessChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceAccessChangedEventArgs: IDeviceAccessChangedEventArgs}
+RT_CLASS!{class DeviceAccessChangedEventArgs: IDeviceAccessChangedEventArgs ["Windows.Devices.Enumeration.DeviceAccessChangedEventArgs"]}
 DEFINE_IID!(IID_IDeviceAccessChangedEventArgs2, 2186424930, 37707, 19248, 161, 120, 173, 195, 159, 47, 43, 227);
 RT_INTERFACE!{interface IDeviceAccessChangedEventArgs2(IDeviceAccessChangedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceAccessChangedEventArgs2] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT
@@ -8818,7 +8818,7 @@ impl IDeviceAccessInformation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceAccessInformation: IDeviceAccessInformation}
+RT_CLASS!{class DeviceAccessInformation: IDeviceAccessInformation ["Windows.Devices.Enumeration.DeviceAccessInformation"]}
 impl RtActivatable<IDeviceAccessInformationStatics> for DeviceAccessInformation {}
 impl DeviceAccessInformation {
     #[inline] pub fn create_from_id(deviceId: &HStringArg) -> Result<Option<ComPtr<DeviceAccessInformation>>> {
@@ -8855,10 +8855,10 @@ impl IDeviceAccessInformationStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DeviceAccessStatus: i32 {
+RT_ENUM! { enum DeviceAccessStatus: i32 ["Windows.Devices.Enumeration.DeviceAccessStatus"] {
     Unspecified (DeviceAccessStatus_Unspecified) = 0, Allowed (DeviceAccessStatus_Allowed) = 1, DeniedByUser (DeviceAccessStatus_DeniedByUser) = 2, DeniedBySystem (DeviceAccessStatus_DeniedBySystem) = 3,
 }}
-RT_ENUM! { enum DeviceClass: i32 {
+RT_ENUM! { enum DeviceClass: i32 ["Windows.Devices.Enumeration.DeviceClass"] {
     All (DeviceClass_All) = 0, AudioCapture (DeviceClass_AudioCapture) = 1, AudioRender (DeviceClass_AudioRender) = 2, PortableStorageDevice (DeviceClass_PortableStorageDevice) = 3, VideoCapture (DeviceClass_VideoCapture) = 4, ImageScanner (DeviceClass_ImageScanner) = 5, Location (DeviceClass_Location) = 6,
 }}
 DEFINE_IID!(IID_IDeviceConnectionChangeTriggerDetails, 3092745228, 48065, 18507, 191, 250, 123, 49, 220, 194, 0, 178);
@@ -8872,7 +8872,7 @@ impl IDeviceConnectionChangeTriggerDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceConnectionChangeTriggerDetails: IDeviceConnectionChangeTriggerDetails}
+RT_CLASS!{class DeviceConnectionChangeTriggerDetails: IDeviceConnectionChangeTriggerDetails ["Windows.Devices.Enumeration.DeviceConnectionChangeTriggerDetails"]}
 DEFINE_IID!(IID_IDeviceDisconnectButtonClickedEventArgs, 2386867565, 63746, 18944, 181, 54, 243, 121, 146, 230, 162, 167);
 RT_INTERFACE!{interface IDeviceDisconnectButtonClickedEventArgs(IDeviceDisconnectButtonClickedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceDisconnectButtonClickedEventArgs] {
     fn get_Device(&self, out: *mut *mut DeviceInformation) -> HRESULT
@@ -8884,7 +8884,7 @@ impl IDeviceDisconnectButtonClickedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceDisconnectButtonClickedEventArgs: IDeviceDisconnectButtonClickedEventArgs}
+RT_CLASS!{class DeviceDisconnectButtonClickedEventArgs: IDeviceDisconnectButtonClickedEventArgs ["Windows.Devices.Enumeration.DeviceDisconnectButtonClickedEventArgs"]}
 DEFINE_IID!(IID_IDeviceInformation, 2879454101, 17304, 18589, 142, 68, 230, 19, 9, 39, 1, 31);
 RT_INTERFACE!{interface IDeviceInformation(IDeviceInformationVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceInformation] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -8943,7 +8943,7 @@ impl IDeviceInformation {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceInformation: IDeviceInformation}
+RT_CLASS!{class DeviceInformation: IDeviceInformation ["Windows.Devices.Enumeration.DeviceInformation"]}
 impl RtActivatable<IDeviceInformationStatics> for DeviceInformation {}
 impl RtActivatable<IDeviceInformationStatics2> for DeviceInformation {}
 impl DeviceInformation {
@@ -9008,7 +9008,7 @@ impl IDeviceInformation2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceInformationCollection: foundation::collections::IVectorView<DeviceInformation>}
+RT_CLASS!{class DeviceInformationCollection: foundation::collections::IVectorView<DeviceInformation> ["Windows.Devices.Enumeration.DeviceInformationCollection"]}
 DEFINE_IID!(IID_IDeviceInformationCustomPairing, 2232650754, 20198, 18708, 131, 112, 16, 122, 57, 20, 76, 14);
 RT_INTERFACE!{interface IDeviceInformationCustomPairing(IDeviceInformationCustomPairingVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceInformationCustomPairing] {
     fn PairAsync(&self, pairingKindsSupported: DevicePairingKinds, out: *mut *mut foundation::IAsyncOperation<DevicePairingResult>) -> HRESULT,
@@ -9043,8 +9043,8 @@ impl IDeviceInformationCustomPairing {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceInformationCustomPairing: IDeviceInformationCustomPairing}
-RT_ENUM! { enum DeviceInformationKind: i32 {
+RT_CLASS!{class DeviceInformationCustomPairing: IDeviceInformationCustomPairing ["Windows.Devices.Enumeration.DeviceInformationCustomPairing"]}
+RT_ENUM! { enum DeviceInformationKind: i32 ["Windows.Devices.Enumeration.DeviceInformationKind"] {
     Unknown (DeviceInformationKind_Unknown) = 0, DeviceInterface (DeviceInformationKind_DeviceInterface) = 1, DeviceContainer (DeviceInformationKind_DeviceContainer) = 2, Device (DeviceInformationKind_Device) = 3, DeviceInterfaceClass (DeviceInformationKind_DeviceInterfaceClass) = 4, AssociationEndpoint (DeviceInformationKind_AssociationEndpoint) = 5, AssociationEndpointContainer (DeviceInformationKind_AssociationEndpointContainer) = 6, AssociationEndpointService (DeviceInformationKind_AssociationEndpointService) = 7, DevicePanel (DeviceInformationKind_DevicePanel) = 8,
 }}
 DEFINE_IID!(IID_IDeviceInformationPairing, 742877685, 63108, 16597, 132, 105, 232, 219, 170, 183, 4, 133);
@@ -9076,7 +9076,7 @@ impl IDeviceInformationPairing {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceInformationPairing: IDeviceInformationPairing}
+RT_CLASS!{class DeviceInformationPairing: IDeviceInformationPairing ["Windows.Devices.Enumeration.DeviceInformationPairing"]}
 impl RtActivatable<IDeviceInformationPairingStatics> for DeviceInformationPairing {}
 impl RtActivatable<IDeviceInformationPairingStatics2> for DeviceInformationPairing {}
 impl DeviceInformationPairing {
@@ -9250,7 +9250,7 @@ impl IDeviceInformationUpdate {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceInformationUpdate: IDeviceInformationUpdate}
+RT_CLASS!{class DeviceInformationUpdate: IDeviceInformationUpdate ["Windows.Devices.Enumeration.DeviceInformationUpdate"]}
 DEFINE_IID!(IID_IDeviceInformationUpdate2, 1570575500, 43123, 18526, 186, 166, 170, 98, 7, 136, 227, 204);
 RT_INTERFACE!{interface IDeviceInformationUpdate2(IDeviceInformationUpdate2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceInformationUpdate2] {
     fn get_Kind(&self, out: *mut DeviceInformationKind) -> HRESULT
@@ -9262,10 +9262,10 @@ impl IDeviceInformationUpdate2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DevicePairingKinds: u32 {
+RT_ENUM! { enum DevicePairingKinds: u32 ["Windows.Devices.Enumeration.DevicePairingKinds"] {
     None (DevicePairingKinds_None) = 0, ConfirmOnly (DevicePairingKinds_ConfirmOnly) = 1, DisplayPin (DevicePairingKinds_DisplayPin) = 2, ProvidePin (DevicePairingKinds_ProvidePin) = 4, ConfirmPinMatch (DevicePairingKinds_ConfirmPinMatch) = 8,
 }}
-RT_ENUM! { enum DevicePairingProtectionLevel: i32 {
+RT_ENUM! { enum DevicePairingProtectionLevel: i32 ["Windows.Devices.Enumeration.DevicePairingProtectionLevel"] {
     Default (DevicePairingProtectionLevel_Default) = 0, None (DevicePairingProtectionLevel_None) = 1, Encryption (DevicePairingProtectionLevel_Encryption) = 2, EncryptionAndAuthentication (DevicePairingProtectionLevel_EncryptionAndAuthentication) = 3,
 }}
 DEFINE_IID!(IID_IDevicePairingRequestedEventArgs, 4145544278, 56939, 18559, 131, 118, 1, 128, 172, 166, 153, 99);
@@ -9307,7 +9307,7 @@ impl IDevicePairingRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePairingRequestedEventArgs: IDevicePairingRequestedEventArgs}
+RT_CLASS!{class DevicePairingRequestedEventArgs: IDevicePairingRequestedEventArgs ["Windows.Devices.Enumeration.DevicePairingRequestedEventArgs"]}
 DEFINE_IID!(IID_IDevicePairingResult, 120259263, 56725, 16421, 155, 55, 222, 81, 173, 186, 55, 183);
 RT_INTERFACE!{interface IDevicePairingResult(IDevicePairingResultVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePairingResult] {
     fn get_Status(&self, out: *mut DevicePairingResultStatus) -> HRESULT,
@@ -9325,8 +9325,8 @@ impl IDevicePairingResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePairingResult: IDevicePairingResult}
-RT_ENUM! { enum DevicePairingResultStatus: i32 {
+RT_CLASS!{class DevicePairingResult: IDevicePairingResult ["Windows.Devices.Enumeration.DevicePairingResult"]}
+RT_ENUM! { enum DevicePairingResultStatus: i32 ["Windows.Devices.Enumeration.DevicePairingResultStatus"] {
     Paired (DevicePairingResultStatus_Paired) = 0, NotReadyToPair (DevicePairingResultStatus_NotReadyToPair) = 1, NotPaired (DevicePairingResultStatus_NotPaired) = 2, AlreadyPaired (DevicePairingResultStatus_AlreadyPaired) = 3, ConnectionRejected (DevicePairingResultStatus_ConnectionRejected) = 4, TooManyConnections (DevicePairingResultStatus_TooManyConnections) = 5, HardwareFailure (DevicePairingResultStatus_HardwareFailure) = 6, AuthenticationTimeout (DevicePairingResultStatus_AuthenticationTimeout) = 7, AuthenticationNotAllowed (DevicePairingResultStatus_AuthenticationNotAllowed) = 8, AuthenticationFailure (DevicePairingResultStatus_AuthenticationFailure) = 9, NoSupportedProfiles (DevicePairingResultStatus_NoSupportedProfiles) = 10, ProtectionLevelCouldNotBeMet (DevicePairingResultStatus_ProtectionLevelCouldNotBeMet) = 11, AccessDenied (DevicePairingResultStatus_AccessDenied) = 12, InvalidCeremonyData (DevicePairingResultStatus_InvalidCeremonyData) = 13, PairingCanceled (DevicePairingResultStatus_PairingCanceled) = 14, OperationAlreadyInProgress (DevicePairingResultStatus_OperationAlreadyInProgress) = 15, RequiredHandlerNotRegistered (DevicePairingResultStatus_RequiredHandlerNotRegistered) = 16, RejectedByHandler (DevicePairingResultStatus_RejectedByHandler) = 17, RemoteDeviceHasAssociation (DevicePairingResultStatus_RemoteDeviceHasAssociation) = 18, Failed (DevicePairingResultStatus_Failed) = 19,
 }}
 DEFINE_IID!(IID_IDevicePairingSettings, 1210888828, 33723, 16910, 190, 81, 102, 2, 178, 34, 222, 84);
@@ -9423,7 +9423,7 @@ impl IDevicePicker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePicker: IDevicePicker}
+RT_CLASS!{class DevicePicker: IDevicePicker ["Windows.Devices.Enumeration.DevicePicker"]}
 impl RtActivatable<IActivationFactory> for DevicePicker {}
 DEFINE_CLSID!(DevicePicker(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,68,101,118,105,99,101,80,105,99,107,101,114,0]) [CLSID_DevicePicker]);
 DEFINE_IID!(IID_IDevicePickerAppearance, 3868857030, 58919, 20184, 155, 108, 70, 10, 244, 69, 229, 109);
@@ -9508,8 +9508,8 @@ impl IDevicePickerAppearance {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePickerAppearance: IDevicePickerAppearance}
-RT_ENUM! { enum DevicePickerDisplayStatusOptions: u32 {
+RT_CLASS!{class DevicePickerAppearance: IDevicePickerAppearance ["Windows.Devices.Enumeration.DevicePickerAppearance"]}
+RT_ENUM! { enum DevicePickerDisplayStatusOptions: u32 ["Windows.Devices.Enumeration.DevicePickerDisplayStatusOptions"] {
     None (DevicePickerDisplayStatusOptions_None) = 0, ShowProgress (DevicePickerDisplayStatusOptions_ShowProgress) = 1, ShowDisconnectButton (DevicePickerDisplayStatusOptions_ShowDisconnectButton) = 2, ShowRetryButton (DevicePickerDisplayStatusOptions_ShowRetryButton) = 4,
 }}
 DEFINE_IID!(IID_IDevicePickerFilter, 2447086242, 22475, 18673, 155, 89, 165, 155, 122, 31, 2, 162);
@@ -9529,7 +9529,7 @@ impl IDevicePickerFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePickerFilter: IDevicePickerFilter}
+RT_CLASS!{class DevicePickerFilter: IDevicePickerFilter ["Windows.Devices.Enumeration.DevicePickerFilter"]}
 DEFINE_IID!(IID_IDeviceSelectedEventArgs, 647944926, 7471, 18752, 132, 2, 65, 86, 184, 29, 60, 119);
 RT_INTERFACE!{interface IDeviceSelectedEventArgs(IDeviceSelectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceSelectedEventArgs] {
     fn get_SelectedDevice(&self, out: *mut *mut DeviceInformation) -> HRESULT
@@ -9541,9 +9541,9 @@ impl IDeviceSelectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceSelectedEventArgs: IDeviceSelectedEventArgs}
-#[cfg(feature="windows-storage")] RT_CLASS!{class DeviceThumbnail: super::super::storage::streams::IRandomAccessStreamWithContentType}
-#[cfg(not(feature="windows-storage"))] RT_CLASS!{class DeviceThumbnail: IInspectable}
+RT_CLASS!{class DeviceSelectedEventArgs: IDeviceSelectedEventArgs ["Windows.Devices.Enumeration.DeviceSelectedEventArgs"]}
+#[cfg(feature="windows-storage")] RT_CLASS!{class DeviceThumbnail: super::super::storage::streams::IRandomAccessStreamWithContentType ["Windows.Devices.Enumeration.DeviceThumbnail"]}
+#[cfg(not(feature="windows-storage"))] RT_CLASS!{class DeviceThumbnail: IInspectable ["Windows.Devices.Enumeration.DeviceThumbnail"]}
 DEFINE_IID!(IID_IDeviceUnpairingResult, 1727285971, 31193, 17483, 146, 207, 169, 46, 247, 37, 113, 199);
 RT_INTERFACE!{interface IDeviceUnpairingResult(IDeviceUnpairingResultVtbl): IInspectable(IInspectableVtbl) [IID_IDeviceUnpairingResult] {
     fn get_Status(&self, out: *mut DeviceUnpairingResultStatus) -> HRESULT
@@ -9555,8 +9555,8 @@ impl IDeviceUnpairingResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceUnpairingResult: IDeviceUnpairingResult}
-RT_ENUM! { enum DeviceUnpairingResultStatus: i32 {
+RT_CLASS!{class DeviceUnpairingResult: IDeviceUnpairingResult ["Windows.Devices.Enumeration.DeviceUnpairingResult"]}
+RT_ENUM! { enum DeviceUnpairingResultStatus: i32 ["Windows.Devices.Enumeration.DeviceUnpairingResultStatus"] {
     Unpaired (DeviceUnpairingResultStatus_Unpaired) = 0, AlreadyUnpaired (DeviceUnpairingResultStatus_AlreadyUnpaired) = 1, OperationAlreadyInProgress (DeviceUnpairingResultStatus_OperationAlreadyInProgress) = 2, AccessDenied (DeviceUnpairingResultStatus_AccessDenied) = 3, Failed (DeviceUnpairingResultStatus_Failed) = 4,
 }}
 DEFINE_IID!(IID_IDeviceWatcher, 3387603325, 36715, 20374, 169, 244, 171, 200, 20, 226, 34, 113);
@@ -9635,7 +9635,7 @@ impl IDeviceWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceWatcher: IDeviceWatcher}
+RT_CLASS!{class DeviceWatcher: IDeviceWatcher ["Windows.Devices.Enumeration.DeviceWatcher"]}
 DEFINE_IID!(IID_IDeviceWatcher2, 4278732142, 60692, 18921, 154, 105, 129, 23, 197, 74, 233, 113);
 RT_INTERFACE!{interface IDeviceWatcher2(IDeviceWatcher2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeviceWatcher2] {
     #[cfg(feature="windows-applicationmodel")] fn GetBackgroundTrigger(&self, requestedEventKinds: *mut foundation::collections::IIterable<DeviceWatcherEventKind>, out: *mut *mut super::super::applicationmodel::background::DeviceWatcherTrigger) -> HRESULT
@@ -9670,11 +9670,11 @@ impl IDeviceWatcherEvent {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceWatcherEvent: IDeviceWatcherEvent}
-RT_ENUM! { enum DeviceWatcherEventKind: i32 {
+RT_CLASS!{class DeviceWatcherEvent: IDeviceWatcherEvent ["Windows.Devices.Enumeration.DeviceWatcherEvent"]}
+RT_ENUM! { enum DeviceWatcherEventKind: i32 ["Windows.Devices.Enumeration.DeviceWatcherEventKind"] {
     Add (DeviceWatcherEventKind_Add) = 0, Update (DeviceWatcherEventKind_Update) = 1, Remove (DeviceWatcherEventKind_Remove) = 2,
 }}
-RT_ENUM! { enum DeviceWatcherStatus: i32 {
+RT_ENUM! { enum DeviceWatcherStatus: i32 ["Windows.Devices.Enumeration.DeviceWatcherStatus"] {
     Created (DeviceWatcherStatus_Created) = 0, Started (DeviceWatcherStatus_Started) = 1, EnumerationCompleted (DeviceWatcherStatus_EnumerationCompleted) = 2, Stopping (DeviceWatcherStatus_Stopping) = 3, Stopped (DeviceWatcherStatus_Stopped) = 4, Aborted (DeviceWatcherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IDeviceWatcherTriggerDetails, 947945753, 19639, 20055, 165, 109, 119, 109, 7, 203, 254, 249);
@@ -9688,7 +9688,7 @@ impl IDeviceWatcherTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeviceWatcherTriggerDetails: IDeviceWatcherTriggerDetails}
+RT_CLASS!{class DeviceWatcherTriggerDetails: IDeviceWatcherTriggerDetails ["Windows.Devices.Enumeration.DeviceWatcherTriggerDetails"]}
 DEFINE_IID!(IID_IEnclosureLocation, 1110706727, 22544, 17820, 170, 187, 198, 94, 31, 129, 62, 207);
 RT_INTERFACE!{interface IEnclosureLocation(IEnclosureLocationVtbl): IInspectable(IInspectableVtbl) [IID_IEnclosureLocation] {
     fn get_InDock(&self, out: *mut bool) -> HRESULT,
@@ -9712,7 +9712,7 @@ impl IEnclosureLocation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EnclosureLocation: IEnclosureLocation}
+RT_CLASS!{class EnclosureLocation: IEnclosureLocation ["Windows.Devices.Enumeration.EnclosureLocation"]}
 DEFINE_IID!(IID_IEnclosureLocation2, 679844187, 57469, 18525, 138, 158, 189, 242, 154, 239, 79, 102);
 RT_INTERFACE!{interface IEnclosureLocation2(IEnclosureLocation2Vtbl): IInspectable(IInspectableVtbl) [IID_IEnclosureLocation2] {
     fn get_RotationAngleInDegreesClockwise(&self, out: *mut u32) -> HRESULT
@@ -9724,7 +9724,7 @@ impl IEnclosureLocation2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum Panel: i32 {
+RT_ENUM! { enum Panel: i32 ["Windows.Devices.Enumeration.Panel"] {
     Unknown (Panel_Unknown) = 0, Front (Panel_Front) = 1, Back (Panel_Back) = 2, Top (Panel_Top) = 3, Bottom (Panel_Bottom) = 4, Left (Panel_Left) = 5, Right (Panel_Right) = 6,
 }}
 pub mod pnp { // Windows.Devices.Enumeration.Pnp
@@ -9757,7 +9757,7 @@ impl IPnpObject {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PnpObject: IPnpObject}
+RT_CLASS!{class PnpObject: IPnpObject ["Windows.Devices.Enumeration.Pnp.PnpObject"]}
 impl RtActivatable<IPnpObjectStatics> for PnpObject {}
 impl PnpObject {
     #[inline] pub fn create_from_id_async(type_: PnpObjectType, id: &HStringArg, requestedProperties: &foundation::collections::IIterable<HString>) -> Result<ComPtr<foundation::IAsyncOperation<PnpObject>>> {
@@ -9777,7 +9777,7 @@ impl PnpObject {
     }
 }
 DEFINE_CLSID!(PnpObject(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,69,110,117,109,101,114,97,116,105,111,110,46,80,110,112,46,80,110,112,79,98,106,101,99,116,0]) [CLSID_PnpObject]);
-RT_CLASS!{class PnpObjectCollection: foundation::collections::IVectorView<PnpObject>}
+RT_CLASS!{class PnpObjectCollection: foundation::collections::IVectorView<PnpObject> ["Windows.Devices.Enumeration.Pnp.PnpObjectCollection"]}
 DEFINE_IID!(IID_IPnpObjectStatics, 3015911997, 53608, 18016, 187, 243, 167, 51, 177, 75, 110, 1);
 RT_INTERFACE!{static interface IPnpObjectStatics(IPnpObjectStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPnpObjectStatics] {
     fn CreateFromIdAsync(&self, type_: PnpObjectType, id: HSTRING, requestedProperties: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncOperation<PnpObject>) -> HRESULT,
@@ -9813,7 +9813,7 @@ impl IPnpObjectStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PnpObjectType: i32 {
+RT_ENUM! { enum PnpObjectType: i32 ["Windows.Devices.Enumeration.Pnp.PnpObjectType"] {
     Unknown (PnpObjectType_Unknown) = 0, DeviceInterface (PnpObjectType_DeviceInterface) = 1, DeviceContainer (PnpObjectType_DeviceContainer) = 2, Device (PnpObjectType_Device) = 3, DeviceInterfaceClass (PnpObjectType_DeviceInterfaceClass) = 4, AssociationEndpoint (PnpObjectType_AssociationEndpoint) = 5, AssociationEndpointContainer (PnpObjectType_AssociationEndpointContainer) = 6, AssociationEndpointService (PnpObjectType_AssociationEndpointService) = 7, DevicePanel (PnpObjectType_DevicePanel) = 8,
 }}
 DEFINE_IID!(IID_IPnpObjectUpdate, 1868163090, 30, 18500, 188, 198, 67, 40, 134, 133, 106, 23);
@@ -9839,7 +9839,7 @@ impl IPnpObjectUpdate {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PnpObjectUpdate: IPnpObjectUpdate}
+RT_CLASS!{class PnpObjectUpdate: IPnpObjectUpdate ["Windows.Devices.Enumeration.Pnp.PnpObjectUpdate"]}
 DEFINE_IID!(IID_IPnpObjectWatcher, 2211011752, 18290, 19066, 172, 168, 228, 140, 66, 168, 156, 68);
 RT_INTERFACE!{interface IPnpObjectWatcher(IPnpObjectWatcherVtbl): IInspectable(IInspectableVtbl) [IID_IPnpObjectWatcher] {
     fn add_Added(&self, handler: *mut foundation::TypedEventHandler<PnpObjectWatcher, PnpObject>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -9916,15 +9916,15 @@ impl IPnpObjectWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PnpObjectWatcher: IPnpObjectWatcher}
+RT_CLASS!{class PnpObjectWatcher: IPnpObjectWatcher ["Windows.Devices.Enumeration.Pnp.PnpObjectWatcher"]}
 } // Windows.Devices.Enumeration.Pnp
 } // Windows.Devices.Enumeration
 pub mod geolocation { // Windows.Devices.Geolocation
 use ::prelude::*;
-RT_ENUM! { enum AltitudeReferenceSystem: i32 {
+RT_ENUM! { enum AltitudeReferenceSystem: i32 ["Windows.Devices.Geolocation.AltitudeReferenceSystem"] {
     Unspecified (AltitudeReferenceSystem_Unspecified) = 0, Terrain (AltitudeReferenceSystem_Terrain) = 1, Ellipsoid (AltitudeReferenceSystem_Ellipsoid) = 2, Geoid (AltitudeReferenceSystem_Geoid) = 3, Surface (AltitudeReferenceSystem_Surface) = 4,
 }}
-RT_STRUCT! { struct BasicGeoposition {
+RT_STRUCT! { struct BasicGeoposition ["Windows.Devices.Geolocation.BasicGeoposition"] {
     Latitude: f64, Longitude: f64, Altitude: f64,
 }}
 DEFINE_IID!(IID_ICivicAddress, 2824239642, 25844, 19784, 188, 234, 246, 176, 8, 236, 163, 76);
@@ -9962,7 +9962,7 @@ impl ICivicAddress {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CivicAddress: ICivicAddress}
+RT_CLASS!{class CivicAddress: ICivicAddress ["Windows.Devices.Geolocation.CivicAddress"]}
 DEFINE_IID!(IID_IGeoboundingBox, 144099339, 10063, 17370, 154, 6, 203, 252, 218, 235, 78, 194);
 RT_INTERFACE!{interface IGeoboundingBox(IGeoboundingBoxVtbl): IInspectable(IInspectableVtbl) [IID_IGeoboundingBox] {
     fn get_NorthwestCorner(&self, out: *mut BasicGeoposition) -> HRESULT,
@@ -9998,7 +9998,7 @@ impl IGeoboundingBox {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeoboundingBox: IGeoboundingBox}
+RT_CLASS!{class GeoboundingBox: IGeoboundingBox ["Windows.Devices.Geolocation.GeoboundingBox"]}
 impl RtActivatable<IGeoboundingBoxFactory> for GeoboundingBox {}
 impl RtActivatable<IGeoboundingBoxStatics> for GeoboundingBox {}
 impl GeoboundingBox {
@@ -10085,7 +10085,7 @@ impl IGeocircle {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geocircle: IGeocircle}
+RT_CLASS!{class Geocircle: IGeocircle ["Windows.Devices.Geolocation.Geocircle"]}
 impl RtActivatable<IGeocircleFactory> for Geocircle {}
 impl Geocircle {
     #[inline] pub fn create(position: BasicGeoposition, radius: f64) -> Result<ComPtr<Geocircle>> {
@@ -10175,7 +10175,7 @@ impl IGeocoordinate {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geocoordinate: IGeocoordinate}
+RT_CLASS!{class Geocoordinate: IGeocoordinate ["Windows.Devices.Geolocation.Geocoordinate"]}
 DEFINE_IID!(IID_IGeocoordinateSatelliteData, 3274339545, 9736, 18252, 145, 44, 6, 221, 73, 15, 74, 247);
 RT_INTERFACE!{interface IGeocoordinateSatelliteData(IGeocoordinateSatelliteDataVtbl): IInspectable(IInspectableVtbl) [IID_IGeocoordinateSatelliteData] {
     fn get_PositionDilutionOfPrecision(&self, out: *mut *mut foundation::IReference<f64>) -> HRESULT,
@@ -10199,7 +10199,7 @@ impl IGeocoordinateSatelliteData {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeocoordinateSatelliteData: IGeocoordinateSatelliteData}
+RT_CLASS!{class GeocoordinateSatelliteData: IGeocoordinateSatelliteData ["Windows.Devices.Geolocation.GeocoordinateSatelliteData"]}
 DEFINE_IID!(IID_IGeocoordinateWithPoint, 4276749605, 53804, 19782, 181, 39, 11, 150, 6, 111, 199, 219);
 RT_INTERFACE!{interface IGeocoordinateWithPoint(IGeocoordinateWithPointVtbl): IInspectable(IInspectableVtbl) [IID_IGeocoordinateWithPoint] {
     fn get_Point(&self, out: *mut *mut Geopoint) -> HRESULT
@@ -10239,7 +10239,7 @@ impl IGeocoordinateWithPositionSourceTimestamp {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GeolocationAccessStatus: i32 {
+RT_ENUM! { enum GeolocationAccessStatus: i32 ["Windows.Devices.Geolocation.GeolocationAccessStatus"] {
     Unspecified (GeolocationAccessStatus_Unspecified) = 0, Allowed (GeolocationAccessStatus_Allowed) = 1, Denied (GeolocationAccessStatus_Denied) = 2,
 }}
 DEFINE_IID!(IID_IGeolocator, 2848178018, 17700, 18825, 138, 169, 222, 1, 157, 46, 85, 31);
@@ -10320,7 +10320,7 @@ impl IGeolocator {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geolocator: IGeolocator}
+RT_CLASS!{class Geolocator: IGeolocator ["Windows.Devices.Geolocation.Geolocator"]}
 impl RtActivatable<IGeolocatorStatics> for Geolocator {}
 impl RtActivatable<IGeolocatorStatics2> for Geolocator {}
 impl RtActivatable<IActivationFactory> for Geolocator {}
@@ -10427,7 +10427,7 @@ impl IGeopath {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geopath: IGeopath}
+RT_CLASS!{class Geopath: IGeopath ["Windows.Devices.Geolocation.Geopath"]}
 impl RtActivatable<IGeopathFactory> for Geopath {}
 impl Geopath {
     #[inline] pub fn create(positions: &foundation::collections::IIterable<BasicGeoposition>) -> Result<ComPtr<Geopath>> {
@@ -10475,7 +10475,7 @@ impl IGeopoint {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geopoint: IGeopoint}
+RT_CLASS!{class Geopoint: IGeopoint ["Windows.Devices.Geolocation.Geopoint"]}
 impl RtActivatable<IGeopointFactory> for Geopoint {}
 impl Geopoint {
     #[inline] pub fn create(position: BasicGeoposition) -> Result<ComPtr<Geopoint>> {
@@ -10529,7 +10529,7 @@ impl IGeoposition {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geoposition: IGeoposition}
+RT_CLASS!{class Geoposition: IGeoposition ["Windows.Devices.Geolocation.Geoposition"]}
 DEFINE_IID!(IID_IGeoposition2, 2137192087, 34417, 19213, 134, 248, 71, 74, 132, 150, 24, 124);
 RT_INTERFACE!{interface IGeoposition2(IGeoposition2Vtbl): IInspectable(IInspectableVtbl) [IID_IGeoposition2] {
     fn get_VenueData(&self, out: *mut *mut VenueData) -> HRESULT
@@ -10564,7 +10564,7 @@ impl IGeoshape {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GeoshapeType: i32 {
+RT_ENUM! { enum GeoshapeType: i32 ["Windows.Devices.Geolocation.GeoshapeType"] {
     Geopoint (GeoshapeType_Geopoint) = 0, Geocircle (GeoshapeType_Geocircle) = 1, Geopath (GeoshapeType_Geopath) = 2, GeoboundingBox (GeoshapeType_GeoboundingBox) = 3,
 }}
 DEFINE_IID!(IID_IGeovisit, 2978445942, 40694, 16811, 160, 221, 121, 62, 206, 118, 226, 222);
@@ -10590,7 +10590,7 @@ impl IGeovisit {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geovisit: IGeovisit}
+RT_CLASS!{class Geovisit: IGeovisit ["Windows.Devices.Geolocation.Geovisit"]}
 DEFINE_IID!(IID_IGeovisitMonitor, 2148633263, 22852, 17809, 131, 193, 57, 102, 71, 245, 79, 44);
 RT_INTERFACE!{interface IGeovisitMonitor(IGeovisitMonitorVtbl): IInspectable(IInspectableVtbl) [IID_IGeovisitMonitor] {
     fn get_MonitoringScope(&self, out: *mut VisitMonitoringScope) -> HRESULT,
@@ -10623,7 +10623,7 @@ impl IGeovisitMonitor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeovisitMonitor: IGeovisitMonitor}
+RT_CLASS!{class GeovisitMonitor: IGeovisitMonitor ["Windows.Devices.Geolocation.GeovisitMonitor"]}
 impl RtActivatable<IGeovisitMonitorStatics> for GeovisitMonitor {}
 impl RtActivatable<IActivationFactory> for GeovisitMonitor {}
 impl GeovisitMonitor {
@@ -10654,7 +10654,7 @@ impl IGeovisitStateChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeovisitStateChangedEventArgs: IGeovisitStateChangedEventArgs}
+RT_CLASS!{class GeovisitStateChangedEventArgs: IGeovisitStateChangedEventArgs ["Windows.Devices.Geolocation.GeovisitStateChangedEventArgs"]}
 DEFINE_IID!(IID_IGeovisitTriggerDetails, 3933670814, 53705, 17739, 153, 183, 178, 248, 205, 210, 72, 47);
 RT_INTERFACE!{interface IGeovisitTriggerDetails(IGeovisitTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IGeovisitTriggerDetails] {
     fn ReadReports(&self, out: *mut *mut foundation::collections::IVectorView<Geovisit>) -> HRESULT
@@ -10666,8 +10666,8 @@ impl IGeovisitTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeovisitTriggerDetails: IGeovisitTriggerDetails}
-RT_ENUM! { enum PositionAccuracy: i32 {
+RT_CLASS!{class GeovisitTriggerDetails: IGeovisitTriggerDetails ["Windows.Devices.Geolocation.GeovisitTriggerDetails"]}
+RT_ENUM! { enum PositionAccuracy: i32 ["Windows.Devices.Geolocation.PositionAccuracy"] {
     Default (PositionAccuracy_Default) = 0, High (PositionAccuracy_High) = 1,
 }}
 DEFINE_IID!(IID_IPositionChangedEventArgs, 931503333, 40222, 18117, 191, 59, 106, 216, 202, 193, 160, 147);
@@ -10681,11 +10681,11 @@ impl IPositionChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PositionChangedEventArgs: IPositionChangedEventArgs}
-RT_ENUM! { enum PositionSource: i32 {
+RT_CLASS!{class PositionChangedEventArgs: IPositionChangedEventArgs ["Windows.Devices.Geolocation.PositionChangedEventArgs"]}
+RT_ENUM! { enum PositionSource: i32 ["Windows.Devices.Geolocation.PositionSource"] {
     Cellular (PositionSource_Cellular) = 0, Satellite (PositionSource_Satellite) = 1, WiFi (PositionSource_WiFi) = 2, IPAddress (PositionSource_IPAddress) = 3, Unknown (PositionSource_Unknown) = 4, Default (PositionSource_Default) = 5, Obfuscated (PositionSource_Obfuscated) = 6,
 }}
-RT_ENUM! { enum PositionStatus: i32 {
+RT_ENUM! { enum PositionStatus: i32 ["Windows.Devices.Geolocation.PositionStatus"] {
     Ready (PositionStatus_Ready) = 0, Initializing (PositionStatus_Initializing) = 1, NoData (PositionStatus_NoData) = 2, Disabled (PositionStatus_Disabled) = 3, NotInitialized (PositionStatus_NotInitialized) = 4, NotAvailable (PositionStatus_NotAvailable) = 5,
 }}
 DEFINE_IID!(IID_IStatusChangedEventArgs, 877908698, 35987, 16657, 162, 5, 154, 236, 252, 155, 229, 192);
@@ -10699,7 +10699,7 @@ impl IStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StatusChangedEventArgs: IStatusChangedEventArgs}
+RT_CLASS!{class StatusChangedEventArgs: IStatusChangedEventArgs ["Windows.Devices.Geolocation.StatusChangedEventArgs"]}
 DEFINE_IID!(IID_IVenueData, 1727238535, 24803, 19247, 181, 39, 79, 83, 241, 195, 198, 119);
 RT_INTERFACE!{interface IVenueData(IVenueDataVtbl): IInspectable(IInspectableVtbl) [IID_IVenueData] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -10717,11 +10717,11 @@ impl IVenueData {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VenueData: IVenueData}
-RT_ENUM! { enum VisitMonitoringScope: i32 {
+RT_CLASS!{class VenueData: IVenueData ["Windows.Devices.Geolocation.VenueData"]}
+RT_ENUM! { enum VisitMonitoringScope: i32 ["Windows.Devices.Geolocation.VisitMonitoringScope"] {
     Venue (VisitMonitoringScope_Venue) = 0, City (VisitMonitoringScope_City) = 1,
 }}
-RT_ENUM! { enum VisitStateChange: i32 {
+RT_ENUM! { enum VisitStateChange: i32 ["Windows.Devices.Geolocation.VisitStateChange"] {
     TrackingLost (VisitStateChange_TrackingLost) = 0, Arrived (VisitStateChange_Arrived) = 1, Departed (VisitStateChange_Departed) = 2, OtherMovement (VisitStateChange_OtherMovement) = 3,
 }}
 pub mod geofencing { // Windows.Devices.Geolocation.Geofencing
@@ -10773,7 +10773,7 @@ impl IGeofence {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Geofence: IGeofence}
+RT_CLASS!{class Geofence: IGeofence ["Windows.Devices.Geolocation.Geofencing.Geofence"]}
 impl RtActivatable<IGeofenceFactory> for Geofence {}
 impl Geofence {
     #[inline] pub fn create(id: &HStringArg, geoshape: &super::IGeoshape) -> Result<ComPtr<Geofence>> {
@@ -10870,7 +10870,7 @@ impl IGeofenceMonitor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeofenceMonitor: IGeofenceMonitor}
+RT_CLASS!{class GeofenceMonitor: IGeofenceMonitor ["Windows.Devices.Geolocation.Geofencing.GeofenceMonitor"]}
 impl RtActivatable<IGeofenceMonitorStatics> for GeofenceMonitor {}
 impl GeofenceMonitor {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<GeofenceMonitor>>> {
@@ -10889,13 +10889,13 @@ impl IGeofenceMonitorStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GeofenceMonitorStatus: i32 {
+RT_ENUM! { enum GeofenceMonitorStatus: i32 ["Windows.Devices.Geolocation.Geofencing.GeofenceMonitorStatus"] {
     Ready (GeofenceMonitorStatus_Ready) = 0, Initializing (GeofenceMonitorStatus_Initializing) = 1, NoData (GeofenceMonitorStatus_NoData) = 2, Disabled (GeofenceMonitorStatus_Disabled) = 3, NotInitialized (GeofenceMonitorStatus_NotInitialized) = 4, NotAvailable (GeofenceMonitorStatus_NotAvailable) = 5,
 }}
-RT_ENUM! { enum GeofenceRemovalReason: i32 {
+RT_ENUM! { enum GeofenceRemovalReason: i32 ["Windows.Devices.Geolocation.Geofencing.GeofenceRemovalReason"] {
     Used (GeofenceRemovalReason_Used) = 0, Expired (GeofenceRemovalReason_Expired) = 1,
 }}
-RT_ENUM! { enum GeofenceState: u32 {
+RT_ENUM! { enum GeofenceState: u32 ["Windows.Devices.Geolocation.Geofencing.GeofenceState"] {
     None (GeofenceState_None) = 0, Entered (GeofenceState_Entered) = 1, Exited (GeofenceState_Exited) = 2, Removed (GeofenceState_Removed) = 4,
 }}
 DEFINE_IID!(IID_IGeofenceStateChangeReport, 2586065944, 9316, 19593, 190, 5, 179, 255, 255, 91, 171, 197);
@@ -10927,15 +10927,15 @@ impl IGeofenceStateChangeReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeofenceStateChangeReport: IGeofenceStateChangeReport}
-RT_ENUM! { enum MonitoredGeofenceStates: u32 {
+RT_CLASS!{class GeofenceStateChangeReport: IGeofenceStateChangeReport ["Windows.Devices.Geolocation.Geofencing.GeofenceStateChangeReport"]}
+RT_ENUM! { enum MonitoredGeofenceStates: u32 ["Windows.Devices.Geolocation.Geofencing.MonitoredGeofenceStates"] {
     None (MonitoredGeofenceStates_None) = 0, Entered (MonitoredGeofenceStates_Entered) = 1, Exited (MonitoredGeofenceStates_Exited) = 2, Removed (MonitoredGeofenceStates_Removed) = 4,
 }}
 } // Windows.Devices.Geolocation.Geofencing
 } // Windows.Devices.Geolocation
 pub mod gpio { // Windows.Devices.Gpio
 use ::prelude::*;
-RT_STRUCT! { struct GpioChangeCount {
+RT_STRUCT! { struct GpioChangeCount ["Windows.Devices.Gpio.GpioChangeCount"] {
     Count: u64, RelativeTime: foundation::TimeSpan,
 }}
 DEFINE_IID!(IID_IGpioChangeCounter, 3411984606, 26625, 17407, 128, 61, 69, 118, 98, 138, 139, 38);
@@ -10982,7 +10982,7 @@ impl IGpioChangeCounter {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GpioChangeCounter: IGpioChangeCounter}
+RT_CLASS!{class GpioChangeCounter: IGpioChangeCounter ["Windows.Devices.Gpio.GpioChangeCounter"]}
 impl RtActivatable<IGpioChangeCounterFactory> for GpioChangeCounter {}
 impl GpioChangeCounter {
     #[inline] pub fn create(pin: &GpioPin) -> Result<ComPtr<GpioChangeCounter>> {
@@ -11001,7 +11001,7 @@ impl IGpioChangeCounterFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GpioChangePolarity: i32 {
+RT_ENUM! { enum GpioChangePolarity: i32 ["Windows.Devices.Gpio.GpioChangePolarity"] {
     Falling (GpioChangePolarity_Falling) = 0, Rising (GpioChangePolarity_Rising) = 1, Both (GpioChangePolarity_Both) = 2,
 }}
 DEFINE_IID!(IID_IGpioChangeReader, 180127839, 57393, 18664, 133, 144, 112, 222, 120, 54, 60, 109);
@@ -11089,7 +11089,7 @@ impl IGpioChangeReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GpioChangeReader: IGpioChangeReader}
+RT_CLASS!{class GpioChangeReader: IGpioChangeReader ["Windows.Devices.Gpio.GpioChangeReader"]}
 impl RtActivatable<IGpioChangeReaderFactory> for GpioChangeReader {}
 impl GpioChangeReader {
     #[inline] pub fn create(pin: &GpioPin) -> Result<ComPtr<GpioChangeReader>> {
@@ -11117,7 +11117,7 @@ impl IGpioChangeReaderFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct GpioChangeRecord {
+RT_STRUCT! { struct GpioChangeRecord ["Windows.Devices.Gpio.GpioChangeRecord"] {
     RelativeTime: foundation::TimeSpan, Edge: GpioPinEdge,
 }}
 DEFINE_IID!(IID_IGpioController, 675287779, 29793, 18076, 168, 188, 97, 214, 157, 8, 165, 60);
@@ -11149,7 +11149,7 @@ impl IGpioController {
         if hr == S_OK { Ok((ComPtr::wrap_optional(pin), openStatus, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GpioController: IGpioController}
+RT_CLASS!{class GpioController: IGpioController ["Windows.Devices.Gpio.GpioController"]}
 impl RtActivatable<IGpioControllerStatics> for GpioController {}
 impl RtActivatable<IGpioControllerStatics2> for GpioController {}
 impl GpioController {
@@ -11192,7 +11192,7 @@ impl IGpioControllerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GpioOpenStatus: i32 {
+RT_ENUM! { enum GpioOpenStatus: i32 ["Windows.Devices.Gpio.GpioOpenStatus"] {
     PinOpened (GpioOpenStatus_PinOpened) = 0, PinUnavailable (GpioOpenStatus_PinUnavailable) = 1, SharingViolation (GpioOpenStatus_SharingViolation) = 2, MuxingConflict (GpioOpenStatus_MuxingConflict) = 3, UnknownError (GpioOpenStatus_UnknownError) = 4,
 }}
 DEFINE_IID!(IID_IGpioPin, 299479175, 44974, 18320, 158, 233, 224, 234, 201, 66, 210, 1);
@@ -11262,14 +11262,14 @@ impl IGpioPin {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GpioPin: IGpioPin}
-RT_ENUM! { enum GpioPinDriveMode: i32 {
+RT_CLASS!{class GpioPin: IGpioPin ["Windows.Devices.Gpio.GpioPin"]}
+RT_ENUM! { enum GpioPinDriveMode: i32 ["Windows.Devices.Gpio.GpioPinDriveMode"] {
     Input (GpioPinDriveMode_Input) = 0, Output (GpioPinDriveMode_Output) = 1, InputPullUp (GpioPinDriveMode_InputPullUp) = 2, InputPullDown (GpioPinDriveMode_InputPullDown) = 3, OutputOpenDrain (GpioPinDriveMode_OutputOpenDrain) = 4, OutputOpenDrainPullUp (GpioPinDriveMode_OutputOpenDrainPullUp) = 5, OutputOpenSource (GpioPinDriveMode_OutputOpenSource) = 6, OutputOpenSourcePullDown (GpioPinDriveMode_OutputOpenSourcePullDown) = 7,
 }}
-RT_ENUM! { enum GpioPinEdge: i32 {
+RT_ENUM! { enum GpioPinEdge: i32 ["Windows.Devices.Gpio.GpioPinEdge"] {
     FallingEdge (GpioPinEdge_FallingEdge) = 0, RisingEdge (GpioPinEdge_RisingEdge) = 1,
 }}
-RT_ENUM! { enum GpioPinValue: i32 {
+RT_ENUM! { enum GpioPinValue: i32 ["Windows.Devices.Gpio.GpioPinValue"] {
     Low (GpioPinValue_Low) = 0, High (GpioPinValue_High) = 1,
 }}
 DEFINE_IID!(IID_IGpioPinValueChangedEventArgs, 825731809, 28733, 16473, 189, 36, 181, 178, 93, 255, 184, 78);
@@ -11283,8 +11283,8 @@ impl IGpioPinValueChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GpioPinValueChangedEventArgs: IGpioPinValueChangedEventArgs}
-RT_ENUM! { enum GpioSharingMode: i32 {
+RT_CLASS!{class GpioPinValueChangedEventArgs: IGpioPinValueChangedEventArgs ["Windows.Devices.Gpio.GpioPinValueChangedEventArgs"]}
+RT_ENUM! { enum GpioSharingMode: i32 ["Windows.Devices.Gpio.GpioSharingMode"] {
     Exclusive (GpioSharingMode_Exclusive) = 0, SharedReadOnly (GpioSharingMode_SharedReadOnly) = 1,
 }}
 pub mod provider { // Windows.Devices.Gpio.Provider
@@ -11384,7 +11384,7 @@ impl IGpioPinProviderValueChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GpioPinProviderValueChangedEventArgs: IGpioPinProviderValueChangedEventArgs}
+RT_CLASS!{class GpioPinProviderValueChangedEventArgs: IGpioPinProviderValueChangedEventArgs ["Windows.Devices.Gpio.Provider.GpioPinProviderValueChangedEventArgs"]}
 impl RtActivatable<IGpioPinProviderValueChangedEventArgsFactory> for GpioPinProviderValueChangedEventArgs {}
 impl GpioPinProviderValueChangedEventArgs {
     #[inline] pub fn create(edge: ProviderGpioPinEdge) -> Result<ComPtr<GpioPinProviderValueChangedEventArgs>> {
@@ -11414,16 +11414,16 @@ impl IGpioProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProviderGpioPinDriveMode: i32 {
+RT_ENUM! { enum ProviderGpioPinDriveMode: i32 ["Windows.Devices.Gpio.Provider.ProviderGpioPinDriveMode"] {
     Input (ProviderGpioPinDriveMode_Input) = 0, Output (ProviderGpioPinDriveMode_Output) = 1, InputPullUp (ProviderGpioPinDriveMode_InputPullUp) = 2, InputPullDown (ProviderGpioPinDriveMode_InputPullDown) = 3, OutputOpenDrain (ProviderGpioPinDriveMode_OutputOpenDrain) = 4, OutputOpenDrainPullUp (ProviderGpioPinDriveMode_OutputOpenDrainPullUp) = 5, OutputOpenSource (ProviderGpioPinDriveMode_OutputOpenSource) = 6, OutputOpenSourcePullDown (ProviderGpioPinDriveMode_OutputOpenSourcePullDown) = 7,
 }}
-RT_ENUM! { enum ProviderGpioPinEdge: i32 {
+RT_ENUM! { enum ProviderGpioPinEdge: i32 ["Windows.Devices.Gpio.Provider.ProviderGpioPinEdge"] {
     FallingEdge (ProviderGpioPinEdge_FallingEdge) = 0, RisingEdge (ProviderGpioPinEdge_RisingEdge) = 1,
 }}
-RT_ENUM! { enum ProviderGpioPinValue: i32 {
+RT_ENUM! { enum ProviderGpioPinValue: i32 ["Windows.Devices.Gpio.Provider.ProviderGpioPinValue"] {
     Low (ProviderGpioPinValue_Low) = 0, High (ProviderGpioPinValue_High) = 1,
 }}
-RT_ENUM! { enum ProviderGpioSharingMode: i32 {
+RT_ENUM! { enum ProviderGpioSharingMode: i32 ["Windows.Devices.Gpio.Provider.ProviderGpioSharingMode"] {
     Exclusive (ProviderGpioSharingMode_Exclusive) = 0, SharedReadOnly (ProviderGpioSharingMode_SharedReadOnly) = 1,
 }}
 } // Windows.Devices.Gpio.Provider
@@ -11551,7 +11551,7 @@ impl ISimpleHapticsController {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SimpleHapticsController: ISimpleHapticsController}
+RT_CLASS!{class SimpleHapticsController: ISimpleHapticsController ["Windows.Devices.Haptics.SimpleHapticsController"]}
 DEFINE_IID!(IID_ISimpleHapticsControllerFeedback, 1029144312, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface ISimpleHapticsControllerFeedback(ISimpleHapticsControllerFeedbackVtbl): IInspectable(IInspectableVtbl) [IID_ISimpleHapticsControllerFeedback] {
     fn get_Waveform(&self, out: *mut u16) -> HRESULT,
@@ -11569,8 +11569,8 @@ impl ISimpleHapticsControllerFeedback {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SimpleHapticsControllerFeedback: ISimpleHapticsControllerFeedback}
-RT_ENUM! { enum VibrationAccessStatus: i32 {
+RT_CLASS!{class SimpleHapticsControllerFeedback: ISimpleHapticsControllerFeedback ["Windows.Devices.Haptics.SimpleHapticsControllerFeedback"]}
+RT_ENUM! { enum VibrationAccessStatus: i32 ["Windows.Devices.Haptics.VibrationAccessStatus"] {
     Allowed (VibrationAccessStatus_Allowed) = 0, DeniedByUser (VibrationAccessStatus_DeniedByUser) = 1, DeniedBySystem (VibrationAccessStatus_DeniedBySystem) = 2, DeniedByEnergySaver (VibrationAccessStatus_DeniedByEnergySaver) = 3,
 }}
 DEFINE_IID!(IID_IVibrationDevice, 1089608254, 34884, 18431, 179, 18, 6, 24, 90, 56, 68, 218);
@@ -11590,7 +11590,7 @@ impl IVibrationDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VibrationDevice: IVibrationDevice}
+RT_CLASS!{class VibrationDevice: IVibrationDevice ["Windows.Devices.Haptics.VibrationDevice"]}
 impl RtActivatable<IVibrationDeviceStatics> for VibrationDevice {}
 impl VibrationDevice {
     #[inline] pub fn request_access_async() -> Result<ComPtr<foundation::IAsyncOperation<VibrationAccessStatus>>> {
@@ -11688,7 +11688,7 @@ impl IHidBooleanControl {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidBooleanControl: IHidBooleanControl}
+RT_CLASS!{class HidBooleanControl: IHidBooleanControl ["Windows.Devices.HumanInterfaceDevice.HidBooleanControl"]}
 DEFINE_IID!(IID_IHidBooleanControlDescription, 1637279043, 10712, 18986, 134, 131, 132, 158, 32, 123, 190, 49);
 RT_INTERFACE!{interface IHidBooleanControlDescription(IHidBooleanControlDescriptionVtbl): IInspectable(IInspectableVtbl) [IID_IHidBooleanControlDescription] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -11730,7 +11730,7 @@ impl IHidBooleanControlDescription {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidBooleanControlDescription: IHidBooleanControlDescription}
+RT_CLASS!{class HidBooleanControlDescription: IHidBooleanControlDescription ["Windows.Devices.HumanInterfaceDevice.HidBooleanControlDescription"]}
 DEFINE_IID!(IID_IHidBooleanControlDescription2, 3371094762, 35447, 19510, 170, 0, 95, 240, 68, 157, 62, 115);
 RT_INTERFACE!{interface IHidBooleanControlDescription2(IHidBooleanControlDescription2Vtbl): IInspectable(IInspectableVtbl) [IID_IHidBooleanControlDescription2] {
     fn get_IsAbsolute(&self, out: *mut bool) -> HRESULT
@@ -11771,8 +11771,8 @@ impl IHidCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidCollection: IHidCollection}
-RT_ENUM! { enum HidCollectionType: i32 {
+RT_CLASS!{class HidCollection: IHidCollection ["Windows.Devices.HumanInterfaceDevice.HidCollection"]}
+RT_ENUM! { enum HidCollectionType: i32 ["Windows.Devices.HumanInterfaceDevice.HidCollectionType"] {
     Physical (HidCollectionType_Physical) = 0, Application (HidCollectionType_Application) = 1, Logical (HidCollectionType_Logical) = 2, Report (HidCollectionType_Report) = 3, NamedArray (HidCollectionType_NamedArray) = 4, UsageSwitch (HidCollectionType_UsageSwitch) = 5, UsageModifier (HidCollectionType_UsageModifier) = 6, Other (HidCollectionType_Other) = 7,
 }}
 DEFINE_IID!(IID_IHidDevice, 1602884839, 8704, 17198, 149, 218, 208, 155, 135, 213, 116, 168);
@@ -11893,7 +11893,7 @@ impl IHidDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidDevice: IHidDevice}
+RT_CLASS!{class HidDevice: IHidDevice ["Windows.Devices.HumanInterfaceDevice.HidDevice"]}
 impl RtActivatable<IHidDeviceStatics> for HidDevice {}
 impl HidDevice {
     #[inline] pub fn get_device_selector(usagePage: u16, usageId: u16) -> Result<HString> {
@@ -11978,7 +11978,7 @@ impl IHidFeatureReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidFeatureReport: IHidFeatureReport}
+RT_CLASS!{class HidFeatureReport: IHidFeatureReport ["Windows.Devices.HumanInterfaceDevice.HidFeatureReport"]}
 DEFINE_IID!(IID_IHidInputReport, 3277655632, 63463, 20109, 178, 62, 202, 187, 229, 107, 144, 233);
 RT_INTERFACE!{interface IHidInputReport(IHidInputReportVtbl): IInspectable(IInspectableVtbl) [IID_IHidInputReport] {
     fn get_Id(&self, out: *mut u16) -> HRESULT,
@@ -12033,7 +12033,7 @@ impl IHidInputReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidInputReport: IHidInputReport}
+RT_CLASS!{class HidInputReport: IHidInputReport ["Windows.Devices.HumanInterfaceDevice.HidInputReport"]}
 DEFINE_IID!(IID_IHidInputReportReceivedEventArgs, 1884931531, 22962, 19906, 152, 92, 10, 220, 97, 54, 250, 45);
 RT_INTERFACE!{interface IHidInputReportReceivedEventArgs(IHidInputReportReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHidInputReportReceivedEventArgs] {
     fn get_Report(&self, out: *mut *mut HidInputReport) -> HRESULT
@@ -12045,7 +12045,7 @@ impl IHidInputReportReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidInputReportReceivedEventArgs: IHidInputReportReceivedEventArgs}
+RT_CLASS!{class HidInputReportReceivedEventArgs: IHidInputReportReceivedEventArgs ["Windows.Devices.HumanInterfaceDevice.HidInputReportReceivedEventArgs"]}
 DEFINE_IID!(IID_IHidNumericControl, 3817476773, 13735, 19317, 137, 200, 251, 31, 40, 177, 8, 35);
 RT_INTERFACE!{interface IHidNumericControl(IHidNumericControlVtbl): IInspectable(IInspectableVtbl) [IID_IHidNumericControl] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -12103,7 +12103,7 @@ impl IHidNumericControl {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidNumericControl: IHidNumericControl}
+RT_CLASS!{class HidNumericControl: IHidNumericControl ["Windows.Devices.HumanInterfaceDevice.HidNumericControl"]}
 DEFINE_IID!(IID_IHidNumericControlDescription, 1670209158, 7575, 19573, 146, 127, 95, 245, 139, 160, 94, 50);
 RT_INTERFACE!{interface IHidNumericControlDescription(IHidNumericControlDescriptionVtbl): IInspectable(IInspectableVtbl) [IID_IHidNumericControlDescription] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -12205,7 +12205,7 @@ impl IHidNumericControlDescription {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidNumericControlDescription: IHidNumericControlDescription}
+RT_CLASS!{class HidNumericControlDescription: IHidNumericControlDescription ["Windows.Devices.HumanInterfaceDevice.HidNumericControlDescription"]}
 DEFINE_IID!(IID_IHidOutputReport, 1657480516, 51350, 17507, 147, 193, 223, 157, 176, 83, 196, 80);
 RT_INTERFACE!{interface IHidOutputReport(IHidOutputReportVtbl): IInspectable(IInspectableVtbl) [IID_IHidOutputReport] {
     fn get_Id(&self, out: *mut u16) -> HRESULT,
@@ -12254,14 +12254,14 @@ impl IHidOutputReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidOutputReport: IHidOutputReport}
-RT_ENUM! { enum HidReportType: i32 {
+RT_CLASS!{class HidOutputReport: IHidOutputReport ["Windows.Devices.HumanInterfaceDevice.HidOutputReport"]}
+RT_ENUM! { enum HidReportType: i32 ["Windows.Devices.HumanInterfaceDevice.HidReportType"] {
     Input (HidReportType_Input) = 0, Output (HidReportType_Output) = 1, Feature (HidReportType_Feature) = 2,
 }}
 } // Windows.Devices.HumanInterfaceDevice
 pub mod i2c { // Windows.Devices.I2c
 use ::prelude::*;
-RT_ENUM! { enum I2cBusSpeed: i32 {
+RT_ENUM! { enum I2cBusSpeed: i32 ["Windows.Devices.I2c.I2cBusSpeed"] {
     StandardMode (I2cBusSpeed_StandardMode) = 0, FastMode (I2cBusSpeed_FastMode) = 1,
 }}
 DEFINE_IID!(IID_II2cConnectionSettings, 4074443527, 43887, 17977, 167, 103, 84, 83, 109, 195, 70, 15);
@@ -12302,7 +12302,7 @@ impl II2cConnectionSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class I2cConnectionSettings: II2cConnectionSettings}
+RT_CLASS!{class I2cConnectionSettings: II2cConnectionSettings ["Windows.Devices.I2c.I2cConnectionSettings"]}
 impl RtActivatable<II2cConnectionSettingsFactory> for I2cConnectionSettings {}
 impl I2cConnectionSettings {
     #[inline] pub fn create(slaveAddress: i32) -> Result<ComPtr<I2cConnectionSettings>> {
@@ -12332,7 +12332,7 @@ impl II2cController {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class I2cController: II2cController}
+RT_CLASS!{class I2cController: II2cController ["Windows.Devices.I2c.I2cController"]}
 impl RtActivatable<II2cControllerStatics> for I2cController {}
 impl I2cController {
     #[inline] pub fn get_controllers_async(provider: &provider::II2cProvider) -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<I2cController>>>> {
@@ -12410,7 +12410,7 @@ impl II2cDevice {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class I2cDevice: II2cDevice}
+RT_CLASS!{class I2cDevice: II2cDevice ["Windows.Devices.I2c.I2cDevice"]}
 impl RtActivatable<II2cDeviceStatics> for I2cDevice {}
 impl I2cDevice {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -12447,13 +12447,13 @@ impl II2cDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum I2cSharingMode: i32 {
+RT_ENUM! { enum I2cSharingMode: i32 ["Windows.Devices.I2c.I2cSharingMode"] {
     Exclusive (I2cSharingMode_Exclusive) = 0, Shared (I2cSharingMode_Shared) = 1,
 }}
-RT_STRUCT! { struct I2cTransferResult {
+RT_STRUCT! { struct I2cTransferResult ["Windows.Devices.I2c.I2cTransferResult"] {
     Status: I2cTransferStatus, BytesTransferred: u32,
 }}
-RT_ENUM! { enum I2cTransferStatus: i32 {
+RT_ENUM! { enum I2cTransferStatus: i32 ["Windows.Devices.I2c.I2cTransferStatus"] {
     FullTransfer (I2cTransferStatus_FullTransfer) = 0, PartialTransfer (I2cTransferStatus_PartialTransfer) = 1, SlaveAddressNotAcknowledged (I2cTransferStatus_SlaveAddressNotAcknowledged) = 2, ClockStretchTimeout (I2cTransferStatus_ClockStretchTimeout) = 3, UnknownError (I2cTransferStatus_UnknownError) = 4,
 }}
 pub mod provider { // Windows.Devices.I2c.Provider
@@ -12524,7 +12524,7 @@ impl II2cProvider {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProviderI2cBusSpeed: i32 {
+RT_ENUM! { enum ProviderI2cBusSpeed: i32 ["Windows.Devices.I2c.Provider.ProviderI2cBusSpeed"] {
     StandardMode (ProviderI2cBusSpeed_StandardMode) = 0, FastMode (ProviderI2cBusSpeed_FastMode) = 1,
 }}
 DEFINE_IID!(IID_IProviderI2cConnectionSettings, 3923463732, 58640, 17591, 128, 157, 242, 248, 91, 85, 83, 57);
@@ -12565,14 +12565,14 @@ impl IProviderI2cConnectionSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProviderI2cConnectionSettings: IProviderI2cConnectionSettings}
-RT_ENUM! { enum ProviderI2cSharingMode: i32 {
+RT_CLASS!{class ProviderI2cConnectionSettings: IProviderI2cConnectionSettings ["Windows.Devices.I2c.Provider.ProviderI2cConnectionSettings"]}
+RT_ENUM! { enum ProviderI2cSharingMode: i32 ["Windows.Devices.I2c.Provider.ProviderI2cSharingMode"] {
     Exclusive (ProviderI2cSharingMode_Exclusive) = 0, Shared (ProviderI2cSharingMode_Shared) = 1,
 }}
-RT_STRUCT! { struct ProviderI2cTransferResult {
+RT_STRUCT! { struct ProviderI2cTransferResult ["Windows.Devices.I2c.Provider.ProviderI2cTransferResult"] {
     Status: ProviderI2cTransferStatus, BytesTransferred: u32,
 }}
-RT_ENUM! { enum ProviderI2cTransferStatus: i32 {
+RT_ENUM! { enum ProviderI2cTransferStatus: i32 ["Windows.Devices.I2c.Provider.ProviderI2cTransferStatus"] {
     FullTransfer (ProviderI2cTransferStatus_FullTransfer) = 0, PartialTransfer (ProviderI2cTransferStatus_PartialTransfer) = 1, SlaveAddressNotAcknowledged (ProviderI2cTransferStatus_SlaveAddressNotAcknowledged) = 2,
 }}
 } // Windows.Devices.I2c.Provider
@@ -12590,7 +12590,7 @@ impl IKeyboardCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyboardCapabilities: IKeyboardCapabilities}
+RT_CLASS!{class KeyboardCapabilities: IKeyboardCapabilities ["Windows.Devices.Input.KeyboardCapabilities"]}
 impl RtActivatable<IActivationFactory> for KeyboardCapabilities {}
 DEFINE_CLSID!(KeyboardCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,75,101,121,98,111,97,114,100,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_KeyboardCapabilities]);
 DEFINE_IID!(IID_IMouseCapabilities, 3164987427, 32217, 19307, 154, 146, 85, 212, 60, 179, 143, 115);
@@ -12628,10 +12628,10 @@ impl IMouseCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MouseCapabilities: IMouseCapabilities}
+RT_CLASS!{class MouseCapabilities: IMouseCapabilities ["Windows.Devices.Input.MouseCapabilities"]}
 impl RtActivatable<IActivationFactory> for MouseCapabilities {}
 DEFINE_CLSID!(MouseCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,77,111,117,115,101,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_MouseCapabilities]);
-RT_STRUCT! { struct MouseDelta {
+RT_STRUCT! { struct MouseDelta ["Windows.Devices.Input.MouseDelta"] {
     X: i32, Y: i32,
 }}
 DEFINE_IID!(IID_IMouseDevice, 2297295960, 62152, 18932, 190, 31, 194, 86, 179, 136, 188, 17);
@@ -12650,7 +12650,7 @@ impl IMouseDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MouseDevice: IMouseDevice}
+RT_CLASS!{class MouseDevice: IMouseDevice ["Windows.Devices.Input.MouseDevice"]}
 impl RtActivatable<IMouseDeviceStatics> for MouseDevice {}
 impl MouseDevice {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<MouseDevice>>> {
@@ -12680,7 +12680,7 @@ impl IMouseEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MouseEventArgs: IMouseEventArgs}
+RT_CLASS!{class MouseEventArgs: IMouseEventArgs ["Windows.Devices.Input.MouseEventArgs"]}
 DEFINE_IID!(IID_IPointerDevice, 2479471356, 60363, 18046, 130, 198, 39, 111, 234, 227, 107, 90);
 RT_INTERFACE!{interface IPointerDevice(IPointerDeviceVtbl): IInspectable(IInspectableVtbl) [IID_IPointerDevice] {
     fn get_PointerDeviceType(&self, out: *mut PointerDeviceType) -> HRESULT,
@@ -12722,7 +12722,7 @@ impl IPointerDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PointerDevice: IPointerDevice}
+RT_CLASS!{class PointerDevice: IPointerDevice ["Windows.Devices.Input.PointerDevice"]}
 impl RtActivatable<IPointerDeviceStatics> for PointerDevice {}
 impl PointerDevice {
     #[inline] pub fn get_pointer_device(pointerId: u32) -> Result<Option<ComPtr<PointerDevice>>> {
@@ -12761,10 +12761,10 @@ impl IPointerDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PointerDeviceType: i32 {
+RT_ENUM! { enum PointerDeviceType: i32 ["Windows.Devices.Input.PointerDeviceType"] {
     Touch (PointerDeviceType_Touch) = 0, Pen (PointerDeviceType_Pen) = 1, Mouse (PointerDeviceType_Mouse) = 2,
 }}
-RT_STRUCT! { struct PointerDeviceUsage {
+RT_STRUCT! { struct PointerDeviceUsage ["Windows.Devices.Input.PointerDeviceUsage"] {
     UsagePage: u32, Usage: u32, MinLogical: i32, MaxLogical: i32, MinPhysical: i32, MaxPhysical: i32, Unit: u32, PhysicalMultiplier: f32,
 }}
 DEFINE_IID!(IID_ITouchCapabilities, 551376377, 5105, 18120, 146, 133, 44, 5, 250, 62, 218, 111);
@@ -12784,12 +12784,12 @@ impl ITouchCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TouchCapabilities: ITouchCapabilities}
+RT_CLASS!{class TouchCapabilities: ITouchCapabilities ["Windows.Devices.Input.TouchCapabilities"]}
 impl RtActivatable<IActivationFactory> for TouchCapabilities {}
 DEFINE_CLSID!(TouchCapabilities(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,73,110,112,117,116,46,84,111,117,99,104,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_TouchCapabilities]);
 pub mod preview { // Windows.Devices.Input.Preview
 use ::prelude::*;
-RT_ENUM! { enum GazeDeviceConfigurationStatePreview: i32 {
+RT_ENUM! { enum GazeDeviceConfigurationStatePreview: i32 ["Windows.Devices.Input.Preview.GazeDeviceConfigurationStatePreview"] {
     Unknown (GazeDeviceConfigurationStatePreview_Unknown) = 0, Ready (GazeDeviceConfigurationStatePreview_Ready) = 1, Configuring (GazeDeviceConfigurationStatePreview_Configuring) = 2, ScreenSetupNeeded (GazeDeviceConfigurationStatePreview_ScreenSetupNeeded) = 3, UserCalibrationNeeded (GazeDeviceConfigurationStatePreview_UserCalibrationNeeded) = 4,
 }}
 DEFINE_IID!(IID_IGazeDevicePreview, 3885924073, 45961, 4583, 178, 1, 200, 211, 255, 183, 87, 33);
@@ -12839,7 +12839,7 @@ impl IGazeDevicePreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeDevicePreview: IGazeDevicePreview}
+RT_CLASS!{class GazeDevicePreview: IGazeDevicePreview ["Windows.Devices.Input.Preview.GazeDevicePreview"]}
 DEFINE_IID!(IID_IGazeDeviceWatcherAddedPreviewEventArgs, 3885924077, 45961, 4583, 178, 1, 200, 211, 255, 183, 87, 33);
 RT_INTERFACE!{interface IGazeDeviceWatcherAddedPreviewEventArgs(IGazeDeviceWatcherAddedPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGazeDeviceWatcherAddedPreviewEventArgs] {
     fn get_Device(&self, out: *mut *mut GazeDevicePreview) -> HRESULT
@@ -12851,7 +12851,7 @@ impl IGazeDeviceWatcherAddedPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeDeviceWatcherAddedPreviewEventArgs: IGazeDeviceWatcherAddedPreviewEventArgs}
+RT_CLASS!{class GazeDeviceWatcherAddedPreviewEventArgs: IGazeDeviceWatcherAddedPreviewEventArgs ["Windows.Devices.Input.Preview.GazeDeviceWatcherAddedPreviewEventArgs"]}
 DEFINE_IID!(IID_IGazeDeviceWatcherPreview, 3885924071, 45961, 4583, 178, 1, 200, 211, 255, 183, 87, 33);
 RT_INTERFACE!{interface IGazeDeviceWatcherPreview(IGazeDeviceWatcherPreviewVtbl): IInspectable(IInspectableVtbl) [IID_IGazeDeviceWatcherPreview] {
     fn add_Added(&self, handler: *mut foundation::TypedEventHandler<GazeDeviceWatcherPreview, GazeDeviceWatcherAddedPreviewEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -12911,7 +12911,7 @@ impl IGazeDeviceWatcherPreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeDeviceWatcherPreview: IGazeDeviceWatcherPreview}
+RT_CLASS!{class GazeDeviceWatcherPreview: IGazeDeviceWatcherPreview ["Windows.Devices.Input.Preview.GazeDeviceWatcherPreview"]}
 DEFINE_IID!(IID_IGazeDeviceWatcherRemovedPreviewEventArgs, 4066582280, 3647, 17183, 166, 6, 80, 179, 90, 249, 74, 28);
 RT_INTERFACE!{interface IGazeDeviceWatcherRemovedPreviewEventArgs(IGazeDeviceWatcherRemovedPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGazeDeviceWatcherRemovedPreviewEventArgs] {
     fn get_Device(&self, out: *mut *mut GazeDevicePreview) -> HRESULT
@@ -12923,7 +12923,7 @@ impl IGazeDeviceWatcherRemovedPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeDeviceWatcherRemovedPreviewEventArgs: IGazeDeviceWatcherRemovedPreviewEventArgs}
+RT_CLASS!{class GazeDeviceWatcherRemovedPreviewEventArgs: IGazeDeviceWatcherRemovedPreviewEventArgs ["Windows.Devices.Input.Preview.GazeDeviceWatcherRemovedPreviewEventArgs"]}
 DEFINE_IID!(IID_IGazeDeviceWatcherUpdatedPreviewEventArgs, 2145923311, 32520, 18231, 136, 225, 74, 131, 174, 78, 72, 133);
 RT_INTERFACE!{interface IGazeDeviceWatcherUpdatedPreviewEventArgs(IGazeDeviceWatcherUpdatedPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGazeDeviceWatcherUpdatedPreviewEventArgs] {
     fn get_Device(&self, out: *mut *mut GazeDevicePreview) -> HRESULT
@@ -12935,7 +12935,7 @@ impl IGazeDeviceWatcherUpdatedPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeDeviceWatcherUpdatedPreviewEventArgs: IGazeDeviceWatcherUpdatedPreviewEventArgs}
+RT_CLASS!{class GazeDeviceWatcherUpdatedPreviewEventArgs: IGazeDeviceWatcherUpdatedPreviewEventArgs ["Windows.Devices.Input.Preview.GazeDeviceWatcherUpdatedPreviewEventArgs"]}
 DEFINE_IID!(IID_IGazeEnteredPreviewEventArgs, 627556163, 4645, 18591, 157, 209, 218, 167, 197, 15, 191, 75);
 RT_INTERFACE!{interface IGazeEnteredPreviewEventArgs(IGazeEnteredPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGazeEnteredPreviewEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -12958,7 +12958,7 @@ impl IGazeEnteredPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeEnteredPreviewEventArgs: IGazeEnteredPreviewEventArgs}
+RT_CLASS!{class GazeEnteredPreviewEventArgs: IGazeEnteredPreviewEventArgs ["Windows.Devices.Input.Preview.GazeEnteredPreviewEventArgs"]}
 DEFINE_IID!(IID_IGazeExitedPreviewEventArgs, 1560998014, 32131, 16623, 159, 10, 251, 193, 187, 220, 197, 172);
 RT_INTERFACE!{interface IGazeExitedPreviewEventArgs(IGazeExitedPreviewEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGazeExitedPreviewEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -12981,7 +12981,7 @@ impl IGazeExitedPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeExitedPreviewEventArgs: IGazeExitedPreviewEventArgs}
+RT_CLASS!{class GazeExitedPreviewEventArgs: IGazeExitedPreviewEventArgs ["Windows.Devices.Input.Preview.GazeExitedPreviewEventArgs"]}
 DEFINE_IID!(IID_IGazeInputSourcePreview, 3885924072, 45961, 4583, 178, 1, 200, 211, 255, 183, 87, 33);
 RT_INTERFACE!{interface IGazeInputSourcePreview(IGazeInputSourcePreviewVtbl): IInspectable(IInspectableVtbl) [IID_IGazeInputSourcePreview] {
     fn add_GazeMoved(&self, handler: *mut foundation::TypedEventHandler<GazeInputSourcePreview, GazeMovedPreviewEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -13020,7 +13020,7 @@ impl IGazeInputSourcePreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeInputSourcePreview: IGazeInputSourcePreview}
+RT_CLASS!{class GazeInputSourcePreview: IGazeInputSourcePreview ["Windows.Devices.Input.Preview.GazeInputSourcePreview"]}
 impl RtActivatable<IGazeInputSourcePreviewStatics> for GazeInputSourcePreview {}
 impl GazeInputSourcePreview {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<GazeInputSourcePreview>>> {
@@ -13076,7 +13076,7 @@ impl IGazeMovedPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazeMovedPreviewEventArgs: IGazeMovedPreviewEventArgs}
+RT_CLASS!{class GazeMovedPreviewEventArgs: IGazeMovedPreviewEventArgs ["Windows.Devices.Input.Preview.GazeMovedPreviewEventArgs"]}
 DEFINE_IID!(IID_IGazePointPreview, 3885924074, 45961, 4583, 178, 1, 200, 211, 255, 183, 87, 33);
 RT_INTERFACE!{interface IGazePointPreview(IGazePointPreviewVtbl): IInspectable(IInspectableVtbl) [IID_IGazePointPreview] {
     fn get_SourceDevice(&self, out: *mut *mut GazeDevicePreview) -> HRESULT,
@@ -13112,7 +13112,7 @@ impl IGazePointPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GazePointPreview: IGazePointPreview}
+RT_CLASS!{class GazePointPreview: IGazePointPreview ["Windows.Devices.Input.Preview.GazePointPreview"]}
 } // Windows.Devices.Input.Preview
 } // Windows.Devices.Input
 pub mod lights { // Windows.Devices.Lights
@@ -13180,7 +13180,7 @@ impl ILamp {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Lamp: ILamp}
+RT_CLASS!{class Lamp: ILamp ["Windows.Devices.Lights.Lamp"]}
 impl RtActivatable<ILampStatics> for Lamp {}
 impl Lamp {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -13354,7 +13354,7 @@ impl ILampArray {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArray: ILampArray}
+RT_CLASS!{class LampArray: ILampArray ["Windows.Devices.Lights.LampArray"]}
 impl RtActivatable<ILampArrayStatics> for LampArray {}
 impl LampArray {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -13365,7 +13365,7 @@ impl LampArray {
     }
 }
 DEFINE_CLSID!(LampArray(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,76,105,103,104,116,115,46,76,97,109,112,65,114,114,97,121,0]) [CLSID_LampArray]);
-RT_ENUM! { enum LampArrayKind: i32 {
+RT_ENUM! { enum LampArrayKind: i32 ["Windows.Devices.Lights.LampArrayKind"] {
     Undefined (LampArrayKind_Undefined) = 0, Keyboard (LampArrayKind_Keyboard) = 1, Mouse (LampArrayKind_Mouse) = 2, GameController (LampArrayKind_GameController) = 3, Peripheral (LampArrayKind_Peripheral) = 4, Scene (LampArrayKind_Scene) = 5, Notification (LampArrayKind_Notification) = 6, Chassis (LampArrayKind_Chassis) = 7, Wearable (LampArrayKind_Wearable) = 8, Furniture (LampArrayKind_Furniture) = 9, Art (LampArrayKind_Art) = 10,
 }}
 DEFINE_IID!(IID_ILampArrayStatics, 2075707789, 24513, 17709, 187, 31, 74, 212, 16, 211, 152, 255);
@@ -13396,7 +13396,7 @@ impl ILampAvailabilityChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampAvailabilityChangedEventArgs: ILampAvailabilityChangedEventArgs}
+RT_CLASS!{class LampAvailabilityChangedEventArgs: ILampAvailabilityChangedEventArgs ["Windows.Devices.Lights.LampAvailabilityChangedEventArgs"]}
 DEFINE_IID!(IID_ILampInfo, 817582620, 2767, 18906, 140, 16, 21, 11, 156, 246, 39, 19);
 RT_INTERFACE!{interface ILampInfo(ILampInfoVtbl): IInspectable(IInspectableVtbl) [IID_ILampInfo] {
     fn get_Index(&self, out: *mut i32) -> HRESULT,
@@ -13464,8 +13464,8 @@ impl ILampInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampInfo: ILampInfo}
-RT_ENUM! { enum LampPurposes: u32 {
+RT_CLASS!{class LampInfo: ILampInfo ["Windows.Devices.Lights.LampInfo"]}
+RT_ENUM! { enum LampPurposes: u32 ["Windows.Devices.Lights.LampPurposes"] {
     Undefined (LampPurposes_Undefined) = 0, Control (LampPurposes_Control) = 1, Accent (LampPurposes_Accent) = 2, Branding (LampPurposes_Branding) = 4, Status (LampPurposes_Status) = 8, Illumination (LampPurposes_Illumination) = 16, Presentation (LampPurposes_Presentation) = 32,
 }}
 DEFINE_IID!(IID_ILampStatics, 2820817260, 34949, 16414, 184, 33, 142, 139, 56, 168, 232, 236);
@@ -13548,7 +13548,7 @@ impl ILampArrayBitmapEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayBitmapEffect: ILampArrayBitmapEffect}
+RT_CLASS!{class LampArrayBitmapEffect: ILampArrayBitmapEffect ["Windows.Devices.Lights.Effects.LampArrayBitmapEffect"]}
 impl RtActivatable<ILampArrayBitmapEffectFactory> for LampArrayBitmapEffect {}
 impl LampArrayBitmapEffect {
     #[inline] pub fn create_instance(lampArray: &super::LampArray, lampIndexes: &[i32]) -> Result<ComPtr<LampArrayBitmapEffect>> {
@@ -13583,7 +13583,7 @@ impl ILampArrayBitmapRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayBitmapRequestedEventArgs: ILampArrayBitmapRequestedEventArgs}
+RT_CLASS!{class LampArrayBitmapRequestedEventArgs: ILampArrayBitmapRequestedEventArgs ["Windows.Devices.Lights.Effects.LampArrayBitmapRequestedEventArgs"]}
 DEFINE_IID!(IID_ILampArrayBlinkEffect, 3955176950, 12229, 19379, 179, 195, 98, 33, 167, 104, 13, 19);
 RT_INTERFACE!{interface ILampArrayBlinkEffect(ILampArrayBlinkEffectVtbl): IInspectable(IInspectableVtbl) [IID_ILampArrayBlinkEffect] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
@@ -13679,7 +13679,7 @@ impl ILampArrayBlinkEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayBlinkEffect: ILampArrayBlinkEffect}
+RT_CLASS!{class LampArrayBlinkEffect: ILampArrayBlinkEffect ["Windows.Devices.Lights.Effects.LampArrayBlinkEffect"]}
 impl RtActivatable<ILampArrayBlinkEffectFactory> for LampArrayBlinkEffect {}
 impl LampArrayBlinkEffect {
     #[inline] pub fn create_instance(lampArray: &super::LampArray, lampIndexes: &[i32]) -> Result<ComPtr<LampArrayBlinkEffect>> {
@@ -13749,7 +13749,7 @@ impl ILampArrayColorRampEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayColorRampEffect: ILampArrayColorRampEffect}
+RT_CLASS!{class LampArrayColorRampEffect: ILampArrayColorRampEffect ["Windows.Devices.Lights.Effects.LampArrayColorRampEffect"]}
 impl RtActivatable<ILampArrayColorRampEffectFactory> for LampArrayColorRampEffect {}
 impl LampArrayColorRampEffect {
     #[inline] pub fn create_instance(lampArray: &super::LampArray, lampIndexes: &[i32]) -> Result<ComPtr<LampArrayColorRampEffect>> {
@@ -13806,7 +13806,7 @@ impl ILampArrayCustomEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayCustomEffect: ILampArrayCustomEffect}
+RT_CLASS!{class LampArrayCustomEffect: ILampArrayCustomEffect ["Windows.Devices.Lights.Effects.LampArrayCustomEffect"]}
 impl RtActivatable<ILampArrayCustomEffectFactory> for LampArrayCustomEffect {}
 impl LampArrayCustomEffect {
     #[inline] pub fn create_instance(lampArray: &super::LampArray, lampIndexes: &[i32]) -> Result<ComPtr<LampArrayCustomEffect>> {
@@ -13841,7 +13841,7 @@ impl ILampArrayEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LampArrayEffectCompletionBehavior: i32 {
+RT_ENUM! { enum LampArrayEffectCompletionBehavior: i32 ["Windows.Devices.Lights.Effects.LampArrayEffectCompletionBehavior"] {
     ClearState (LampArrayEffectCompletionBehavior_ClearState) = 0, KeepState (LampArrayEffectCompletionBehavior_KeepState) = 1,
 }}
 DEFINE_IID!(IID_ILampArrayEffectPlaylist, 2112195582, 28513, 16643, 152, 199, 214, 99, 47, 123, 145, 105);
@@ -13907,7 +13907,7 @@ impl ILampArrayEffectPlaylist {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayEffectPlaylist: ILampArrayEffectPlaylist}
+RT_CLASS!{class LampArrayEffectPlaylist: ILampArrayEffectPlaylist ["Windows.Devices.Lights.Effects.LampArrayEffectPlaylist"]}
 impl RtActivatable<ILampArrayEffectPlaylistStatics> for LampArrayEffectPlaylist {}
 impl RtActivatable<IActivationFactory> for LampArrayEffectPlaylist {}
 impl LampArrayEffectPlaylist {
@@ -13942,10 +13942,10 @@ impl ILampArrayEffectPlaylistStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LampArrayEffectStartMode: i32 {
+RT_ENUM! { enum LampArrayEffectStartMode: i32 ["Windows.Devices.Lights.Effects.LampArrayEffectStartMode"] {
     Sequential (LampArrayEffectStartMode_Sequential) = 0, Simultaneous (LampArrayEffectStartMode_Simultaneous) = 1,
 }}
-RT_ENUM! { enum LampArrayRepetitionMode: i32 {
+RT_ENUM! { enum LampArrayRepetitionMode: i32 ["Windows.Devices.Lights.Effects.LampArrayRepetitionMode"] {
     Occurrences (LampArrayRepetitionMode_Occurrences) = 0, Forever (LampArrayRepetitionMode_Forever) = 1,
 }}
 DEFINE_IID!(IID_ILampArraySolidEffect, 1142915603, 17356, 19251, 128, 235, 198, 221, 222, 125, 200, 237);
@@ -13999,7 +13999,7 @@ impl ILampArraySolidEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArraySolidEffect: ILampArraySolidEffect}
+RT_CLASS!{class LampArraySolidEffect: ILampArraySolidEffect ["Windows.Devices.Lights.Effects.LampArraySolidEffect"]}
 impl RtActivatable<ILampArraySolidEffectFactory> for LampArraySolidEffect {}
 impl LampArraySolidEffect {
     #[inline] pub fn create_instance(lampArray: &super::LampArray, lampIndexes: &[i32]) -> Result<ComPtr<LampArraySolidEffect>> {
@@ -14049,12 +14049,12 @@ impl ILampArrayUpdateRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LampArrayUpdateRequestedEventArgs: ILampArrayUpdateRequestedEventArgs}
+RT_CLASS!{class LampArrayUpdateRequestedEventArgs: ILampArrayUpdateRequestedEventArgs ["Windows.Devices.Lights.Effects.LampArrayUpdateRequestedEventArgs"]}
 } // Windows.Devices.Lights.Effects
 } // Windows.Devices.Lights
 pub mod midi { // Windows.Devices.Midi
 use ::prelude::*;
-RT_CLASS!{class MidiActiveSensingMessage: IMidiMessage}
+RT_CLASS!{class MidiActiveSensingMessage: IMidiMessage ["Windows.Devices.Midi.MidiActiveSensingMessage"]}
 impl RtActivatable<IActivationFactory> for MidiActiveSensingMessage {}
 DEFINE_CLSID!(MidiActiveSensingMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,65,99,116,105,118,101,83,101,110,115,105,110,103,77,101,115,115,97,103,101,0]) [CLSID_MidiActiveSensingMessage]);
 DEFINE_IID!(IID_IMidiChannelPressureMessage, 3189745760, 25268, 19794, 163, 126, 146, 229, 77, 53, 185, 9);
@@ -14074,7 +14074,7 @@ impl IMidiChannelPressureMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiChannelPressureMessage: IMidiChannelPressureMessage}
+RT_CLASS!{class MidiChannelPressureMessage: IMidiChannelPressureMessage ["Windows.Devices.Midi.MidiChannelPressureMessage"]}
 impl RtActivatable<IMidiChannelPressureMessageFactory> for MidiChannelPressureMessage {}
 impl MidiChannelPressureMessage {
     #[inline] pub fn create_midi_channel_pressure_message(channel: u8, pressure: u8) -> Result<ComPtr<MidiChannelPressureMessage>> {
@@ -14093,7 +14093,7 @@ impl IMidiChannelPressureMessageFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiContinueMessage: IMidiMessage}
+RT_CLASS!{class MidiContinueMessage: IMidiMessage ["Windows.Devices.Midi.MidiContinueMessage"]}
 impl RtActivatable<IActivationFactory> for MidiContinueMessage {}
 DEFINE_CLSID!(MidiContinueMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,67,111,110,116,105,110,117,101,77,101,115,115,97,103,101,0]) [CLSID_MidiContinueMessage]);
 DEFINE_IID!(IID_IMidiControlChangeMessage, 3085000579, 30733, 16479, 183, 129, 62, 21, 152, 201, 127, 64);
@@ -14119,7 +14119,7 @@ impl IMidiControlChangeMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiControlChangeMessage: IMidiControlChangeMessage}
+RT_CLASS!{class MidiControlChangeMessage: IMidiControlChangeMessage ["Windows.Devices.Midi.MidiControlChangeMessage"]}
 impl RtActivatable<IMidiControlChangeMessageFactory> for MidiControlChangeMessage {}
 impl MidiControlChangeMessage {
     #[inline] pub fn create_midi_control_change_message(channel: u8, controller: u8, controlValue: u8) -> Result<ComPtr<MidiControlChangeMessage>> {
@@ -14160,7 +14160,7 @@ impl IMidiInPort {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiInPort: IMidiInPort}
+RT_CLASS!{class MidiInPort: IMidiInPort ["Windows.Devices.Midi.MidiInPort"]}
 impl RtActivatable<IMidiInPortStatics> for MidiInPort {}
 impl MidiInPort {
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<MidiInPort>>> {
@@ -14223,8 +14223,8 @@ impl IMidiMessageReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiMessageReceivedEventArgs: IMidiMessageReceivedEventArgs}
-RT_ENUM! { enum MidiMessageType: i32 {
+RT_CLASS!{class MidiMessageReceivedEventArgs: IMidiMessageReceivedEventArgs ["Windows.Devices.Midi.MidiMessageReceivedEventArgs"]}
+RT_ENUM! { enum MidiMessageType: i32 ["Windows.Devices.Midi.MidiMessageType"] {
     None (MidiMessageType_None) = 0, NoteOff (MidiMessageType_NoteOff) = 128, NoteOn (MidiMessageType_NoteOn) = 144, PolyphonicKeyPressure (MidiMessageType_PolyphonicKeyPressure) = 160, ControlChange (MidiMessageType_ControlChange) = 176, ProgramChange (MidiMessageType_ProgramChange) = 192, ChannelPressure (MidiMessageType_ChannelPressure) = 208, PitchBendChange (MidiMessageType_PitchBendChange) = 224, SystemExclusive (MidiMessageType_SystemExclusive) = 240, MidiTimeCode (MidiMessageType_MidiTimeCode) = 241, SongPositionPointer (MidiMessageType_SongPositionPointer) = 242, SongSelect (MidiMessageType_SongSelect) = 243, TuneRequest (MidiMessageType_TuneRequest) = 246, EndSystemExclusive (MidiMessageType_EndSystemExclusive) = 247, TimingClock (MidiMessageType_TimingClock) = 248, Start (MidiMessageType_Start) = 250, Continue (MidiMessageType_Continue) = 251, Stop (MidiMessageType_Stop) = 252, ActiveSensing (MidiMessageType_ActiveSensing) = 254, SystemReset (MidiMessageType_SystemReset) = 255,
 }}
 DEFINE_IID!(IID_IMidiNoteOffMessage, 385714932, 6542, 19855, 166, 84, 211, 5, 162, 147, 84, 143);
@@ -14250,7 +14250,7 @@ impl IMidiNoteOffMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiNoteOffMessage: IMidiNoteOffMessage}
+RT_CLASS!{class MidiNoteOffMessage: IMidiNoteOffMessage ["Windows.Devices.Midi.MidiNoteOffMessage"]}
 impl RtActivatable<IMidiNoteOffMessageFactory> for MidiNoteOffMessage {}
 impl MidiNoteOffMessage {
     #[inline] pub fn create_midi_note_off_message(channel: u8, note: u8, velocity: u8) -> Result<ComPtr<MidiNoteOffMessage>> {
@@ -14292,7 +14292,7 @@ impl IMidiNoteOnMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiNoteOnMessage: IMidiNoteOnMessage}
+RT_CLASS!{class MidiNoteOnMessage: IMidiNoteOnMessage ["Windows.Devices.Midi.MidiNoteOnMessage"]}
 impl RtActivatable<IMidiNoteOnMessageFactory> for MidiNoteOnMessage {}
 impl MidiNoteOnMessage {
     #[inline] pub fn create_midi_note_on_message(channel: u8, note: u8, velocity: u8) -> Result<ComPtr<MidiNoteOnMessage>> {
@@ -14333,7 +14333,7 @@ impl IMidiOutPort {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiOutPort: IMidiOutPort}
+RT_CLASS!{class MidiOutPort: IMidiOutPort ["Windows.Devices.Midi.MidiOutPort"]}
 impl RtActivatable<IMidiOutPortStatics> for MidiOutPort {}
 impl MidiOutPort {
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<IMidiOutPort>>> {
@@ -14378,7 +14378,7 @@ impl IMidiPitchBendChangeMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiPitchBendChangeMessage: IMidiPitchBendChangeMessage}
+RT_CLASS!{class MidiPitchBendChangeMessage: IMidiPitchBendChangeMessage ["Windows.Devices.Midi.MidiPitchBendChangeMessage"]}
 impl RtActivatable<IMidiPitchBendChangeMessageFactory> for MidiPitchBendChangeMessage {}
 impl MidiPitchBendChangeMessage {
     #[inline] pub fn create_midi_pitch_bend_change_message(channel: u8, bend: u16) -> Result<ComPtr<MidiPitchBendChangeMessage>> {
@@ -14420,7 +14420,7 @@ impl IMidiPolyphonicKeyPressureMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiPolyphonicKeyPressureMessage: IMidiPolyphonicKeyPressureMessage}
+RT_CLASS!{class MidiPolyphonicKeyPressureMessage: IMidiPolyphonicKeyPressureMessage ["Windows.Devices.Midi.MidiPolyphonicKeyPressureMessage"]}
 impl RtActivatable<IMidiPolyphonicKeyPressureMessageFactory> for MidiPolyphonicKeyPressureMessage {}
 impl MidiPolyphonicKeyPressureMessage {
     #[inline] pub fn create_midi_polyphonic_key_pressure_message(channel: u8, note: u8, pressure: u8) -> Result<ComPtr<MidiPolyphonicKeyPressureMessage>> {
@@ -14456,7 +14456,7 @@ impl IMidiProgramChangeMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiProgramChangeMessage: IMidiProgramChangeMessage}
+RT_CLASS!{class MidiProgramChangeMessage: IMidiProgramChangeMessage ["Windows.Devices.Midi.MidiProgramChangeMessage"]}
 impl RtActivatable<IMidiProgramChangeMessageFactory> for MidiProgramChangeMessage {}
 impl MidiProgramChangeMessage {
     #[inline] pub fn create_midi_program_change_message(channel: u8, program: u8) -> Result<ComPtr<MidiProgramChangeMessage>> {
@@ -14486,7 +14486,7 @@ impl IMidiSongPositionPointerMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiSongPositionPointerMessage: IMidiSongPositionPointerMessage}
+RT_CLASS!{class MidiSongPositionPointerMessage: IMidiSongPositionPointerMessage ["Windows.Devices.Midi.MidiSongPositionPointerMessage"]}
 impl RtActivatable<IMidiSongPositionPointerMessageFactory> for MidiSongPositionPointerMessage {}
 impl MidiSongPositionPointerMessage {
     #[inline] pub fn create_midi_song_position_pointer_message(beats: u16) -> Result<ComPtr<MidiSongPositionPointerMessage>> {
@@ -14516,7 +14516,7 @@ impl IMidiSongSelectMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiSongSelectMessage: IMidiSongSelectMessage}
+RT_CLASS!{class MidiSongSelectMessage: IMidiSongSelectMessage ["Windows.Devices.Midi.MidiSongSelectMessage"]}
 impl RtActivatable<IMidiSongSelectMessageFactory> for MidiSongSelectMessage {}
 impl MidiSongSelectMessage {
     #[inline] pub fn create_midi_song_select_message(song: u8) -> Result<ComPtr<MidiSongSelectMessage>> {
@@ -14535,10 +14535,10 @@ impl IMidiSongSelectMessageFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiStartMessage: IMidiMessage}
+RT_CLASS!{class MidiStartMessage: IMidiMessage ["Windows.Devices.Midi.MidiStartMessage"]}
 impl RtActivatable<IActivationFactory> for MidiStartMessage {}
 DEFINE_CLSID!(MidiStartMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,116,97,114,116,77,101,115,115,97,103,101,0]) [CLSID_MidiStartMessage]);
-RT_CLASS!{class MidiStopMessage: IMidiMessage}
+RT_CLASS!{class MidiStopMessage: IMidiMessage ["Windows.Devices.Midi.MidiStopMessage"]}
 impl RtActivatable<IActivationFactory> for MidiStopMessage {}
 DEFINE_CLSID!(MidiStopMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,116,111,112,77,101,115,115,97,103,101,0]) [CLSID_MidiStopMessage]);
 DEFINE_IID!(IID_IMidiSynthesizer, 4040824158, 56208, 16479, 184, 174, 33, 210, 225, 127, 46, 69);
@@ -14563,7 +14563,7 @@ impl IMidiSynthesizer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiSynthesizer: IMidiSynthesizer}
+RT_CLASS!{class MidiSynthesizer: IMidiSynthesizer ["Windows.Devices.Midi.MidiSynthesizer"]}
 impl RtActivatable<IMidiSynthesizerStatics> for MidiSynthesizer {}
 impl MidiSynthesizer {
     #[inline] pub fn create_async() -> Result<ComPtr<foundation::IAsyncOperation<MidiSynthesizer>>> {
@@ -14600,7 +14600,7 @@ impl IMidiSynthesizerStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiSystemExclusiveMessage: IMidiMessage}
+RT_CLASS!{class MidiSystemExclusiveMessage: IMidiMessage ["Windows.Devices.Midi.MidiSystemExclusiveMessage"]}
 impl RtActivatable<IMidiSystemExclusiveMessageFactory> for MidiSystemExclusiveMessage {}
 impl MidiSystemExclusiveMessage {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_midi_system_exclusive_message(rawData: &super::super::storage::streams::IBuffer) -> Result<ComPtr<MidiSystemExclusiveMessage>> {
@@ -14619,7 +14619,7 @@ impl IMidiSystemExclusiveMessageFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiSystemResetMessage: IMidiMessage}
+RT_CLASS!{class MidiSystemResetMessage: IMidiMessage ["Windows.Devices.Midi.MidiSystemResetMessage"]}
 impl RtActivatable<IActivationFactory> for MidiSystemResetMessage {}
 DEFINE_CLSID!(MidiSystemResetMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,83,121,115,116,101,109,82,101,115,101,116,77,101,115,115,97,103,101,0]) [CLSID_MidiSystemResetMessage]);
 DEFINE_IID!(IID_IMidiTimeCodeMessage, 200738941, 64099, 18972, 141, 235, 192, 232, 119, 150, 166, 215);
@@ -14639,7 +14639,7 @@ impl IMidiTimeCodeMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiTimeCodeMessage: IMidiTimeCodeMessage}
+RT_CLASS!{class MidiTimeCodeMessage: IMidiTimeCodeMessage ["Windows.Devices.Midi.MidiTimeCodeMessage"]}
 impl RtActivatable<IMidiTimeCodeMessageFactory> for MidiTimeCodeMessage {}
 impl MidiTimeCodeMessage {
     #[inline] pub fn create_midi_time_code_message(frameType: u8, values: u8) -> Result<ComPtr<MidiTimeCodeMessage>> {
@@ -14658,10 +14658,10 @@ impl IMidiTimeCodeMessageFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MidiTimingClockMessage: IMidiMessage}
+RT_CLASS!{class MidiTimingClockMessage: IMidiMessage ["Windows.Devices.Midi.MidiTimingClockMessage"]}
 impl RtActivatable<IActivationFactory> for MidiTimingClockMessage {}
 DEFINE_CLSID!(MidiTimingClockMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,84,105,109,105,110,103,67,108,111,99,107,77,101,115,115,97,103,101,0]) [CLSID_MidiTimingClockMessage]);
-RT_CLASS!{class MidiTuneRequestMessage: IMidiMessage}
+RT_CLASS!{class MidiTuneRequestMessage: IMidiMessage ["Windows.Devices.Midi.MidiTuneRequestMessage"]}
 impl RtActivatable<IActivationFactory> for MidiTuneRequestMessage {}
 DEFINE_CLSID!(MidiTuneRequestMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,77,105,100,105,46,77,105,100,105,84,117,110,101,82,101,113,117,101,115,116,77,101,115,115,97,103,101,0]) [CLSID_MidiTuneRequestMessage]);
 } // Windows.Devices.Midi
@@ -15042,7 +15042,7 @@ impl IPerceptionColorFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrame: IPerceptionColorFrame}
+RT_CLASS!{class PerceptionColorFrame: IPerceptionColorFrame ["Windows.Devices.Perception.PerceptionColorFrame"]}
 DEFINE_IID!(IID_IPerceptionColorFrameArrivedEventArgs, 2410480341, 34551, 19853, 185, 102, 90, 55, 97, 186, 159, 89);
 RT_INTERFACE!{interface IPerceptionColorFrameArrivedEventArgs(IPerceptionColorFrameArrivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionColorFrameArrivedEventArgs] {
     fn get_RelativeTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -15060,7 +15060,7 @@ impl IPerceptionColorFrameArrivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrameArrivedEventArgs: IPerceptionColorFrameArrivedEventArgs}
+RT_CLASS!{class PerceptionColorFrameArrivedEventArgs: IPerceptionColorFrameArrivedEventArgs ["Windows.Devices.Perception.PerceptionColorFrameArrivedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionColorFrameReader, 1985017198, 47605, 17947, 131, 173, 242, 34, 175, 42, 170, 220);
 RT_INTERFACE!{interface IPerceptionColorFrameReader(IPerceptionColorFrameReaderVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionColorFrameReader] {
     fn add_FrameArrived(&self, handler: *mut foundation::TypedEventHandler<PerceptionColorFrameReader, PerceptionColorFrameArrivedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -15100,7 +15100,7 @@ impl IPerceptionColorFrameReader {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrameReader: IPerceptionColorFrameReader}
+RT_CLASS!{class PerceptionColorFrameReader: IPerceptionColorFrameReader ["Windows.Devices.Perception.PerceptionColorFrameReader"]}
 DEFINE_IID!(IID_IPerceptionColorFrameSource, 3698178684, 2904, 18061, 156, 161, 109, 176, 76, 192, 71, 124);
 RT_INTERFACE!{interface IPerceptionColorFrameSource(IPerceptionColorFrameSourceVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionColorFrameSource] {
     fn add_AvailableChanged(&self, handler: *mut foundation::TypedEventHandler<PerceptionColorFrameSource, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -15276,7 +15276,7 @@ impl IPerceptionColorFrameSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrameSource: IPerceptionColorFrameSource}
+RT_CLASS!{class PerceptionColorFrameSource: IPerceptionColorFrameSource ["Windows.Devices.Perception.PerceptionColorFrameSource"]}
 impl RtActivatable<IPerceptionColorFrameSourceStatics> for PerceptionColorFrameSource {}
 impl PerceptionColorFrameSource {
     #[inline] pub fn create_watcher() -> Result<Option<ComPtr<PerceptionColorFrameSourceWatcher>>> {
@@ -15315,7 +15315,7 @@ impl IPerceptionColorFrameSourceAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrameSourceAddedEventArgs: IPerceptionColorFrameSourceAddedEventArgs}
+RT_CLASS!{class PerceptionColorFrameSourceAddedEventArgs: IPerceptionColorFrameSourceAddedEventArgs ["Windows.Devices.Perception.PerceptionColorFrameSourceAddedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionColorFrameSourceRemovedEventArgs, 3531078249, 60236, 17135, 186, 79, 40, 143, 97, 92, 147, 193);
 RT_INTERFACE!{interface IPerceptionColorFrameSourceRemovedEventArgs(IPerceptionColorFrameSourceRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionColorFrameSourceRemovedEventArgs] {
     fn get_FrameSource(&self, out: *mut *mut PerceptionColorFrameSource) -> HRESULT
@@ -15327,7 +15327,7 @@ impl IPerceptionColorFrameSourceRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrameSourceRemovedEventArgs: IPerceptionColorFrameSourceRemovedEventArgs}
+RT_CLASS!{class PerceptionColorFrameSourceRemovedEventArgs: IPerceptionColorFrameSourceRemovedEventArgs ["Windows.Devices.Perception.PerceptionColorFrameSourceRemovedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionColorFrameSourceStatics, 1576258722, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 73);
 RT_INTERFACE!{static interface IPerceptionColorFrameSourceStatics(IPerceptionColorFrameSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionColorFrameSourceStatics] {
     fn CreateWatcher(&self, out: *mut *mut PerceptionColorFrameSourceWatcher) -> HRESULT,
@@ -15422,7 +15422,7 @@ impl IPerceptionColorFrameSourceWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionColorFrameSourceWatcher: IPerceptionColorFrameSourceWatcher}
+RT_CLASS!{class PerceptionColorFrameSourceWatcher: IPerceptionColorFrameSourceWatcher ["Windows.Devices.Perception.PerceptionColorFrameSourceWatcher"]}
 DEFINE_IID!(IID_IPerceptionControlSession, 2576975443, 23101, 16767, 146, 57, 241, 136, 158, 84, 139, 72);
 RT_INTERFACE!{interface IPerceptionControlSession(IPerceptionControlSessionVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionControlSession] {
     fn add_ControlLost(&self, handler: *mut foundation::TypedEventHandler<PerceptionControlSession, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -15445,7 +15445,7 @@ impl IPerceptionControlSession {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionControlSession: IPerceptionControlSession}
+RT_CLASS!{class PerceptionControlSession: IPerceptionControlSession ["Windows.Devices.Perception.PerceptionControlSession"]}
 DEFINE_IID!(IID_IPerceptionDepthCorrelatedCameraIntrinsics, 1699269121, 34526, 23521, 101, 130, 128, 127, 207, 76, 149, 207);
 RT_INTERFACE!{interface IPerceptionDepthCorrelatedCameraIntrinsics(IPerceptionDepthCorrelatedCameraIntrinsicsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthCorrelatedCameraIntrinsics] {
     fn UnprojectPixelAtCorrelatedDepth(&self, pixelCoordinate: foundation::Point, depthFrame: *mut PerceptionDepthFrame, out: *mut foundation::numerics::Vector3) -> HRESULT,
@@ -15474,7 +15474,7 @@ impl IPerceptionDepthCorrelatedCameraIntrinsics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthCorrelatedCameraIntrinsics: IPerceptionDepthCorrelatedCameraIntrinsics}
+RT_CLASS!{class PerceptionDepthCorrelatedCameraIntrinsics: IPerceptionDepthCorrelatedCameraIntrinsics ["Windows.Devices.Perception.PerceptionDepthCorrelatedCameraIntrinsics"]}
 DEFINE_IID!(IID_IPerceptionDepthCorrelatedCoordinateMapper, 1531813149, 46582, 18076, 184, 194, 185, 122, 69, 230, 134, 59);
 RT_INTERFACE!{interface IPerceptionDepthCorrelatedCoordinateMapper(IPerceptionDepthCorrelatedCoordinateMapperVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthCorrelatedCoordinateMapper] {
     fn MapPixelToTarget(&self, sourcePixelCoordinate: foundation::Point, depthFrame: *mut PerceptionDepthFrame, out: *mut foundation::Point) -> HRESULT,
@@ -15503,7 +15503,7 @@ impl IPerceptionDepthCorrelatedCoordinateMapper {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthCorrelatedCoordinateMapper: IPerceptionDepthCorrelatedCoordinateMapper}
+RT_CLASS!{class PerceptionDepthCorrelatedCoordinateMapper: IPerceptionDepthCorrelatedCoordinateMapper ["Windows.Devices.Perception.PerceptionDepthCorrelatedCoordinateMapper"]}
 DEFINE_IID!(IID_IPerceptionDepthFrame, 2742780412, 39174, 20477, 145, 97, 0, 36, 179, 96, 182, 87);
 RT_INTERFACE!{interface IPerceptionDepthFrame(IPerceptionDepthFrameVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrame] {
     #[cfg(feature="windows-media")] fn get_VideoFrame(&self, out: *mut *mut super::super::media::VideoFrame) -> HRESULT
@@ -15515,7 +15515,7 @@ impl IPerceptionDepthFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrame: IPerceptionDepthFrame}
+RT_CLASS!{class PerceptionDepthFrame: IPerceptionDepthFrame ["Windows.Devices.Perception.PerceptionDepthFrame"]}
 DEFINE_IID!(IID_IPerceptionDepthFrameArrivedEventArgs, 1144858034, 45698, 17975, 145, 115, 172, 151, 132, 53, 201, 133);
 RT_INTERFACE!{interface IPerceptionDepthFrameArrivedEventArgs(IPerceptionDepthFrameArrivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrameArrivedEventArgs] {
     fn get_RelativeTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -15533,7 +15533,7 @@ impl IPerceptionDepthFrameArrivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrameArrivedEventArgs: IPerceptionDepthFrameArrivedEventArgs}
+RT_CLASS!{class PerceptionDepthFrameArrivedEventArgs: IPerceptionDepthFrameArrivedEventArgs ["Windows.Devices.Perception.PerceptionDepthFrameArrivedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionDepthFrameReader, 2980298911, 10651, 17938, 164, 247, 39, 15, 37, 160, 150, 236);
 RT_INTERFACE!{interface IPerceptionDepthFrameReader(IPerceptionDepthFrameReaderVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrameReader] {
     fn add_FrameArrived(&self, handler: *mut foundation::TypedEventHandler<PerceptionDepthFrameReader, PerceptionDepthFrameArrivedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -15573,7 +15573,7 @@ impl IPerceptionDepthFrameReader {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrameReader: IPerceptionDepthFrameReader}
+RT_CLASS!{class PerceptionDepthFrameReader: IPerceptionDepthFrameReader ["Windows.Devices.Perception.PerceptionDepthFrameReader"]}
 DEFINE_IID!(IID_IPerceptionDepthFrameSource, 2043950038, 18427, 19953, 191, 201, 240, 29, 64, 189, 153, 66);
 RT_INTERFACE!{interface IPerceptionDepthFrameSource(IPerceptionDepthFrameSourceVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrameSource] {
     fn add_AvailableChanged(&self, handler: *mut foundation::TypedEventHandler<PerceptionDepthFrameSource, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -15749,7 +15749,7 @@ impl IPerceptionDepthFrameSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrameSource: IPerceptionDepthFrameSource}
+RT_CLASS!{class PerceptionDepthFrameSource: IPerceptionDepthFrameSource ["Windows.Devices.Perception.PerceptionDepthFrameSource"]}
 impl RtActivatable<IPerceptionDepthFrameSourceStatics> for PerceptionDepthFrameSource {}
 impl PerceptionDepthFrameSource {
     #[inline] pub fn create_watcher() -> Result<Option<ComPtr<PerceptionDepthFrameSourceWatcher>>> {
@@ -15788,7 +15788,7 @@ impl IPerceptionDepthFrameSourceAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrameSourceAddedEventArgs: IPerceptionDepthFrameSourceAddedEventArgs}
+RT_CLASS!{class PerceptionDepthFrameSourceAddedEventArgs: IPerceptionDepthFrameSourceAddedEventArgs ["Windows.Devices.Perception.PerceptionDepthFrameSourceAddedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionDepthFrameSourceRemovedEventArgs, 2696989773, 59756, 19841, 134, 221, 56, 185, 94, 73, 198, 223);
 RT_INTERFACE!{interface IPerceptionDepthFrameSourceRemovedEventArgs(IPerceptionDepthFrameSourceRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrameSourceRemovedEventArgs] {
     fn get_FrameSource(&self, out: *mut *mut PerceptionDepthFrameSource) -> HRESULT
@@ -15800,7 +15800,7 @@ impl IPerceptionDepthFrameSourceRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrameSourceRemovedEventArgs: IPerceptionDepthFrameSourceRemovedEventArgs}
+RT_CLASS!{class PerceptionDepthFrameSourceRemovedEventArgs: IPerceptionDepthFrameSourceRemovedEventArgs ["Windows.Devices.Perception.PerceptionDepthFrameSourceRemovedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionDepthFrameSourceStatics, 1576258722, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 72);
 RT_INTERFACE!{static interface IPerceptionDepthFrameSourceStatics(IPerceptionDepthFrameSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionDepthFrameSourceStatics] {
     fn CreateWatcher(&self, out: *mut *mut PerceptionDepthFrameSourceWatcher) -> HRESULT,
@@ -15895,8 +15895,8 @@ impl IPerceptionDepthFrameSourceWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionDepthFrameSourceWatcher: IPerceptionDepthFrameSourceWatcher}
-RT_ENUM! { enum PerceptionFrameSourceAccessStatus: i32 {
+RT_CLASS!{class PerceptionDepthFrameSourceWatcher: IPerceptionDepthFrameSourceWatcher ["Windows.Devices.Perception.PerceptionDepthFrameSourceWatcher"]}
+RT_ENUM! { enum PerceptionFrameSourceAccessStatus: i32 ["Windows.Devices.Perception.PerceptionFrameSourceAccessStatus"] {
     Unspecified (PerceptionFrameSourceAccessStatus_Unspecified) = 0, Allowed (PerceptionFrameSourceAccessStatus_Allowed) = 1, DeniedByUser (PerceptionFrameSourceAccessStatus_DeniedByUser) = 2, DeniedBySystem (PerceptionFrameSourceAccessStatus_DeniedBySystem) = 3,
 }}
 DEFINE_IID!(IID_IPerceptionFrameSourcePropertiesChangedEventArgs, 1818812520, 48369, 20172, 184, 145, 118, 37, 209, 36, 75, 107);
@@ -15916,7 +15916,7 @@ impl IPerceptionFrameSourcePropertiesChangedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionFrameSourcePropertiesChangedEventArgs: IPerceptionFrameSourcePropertiesChangedEventArgs}
+RT_CLASS!{class PerceptionFrameSourcePropertiesChangedEventArgs: IPerceptionFrameSourcePropertiesChangedEventArgs ["Windows.Devices.Perception.PerceptionFrameSourcePropertiesChangedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionFrameSourcePropertyChangeResult, 506673418, 15504, 19746, 184, 152, 244, 43, 186, 100, 24, 255);
 RT_INTERFACE!{interface IPerceptionFrameSourcePropertyChangeResult(IPerceptionFrameSourcePropertyChangeResultVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionFrameSourcePropertyChangeResult] {
     fn get_Status(&self, out: *mut PerceptionFrameSourcePropertyChangeStatus) -> HRESULT,
@@ -15934,8 +15934,8 @@ impl IPerceptionFrameSourcePropertyChangeResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionFrameSourcePropertyChangeResult: IPerceptionFrameSourcePropertyChangeResult}
-RT_ENUM! { enum PerceptionFrameSourcePropertyChangeStatus: i32 {
+RT_CLASS!{class PerceptionFrameSourcePropertyChangeResult: IPerceptionFrameSourcePropertyChangeResult ["Windows.Devices.Perception.PerceptionFrameSourcePropertyChangeResult"]}
+RT_ENUM! { enum PerceptionFrameSourcePropertyChangeStatus: i32 ["Windows.Devices.Perception.PerceptionFrameSourcePropertyChangeStatus"] {
     Unknown (PerceptionFrameSourcePropertyChangeStatus_Unknown) = 0, Accepted (PerceptionFrameSourcePropertyChangeStatus_Accepted) = 1, LostControl (PerceptionFrameSourcePropertyChangeStatus_LostControl) = 2, PropertyNotSupported (PerceptionFrameSourcePropertyChangeStatus_PropertyNotSupported) = 3, PropertyReadOnly (PerceptionFrameSourcePropertyChangeStatus_PropertyReadOnly) = 4, ValueOutOfRange (PerceptionFrameSourcePropertyChangeStatus_ValueOutOfRange) = 5,
 }}
 DEFINE_IID!(IID_IPerceptionInfraredFrame, 2961728118, 33950, 19578, 138, 230, 181, 96, 100, 83, 33, 83);
@@ -15949,7 +15949,7 @@ impl IPerceptionInfraredFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrame: IPerceptionInfraredFrame}
+RT_CLASS!{class PerceptionInfraredFrame: IPerceptionInfraredFrame ["Windows.Devices.Perception.PerceptionInfraredFrame"]}
 DEFINE_IID!(IID_IPerceptionInfraredFrameArrivedEventArgs, 2675440327, 46269, 18519, 157, 80, 190, 142, 240, 117, 218, 239);
 RT_INTERFACE!{interface IPerceptionInfraredFrameArrivedEventArgs(IPerceptionInfraredFrameArrivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionInfraredFrameArrivedEventArgs] {
     fn get_RelativeTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -15967,7 +15967,7 @@ impl IPerceptionInfraredFrameArrivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrameArrivedEventArgs: IPerceptionInfraredFrameArrivedEventArgs}
+RT_CLASS!{class PerceptionInfraredFrameArrivedEventArgs: IPerceptionInfraredFrameArrivedEventArgs ["Windows.Devices.Perception.PerceptionInfraredFrameArrivedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionInfraredFrameReader, 2036387352, 54171, 20424, 160, 74, 146, 151, 52, 198, 117, 108);
 RT_INTERFACE!{interface IPerceptionInfraredFrameReader(IPerceptionInfraredFrameReaderVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionInfraredFrameReader] {
     fn add_FrameArrived(&self, handler: *mut foundation::TypedEventHandler<PerceptionInfraredFrameReader, PerceptionInfraredFrameArrivedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -16007,7 +16007,7 @@ impl IPerceptionInfraredFrameReader {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrameReader: IPerceptionInfraredFrameReader}
+RT_CLASS!{class PerceptionInfraredFrameReader: IPerceptionInfraredFrameReader ["Windows.Devices.Perception.PerceptionInfraredFrameReader"]}
 DEFINE_IID!(IID_IPerceptionInfraredFrameSource, 1437632322, 6152, 18766, 158, 48, 157, 42, 123, 232, 247, 0);
 RT_INTERFACE!{interface IPerceptionInfraredFrameSource(IPerceptionInfraredFrameSourceVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionInfraredFrameSource] {
     fn add_AvailableChanged(&self, handler: *mut foundation::TypedEventHandler<PerceptionInfraredFrameSource, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -16183,7 +16183,7 @@ impl IPerceptionInfraredFrameSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrameSource: IPerceptionInfraredFrameSource}
+RT_CLASS!{class PerceptionInfraredFrameSource: IPerceptionInfraredFrameSource ["Windows.Devices.Perception.PerceptionInfraredFrameSource"]}
 impl RtActivatable<IPerceptionInfraredFrameSourceStatics> for PerceptionInfraredFrameSource {}
 impl PerceptionInfraredFrameSource {
     #[inline] pub fn create_watcher() -> Result<Option<ComPtr<PerceptionInfraredFrameSourceWatcher>>> {
@@ -16222,7 +16222,7 @@ impl IPerceptionInfraredFrameSourceAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrameSourceAddedEventArgs: IPerceptionInfraredFrameSourceAddedEventArgs}
+RT_CLASS!{class PerceptionInfraredFrameSourceAddedEventArgs: IPerceptionInfraredFrameSourceAddedEventArgs ["Windows.Devices.Perception.PerceptionInfraredFrameSourceAddedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionInfraredFrameSourceRemovedEventArgs, 3927605361, 31344, 19041, 175, 148, 7, 48, 56, 83, 246, 149);
 RT_INTERFACE!{interface IPerceptionInfraredFrameSourceRemovedEventArgs(IPerceptionInfraredFrameSourceRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionInfraredFrameSourceRemovedEventArgs] {
     fn get_FrameSource(&self, out: *mut *mut PerceptionInfraredFrameSource) -> HRESULT
@@ -16234,7 +16234,7 @@ impl IPerceptionInfraredFrameSourceRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrameSourceRemovedEventArgs: IPerceptionInfraredFrameSourceRemovedEventArgs}
+RT_CLASS!{class PerceptionInfraredFrameSourceRemovedEventArgs: IPerceptionInfraredFrameSourceRemovedEventArgs ["Windows.Devices.Perception.PerceptionInfraredFrameSourceRemovedEventArgs"]}
 DEFINE_IID!(IID_IPerceptionInfraredFrameSourceStatics, 1576258722, 504, 19079, 184, 89, 213, 229, 183, 225, 222, 71);
 RT_INTERFACE!{static interface IPerceptionInfraredFrameSourceStatics(IPerceptionInfraredFrameSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionInfraredFrameSourceStatics] {
     fn CreateWatcher(&self, out: *mut *mut PerceptionInfraredFrameSourceWatcher) -> HRESULT,
@@ -16329,7 +16329,7 @@ impl IPerceptionInfraredFrameSourceWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionInfraredFrameSourceWatcher: IPerceptionInfraredFrameSourceWatcher}
+RT_CLASS!{class PerceptionInfraredFrameSourceWatcher: IPerceptionInfraredFrameSourceWatcher ["Windows.Devices.Perception.PerceptionInfraredFrameSourceWatcher"]}
 DEFINE_IID!(IID_IPerceptionVideoProfile, 1970683555, 282, 18190, 130, 37, 111, 5, 173, 226, 86, 72);
 RT_INTERFACE!{interface IPerceptionVideoProfile(IPerceptionVideoProfileVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionVideoProfile] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -16373,7 +16373,7 @@ impl IPerceptionVideoProfile {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionVideoProfile: IPerceptionVideoProfile}
+RT_CLASS!{class PerceptionVideoProfile: IPerceptionVideoProfile ["Windows.Devices.Perception.PerceptionVideoProfile"]}
 pub mod provider { // Windows.Devices.Perception.Provider
 use ::prelude::*;
 RT_CLASS!{static class KnownPerceptionFrameKind}
@@ -16424,7 +16424,7 @@ impl IPerceptionControlGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionControlGroup: IPerceptionControlGroup}
+RT_CLASS!{class PerceptionControlGroup: IPerceptionControlGroup ["Windows.Devices.Perception.Provider.PerceptionControlGroup"]}
 impl RtActivatable<IPerceptionControlGroupFactory> for PerceptionControlGroup {}
 impl PerceptionControlGroup {
     #[inline] pub fn create(ids: &foundation::collections::IIterable<HString>) -> Result<ComPtr<PerceptionControlGroup>> {
@@ -16466,7 +16466,7 @@ impl IPerceptionCorrelation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionCorrelation: IPerceptionCorrelation}
+RT_CLASS!{class PerceptionCorrelation: IPerceptionCorrelation ["Windows.Devices.Perception.Provider.PerceptionCorrelation"]}
 impl RtActivatable<IPerceptionCorrelationFactory> for PerceptionCorrelation {}
 impl PerceptionCorrelation {
     #[inline] pub fn create(targetId: &HStringArg, position: foundation::numerics::Vector3, orientation: foundation::numerics::Quaternion) -> Result<ComPtr<PerceptionCorrelation>> {
@@ -16496,7 +16496,7 @@ impl IPerceptionCorrelationGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionCorrelationGroup: IPerceptionCorrelationGroup}
+RT_CLASS!{class PerceptionCorrelationGroup: IPerceptionCorrelationGroup ["Windows.Devices.Perception.Provider.PerceptionCorrelationGroup"]}
 impl RtActivatable<IPerceptionCorrelationGroupFactory> for PerceptionCorrelationGroup {}
 impl PerceptionCorrelationGroup {
     #[inline] pub fn create(relativeLocations: &foundation::collections::IIterable<PerceptionCorrelation>) -> Result<ComPtr<PerceptionCorrelationGroup>> {
@@ -16526,7 +16526,7 @@ impl IPerceptionFaceAuthenticationGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionFaceAuthenticationGroup: IPerceptionFaceAuthenticationGroup}
+RT_CLASS!{class PerceptionFaceAuthenticationGroup: IPerceptionFaceAuthenticationGroup ["Windows.Devices.Perception.Provider.PerceptionFaceAuthenticationGroup"]}
 impl RtActivatable<IPerceptionFaceAuthenticationGroupFactory> for PerceptionFaceAuthenticationGroup {}
 impl PerceptionFaceAuthenticationGroup {
     #[inline] pub fn create(ids: &foundation::collections::IIterable<HString>, startHandler: &PerceptionStartFaceAuthenticationHandler, stopHandler: &PerceptionStopFaceAuthenticationHandler) -> Result<ComPtr<PerceptionFaceAuthenticationGroup>> {
@@ -16573,7 +16573,7 @@ impl IPerceptionFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionFrame: IPerceptionFrame}
+RT_CLASS!{class PerceptionFrame: IPerceptionFrame ["Windows.Devices.Perception.Provider.PerceptionFrame"]}
 DEFINE_IID!(IID_IPerceptionFrameProvider, 2035251897, 45949, 15155, 161, 13, 48, 98, 100, 25, 206, 101);
 RT_INTERFACE!{interface IPerceptionFrameProvider(IPerceptionFrameProviderVtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionFrameProvider] {
     fn get_FrameProviderInfo(&self, out: *mut *mut PerceptionFrameProviderInfo) -> HRESULT,
@@ -16672,7 +16672,7 @@ impl IPerceptionFrameProviderInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionFrameProviderInfo: IPerceptionFrameProviderInfo}
+RT_CLASS!{class PerceptionFrameProviderInfo: IPerceptionFrameProviderInfo ["Windows.Devices.Perception.Provider.PerceptionFrameProviderInfo"]}
 impl RtActivatable<IActivationFactory> for PerceptionFrameProviderInfo {}
 DEFINE_CLSID!(PerceptionFrameProviderInfo(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,101,114,99,101,112,116,105,111,110,46,80,114,111,118,105,100,101,114,46,80,101,114,99,101,112,116,105,111,110,70,114,97,109,101,80,114,111,118,105,100,101,114,73,110,102,111,0]) [CLSID_PerceptionFrameProviderInfo]);
 DEFINE_IID!(IID_IPerceptionFrameProviderManager, 2841234951, 60115, 13279, 142, 193, 185, 36, 171, 224, 25, 196);
@@ -16810,7 +16810,7 @@ impl IPerceptionPropertyChangeRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionPropertyChangeRequest: IPerceptionPropertyChangeRequest}
+RT_CLASS!{class PerceptionPropertyChangeRequest: IPerceptionPropertyChangeRequest ["Windows.Devices.Perception.Provider.PerceptionPropertyChangeRequest"]}
 DEFINE_IID!(IID_PerceptionStartFaceAuthenticationHandler, 1954639146, 8336, 18032, 140, 72, 239, 57, 231, 255, 124, 38);
 RT_DELEGATE!{delegate PerceptionStartFaceAuthenticationHandler(PerceptionStartFaceAuthenticationHandlerVtbl, PerceptionStartFaceAuthenticationHandlerImpl) [IID_PerceptionStartFaceAuthenticationHandler] {
     fn Invoke(&self, sender: *mut PerceptionFaceAuthenticationGroup, out: *mut bool) -> HRESULT
@@ -16849,7 +16849,7 @@ impl IPerceptionVideoFrameAllocator {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionVideoFrameAllocator: IPerceptionVideoFrameAllocator}
+RT_CLASS!{class PerceptionVideoFrameAllocator: IPerceptionVideoFrameAllocator ["Windows.Devices.Perception.Provider.PerceptionVideoFrameAllocator"]}
 impl RtActivatable<IPerceptionVideoFrameAllocatorFactory> for PerceptionVideoFrameAllocator {}
 impl PerceptionVideoFrameAllocator {
     #[cfg(feature="windows-graphics")] #[inline] pub fn create(maxOutstandingFrameCountForWrite: u32, format: ::rt::gen::windows::graphics::imaging::BitmapPixelFormat, resolution: foundation::Size, alpha: ::rt::gen::windows::graphics::imaging::BitmapAlphaMode) -> Result<ComPtr<PerceptionVideoFrameAllocator>> {
@@ -16943,7 +16943,7 @@ impl IBarcodeScanner {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScanner: IBarcodeScanner}
+RT_CLASS!{class BarcodeScanner: IBarcodeScanner ["Windows.Devices.PointOfService.BarcodeScanner"]}
 impl RtActivatable<IBarcodeScannerStatics> for BarcodeScanner {}
 impl RtActivatable<IBarcodeScannerStatics2> for BarcodeScanner {}
 impl BarcodeScanner {
@@ -17001,7 +17001,7 @@ impl IBarcodeScannerCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerCapabilities: IBarcodeScannerCapabilities}
+RT_CLASS!{class BarcodeScannerCapabilities: IBarcodeScannerCapabilities ["Windows.Devices.PointOfService.BarcodeScannerCapabilities"]}
 DEFINE_IID!(IID_IBarcodeScannerCapabilities1, 2388308969, 3628, 18223, 161, 204, 238, 128, 84, 182, 166, 132);
 RT_INTERFACE!{interface IBarcodeScannerCapabilities1(IBarcodeScannerCapabilities1Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerCapabilities1] {
     fn get_IsSoftwareTriggerSupported(&self, out: *mut bool) -> HRESULT
@@ -17035,7 +17035,7 @@ impl IBarcodeScannerDataReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerDataReceivedEventArgs: IBarcodeScannerDataReceivedEventArgs}
+RT_CLASS!{class BarcodeScannerDataReceivedEventArgs: IBarcodeScannerDataReceivedEventArgs ["Windows.Devices.PointOfService.BarcodeScannerDataReceivedEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerErrorOccurredEventArgs, 751984687, 53050, 16386, 167, 90, 197, 236, 70, 143, 10, 32);
 RT_INTERFACE!{interface IBarcodeScannerErrorOccurredEventArgs(IBarcodeScannerErrorOccurredEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerErrorOccurredEventArgs] {
     fn get_PartialInputData(&self, out: *mut *mut BarcodeScannerReport) -> HRESULT,
@@ -17059,7 +17059,7 @@ impl IBarcodeScannerErrorOccurredEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerErrorOccurredEventArgs: IBarcodeScannerErrorOccurredEventArgs}
+RT_CLASS!{class BarcodeScannerErrorOccurredEventArgs: IBarcodeScannerErrorOccurredEventArgs ["Windows.Devices.PointOfService.BarcodeScannerErrorOccurredEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerImagePreviewReceivedEventArgs, 4088913541, 28299, 17230, 159, 88, 6, 239, 38, 188, 75, 175);
 RT_INTERFACE!{interface IBarcodeScannerImagePreviewReceivedEventArgs(IBarcodeScannerImagePreviewReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerImagePreviewReceivedEventArgs] {
     #[cfg(feature="windows-storage")] fn get_Preview(&self, out: *mut *mut super::super::storage::streams::IRandomAccessStreamWithContentType) -> HRESULT
@@ -17071,7 +17071,7 @@ impl IBarcodeScannerImagePreviewReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerImagePreviewReceivedEventArgs: IBarcodeScannerImagePreviewReceivedEventArgs}
+RT_CLASS!{class BarcodeScannerImagePreviewReceivedEventArgs: IBarcodeScannerImagePreviewReceivedEventArgs ["Windows.Devices.PointOfService.BarcodeScannerImagePreviewReceivedEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerReport, 1558501552, 42121, 19350, 134, 196, 240, 191, 138, 55, 117, 61);
 RT_INTERFACE!{interface IBarcodeScannerReport(IBarcodeScannerReportVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerReport] {
     fn get_ScanDataType(&self, out: *mut u32) -> HRESULT,
@@ -17095,7 +17095,7 @@ impl IBarcodeScannerReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerReport: IBarcodeScannerReport}
+RT_CLASS!{class BarcodeScannerReport: IBarcodeScannerReport ["Windows.Devices.PointOfService.BarcodeScannerReport"]}
 impl RtActivatable<IBarcodeScannerReportFactory> for BarcodeScannerReport {}
 impl BarcodeScannerReport {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_instance(scanDataType: u32, scanData: &super::super::storage::streams::IBuffer, scanDataLabel: &super::super::storage::streams::IBuffer) -> Result<ComPtr<BarcodeScannerReport>> {
@@ -17148,7 +17148,7 @@ impl IBarcodeScannerStatics2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BarcodeScannerStatus: i32 {
+RT_ENUM! { enum BarcodeScannerStatus: i32 ["Windows.Devices.PointOfService.BarcodeScannerStatus"] {
     Online (BarcodeScannerStatus_Online) = 0, Off (BarcodeScannerStatus_Off) = 1, Offline (BarcodeScannerStatus_Offline) = 2, OffOrOffline (BarcodeScannerStatus_OffOrOffline) = 3, Extended (BarcodeScannerStatus_Extended) = 4,
 }}
 DEFINE_IID!(IID_IBarcodeScannerStatusUpdatedEventArgs, 895321478, 40003, 17963, 169, 26, 129, 109, 201, 127, 69, 44);
@@ -17168,7 +17168,7 @@ impl IBarcodeScannerStatusUpdatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerStatusUpdatedEventArgs: IBarcodeScannerStatusUpdatedEventArgs}
+RT_CLASS!{class BarcodeScannerStatusUpdatedEventArgs: IBarcodeScannerStatusUpdatedEventArgs ["Windows.Devices.PointOfService.BarcodeScannerStatusUpdatedEventArgs"]}
 RT_CLASS!{static class BarcodeSymbologies}
 impl RtActivatable<IBarcodeSymbologiesStatics> for BarcodeSymbologies {}
 impl RtActivatable<IBarcodeSymbologiesStatics2> for BarcodeSymbologies {}
@@ -18118,8 +18118,8 @@ impl IBarcodeSymbologyAttributes {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeSymbologyAttributes: IBarcodeSymbologyAttributes}
-RT_ENUM! { enum BarcodeSymbologyDecodeLengthKind: i32 {
+RT_CLASS!{class BarcodeSymbologyAttributes: IBarcodeSymbologyAttributes ["Windows.Devices.PointOfService.BarcodeSymbologyAttributes"]}
+RT_ENUM! { enum BarcodeSymbologyDecodeLengthKind: i32 ["Windows.Devices.PointOfService.BarcodeSymbologyDecodeLengthKind"] {
     AnyLength (BarcodeSymbologyDecodeLengthKind_AnyLength) = 0, Discrete (BarcodeSymbologyDecodeLengthKind_Discrete) = 1, Range (BarcodeSymbologyDecodeLengthKind_Range) = 2,
 }}
 DEFINE_IID!(IID_ICashDrawer, 2676553160, 56916, 19182, 168, 144, 146, 11, 203, 254, 48, 252);
@@ -18186,7 +18186,7 @@ impl ICashDrawer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawer: ICashDrawer}
+RT_CLASS!{class CashDrawer: ICashDrawer ["Windows.Devices.PointOfService.CashDrawer"]}
 impl RtActivatable<ICashDrawerStatics> for CashDrawer {}
 impl RtActivatable<ICashDrawerStatics2> for CashDrawer {}
 impl CashDrawer {
@@ -18245,7 +18245,7 @@ impl ICashDrawerCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawerCapabilities: ICashDrawerCapabilities}
+RT_CLASS!{class CashDrawerCapabilities: ICashDrawerCapabilities ["Windows.Devices.PointOfService.CashDrawerCapabilities"]}
 DEFINE_IID!(IID_ICashDrawerCloseAlarm, 1811451079, 28515, 17166, 171, 59, 149, 215, 95, 251, 232, 127);
 RT_INTERFACE!{interface ICashDrawerCloseAlarm(ICashDrawerCloseAlarmVtbl): IInspectable(IInspectableVtbl) [IID_ICashDrawerCloseAlarm] {
     fn put_AlarmTimeout(&self, value: foundation::TimeSpan) -> HRESULT,
@@ -18312,8 +18312,8 @@ impl ICashDrawerCloseAlarm {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawerCloseAlarm: ICashDrawerCloseAlarm}
-RT_CLASS!{class CashDrawerClosedEventArgs: ICashDrawerEventSourceEventArgs}
+RT_CLASS!{class CashDrawerCloseAlarm: ICashDrawerCloseAlarm ["Windows.Devices.PointOfService.CashDrawerCloseAlarm"]}
+RT_CLASS!{class CashDrawerClosedEventArgs: ICashDrawerEventSourceEventArgs ["Windows.Devices.PointOfService.CashDrawerClosedEventArgs"]}
 DEFINE_IID!(IID_ICashDrawerEventSource, 3758548076, 62201, 17455, 141, 214, 6, 193, 10, 66, 39, 186);
 RT_INTERFACE!{interface ICashDrawerEventSource(ICashDrawerEventSourceVtbl): IInspectable(IInspectableVtbl) [IID_ICashDrawerEventSource] {
     fn add_DrawerClosed(&self, handler: *mut foundation::TypedEventHandler<CashDrawerEventSource, CashDrawerClosedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -18341,7 +18341,7 @@ impl ICashDrawerEventSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawerEventSource: ICashDrawerEventSource}
+RT_CLASS!{class CashDrawerEventSource: ICashDrawerEventSource ["Windows.Devices.PointOfService.CashDrawerEventSource"]}
 DEFINE_IID!(IID_ICashDrawerEventSourceEventArgs, 1774926785, 5247, 16924, 156, 35, 9, 1, 35, 187, 120, 108);
 RT_INTERFACE!{interface ICashDrawerEventSourceEventArgs(ICashDrawerEventSourceEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICashDrawerEventSourceEventArgs] {
     fn get_CashDrawer(&self, out: *mut *mut CashDrawer) -> HRESULT
@@ -18353,7 +18353,7 @@ impl ICashDrawerEventSourceEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawerOpenedEventArgs: ICashDrawerEventSourceEventArgs}
+RT_CLASS!{class CashDrawerOpenedEventArgs: ICashDrawerEventSourceEventArgs ["Windows.Devices.PointOfService.CashDrawerOpenedEventArgs"]}
 DEFINE_IID!(IID_ICashDrawerStatics, 3751843162, 54327, 20479, 181, 71, 221, 169, 105, 164, 248, 131);
 RT_INTERFACE!{static interface ICashDrawerStatics(ICashDrawerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICashDrawerStatics] {
     fn GetDefaultAsync(&self, out: *mut *mut foundation::IAsyncOperation<CashDrawer>) -> HRESULT,
@@ -18405,8 +18405,8 @@ impl ICashDrawerStatus {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawerStatus: ICashDrawerStatus}
-RT_ENUM! { enum CashDrawerStatusKind: i32 {
+RT_CLASS!{class CashDrawerStatus: ICashDrawerStatus ["Windows.Devices.PointOfService.CashDrawerStatus"]}
+RT_ENUM! { enum CashDrawerStatusKind: i32 ["Windows.Devices.PointOfService.CashDrawerStatusKind"] {
     Online (CashDrawerStatusKind_Online) = 0, Off (CashDrawerStatusKind_Off) = 1, Offline (CashDrawerStatusKind_Offline) = 2, OffOrOffline (CashDrawerStatusKind_OffOrOffline) = 3, Extended (CashDrawerStatusKind_Extended) = 4,
 }}
 DEFINE_IID!(IID_ICashDrawerStatusUpdatedEventArgs, 816507274, 3440, 17820, 149, 83, 135, 225, 36, 197, 36, 136);
@@ -18420,7 +18420,7 @@ impl ICashDrawerStatusUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CashDrawerStatusUpdatedEventArgs: ICashDrawerStatusUpdatedEventArgs}
+RT_CLASS!{class CashDrawerStatusUpdatedEventArgs: ICashDrawerStatusUpdatedEventArgs ["Windows.Devices.PointOfService.CashDrawerStatusUpdatedEventArgs"]}
 DEFINE_IID!(IID_IClaimedBarcodeScanner, 1248048284, 36772, 17202, 187, 38, 148, 93, 17, 216, 30, 15);
 RT_INTERFACE!{interface IClaimedBarcodeScanner(IClaimedBarcodeScannerVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedBarcodeScanner] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -18567,7 +18567,7 @@ impl IClaimedBarcodeScanner {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedBarcodeScanner: IClaimedBarcodeScanner}
+RT_CLASS!{class ClaimedBarcodeScanner: IClaimedBarcodeScanner ["Windows.Devices.PointOfService.ClaimedBarcodeScanner"]}
 DEFINE_IID!(IID_IClaimedBarcodeScanner1, 4128943372, 34129, 17076, 153, 140, 151, 12, 32, 33, 10, 34);
 RT_INTERFACE!{interface IClaimedBarcodeScanner1(IClaimedBarcodeScanner1Vtbl): IInspectable(IInspectableVtbl) [IID_IClaimedBarcodeScanner1] {
     fn StartSoftwareTriggerAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -18649,7 +18649,7 @@ DEFINE_IID!(IID_IClaimedBarcodeScannerClosedEventArgs, 3481097353, 41516, 19557,
 RT_INTERFACE!{interface IClaimedBarcodeScannerClosedEventArgs(IClaimedBarcodeScannerClosedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedBarcodeScannerClosedEventArgs] {
     
 }}
-RT_CLASS!{class ClaimedBarcodeScannerClosedEventArgs: IClaimedBarcodeScannerClosedEventArgs}
+RT_CLASS!{class ClaimedBarcodeScannerClosedEventArgs: IClaimedBarcodeScannerClosedEventArgs ["Windows.Devices.PointOfService.ClaimedBarcodeScannerClosedEventArgs"]}
 DEFINE_IID!(IID_IClaimedCashDrawer, 3393165743, 43960, 17089, 138, 132, 92, 102, 81, 47, 90, 117);
 RT_INTERFACE!{interface IClaimedCashDrawer(IClaimedCashDrawerVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedCashDrawer] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -18726,7 +18726,7 @@ impl IClaimedCashDrawer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedCashDrawer: IClaimedCashDrawer}
+RT_CLASS!{class ClaimedCashDrawer: IClaimedCashDrawer ["Windows.Devices.PointOfService.ClaimedCashDrawer"]}
 DEFINE_IID!(IID_IClaimedCashDrawer2, 2629481890, 56898, 19803, 176, 193, 155, 87, 162, 186, 137, 195);
 RT_INTERFACE!{interface IClaimedCashDrawer2(IClaimedCashDrawer2Vtbl): IInspectable(IInspectableVtbl) [IID_IClaimedCashDrawer2] {
     fn add_Closed(&self, handler: *mut foundation::TypedEventHandler<ClaimedCashDrawer, ClaimedCashDrawerClosedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -18747,7 +18747,7 @@ DEFINE_IID!(IID_IClaimedCashDrawerClosedEventArgs, 3428269875, 16180, 19548, 186
 RT_INTERFACE!{interface IClaimedCashDrawerClosedEventArgs(IClaimedCashDrawerClosedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedCashDrawerClosedEventArgs] {
     
 }}
-RT_CLASS!{class ClaimedCashDrawerClosedEventArgs: IClaimedCashDrawerClosedEventArgs}
+RT_CLASS!{class ClaimedCashDrawerClosedEventArgs: IClaimedCashDrawerClosedEventArgs ["Windows.Devices.PointOfService.ClaimedCashDrawerClosedEventArgs"]}
 DEFINE_IID!(IID_IClaimedJournalPrinter, 1743390256, 20861, 18559, 159, 223, 210, 224, 160, 162, 100, 165);
 RT_INTERFACE!{interface IClaimedJournalPrinter(IClaimedJournalPrinterVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedJournalPrinter] {
     fn CreateJob(&self, out: *mut *mut JournalPrintJob) -> HRESULT
@@ -18759,7 +18759,7 @@ impl IClaimedJournalPrinter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedJournalPrinter: IClaimedJournalPrinter}
+RT_CLASS!{class ClaimedJournalPrinter: IClaimedJournalPrinter ["Windows.Devices.PointOfService.ClaimedJournalPrinter"]}
 DEFINE_IID!(IID_IClaimedLineDisplay, 302696816, 39541, 19151, 170, 231, 9, 151, 43, 207, 135, 148);
 RT_INTERFACE!{interface IClaimedLineDisplay(IClaimedLineDisplayVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedLineDisplay] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -18829,7 +18829,7 @@ impl IClaimedLineDisplay {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedLineDisplay: IClaimedLineDisplay}
+RT_CLASS!{class ClaimedLineDisplay: IClaimedLineDisplay ["Windows.Devices.PointOfService.ClaimedLineDisplay"]}
 impl RtActivatable<IClaimedLineDisplayStatics> for ClaimedLineDisplay {}
 impl ClaimedLineDisplay {
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<ClaimedLineDisplay>>> {
@@ -18969,7 +18969,7 @@ DEFINE_IID!(IID_IClaimedLineDisplayClosedEventArgs, 4178965348, 54229, 20240, 18
 RT_INTERFACE!{interface IClaimedLineDisplayClosedEventArgs(IClaimedLineDisplayClosedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedLineDisplayClosedEventArgs] {
     
 }}
-RT_CLASS!{class ClaimedLineDisplayClosedEventArgs: IClaimedLineDisplayClosedEventArgs}
+RT_CLASS!{class ClaimedLineDisplayClosedEventArgs: IClaimedLineDisplayClosedEventArgs ["Windows.Devices.PointOfService.ClaimedLineDisplayClosedEventArgs"]}
 DEFINE_IID!(IID_IClaimedLineDisplayStatics, 2026543355, 35691, 18803, 134, 240, 62, 87, 12, 53, 24, 37);
 RT_INTERFACE!{static interface IClaimedLineDisplayStatics(IClaimedLineDisplayStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedLineDisplayStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncOperation<ClaimedLineDisplay>) -> HRESULT,
@@ -19185,7 +19185,7 @@ impl IClaimedMagneticStripeReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedMagneticStripeReader: IClaimedMagneticStripeReader}
+RT_CLASS!{class ClaimedMagneticStripeReader: IClaimedMagneticStripeReader ["Windows.Devices.PointOfService.ClaimedMagneticStripeReader"]}
 DEFINE_IID!(IID_IClaimedMagneticStripeReader2, 594522079, 58076, 19837, 156, 120, 6, 13, 242, 191, 41, 40);
 RT_INTERFACE!{interface IClaimedMagneticStripeReader2(IClaimedMagneticStripeReader2Vtbl): IInspectable(IInspectableVtbl) [IID_IClaimedMagneticStripeReader2] {
     fn add_Closed(&self, handler: *mut foundation::TypedEventHandler<ClaimedMagneticStripeReader, ClaimedMagneticStripeReaderClosedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -19206,7 +19206,7 @@ DEFINE_IID!(IID_IClaimedMagneticStripeReaderClosedEventArgs, 346925370, 44493, 1
 RT_INTERFACE!{interface IClaimedMagneticStripeReaderClosedEventArgs(IClaimedMagneticStripeReaderClosedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedMagneticStripeReaderClosedEventArgs] {
     
 }}
-RT_CLASS!{class ClaimedMagneticStripeReaderClosedEventArgs: IClaimedMagneticStripeReaderClosedEventArgs}
+RT_CLASS!{class ClaimedMagneticStripeReaderClosedEventArgs: IClaimedMagneticStripeReaderClosedEventArgs ["Windows.Devices.PointOfService.ClaimedMagneticStripeReaderClosedEventArgs"]}
 DEFINE_IID!(IID_IClaimedPosPrinter, 1835322892, 57406, 19220, 163, 142, 194, 140, 52, 184, 99, 83);
 RT_INTERFACE!{interface IClaimedPosPrinter(IClaimedPosPrinterVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedPosPrinter] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19322,7 +19322,7 @@ impl IClaimedPosPrinter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedPosPrinter: IClaimedPosPrinter}
+RT_CLASS!{class ClaimedPosPrinter: IClaimedPosPrinter ["Windows.Devices.PointOfService.ClaimedPosPrinter"]}
 DEFINE_IID!(IID_IClaimedPosPrinter2, 1542955989, 20888, 17274, 130, 223, 88, 153, 147, 250, 119, 225);
 RT_INTERFACE!{interface IClaimedPosPrinter2(IClaimedPosPrinter2Vtbl): IInspectable(IInspectableVtbl) [IID_IClaimedPosPrinter2] {
     fn add_Closed(&self, handler: *mut foundation::TypedEventHandler<ClaimedPosPrinter, ClaimedPosPrinterClosedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -19343,7 +19343,7 @@ DEFINE_IID!(IID_IClaimedPosPrinterClosedEventArgs, 3803685499, 19776, 18205, 146
 RT_INTERFACE!{interface IClaimedPosPrinterClosedEventArgs(IClaimedPosPrinterClosedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedPosPrinterClosedEventArgs] {
     
 }}
-RT_CLASS!{class ClaimedPosPrinterClosedEventArgs: IClaimedPosPrinterClosedEventArgs}
+RT_CLASS!{class ClaimedPosPrinterClosedEventArgs: IClaimedPosPrinterClosedEventArgs ["Windows.Devices.PointOfService.ClaimedPosPrinterClosedEventArgs"]}
 DEFINE_IID!(IID_IClaimedReceiptPrinter, 2597485172, 56673, 20194, 152, 55, 91, 93, 114, 213, 56, 185);
 RT_INTERFACE!{interface IClaimedReceiptPrinter(IClaimedReceiptPrinterVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedReceiptPrinter] {
     fn get_SidewaysMaxLines(&self, out: *mut u32) -> HRESULT,
@@ -19385,7 +19385,7 @@ impl IClaimedReceiptPrinter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedReceiptPrinter: IClaimedReceiptPrinter}
+RT_CLASS!{class ClaimedReceiptPrinter: IClaimedReceiptPrinter ["Windows.Devices.PointOfService.ClaimedReceiptPrinter"]}
 DEFINE_IID!(IID_IClaimedSlipPrinter, 3177050098, 44944, 20106, 183, 123, 227, 174, 156, 166, 58, 127);
 RT_INTERFACE!{interface IClaimedSlipPrinter(IClaimedSlipPrinterVtbl): IInspectable(IInspectableVtbl) [IID_IClaimedSlipPrinter] {
     fn get_SidewaysMaxLines(&self, out: *mut u32) -> HRESULT,
@@ -19466,7 +19466,7 @@ impl IClaimedSlipPrinter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClaimedSlipPrinter: IClaimedSlipPrinter}
+RT_CLASS!{class ClaimedSlipPrinter: IClaimedSlipPrinter ["Windows.Devices.PointOfService.ClaimedSlipPrinter"]}
 DEFINE_IID!(IID_ICommonClaimedPosPrinterStation, 3085657768, 65162, 19707, 139, 66, 227, 91, 40, 12, 178, 124);
 RT_INTERFACE!{interface ICommonClaimedPosPrinterStation(ICommonClaimedPosPrinterStationVtbl): IInspectable(IInspectableVtbl) [IID_ICommonClaimedPosPrinterStation] {
     fn put_CharactersPerLine(&self, value: u32) -> HRESULT,
@@ -19727,8 +19727,8 @@ DEFINE_IID!(IID_IJournalPrinterCapabilities, 995937347, 57415, 17507, 187, 88, 2
 RT_INTERFACE!{interface IJournalPrinterCapabilities(IJournalPrinterCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IJournalPrinterCapabilities] {
     
 }}
-RT_CLASS!{class JournalPrinterCapabilities: IJournalPrinterCapabilities}
-RT_CLASS!{class JournalPrintJob: IPosPrinterJob}
+RT_CLASS!{class JournalPrinterCapabilities: IJournalPrinterCapabilities ["Windows.Devices.PointOfService.JournalPrinterCapabilities"]}
+RT_CLASS!{class JournalPrintJob: IPosPrinterJob ["Windows.Devices.PointOfService.JournalPrintJob"]}
 DEFINE_IID!(IID_ILineDisplay, 620093262, 15513, 17634, 183, 63, 229, 27, 227, 99, 122, 140);
 RT_INTERFACE!{interface ILineDisplay(ILineDisplayVtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplay] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -19782,7 +19782,7 @@ impl ILineDisplay {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplay: ILineDisplay}
+RT_CLASS!{class LineDisplay: ILineDisplay ["Windows.Devices.PointOfService.LineDisplay"]}
 impl RtActivatable<ILineDisplayStatics> for LineDisplay {}
 impl RtActivatable<ILineDisplayStatics2> for LineDisplay {}
 impl LineDisplay {
@@ -19896,7 +19896,7 @@ impl ILineDisplayAttributes {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayAttributes: ILineDisplayAttributes}
+RT_CLASS!{class LineDisplayAttributes: ILineDisplayAttributes ["Windows.Devices.PointOfService.LineDisplayAttributes"]}
 DEFINE_IID!(IID_ILineDisplayCapabilities, 1511372241, 36293, 19356, 145, 114, 48, 62, 71, 183, 12, 85);
 RT_INTERFACE!{interface ILineDisplayCapabilities(ILineDisplayCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplayCapabilities] {
     fn get_IsStatisticsReportingSupported(&self, out: *mut bool) -> HRESULT,
@@ -20010,7 +20010,7 @@ impl ILineDisplayCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayCapabilities: ILineDisplayCapabilities}
+RT_CLASS!{class LineDisplayCapabilities: ILineDisplayCapabilities ["Windows.Devices.PointOfService.LineDisplayCapabilities"]}
 DEFINE_IID!(IID_ILineDisplayCursor, 3974102085, 30026, 20027, 171, 43, 21, 17, 129, 8, 86, 5);
 RT_INTERFACE!{interface ILineDisplayCursor(ILineDisplayCursorVtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplayCursor] {
     fn get_CanCustomize(&self, out: *mut bool) -> HRESULT,
@@ -20070,7 +20070,7 @@ impl ILineDisplayCursor {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayCursor: ILineDisplayCursor}
+RT_CLASS!{class LineDisplayCursor: ILineDisplayCursor ["Windows.Devices.PointOfService.LineDisplayCursor"]}
 DEFINE_IID!(IID_ILineDisplayCursorAttributes, 1311593726, 20477, 16784, 170, 225, 206, 40, 95, 32, 200, 150);
 RT_INTERFACE!{interface ILineDisplayCursorAttributes(ILineDisplayCursorAttributesVtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplayCursorAttributes] {
     fn get_IsBlinkEnabled(&self, out: *mut bool) -> HRESULT,
@@ -20120,8 +20120,8 @@ impl ILineDisplayCursorAttributes {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayCursorAttributes: ILineDisplayCursorAttributes}
-RT_ENUM! { enum LineDisplayCursorType: i32 {
+RT_CLASS!{class LineDisplayCursorAttributes: ILineDisplayCursorAttributes ["Windows.Devices.PointOfService.LineDisplayCursorAttributes"]}
+RT_ENUM! { enum LineDisplayCursorType: i32 ["Windows.Devices.PointOfService.LineDisplayCursorType"] {
     None (LineDisplayCursorType_None) = 0, Block (LineDisplayCursorType_Block) = 1, HalfBlock (LineDisplayCursorType_HalfBlock) = 2, Underline (LineDisplayCursorType_Underline) = 3, Reverse (LineDisplayCursorType_Reverse) = 4, Other (LineDisplayCursorType_Other) = 5,
 }}
 DEFINE_IID!(IID_ILineDisplayCustomGlyphs, 576190012, 62051, 17649, 161, 160, 231, 80, 166, 160, 236, 84);
@@ -20147,11 +20147,11 @@ impl ILineDisplayCustomGlyphs {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayCustomGlyphs: ILineDisplayCustomGlyphs}
-RT_ENUM! { enum LineDisplayDescriptorState: i32 {
+RT_CLASS!{class LineDisplayCustomGlyphs: ILineDisplayCustomGlyphs ["Windows.Devices.PointOfService.LineDisplayCustomGlyphs"]}
+RT_ENUM! { enum LineDisplayDescriptorState: i32 ["Windows.Devices.PointOfService.LineDisplayDescriptorState"] {
     Off (LineDisplayDescriptorState_Off) = 0, On (LineDisplayDescriptorState_On) = 1, Blink (LineDisplayDescriptorState_Blink) = 2,
 }}
-RT_ENUM! { enum LineDisplayHorizontalAlignment: i32 {
+RT_ENUM! { enum LineDisplayHorizontalAlignment: i32 ["Windows.Devices.PointOfService.LineDisplayHorizontalAlignment"] {
     Left (LineDisplayHorizontalAlignment_Left) = 0, Center (LineDisplayHorizontalAlignment_Center) = 1, Right (LineDisplayHorizontalAlignment_Right) = 2,
 }}
 DEFINE_IID!(IID_ILineDisplayMarquee, 2748530238, 62570, 19322, 188, 33, 83, 235, 59, 87, 248, 180);
@@ -20204,14 +20204,14 @@ impl ILineDisplayMarquee {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayMarquee: ILineDisplayMarquee}
-RT_ENUM! { enum LineDisplayMarqueeFormat: i32 {
+RT_CLASS!{class LineDisplayMarquee: ILineDisplayMarquee ["Windows.Devices.PointOfService.LineDisplayMarquee"]}
+RT_ENUM! { enum LineDisplayMarqueeFormat: i32 ["Windows.Devices.PointOfService.LineDisplayMarqueeFormat"] {
     None (LineDisplayMarqueeFormat_None) = 0, Walk (LineDisplayMarqueeFormat_Walk) = 1, Place (LineDisplayMarqueeFormat_Place) = 2,
 }}
-RT_ENUM! { enum LineDisplayPowerStatus: i32 {
+RT_ENUM! { enum LineDisplayPowerStatus: i32 ["Windows.Devices.PointOfService.LineDisplayPowerStatus"] {
     Unknown (LineDisplayPowerStatus_Unknown) = 0, Online (LineDisplayPowerStatus_Online) = 1, Off (LineDisplayPowerStatus_Off) = 2, Offline (LineDisplayPowerStatus_Offline) = 3, OffOrOffline (LineDisplayPowerStatus_OffOrOffline) = 4,
 }}
-RT_ENUM! { enum LineDisplayScrollDirection: i32 {
+RT_ENUM! { enum LineDisplayScrollDirection: i32 ["Windows.Devices.PointOfService.LineDisplayScrollDirection"] {
     Up (LineDisplayScrollDirection_Up) = 0, Down (LineDisplayScrollDirection_Down) = 1, Left (LineDisplayScrollDirection_Left) = 2, Right (LineDisplayScrollDirection_Right) = 3,
 }}
 DEFINE_IID!(IID_ILineDisplayStatics, 36552886, 4528, 18064, 149, 71, 11, 57, 197, 175, 33, 20);
@@ -20277,7 +20277,7 @@ impl ILineDisplayStatisticsCategorySelector {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayStatisticsCategorySelector: ILineDisplayStatisticsCategorySelector}
+RT_CLASS!{class LineDisplayStatisticsCategorySelector: ILineDisplayStatisticsCategorySelector ["Windows.Devices.PointOfService.LineDisplayStatisticsCategorySelector"]}
 DEFINE_IID!(IID_ILineDisplayStatusUpdatedEventArgs, 3721755674, 34555, 20154, 147, 209, 111, 94, 218, 82, 183, 82);
 RT_INTERFACE!{interface ILineDisplayStatusUpdatedEventArgs(ILineDisplayStatusUpdatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplayStatusUpdatedEventArgs] {
     fn get_Status(&self, out: *mut LineDisplayPowerStatus) -> HRESULT
@@ -20289,7 +20289,7 @@ impl ILineDisplayStatusUpdatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayStatusUpdatedEventArgs: ILineDisplayStatusUpdatedEventArgs}
+RT_CLASS!{class LineDisplayStatusUpdatedEventArgs: ILineDisplayStatusUpdatedEventArgs ["Windows.Devices.PointOfService.LineDisplayStatusUpdatedEventArgs"]}
 DEFINE_IID!(IID_ILineDisplayStoredBitmap, 4129378651, 55326, 17338, 191, 27, 188, 250, 60, 120, 91, 160);
 RT_INTERFACE!{interface ILineDisplayStoredBitmap(ILineDisplayStoredBitmapVtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplayStoredBitmap] {
     fn get_EscapeSequence(&self, out: *mut HSTRING) -> HRESULT,
@@ -20307,14 +20307,14 @@ impl ILineDisplayStoredBitmap {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayStoredBitmap: ILineDisplayStoredBitmap}
-RT_ENUM! { enum LineDisplayTextAttribute: i32 {
+RT_CLASS!{class LineDisplayStoredBitmap: ILineDisplayStoredBitmap ["Windows.Devices.PointOfService.LineDisplayStoredBitmap"]}
+RT_ENUM! { enum LineDisplayTextAttribute: i32 ["Windows.Devices.PointOfService.LineDisplayTextAttribute"] {
     Normal (LineDisplayTextAttribute_Normal) = 0, Blink (LineDisplayTextAttribute_Blink) = 1, Reverse (LineDisplayTextAttribute_Reverse) = 2, ReverseBlink (LineDisplayTextAttribute_ReverseBlink) = 3,
 }}
-RT_ENUM! { enum LineDisplayTextAttributeGranularity: i32 {
+RT_ENUM! { enum LineDisplayTextAttributeGranularity: i32 ["Windows.Devices.PointOfService.LineDisplayTextAttributeGranularity"] {
     NotSupported (LineDisplayTextAttributeGranularity_NotSupported) = 0, EntireDisplay (LineDisplayTextAttributeGranularity_EntireDisplay) = 1, PerCharacter (LineDisplayTextAttributeGranularity_PerCharacter) = 2,
 }}
-RT_ENUM! { enum LineDisplayVerticalAlignment: i32 {
+RT_ENUM! { enum LineDisplayVerticalAlignment: i32 ["Windows.Devices.PointOfService.LineDisplayVerticalAlignment"] {
     Top (LineDisplayVerticalAlignment_Top) = 0, Center (LineDisplayVerticalAlignment_Center) = 1, Bottom (LineDisplayVerticalAlignment_Bottom) = 2,
 }}
 DEFINE_IID!(IID_ILineDisplayWindow, 3525308148, 9060, 19429, 190, 225, 133, 22, 128, 175, 73, 100);
@@ -20375,7 +20375,7 @@ impl ILineDisplayWindow {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LineDisplayWindow: ILineDisplayWindow}
+RT_CLASS!{class LineDisplayWindow: ILineDisplayWindow ["Windows.Devices.PointOfService.LineDisplayWindow"]}
 DEFINE_IID!(IID_ILineDisplayWindow2, 2841436902, 48600, 17253, 142, 17, 222, 148, 222, 141, 255, 2);
 RT_INTERFACE!{interface ILineDisplayWindow2(ILineDisplayWindow2Vtbl): IInspectable(IInspectableVtbl) [IID_ILineDisplayWindow2] {
     fn get_Cursor(&self, out: *mut *mut LineDisplayCursor) -> HRESULT,
@@ -20500,7 +20500,7 @@ impl IMagneticStripeReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReader: IMagneticStripeReader}
+RT_CLASS!{class MagneticStripeReader: IMagneticStripeReader ["Windows.Devices.PointOfService.MagneticStripeReader"]}
 impl RtActivatable<IMagneticStripeReaderStatics> for MagneticStripeReader {}
 impl RtActivatable<IMagneticStripeReaderStatics2> for MagneticStripeReader {}
 impl MagneticStripeReader {
@@ -20637,11 +20637,11 @@ impl IMagneticStripeReaderAamvaCardDataReceivedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderAamvaCardDataReceivedEventArgs: IMagneticStripeReaderAamvaCardDataReceivedEventArgs}
-RT_ENUM! { enum MagneticStripeReaderAuthenticationLevel: i32 {
+RT_CLASS!{class MagneticStripeReaderAamvaCardDataReceivedEventArgs: IMagneticStripeReaderAamvaCardDataReceivedEventArgs ["Windows.Devices.PointOfService.MagneticStripeReaderAamvaCardDataReceivedEventArgs"]}
+RT_ENUM! { enum MagneticStripeReaderAuthenticationLevel: i32 ["Windows.Devices.PointOfService.MagneticStripeReaderAuthenticationLevel"] {
     NotSupported (MagneticStripeReaderAuthenticationLevel_NotSupported) = 0, Optional (MagneticStripeReaderAuthenticationLevel_Optional) = 1, Required (MagneticStripeReaderAuthenticationLevel_Required) = 2,
 }}
-RT_ENUM! { enum MagneticStripeReaderAuthenticationProtocol: i32 {
+RT_ENUM! { enum MagneticStripeReaderAuthenticationProtocol: i32 ["Windows.Devices.PointOfService.MagneticStripeReaderAuthenticationProtocol"] {
     None (MagneticStripeReaderAuthenticationProtocol_None) = 0, ChallengeResponse (MagneticStripeReaderAuthenticationProtocol_ChallengeResponse) = 1,
 }}
 DEFINE_IID!(IID_IMagneticStripeReaderBankCardDataReceivedEventArgs, 781551651, 41754, 18275, 136, 44, 35, 114, 94, 57, 176, 142);
@@ -20703,7 +20703,7 @@ impl IMagneticStripeReaderBankCardDataReceivedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderBankCardDataReceivedEventArgs: IMagneticStripeReaderBankCardDataReceivedEventArgs}
+RT_CLASS!{class MagneticStripeReaderBankCardDataReceivedEventArgs: IMagneticStripeReaderBankCardDataReceivedEventArgs ["Windows.Devices.PointOfService.MagneticStripeReaderBankCardDataReceivedEventArgs"]}
 DEFINE_IID!(IID_IMagneticStripeReaderCapabilities, 1898479772, 50240, 17570, 164, 103, 70, 145, 117, 208, 40, 150);
 RT_INTERFACE!{interface IMagneticStripeReaderCapabilities(IMagneticStripeReaderCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IMagneticStripeReaderCapabilities] {
     fn get_CardAuthentication(&self, out: *mut HSTRING) -> HRESULT,
@@ -20775,7 +20775,7 @@ impl IMagneticStripeReaderCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderCapabilities: IMagneticStripeReaderCapabilities}
+RT_CLASS!{class MagneticStripeReaderCapabilities: IMagneticStripeReaderCapabilities ["Windows.Devices.PointOfService.MagneticStripeReaderCapabilities"]}
 RT_CLASS!{static class MagneticStripeReaderCardTypes}
 impl RtActivatable<IMagneticStripeReaderCardTypesStatics> for MagneticStripeReaderCardTypes {}
 impl MagneticStripeReaderCardTypes {
@@ -20900,8 +20900,8 @@ impl IMagneticStripeReaderErrorOccurredEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderErrorOccurredEventArgs: IMagneticStripeReaderErrorOccurredEventArgs}
-RT_ENUM! { enum MagneticStripeReaderErrorReportingType: i32 {
+RT_CLASS!{class MagneticStripeReaderErrorOccurredEventArgs: IMagneticStripeReaderErrorOccurredEventArgs ["Windows.Devices.PointOfService.MagneticStripeReaderErrorOccurredEventArgs"]}
+RT_ENUM! { enum MagneticStripeReaderErrorReportingType: i32 ["Windows.Devices.PointOfService.MagneticStripeReaderErrorReportingType"] {
     CardLevel (MagneticStripeReaderErrorReportingType_CardLevel) = 0, TrackLevel (MagneticStripeReaderErrorReportingType_TrackLevel) = 1,
 }}
 DEFINE_IID!(IID_IMagneticStripeReaderReport, 1784373319, 39344, 16776, 190, 241, 237, 223, 121, 247, 143, 230);
@@ -20963,7 +20963,7 @@ impl IMagneticStripeReaderReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderReport: IMagneticStripeReaderReport}
+RT_CLASS!{class MagneticStripeReaderReport: IMagneticStripeReaderReport ["Windows.Devices.PointOfService.MagneticStripeReaderReport"]}
 DEFINE_IID!(IID_IMagneticStripeReaderStatics, 3294604106, 61399, 18272, 165, 206, 21, 176, 228, 126, 148, 235);
 RT_INTERFACE!{static interface IMagneticStripeReaderStatics(IMagneticStripeReaderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMagneticStripeReaderStatics] {
     fn GetDefaultAsync(&self, out: *mut *mut foundation::IAsyncOperation<MagneticStripeReader>) -> HRESULT,
@@ -20998,7 +20998,7 @@ impl IMagneticStripeReaderStatics2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MagneticStripeReaderStatus: i32 {
+RT_ENUM! { enum MagneticStripeReaderStatus: i32 ["Windows.Devices.PointOfService.MagneticStripeReaderStatus"] {
     Unauthenticated (MagneticStripeReaderStatus_Unauthenticated) = 0, Authenticated (MagneticStripeReaderStatus_Authenticated) = 1, Extended (MagneticStripeReaderStatus_Extended) = 2,
 }}
 DEFINE_IID!(IID_IMagneticStripeReaderStatusUpdatedEventArgs, 164391856, 12898, 16413, 158, 138, 232, 13, 99, 88, 144, 107);
@@ -21018,7 +21018,7 @@ impl IMagneticStripeReaderStatusUpdatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderStatusUpdatedEventArgs: IMagneticStripeReaderStatusUpdatedEventArgs}
+RT_CLASS!{class MagneticStripeReaderStatusUpdatedEventArgs: IMagneticStripeReaderStatusUpdatedEventArgs ["Windows.Devices.PointOfService.MagneticStripeReaderStatusUpdatedEventArgs"]}
 DEFINE_IID!(IID_IMagneticStripeReaderTrackData, 273479281, 19101, 17518, 171, 197, 32, 64, 35, 7, 186, 54);
 RT_INTERFACE!{interface IMagneticStripeReaderTrackData(IMagneticStripeReaderTrackDataVtbl): IInspectable(IInspectableVtbl) [IID_IMagneticStripeReaderTrackData] {
     #[cfg(feature="windows-storage")] fn get_Data(&self, out: *mut *mut super::super::storage::streams::IBuffer) -> HRESULT,
@@ -21042,11 +21042,11 @@ impl IMagneticStripeReaderTrackData {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderTrackData: IMagneticStripeReaderTrackData}
-RT_ENUM! { enum MagneticStripeReaderTrackErrorType: i32 {
+RT_CLASS!{class MagneticStripeReaderTrackData: IMagneticStripeReaderTrackData ["Windows.Devices.PointOfService.MagneticStripeReaderTrackData"]}
+RT_ENUM! { enum MagneticStripeReaderTrackErrorType: i32 ["Windows.Devices.PointOfService.MagneticStripeReaderTrackErrorType"] {
     None (MagneticStripeReaderTrackErrorType_None) = 0, StartSentinelError (MagneticStripeReaderTrackErrorType_StartSentinelError) = 1, EndSentinelError (MagneticStripeReaderTrackErrorType_EndSentinelError) = 2, ParityError (MagneticStripeReaderTrackErrorType_ParityError) = 3, LrcError (MagneticStripeReaderTrackErrorType_LrcError) = 4, Unknown (MagneticStripeReaderTrackErrorType_Unknown) = -1,
 }}
-RT_ENUM! { enum MagneticStripeReaderTrackIds: i32 {
+RT_ENUM! { enum MagneticStripeReaderTrackIds: i32 ["Windows.Devices.PointOfService.MagneticStripeReaderTrackIds"] {
     None (MagneticStripeReaderTrackIds_None) = 0, Track1 (MagneticStripeReaderTrackIds_Track1) = 1, Track2 (MagneticStripeReaderTrackIds_Track2) = 2, Track3 (MagneticStripeReaderTrackIds_Track3) = 4, Track4 (MagneticStripeReaderTrackIds_Track4) = 8,
 }}
 DEFINE_IID!(IID_IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs, 2936689940, 22988, 19040, 153, 232, 153, 165, 61, 172, 229, 170);
@@ -21060,8 +21060,8 @@ impl IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs: IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs}
-RT_ENUM! { enum PosConnectionTypes: u32 {
+RT_CLASS!{class MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs: IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs ["Windows.Devices.PointOfService.MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs"]}
+RT_ENUM! { enum PosConnectionTypes: u32 ["Windows.Devices.PointOfService.PosConnectionTypes"] {
     Local (PosConnectionTypes_Local) = 1, IP (PosConnectionTypes_IP) = 2, Bluetooth (PosConnectionTypes_Bluetooth) = 4, All (PosConnectionTypes_All) = 4294967295,
 }}
 DEFINE_IID!(IID_IPosPrinter, 704889102, 39449, 18945, 153, 79, 18, 223, 173, 106, 220, 191);
@@ -21128,7 +21128,7 @@ impl IPosPrinter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PosPrinter: IPosPrinter}
+RT_CLASS!{class PosPrinter: IPosPrinter ["Windows.Devices.PointOfService.PosPrinter"]}
 impl RtActivatable<IPosPrinterStatics> for PosPrinter {}
 impl RtActivatable<IPosPrinterStatics2> for PosPrinter {}
 impl PosPrinter {
@@ -21146,10 +21146,10 @@ impl PosPrinter {
     }
 }
 DEFINE_CLSID!(PosPrinter(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,80,111,115,80,114,105,110,116,101,114,0]) [CLSID_PosPrinter]);
-RT_ENUM! { enum PosPrinterAlignment: i32 {
+RT_ENUM! { enum PosPrinterAlignment: i32 ["Windows.Devices.PointOfService.PosPrinterAlignment"] {
     Left (PosPrinterAlignment_Left) = 0, Center (PosPrinterAlignment_Center) = 1, Right (PosPrinterAlignment_Right) = 2,
 }}
-RT_ENUM! { enum PosPrinterBarcodeTextPosition: i32 {
+RT_ENUM! { enum PosPrinterBarcodeTextPosition: i32 ["Windows.Devices.PointOfService.PosPrinterBarcodeTextPosition"] {
     None (PosPrinterBarcodeTextPosition_None) = 0, Above (PosPrinterBarcodeTextPosition_Above) = 1, Below (PosPrinterBarcodeTextPosition_Below) = 2,
 }}
 DEFINE_IID!(IID_IPosPrinterCapabilities, 3454621473, 17280, 18821, 173, 197, 57, 219, 48, 205, 147, 188);
@@ -21217,8 +21217,8 @@ impl IPosPrinterCapabilities {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PosPrinterCapabilities: IPosPrinterCapabilities}
-RT_ENUM! { enum PosPrinterCartridgeSensors: u32 {
+RT_CLASS!{class PosPrinterCapabilities: IPosPrinterCapabilities ["Windows.Devices.PointOfService.PosPrinterCapabilities"]}
+RT_ENUM! { enum PosPrinterCartridgeSensors: u32 ["Windows.Devices.PointOfService.PosPrinterCartridgeSensors"] {
     None (PosPrinterCartridgeSensors_None) = 0, Removed (PosPrinterCartridgeSensors_Removed) = 1, Empty (PosPrinterCartridgeSensors_Empty) = 2, HeadCleaning (PosPrinterCartridgeSensors_HeadCleaning) = 4, NearEnd (PosPrinterCartridgeSensors_NearEnd) = 8,
 }}
 RT_CLASS!{static class PosPrinterCharacterSetIds}
@@ -21258,10 +21258,10 @@ impl IPosPrinterCharacterSetIdsStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PosPrinterColorCapabilities: u32 {
+RT_ENUM! { enum PosPrinterColorCapabilities: u32 ["Windows.Devices.PointOfService.PosPrinterColorCapabilities"] {
     None (PosPrinterColorCapabilities_None) = 0, Primary (PosPrinterColorCapabilities_Primary) = 1, Custom1 (PosPrinterColorCapabilities_Custom1) = 2, Custom2 (PosPrinterColorCapabilities_Custom2) = 4, Custom3 (PosPrinterColorCapabilities_Custom3) = 8, Custom4 (PosPrinterColorCapabilities_Custom4) = 16, Custom5 (PosPrinterColorCapabilities_Custom5) = 32, Custom6 (PosPrinterColorCapabilities_Custom6) = 64, Cyan (PosPrinterColorCapabilities_Cyan) = 128, Magenta (PosPrinterColorCapabilities_Magenta) = 256, Yellow (PosPrinterColorCapabilities_Yellow) = 512, Full (PosPrinterColorCapabilities_Full) = 1024,
 }}
-RT_ENUM! { enum PosPrinterColorCartridge: i32 {
+RT_ENUM! { enum PosPrinterColorCartridge: i32 ["Windows.Devices.PointOfService.PosPrinterColorCartridge"] {
     Unknown (PosPrinterColorCartridge_Unknown) = 0, Primary (PosPrinterColorCartridge_Primary) = 1, Custom1 (PosPrinterColorCartridge_Custom1) = 2, Custom2 (PosPrinterColorCartridge_Custom2) = 3, Custom3 (PosPrinterColorCartridge_Custom3) = 4, Custom4 (PosPrinterColorCartridge_Custom4) = 5, Custom5 (PosPrinterColorCartridge_Custom5) = 6, Custom6 (PosPrinterColorCartridge_Custom6) = 7, Cyan (PosPrinterColorCartridge_Cyan) = 8, Magenta (PosPrinterColorCartridge_Magenta) = 9, Yellow (PosPrinterColorCartridge_Yellow) = 10,
 }}
 DEFINE_IID!(IID_IPosPrinterJob, 2593390684, 1557, 17809, 165, 143, 48, 248, 126, 223, 226, 228);
@@ -21290,33 +21290,33 @@ impl IPosPrinterJob {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PosPrinterLineDirection: i32 {
+RT_ENUM! { enum PosPrinterLineDirection: i32 ["Windows.Devices.PointOfService.PosPrinterLineDirection"] {
     Horizontal (PosPrinterLineDirection_Horizontal) = 0, Vertical (PosPrinterLineDirection_Vertical) = 1,
 }}
-RT_ENUM! { enum PosPrinterLineStyle: i32 {
+RT_ENUM! { enum PosPrinterLineStyle: i32 ["Windows.Devices.PointOfService.PosPrinterLineStyle"] {
     SingleSolid (PosPrinterLineStyle_SingleSolid) = 0, DoubleSolid (PosPrinterLineStyle_DoubleSolid) = 1, Broken (PosPrinterLineStyle_Broken) = 2, Chain (PosPrinterLineStyle_Chain) = 3,
 }}
-RT_ENUM! { enum PosPrinterMapMode: i32 {
+RT_ENUM! { enum PosPrinterMapMode: i32 ["Windows.Devices.PointOfService.PosPrinterMapMode"] {
     Dots (PosPrinterMapMode_Dots) = 0, Twips (PosPrinterMapMode_Twips) = 1, English (PosPrinterMapMode_English) = 2, Metric (PosPrinterMapMode_Metric) = 3,
 }}
-RT_ENUM! { enum PosPrinterMarkFeedCapabilities: u32 {
+RT_ENUM! { enum PosPrinterMarkFeedCapabilities: u32 ["Windows.Devices.PointOfService.PosPrinterMarkFeedCapabilities"] {
     None (PosPrinterMarkFeedCapabilities_None) = 0, ToTakeUp (PosPrinterMarkFeedCapabilities_ToTakeUp) = 1, ToCutter (PosPrinterMarkFeedCapabilities_ToCutter) = 2, ToCurrentTopOfForm (PosPrinterMarkFeedCapabilities_ToCurrentTopOfForm) = 4, ToNextTopOfForm (PosPrinterMarkFeedCapabilities_ToNextTopOfForm) = 8,
 }}
-RT_ENUM! { enum PosPrinterMarkFeedKind: i32 {
+RT_ENUM! { enum PosPrinterMarkFeedKind: i32 ["Windows.Devices.PointOfService.PosPrinterMarkFeedKind"] {
     ToTakeUp (PosPrinterMarkFeedKind_ToTakeUp) = 0, ToCutter (PosPrinterMarkFeedKind_ToCutter) = 1, ToCurrentTopOfForm (PosPrinterMarkFeedKind_ToCurrentTopOfForm) = 2, ToNextTopOfForm (PosPrinterMarkFeedKind_ToNextTopOfForm) = 3,
 }}
-RT_ENUM! { enum PosPrinterPrintSide: i32 {
+RT_ENUM! { enum PosPrinterPrintSide: i32 ["Windows.Devices.PointOfService.PosPrinterPrintSide"] {
     Unknown (PosPrinterPrintSide_Unknown) = 0, Side1 (PosPrinterPrintSide_Side1) = 1, Side2 (PosPrinterPrintSide_Side2) = 2,
 }}
 DEFINE_IID!(IID_IPosPrinterReleaseDeviceRequestedEventArgs, 734765913, 7407, 16562, 158, 203, 249, 39, 248, 86, 174, 60);
 RT_INTERFACE!{interface IPosPrinterReleaseDeviceRequestedEventArgs(IPosPrinterReleaseDeviceRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPosPrinterReleaseDeviceRequestedEventArgs] {
     
 }}
-RT_CLASS!{class PosPrinterReleaseDeviceRequestedEventArgs: IPosPrinterReleaseDeviceRequestedEventArgs}
-RT_ENUM! { enum PosPrinterRotation: i32 {
+RT_CLASS!{class PosPrinterReleaseDeviceRequestedEventArgs: IPosPrinterReleaseDeviceRequestedEventArgs ["Windows.Devices.PointOfService.PosPrinterReleaseDeviceRequestedEventArgs"]}
+RT_ENUM! { enum PosPrinterRotation: i32 ["Windows.Devices.PointOfService.PosPrinterRotation"] {
     Normal (PosPrinterRotation_Normal) = 0, Right90 (PosPrinterRotation_Right90) = 1, Left90 (PosPrinterRotation_Left90) = 2, Rotate180 (PosPrinterRotation_Rotate180) = 3,
 }}
-RT_ENUM! { enum PosPrinterRuledLineCapabilities: u32 {
+RT_ENUM! { enum PosPrinterRuledLineCapabilities: u32 ["Windows.Devices.PointOfService.PosPrinterRuledLineCapabilities"] {
     None (PosPrinterRuledLineCapabilities_None) = 0, Horizontal (PosPrinterRuledLineCapabilities_Horizontal) = 1, Vertical (PosPrinterRuledLineCapabilities_Vertical) = 2,
 }}
 DEFINE_IID!(IID_IPosPrinterStatics, 2363544810, 4911, 19679, 166, 74, 45, 13, 124, 150, 168, 91);
@@ -21370,8 +21370,8 @@ impl IPosPrinterStatus {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PosPrinterStatus: IPosPrinterStatus}
-RT_ENUM! { enum PosPrinterStatusKind: i32 {
+RT_CLASS!{class PosPrinterStatus: IPosPrinterStatus ["Windows.Devices.PointOfService.PosPrinterStatus"]}
+RT_ENUM! { enum PosPrinterStatusKind: i32 ["Windows.Devices.PointOfService.PosPrinterStatusKind"] {
     Online (PosPrinterStatusKind_Online) = 0, Off (PosPrinterStatusKind_Off) = 1, Offline (PosPrinterStatusKind_Offline) = 2, OffOrOffline (PosPrinterStatusKind_OffOrOffline) = 3, Extended (PosPrinterStatusKind_Extended) = 4,
 }}
 DEFINE_IID!(IID_IPosPrinterStatusUpdatedEventArgs, 786139103, 5030, 17037, 186, 129, 176, 231, 195, 229, 163, 205);
@@ -21385,7 +21385,7 @@ impl IPosPrinterStatusUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PosPrinterStatusUpdatedEventArgs: IPosPrinterStatusUpdatedEventArgs}
+RT_CLASS!{class PosPrinterStatusUpdatedEventArgs: IPosPrinterStatusUpdatedEventArgs ["Windows.Devices.PointOfService.PosPrinterStatusUpdatedEventArgs"]}
 DEFINE_IID!(IID_IReceiptOrSlipJob, 1394710974, 51395, 19906, 137, 233, 92, 74, 55, 179, 77, 220);
 RT_INTERFACE!{interface IReceiptOrSlipJob(IReceiptOrSlipJobVtbl): IInspectable(IInspectableVtbl) [IID_IReceiptOrSlipJob] {
     fn SetBarcodeRotation(&self, value: PosPrinterRotation) -> HRESULT,
@@ -21489,7 +21489,7 @@ impl IReceiptPrinterCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ReceiptPrinterCapabilities: IReceiptPrinterCapabilities}
+RT_CLASS!{class ReceiptPrinterCapabilities: IReceiptPrinterCapabilities ["Windows.Devices.PointOfService.ReceiptPrinterCapabilities"]}
 DEFINE_IID!(IID_IReceiptPrintJob, 2861958766, 44205, 19321, 157, 15, 192, 207, 192, 141, 199, 123);
 RT_INTERFACE!{interface IReceiptPrintJob(IReceiptPrintJobVtbl): IInspectable(IInspectableVtbl) [IID_IReceiptPrintJob] {
     fn MarkFeed(&self, kind: PosPrinterMarkFeedKind) -> HRESULT,
@@ -21510,7 +21510,7 @@ impl IReceiptPrintJob {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ReceiptPrintJob: IReceiptPrintJob}
+RT_CLASS!{class ReceiptPrintJob: IReceiptPrintJob ["Windows.Devices.PointOfService.ReceiptPrintJob"]}
 DEFINE_IID!(IID_ISlipPrinterCapabilities, 2578539417, 18572, 16727, 138, 194, 159, 87, 247, 8, 211, 219);
 RT_INTERFACE!{interface ISlipPrinterCapabilities(ISlipPrinterCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_ISlipPrinterCapabilities] {
     fn get_IsFullLengthSupported(&self, out: *mut bool) -> HRESULT,
@@ -21528,8 +21528,8 @@ impl ISlipPrinterCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SlipPrinterCapabilities: ISlipPrinterCapabilities}
-RT_CLASS!{class SlipPrintJob: IReceiptOrSlipJob}
+RT_CLASS!{class SlipPrinterCapabilities: ISlipPrinterCapabilities ["Windows.Devices.PointOfService.SlipPrinterCapabilities"]}
+RT_CLASS!{class SlipPrintJob: IReceiptOrSlipJob ["Windows.Devices.PointOfService.SlipPrintJob"]}
 DEFINE_IID!(IID_IUnifiedPosErrorData, 731483194, 21852, 18569, 142, 216, 197, 153, 187, 58, 113, 42);
 RT_INTERFACE!{interface IUnifiedPosErrorData(IUnifiedPosErrorDataVtbl): IInspectable(IInspectableVtbl) [IID_IUnifiedPosErrorData] {
     fn get_Message(&self, out: *mut HSTRING) -> HRESULT,
@@ -21559,7 +21559,7 @@ impl IUnifiedPosErrorData {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UnifiedPosErrorData: IUnifiedPosErrorData}
+RT_CLASS!{class UnifiedPosErrorData: IUnifiedPosErrorData ["Windows.Devices.PointOfService.UnifiedPosErrorData"]}
 impl RtActivatable<IUnifiedPosErrorDataFactory> for UnifiedPosErrorData {}
 impl UnifiedPosErrorData {
     #[inline] pub fn create_instance(message: &HStringArg, severity: UnifiedPosErrorSeverity, reason: UnifiedPosErrorReason, extendedReason: u32) -> Result<ComPtr<UnifiedPosErrorData>> {
@@ -21578,16 +21578,16 @@ impl IUnifiedPosErrorDataFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UnifiedPosErrorReason: i32 {
+RT_ENUM! { enum UnifiedPosErrorReason: i32 ["Windows.Devices.PointOfService.UnifiedPosErrorReason"] {
     UnknownErrorReason (UnifiedPosErrorReason_UnknownErrorReason) = 0, NoService (UnifiedPosErrorReason_NoService) = 1, Disabled (UnifiedPosErrorReason_Disabled) = 2, Illegal (UnifiedPosErrorReason_Illegal) = 3, NoHardware (UnifiedPosErrorReason_NoHardware) = 4, Closed (UnifiedPosErrorReason_Closed) = 5, Offline (UnifiedPosErrorReason_Offline) = 6, Failure (UnifiedPosErrorReason_Failure) = 7, Timeout (UnifiedPosErrorReason_Timeout) = 8, Busy (UnifiedPosErrorReason_Busy) = 9, Extended (UnifiedPosErrorReason_Extended) = 10,
 }}
-RT_ENUM! { enum UnifiedPosErrorSeverity: i32 {
+RT_ENUM! { enum UnifiedPosErrorSeverity: i32 ["Windows.Devices.PointOfService.UnifiedPosErrorSeverity"] {
     UnknownErrorSeverity (UnifiedPosErrorSeverity_UnknownErrorSeverity) = 0, Warning (UnifiedPosErrorSeverity_Warning) = 1, Recoverable (UnifiedPosErrorSeverity_Recoverable) = 2, Unrecoverable (UnifiedPosErrorSeverity_Unrecoverable) = 3, AssistanceRequired (UnifiedPosErrorSeverity_AssistanceRequired) = 4, Fatal (UnifiedPosErrorSeverity_Fatal) = 5,
 }}
-RT_ENUM! { enum UnifiedPosHealthCheckLevel: i32 {
+RT_ENUM! { enum UnifiedPosHealthCheckLevel: i32 ["Windows.Devices.PointOfService.UnifiedPosHealthCheckLevel"] {
     UnknownHealthCheckLevel (UnifiedPosHealthCheckLevel_UnknownHealthCheckLevel) = 0, POSInternal (UnifiedPosHealthCheckLevel_POSInternal) = 1, External (UnifiedPosHealthCheckLevel_External) = 2, Interactive (UnifiedPosHealthCheckLevel_Interactive) = 3,
 }}
-RT_ENUM! { enum UnifiedPosPowerReportingType: i32 {
+RT_ENUM! { enum UnifiedPosPowerReportingType: i32 ["Windows.Devices.PointOfService.UnifiedPosPowerReportingType"] {
     UnknownPowerReportingType (UnifiedPosPowerReportingType_UnknownPowerReportingType) = 0, Standard (UnifiedPosPowerReportingType_Standard) = 1, Advanced (UnifiedPosPowerReportingType_Advanced) = 2,
 }}
 pub mod provider { // Windows.Devices.PointOfService.Provider
@@ -21609,7 +21609,7 @@ impl IBarcodeScannerDisableScannerRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerDisableScannerRequest: IBarcodeScannerDisableScannerRequest}
+RT_CLASS!{class BarcodeScannerDisableScannerRequest: IBarcodeScannerDisableScannerRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerDisableScannerRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerDisableScannerRequest2, 3437225509, 26051, 19660, 180, 87, 243, 156, 122, 158, 166, 13);
 RT_INTERFACE!{interface IBarcodeScannerDisableScannerRequest2(IBarcodeScannerDisableScannerRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerDisableScannerRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21644,7 +21644,7 @@ impl IBarcodeScannerDisableScannerRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerDisableScannerRequestEventArgs: IBarcodeScannerDisableScannerRequestEventArgs}
+RT_CLASS!{class BarcodeScannerDisableScannerRequestEventArgs: IBarcodeScannerDisableScannerRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerDisableScannerRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerEnableScannerRequest, 3233016250, 33130, 17707, 189, 119, 183, 228, 83, 236, 68, 109);
 RT_INTERFACE!{interface IBarcodeScannerEnableScannerRequest(IBarcodeScannerEnableScannerRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerEnableScannerRequest] {
     fn ReportCompletedAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21662,7 +21662,7 @@ impl IBarcodeScannerEnableScannerRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerEnableScannerRequest: IBarcodeScannerEnableScannerRequest}
+RT_CLASS!{class BarcodeScannerEnableScannerRequest: IBarcodeScannerEnableScannerRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerEnableScannerRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerEnableScannerRequest2, 1906635432, 39173, 16812, 145, 33, 182, 69, 145, 106, 132, 161);
 RT_INTERFACE!{interface IBarcodeScannerEnableScannerRequest2(IBarcodeScannerEnableScannerRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerEnableScannerRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21697,7 +21697,7 @@ impl IBarcodeScannerEnableScannerRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerEnableScannerRequestEventArgs: IBarcodeScannerEnableScannerRequestEventArgs}
+RT_CLASS!{class BarcodeScannerEnableScannerRequestEventArgs: IBarcodeScannerEnableScannerRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerEnableScannerRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerFrameReader, 3687262983, 25795, 18475, 147, 200, 101, 251, 51, 194, 34, 8);
 RT_INTERFACE!{interface IBarcodeScannerFrameReader(IBarcodeScannerFrameReaderVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerFrameReader] {
     fn StartAsync(&self, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -21738,7 +21738,7 @@ impl IBarcodeScannerFrameReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerFrameReader: IBarcodeScannerFrameReader}
+RT_CLASS!{class BarcodeScannerFrameReader: IBarcodeScannerFrameReader ["Windows.Devices.PointOfService.Provider.BarcodeScannerFrameReader"]}
 DEFINE_IID!(IID_IBarcodeScannerFrameReaderFrameArrivedEventArgs, 2965100036, 21757, 17261, 134, 41, 113, 46, 120, 114, 35, 221);
 RT_INTERFACE!{interface IBarcodeScannerFrameReaderFrameArrivedEventArgs(IBarcodeScannerFrameReaderFrameArrivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerFrameReaderFrameArrivedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut foundation::Deferral) -> HRESULT
@@ -21750,7 +21750,7 @@ impl IBarcodeScannerFrameReaderFrameArrivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerFrameReaderFrameArrivedEventArgs: IBarcodeScannerFrameReaderFrameArrivedEventArgs}
+RT_CLASS!{class BarcodeScannerFrameReaderFrameArrivedEventArgs: IBarcodeScannerFrameReaderFrameArrivedEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerFrameReaderFrameArrivedEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerGetSymbologyAttributesRequest, 2541012074, 22756, 19551, 184, 233, 228, 20, 103, 99, 39, 0);
 RT_INTERFACE!{interface IBarcodeScannerGetSymbologyAttributesRequest(IBarcodeScannerGetSymbologyAttributesRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerGetSymbologyAttributesRequest] {
     fn get_Symbology(&self, out: *mut u32) -> HRESULT,
@@ -21774,7 +21774,7 @@ impl IBarcodeScannerGetSymbologyAttributesRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerGetSymbologyAttributesRequest: IBarcodeScannerGetSymbologyAttributesRequest}
+RT_CLASS!{class BarcodeScannerGetSymbologyAttributesRequest: IBarcodeScannerGetSymbologyAttributesRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerGetSymbologyAttributesRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerGetSymbologyAttributesRequest2, 1785342739, 30120, 18939, 184, 82, 191, 185, 61, 118, 10, 247);
 RT_INTERFACE!{interface IBarcodeScannerGetSymbologyAttributesRequest2(IBarcodeScannerGetSymbologyAttributesRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerGetSymbologyAttributesRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21809,7 +21809,7 @@ impl IBarcodeScannerGetSymbologyAttributesRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerGetSymbologyAttributesRequestEventArgs: IBarcodeScannerGetSymbologyAttributesRequestEventArgs}
+RT_CLASS!{class BarcodeScannerGetSymbologyAttributesRequestEventArgs: IBarcodeScannerGetSymbologyAttributesRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerGetSymbologyAttributesRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerHideVideoPreviewRequest, 4199464575, 26224, 16609, 185, 11, 187, 16, 216, 212, 37, 250);
 RT_INTERFACE!{interface IBarcodeScannerHideVideoPreviewRequest(IBarcodeScannerHideVideoPreviewRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerHideVideoPreviewRequest] {
     fn ReportCompletedAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21827,7 +21827,7 @@ impl IBarcodeScannerHideVideoPreviewRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerHideVideoPreviewRequest: IBarcodeScannerHideVideoPreviewRequest}
+RT_CLASS!{class BarcodeScannerHideVideoPreviewRequest: IBarcodeScannerHideVideoPreviewRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerHideVideoPreviewRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerHideVideoPreviewRequest2, 2116567901, 38932, 17181, 162, 242, 214, 36, 140, 90, 212, 181);
 RT_INTERFACE!{interface IBarcodeScannerHideVideoPreviewRequest2(IBarcodeScannerHideVideoPreviewRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerHideVideoPreviewRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -21862,7 +21862,7 @@ impl IBarcodeScannerHideVideoPreviewRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerHideVideoPreviewRequestEventArgs: IBarcodeScannerHideVideoPreviewRequestEventArgs}
+RT_CLASS!{class BarcodeScannerHideVideoPreviewRequestEventArgs: IBarcodeScannerHideVideoPreviewRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerHideVideoPreviewRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerProviderConnection, 3024800749, 2874, 20387, 134, 197, 73, 30, 163, 7, 128, 235);
 RT_INTERFACE!{interface IBarcodeScannerProviderConnection(IBarcodeScannerProviderConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerProviderConnection] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -22036,7 +22036,7 @@ impl IBarcodeScannerProviderConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerProviderConnection: IBarcodeScannerProviderConnection}
+RT_CLASS!{class BarcodeScannerProviderConnection: IBarcodeScannerProviderConnection ["Windows.Devices.PointOfService.Provider.BarcodeScannerProviderConnection"]}
 DEFINE_IID!(IID_IBarcodeScannerProviderConnection2, 3197850573, 4404, 16780, 160, 107, 4, 66, 58, 115, 243, 215);
 RT_INTERFACE!{interface IBarcodeScannerProviderConnection2(IBarcodeScannerProviderConnection2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerProviderConnection2] {
     fn CreateFrameReaderAsync(&self, out: *mut *mut foundation::IAsyncOperation<BarcodeScannerFrameReader>) -> HRESULT,
@@ -22071,7 +22071,7 @@ impl IBarcodeScannerProviderTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerProviderTriggerDetails: IBarcodeScannerProviderTriggerDetails}
+RT_CLASS!{class BarcodeScannerProviderTriggerDetails: IBarcodeScannerProviderTriggerDetails ["Windows.Devices.PointOfService.Provider.BarcodeScannerProviderTriggerDetails"]}
 DEFINE_IID!(IID_IBarcodeScannerSetActiveSymbologiesRequest, 3678352057, 63450, 16801, 159, 121, 7, 188, 217, 95, 11, 223);
 RT_INTERFACE!{interface IBarcodeScannerSetActiveSymbologiesRequest(IBarcodeScannerSetActiveSymbologiesRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerSetActiveSymbologiesRequest] {
     fn get_Symbologies(&self, out: *mut *mut foundation::collections::IVectorView<u32>) -> HRESULT,
@@ -22095,7 +22095,7 @@ impl IBarcodeScannerSetActiveSymbologiesRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerSetActiveSymbologiesRequest: IBarcodeScannerSetActiveSymbologiesRequest}
+RT_CLASS!{class BarcodeScannerSetActiveSymbologiesRequest: IBarcodeScannerSetActiveSymbologiesRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerSetActiveSymbologiesRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerSetActiveSymbologiesRequest2, 4127157983, 64154, 18249, 177, 27, 232, 252, 203, 117, 188, 107);
 RT_INTERFACE!{interface IBarcodeScannerSetActiveSymbologiesRequest2(IBarcodeScannerSetActiveSymbologiesRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerSetActiveSymbologiesRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22130,7 +22130,7 @@ impl IBarcodeScannerSetActiveSymbologiesRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerSetActiveSymbologiesRequestEventArgs: IBarcodeScannerSetActiveSymbologiesRequestEventArgs}
+RT_CLASS!{class BarcodeScannerSetActiveSymbologiesRequestEventArgs: IBarcodeScannerSetActiveSymbologiesRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerSetActiveSymbologiesRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerSetSymbologyAttributesRequest, 855343439, 41855, 18608, 172, 234, 220, 225, 72, 15, 18, 174);
 RT_INTERFACE!{interface IBarcodeScannerSetSymbologyAttributesRequest(IBarcodeScannerSetSymbologyAttributesRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerSetSymbologyAttributesRequest] {
     fn get_Symbology(&self, out: *mut u32) -> HRESULT,
@@ -22160,7 +22160,7 @@ impl IBarcodeScannerSetSymbologyAttributesRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerSetSymbologyAttributesRequest: IBarcodeScannerSetSymbologyAttributesRequest}
+RT_CLASS!{class BarcodeScannerSetSymbologyAttributesRequest: IBarcodeScannerSetSymbologyAttributesRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerSetSymbologyAttributesRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerSetSymbologyAttributesRequest2, 3757817793, 56232, 19319, 190, 30, 181, 108, 215, 47, 101, 179);
 RT_INTERFACE!{interface IBarcodeScannerSetSymbologyAttributesRequest2(IBarcodeScannerSetSymbologyAttributesRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerSetSymbologyAttributesRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22195,7 +22195,7 @@ impl IBarcodeScannerSetSymbologyAttributesRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerSetSymbologyAttributesRequestEventArgs: IBarcodeScannerSetSymbologyAttributesRequestEventArgs}
+RT_CLASS!{class BarcodeScannerSetSymbologyAttributesRequestEventArgs: IBarcodeScannerSetSymbologyAttributesRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerSetSymbologyAttributesRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerStartSoftwareTriggerRequest, 3824843559, 65378, 17492, 175, 74, 203, 97, 68, 163, 227, 247);
 RT_INTERFACE!{interface IBarcodeScannerStartSoftwareTriggerRequest(IBarcodeScannerStartSoftwareTriggerRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerStartSoftwareTriggerRequest] {
     fn ReportCompletedAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22213,7 +22213,7 @@ impl IBarcodeScannerStartSoftwareTriggerRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerStartSoftwareTriggerRequest: IBarcodeScannerStartSoftwareTriggerRequest}
+RT_CLASS!{class BarcodeScannerStartSoftwareTriggerRequest: IBarcodeScannerStartSoftwareTriggerRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerStartSoftwareTriggerRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerStartSoftwareTriggerRequest2, 3950158428, 26200, 18277, 166, 142, 50, 116, 130, 101, 61, 235);
 RT_INTERFACE!{interface IBarcodeScannerStartSoftwareTriggerRequest2(IBarcodeScannerStartSoftwareTriggerRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerStartSoftwareTriggerRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22248,7 +22248,7 @@ impl IBarcodeScannerStartSoftwareTriggerRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerStartSoftwareTriggerRequestEventArgs: IBarcodeScannerStartSoftwareTriggerRequestEventArgs}
+RT_CLASS!{class BarcodeScannerStartSoftwareTriggerRequestEventArgs: IBarcodeScannerStartSoftwareTriggerRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerStartSoftwareTriggerRequestEventArgs"]}
 DEFINE_IID!(IID_IBarcodeScannerStopSoftwareTriggerRequest, 1872736053, 57991, 19624, 183, 13, 90, 145, 214, 148, 246, 104);
 RT_INTERFACE!{interface IBarcodeScannerStopSoftwareTriggerRequest(IBarcodeScannerStopSoftwareTriggerRequestVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerStopSoftwareTriggerRequest] {
     fn ReportCompletedAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22266,7 +22266,7 @@ impl IBarcodeScannerStopSoftwareTriggerRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerStopSoftwareTriggerRequest: IBarcodeScannerStopSoftwareTriggerRequest}
+RT_CLASS!{class BarcodeScannerStopSoftwareTriggerRequest: IBarcodeScannerStopSoftwareTriggerRequest ["Windows.Devices.PointOfService.Provider.BarcodeScannerStopSoftwareTriggerRequest"]}
 DEFINE_IID!(IID_IBarcodeScannerStopSoftwareTriggerRequest2, 3411527133, 65104, 18936, 160, 180, 189, 194, 48, 129, 77, 162);
 RT_INTERFACE!{interface IBarcodeScannerStopSoftwareTriggerRequest2(IBarcodeScannerStopSoftwareTriggerRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeScannerStopSoftwareTriggerRequest2] {
     fn ReportFailedWithFailedReasonAsync(&self, reason: i32, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -22301,8 +22301,8 @@ impl IBarcodeScannerStopSoftwareTriggerRequestEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerStopSoftwareTriggerRequestEventArgs: IBarcodeScannerStopSoftwareTriggerRequestEventArgs}
-RT_ENUM! { enum BarcodeScannerTriggerState: i32 {
+RT_CLASS!{class BarcodeScannerStopSoftwareTriggerRequestEventArgs: IBarcodeScannerStopSoftwareTriggerRequestEventArgs ["Windows.Devices.PointOfService.Provider.BarcodeScannerStopSoftwareTriggerRequestEventArgs"]}
+RT_ENUM! { enum BarcodeScannerTriggerState: i32 ["Windows.Devices.PointOfService.Provider.BarcodeScannerTriggerState"] {
     Released (BarcodeScannerTriggerState_Released) = 0, Pressed (BarcodeScannerTriggerState_Pressed) = 1,
 }}
 DEFINE_IID!(IID_IBarcodeScannerVideoFrame, 2119717448, 40439, 16673, 161, 117, 128, 29, 128, 0, 17, 46);
@@ -22335,7 +22335,7 @@ impl IBarcodeScannerVideoFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeScannerVideoFrame: IBarcodeScannerVideoFrame}
+RT_CLASS!{class BarcodeScannerVideoFrame: IBarcodeScannerVideoFrame ["Windows.Devices.PointOfService.Provider.BarcodeScannerVideoFrame"]}
 DEFINE_IID!(IID_IBarcodeSymbologyAttributesBuilder, 3313175743, 58613, 16569, 132, 207, 230, 63, 186, 234, 66, 180);
 RT_INTERFACE!{interface IBarcodeSymbologyAttributesBuilder(IBarcodeSymbologyAttributesBuilderVtbl): IInspectable(IInspectableVtbl) [IID_IBarcodeSymbologyAttributesBuilder] {
     fn get_IsCheckDigitValidationSupported(&self, out: *mut bool) -> HRESULT,
@@ -22380,7 +22380,7 @@ impl IBarcodeSymbologyAttributesBuilder {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarcodeSymbologyAttributesBuilder: IBarcodeSymbologyAttributesBuilder}
+RT_CLASS!{class BarcodeSymbologyAttributesBuilder: IBarcodeSymbologyAttributesBuilder ["Windows.Devices.PointOfService.Provider.BarcodeSymbologyAttributesBuilder"]}
 impl RtActivatable<IActivationFactory> for BarcodeSymbologyAttributesBuilder {}
 DEFINE_CLSID!(BarcodeSymbologyAttributesBuilder(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,80,111,105,110,116,79,102,83,101,114,118,105,99,101,46,80,114,111,118,105,100,101,114,46,66,97,114,99,111,100,101,83,121,109,98,111,108,111,103,121,65,116,116,114,105,98,117,116,101,115,66,117,105,108,100,101,114,0]) [CLSID_BarcodeSymbologyAttributesBuilder]);
 } // Windows.Devices.PointOfService.Provider
@@ -22415,7 +22415,7 @@ impl IServiceDeviceStatics {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ServiceDeviceType: i32 {
+RT_ENUM! { enum ServiceDeviceType: i32 ["Windows.Devices.Portable.ServiceDeviceType"] {
     CalendarService (ServiceDeviceType_CalendarService) = 0, ContactsService (ServiceDeviceType_ContactsService) = 1, DeviceStatusService (ServiceDeviceType_DeviceStatusService) = 2, NotesService (ServiceDeviceType_NotesService) = 3, RingtonesService (ServiceDeviceType_RingtonesService) = 4, SmsService (ServiceDeviceType_SmsService) = 5, TasksService (ServiceDeviceType_TasksService) = 6,
 }}
 RT_CLASS!{static class StorageDevice}
@@ -22478,7 +22478,7 @@ impl IBattery {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Battery: IBattery}
+RT_CLASS!{class Battery: IBattery ["Windows.Devices.Power.Battery"]}
 impl RtActivatable<IBatteryStatics> for Battery {}
 impl Battery {
     #[inline] pub fn get_aggregate_battery() -> Result<Option<ComPtr<Battery>>> {
@@ -22527,7 +22527,7 @@ impl IBatteryReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BatteryReport: IBatteryReport}
+RT_CLASS!{class BatteryReport: IBatteryReport ["Windows.Devices.Power.BatteryReport"]}
 DEFINE_IID!(IID_IBatteryStatics, 2043507382, 40542, 17490, 190, 166, 223, 205, 84, 30, 89, 127);
 RT_INTERFACE!{static interface IBatteryStatics(IBatteryStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBatteryStatics] {
     fn get_AggregateBattery(&self, out: *mut *mut Battery) -> HRESULT,
@@ -22565,7 +22565,7 @@ impl IPrint3DDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DDevice: IPrint3DDevice}
+RT_CLASS!{class Print3DDevice: IPrint3DDevice ["Windows.Devices.Printers.Print3DDevice"]}
 impl RtActivatable<IPrint3DDeviceStatics> for Print3DDevice {}
 impl Print3DDevice {
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<Print3DDevice>>> {
@@ -22616,7 +22616,7 @@ impl IPrintSchema {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintSchema: IPrintSchema}
+RT_CLASS!{class PrintSchema: IPrintSchema ["Windows.Devices.Printers.PrintSchema"]}
 pub mod extensions { // Windows.Devices.Printers.Extensions
 use ::prelude::*;
 DEFINE_IID!(IID_IPrint3DWorkflow, 3312415933, 13929, 19046, 171, 66, 200, 21, 25, 48, 205, 52);
@@ -22658,7 +22658,7 @@ impl IPrint3DWorkflow {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DWorkflow: IPrint3DWorkflow}
+RT_CLASS!{class Print3DWorkflow: IPrint3DWorkflow ["Windows.Devices.Printers.Extensions.Print3DWorkflow"]}
 DEFINE_IID!(IID_IPrint3DWorkflow2, 2728838479, 35521, 18712, 151, 65, 227, 79, 48, 4, 35, 158);
 RT_INTERFACE!{interface IPrint3DWorkflow2(IPrint3DWorkflow2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DWorkflow2] {
     fn add_PrinterChanged(&self, eventHandler: *mut foundation::TypedEventHandler<Print3DWorkflow, Print3DWorkflowPrinterChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -22675,7 +22675,7 @@ impl IPrint3DWorkflow2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum Print3DWorkflowDetail: i32 {
+RT_ENUM! { enum Print3DWorkflowDetail: i32 ["Windows.Devices.Printers.Extensions.Print3DWorkflowDetail"] {
     Unknown (Print3DWorkflowDetail_Unknown) = 0, ModelExceedsPrintBed (Print3DWorkflowDetail_ModelExceedsPrintBed) = 1, UploadFailed (Print3DWorkflowDetail_UploadFailed) = 2, InvalidMaterialSelection (Print3DWorkflowDetail_InvalidMaterialSelection) = 3, InvalidModel (Print3DWorkflowDetail_InvalidModel) = 4, ModelNotManifold (Print3DWorkflowDetail_ModelNotManifold) = 5, InvalidPrintTicket (Print3DWorkflowDetail_InvalidPrintTicket) = 6,
 }}
 DEFINE_IID!(IID_IPrint3DWorkflowPrinterChangedEventArgs, 1159881730, 38396, 18503, 147, 179, 19, 77, 191, 92, 96, 247);
@@ -22689,7 +22689,7 @@ impl IPrint3DWorkflowPrinterChangedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DWorkflowPrinterChangedEventArgs: IPrint3DWorkflowPrinterChangedEventArgs}
+RT_CLASS!{class Print3DWorkflowPrinterChangedEventArgs: IPrint3DWorkflowPrinterChangedEventArgs ["Windows.Devices.Printers.Extensions.Print3DWorkflowPrinterChangedEventArgs"]}
 DEFINE_IID!(IID_IPrint3DWorkflowPrintRequestedEventArgs, 435734616, 23240, 19285, 138, 95, 230, 21, 103, 218, 251, 77);
 RT_INTERFACE!{interface IPrint3DWorkflowPrintRequestedEventArgs(IPrint3DWorkflowPrintRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DWorkflowPrintRequestedEventArgs] {
     fn get_Status(&self, out: *mut Print3DWorkflowStatus) -> HRESULT,
@@ -22716,8 +22716,8 @@ impl IPrint3DWorkflowPrintRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DWorkflowPrintRequestedEventArgs: IPrint3DWorkflowPrintRequestedEventArgs}
-RT_ENUM! { enum Print3DWorkflowStatus: i32 {
+RT_CLASS!{class Print3DWorkflowPrintRequestedEventArgs: IPrint3DWorkflowPrintRequestedEventArgs ["Windows.Devices.Printers.Extensions.Print3DWorkflowPrintRequestedEventArgs"]}
+RT_ENUM! { enum Print3DWorkflowStatus: i32 ["Windows.Devices.Printers.Extensions.Print3DWorkflowStatus"] {
     Abandoned (Print3DWorkflowStatus_Abandoned) = 0, Canceled (Print3DWorkflowStatus_Canceled) = 1, Failed (Print3DWorkflowStatus_Failed) = 2, Slicing (Print3DWorkflowStatus_Slicing) = 3, Submitted (Print3DWorkflowStatus_Submitted) = 4,
 }}
 RT_CLASS!{static class PrintExtensionContext}
@@ -22761,7 +22761,7 @@ impl IPrintNotificationEventDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintNotificationEventDetails: IPrintNotificationEventDetails}
+RT_CLASS!{class PrintNotificationEventDetails: IPrintNotificationEventDetails ["Windows.Devices.Printers.Extensions.PrintNotificationEventDetails"]}
 DEFINE_IID!(IID_IPrintTaskConfiguration, 3821151313, 15012, 18565, 146, 64, 49, 31, 95, 143, 190, 157);
 RT_INTERFACE!{interface IPrintTaskConfiguration(IPrintTaskConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskConfiguration] {
     fn get_PrinterExtensionContext(&self, out: *mut *mut IInspectable) -> HRESULT,
@@ -22784,7 +22784,7 @@ impl IPrintTaskConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskConfiguration: IPrintTaskConfiguration}
+RT_CLASS!{class PrintTaskConfiguration: IPrintTaskConfiguration ["Windows.Devices.Printers.Extensions.PrintTaskConfiguration"]}
 DEFINE_IID!(IID_IPrintTaskConfigurationSaveRequest, 4004458443, 25118, 19298, 172, 119, 178, 129, 204, 224, 141, 96);
 RT_INTERFACE!{interface IPrintTaskConfigurationSaveRequest(IPrintTaskConfigurationSaveRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskConfigurationSaveRequest] {
     fn Cancel(&self) -> HRESULT,
@@ -22812,7 +22812,7 @@ impl IPrintTaskConfigurationSaveRequest {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskConfigurationSaveRequest: IPrintTaskConfigurationSaveRequest}
+RT_CLASS!{class PrintTaskConfigurationSaveRequest: IPrintTaskConfigurationSaveRequest ["Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequest"]}
 DEFINE_IID!(IID_IPrintTaskConfigurationSaveRequestedDeferral, 3914978664, 63273, 17572, 135, 29, 189, 6, 40, 105, 106, 51);
 RT_INTERFACE!{interface IPrintTaskConfigurationSaveRequestedDeferral(IPrintTaskConfigurationSaveRequestedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskConfigurationSaveRequestedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -22823,7 +22823,7 @@ impl IPrintTaskConfigurationSaveRequestedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskConfigurationSaveRequestedDeferral: IPrintTaskConfigurationSaveRequestedDeferral}
+RT_CLASS!{class PrintTaskConfigurationSaveRequestedDeferral: IPrintTaskConfigurationSaveRequestedDeferral ["Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequestedDeferral"]}
 DEFINE_IID!(IID_IPrintTaskConfigurationSaveRequestedEventArgs, 3765184633, 3425, 18744, 145, 208, 150, 164, 91, 238, 132, 121);
 RT_INTERFACE!{interface IPrintTaskConfigurationSaveRequestedEventArgs(IPrintTaskConfigurationSaveRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskConfigurationSaveRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut PrintTaskConfigurationSaveRequest) -> HRESULT
@@ -22835,7 +22835,7 @@ impl IPrintTaskConfigurationSaveRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskConfigurationSaveRequestedEventArgs: IPrintTaskConfigurationSaveRequestedEventArgs}
+RT_CLASS!{class PrintTaskConfigurationSaveRequestedEventArgs: IPrintTaskConfigurationSaveRequestedEventArgs ["Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequestedEventArgs"]}
 } // Windows.Devices.Printers.Extensions
 } // Windows.Devices.Printers
 pub mod pwm { // Windows.Devices.Pwm
@@ -22881,7 +22881,7 @@ impl IPwmController {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PwmController: IPwmController}
+RT_CLASS!{class PwmController: IPwmController ["Windows.Devices.Pwm.PwmController"]}
 impl RtActivatable<IPwmControllerStatics> for PwmController {}
 impl RtActivatable<IPwmControllerStatics2> for PwmController {}
 impl RtActivatable<IPwmControllerStatics3> for PwmController {}
@@ -22997,8 +22997,8 @@ impl IPwmPin {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PwmPin: IPwmPin}
-RT_ENUM! { enum PwmPulsePolarity: i32 {
+RT_CLASS!{class PwmPin: IPwmPin ["Windows.Devices.Pwm.PwmPin"]}
+RT_ENUM! { enum PwmPulsePolarity: i32 ["Windows.Devices.Pwm.PwmPulsePolarity"] {
     ActiveHigh (PwmPulsePolarity_ActiveHigh) = 0, ActiveLow (PwmPulsePolarity_ActiveLow) = 1,
 }}
 pub mod provider { // Windows.Devices.Pwm.Provider
@@ -23118,7 +23118,7 @@ impl IRadio {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Radio: IRadio}
+RT_CLASS!{class Radio: IRadio ["Windows.Devices.Radios.Radio"]}
 impl RtActivatable<IRadioStatics> for Radio {}
 impl Radio {
     #[inline] pub fn get_radios_async() -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<Radio>>>> {
@@ -23135,13 +23135,13 @@ impl Radio {
     }
 }
 DEFINE_CLSID!(Radio(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,82,97,100,105,111,115,46,82,97,100,105,111,0]) [CLSID_Radio]);
-RT_ENUM! { enum RadioAccessStatus: i32 {
+RT_ENUM! { enum RadioAccessStatus: i32 ["Windows.Devices.Radios.RadioAccessStatus"] {
     Unspecified (RadioAccessStatus_Unspecified) = 0, Allowed (RadioAccessStatus_Allowed) = 1, DeniedByUser (RadioAccessStatus_DeniedByUser) = 2, DeniedBySystem (RadioAccessStatus_DeniedBySystem) = 3,
 }}
-RT_ENUM! { enum RadioKind: i32 {
+RT_ENUM! { enum RadioKind: i32 ["Windows.Devices.Radios.RadioKind"] {
     Other (RadioKind_Other) = 0, WiFi (RadioKind_WiFi) = 1, MobileBroadband (RadioKind_MobileBroadband) = 2, Bluetooth (RadioKind_Bluetooth) = 3, FM (RadioKind_FM) = 4,
 }}
-RT_ENUM! { enum RadioState: i32 {
+RT_ENUM! { enum RadioState: i32 ["Windows.Devices.Radios.RadioState"] {
     Unknown (RadioState_Unknown) = 0, On (RadioState_On) = 1, Off (RadioState_Off) = 2, Disabled (RadioState_Disabled) = 3,
 }}
 DEFINE_IID!(IID_IRadioStatics, 1605804334, 26571, 18094, 170, 233, 101, 145, 159, 134, 239, 244);
@@ -23235,7 +23235,7 @@ impl IImageScanner {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageScanner: IImageScanner}
+RT_CLASS!{class ImageScanner: IImageScanner ["Windows.Devices.Scanners.ImageScanner"]}
 impl RtActivatable<IImageScannerStatics> for ImageScanner {}
 impl ImageScanner {
     #[inline] pub fn from_id_async(deviceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<ImageScanner>>> {
@@ -23246,11 +23246,11 @@ impl ImageScanner {
     }
 }
 DEFINE_CLSID!(ImageScanner(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,99,97,110,110,101,114,115,46,73,109,97,103,101,83,99,97,110,110,101,114,0]) [CLSID_ImageScanner]);
-RT_CLASS!{class ImageScannerAutoConfiguration: IImageScannerFormatConfiguration}
-RT_ENUM! { enum ImageScannerAutoCroppingMode: i32 {
+RT_CLASS!{class ImageScannerAutoConfiguration: IImageScannerFormatConfiguration ["Windows.Devices.Scanners.ImageScannerAutoConfiguration"]}
+RT_ENUM! { enum ImageScannerAutoCroppingMode: i32 ["Windows.Devices.Scanners.ImageScannerAutoCroppingMode"] {
     Disabled (ImageScannerAutoCroppingMode_Disabled) = 0, SingleRegion (ImageScannerAutoCroppingMode_SingleRegion) = 1, MultipleRegion (ImageScannerAutoCroppingMode_MultipleRegion) = 2,
 }}
-RT_ENUM! { enum ImageScannerColorMode: i32 {
+RT_ENUM! { enum ImageScannerColorMode: i32 ["Windows.Devices.Scanners.ImageScannerColorMode"] {
     Color (ImageScannerColorMode_Color) = 0, Grayscale (ImageScannerColorMode_Grayscale) = 1, Monochrome (ImageScannerColorMode_Monochrome) = 2, AutoColor (ImageScannerColorMode_AutoColor) = 3,
 }}
 DEFINE_IID!(IID_IImageScannerFeederConfiguration, 1958587630, 64151, 19479, 130, 128, 64, 227, 156, 109, 204, 103);
@@ -23359,9 +23359,9 @@ impl IImageScannerFeederConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageScannerFeederConfiguration: IImageScannerFormatConfiguration}
-RT_CLASS!{class ImageScannerFlatbedConfiguration: IImageScannerFormatConfiguration}
-RT_ENUM! { enum ImageScannerFormat: i32 {
+RT_CLASS!{class ImageScannerFeederConfiguration: IImageScannerFormatConfiguration ["Windows.Devices.Scanners.ImageScannerFeederConfiguration"]}
+RT_CLASS!{class ImageScannerFlatbedConfiguration: IImageScannerFormatConfiguration ["Windows.Devices.Scanners.ImageScannerFlatbedConfiguration"]}
+RT_ENUM! { enum ImageScannerFormat: i32 ["Windows.Devices.Scanners.ImageScannerFormat"] {
     Jpeg (ImageScannerFormat_Jpeg) = 0, Png (ImageScannerFormat_Png) = 1, DeviceIndependentBitmap (ImageScannerFormat_DeviceIndependentBitmap) = 2, Tiff (ImageScannerFormat_Tiff) = 3, Xps (ImageScannerFormat_Xps) = 4, OpenXps (ImageScannerFormat_OpenXps) = 5, Pdf (ImageScannerFormat_Pdf) = 6,
 }}
 DEFINE_IID!(IID_IImageScannerFormatConfiguration, 2921815313, 56031, 16400, 191, 16, 204, 165, 200, 61, 203, 176);
@@ -23409,8 +23409,8 @@ impl IImageScannerPreviewResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageScannerPreviewResult: IImageScannerPreviewResult}
-RT_STRUCT! { struct ImageScannerResolution {
+RT_CLASS!{class ImageScannerPreviewResult: IImageScannerPreviewResult ["Windows.Devices.Scanners.ImageScannerPreviewResult"]}
+RT_STRUCT! { struct ImageScannerResolution ["Windows.Devices.Scanners.ImageScannerResolution"] {
     DpiX: f32, DpiY: f32,
 }}
 DEFINE_IID!(IID_IImageScannerScanResult, 3373671629, 36919, 20040, 132, 193, 172, 9, 117, 7, 107, 197);
@@ -23424,8 +23424,8 @@ impl IImageScannerScanResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageScannerScanResult: IImageScannerScanResult}
-RT_ENUM! { enum ImageScannerScanSource: i32 {
+RT_CLASS!{class ImageScannerScanResult: IImageScannerScanResult ["Windows.Devices.Scanners.ImageScannerScanResult"]}
+RT_ENUM! { enum ImageScannerScanSource: i32 ["Windows.Devices.Scanners.ImageScannerScanSource"] {
     Default (ImageScannerScanSource_Default) = 0, Flatbed (ImageScannerScanSource_Flatbed) = 1, Feeder (ImageScannerScanSource_Feeder) = 2, AutoConfigured (ImageScannerScanSource_AutoConfigured) = 3,
 }}
 DEFINE_IID!(IID_IImageScannerSourceConfiguration, 3216310357, 2884, 19586, 158, 137, 32, 95, 156, 35, 78, 89);
@@ -23671,7 +23671,7 @@ impl IAccelerometer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Accelerometer: IAccelerometer}
+RT_CLASS!{class Accelerometer: IAccelerometer ["Windows.Devices.Sensors.Accelerometer"]}
 impl RtActivatable<IAccelerometerStatics> for Accelerometer {}
 impl RtActivatable<IAccelerometerStatics2> for Accelerometer {}
 impl RtActivatable<IAccelerometerStatics3> for Accelerometer {}
@@ -23779,7 +23779,7 @@ impl IAccelerometerReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccelerometerReading: IAccelerometerReading}
+RT_CLASS!{class AccelerometerReading: IAccelerometerReading ["Windows.Devices.Sensors.AccelerometerReading"]}
 DEFINE_IID!(IID_IAccelerometerReading2, 176573090, 5550, 19008, 190, 85, 219, 88, 215, 222, 115, 137);
 RT_INTERFACE!{interface IAccelerometerReading2(IAccelerometerReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IAccelerometerReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -23808,8 +23808,8 @@ impl IAccelerometerReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccelerometerReadingChangedEventArgs: IAccelerometerReadingChangedEventArgs}
-RT_ENUM! { enum AccelerometerReadingType: i32 {
+RT_CLASS!{class AccelerometerReadingChangedEventArgs: IAccelerometerReadingChangedEventArgs ["Windows.Devices.Sensors.AccelerometerReadingChangedEventArgs"]}
+RT_ENUM! { enum AccelerometerReadingType: i32 ["Windows.Devices.Sensors.AccelerometerReadingType"] {
     Standard (AccelerometerReadingType_Standard) = 0, Linear (AccelerometerReadingType_Linear) = 1, Gravity (AccelerometerReadingType_Gravity) = 2,
 }}
 DEFINE_IID!(IID_IAccelerometerShakenEventArgs, 2516517329, 18984, 20277, 152, 232, 129, 120, 170, 228, 8, 74);
@@ -23823,7 +23823,7 @@ impl IAccelerometerShakenEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccelerometerShakenEventArgs: IAccelerometerShakenEventArgs}
+RT_CLASS!{class AccelerometerShakenEventArgs: IAccelerometerShakenEventArgs ["Windows.Devices.Sensors.AccelerometerShakenEventArgs"]}
 DEFINE_IID!(IID_IAccelerometerStatics, 2783087476, 23175, 18989, 190, 204, 15, 144, 110, 160, 97, 221);
 RT_INTERFACE!{static interface IAccelerometerStatics(IAccelerometerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAccelerometerStatics] {
     fn GetDefault(&self, out: *mut *mut Accelerometer) -> HRESULT
@@ -23915,7 +23915,7 @@ impl IActivitySensor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivitySensor: IActivitySensor}
+RT_CLASS!{class ActivitySensor: IActivitySensor ["Windows.Devices.Sensors.ActivitySensor"]}
 impl RtActivatable<IActivitySensorStatics> for ActivitySensor {}
 impl ActivitySensor {
     #[inline] pub fn get_default_async() -> Result<ComPtr<foundation::IAsyncOperation<ActivitySensor>>> {
@@ -23958,7 +23958,7 @@ impl IActivitySensorReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivitySensorReading: IActivitySensorReading}
+RT_CLASS!{class ActivitySensorReading: IActivitySensorReading ["Windows.Devices.Sensors.ActivitySensorReading"]}
 DEFINE_IID!(IID_IActivitySensorReadingChangedEventArgs, 3728238359, 44726, 20167, 148, 106, 217, 204, 25, 185, 81, 236);
 RT_INTERFACE!{interface IActivitySensorReadingChangedEventArgs(IActivitySensorReadingChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IActivitySensorReadingChangedEventArgs] {
     fn get_Reading(&self, out: *mut *mut ActivitySensorReading) -> HRESULT
@@ -23970,7 +23970,7 @@ impl IActivitySensorReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivitySensorReadingChangedEventArgs: IActivitySensorReadingChangedEventArgs}
+RT_CLASS!{class ActivitySensorReadingChangedEventArgs: IActivitySensorReadingChangedEventArgs ["Windows.Devices.Sensors.ActivitySensorReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IActivitySensorReadingChangeReport, 1329342741, 55611, 18365, 150, 10, 242, 15, 178, 243, 34, 185);
 RT_INTERFACE!{interface IActivitySensorReadingChangeReport(IActivitySensorReadingChangeReportVtbl): IInspectable(IInspectableVtbl) [IID_IActivitySensorReadingChangeReport] {
     fn get_Reading(&self, out: *mut *mut ActivitySensorReading) -> HRESULT
@@ -23982,8 +23982,8 @@ impl IActivitySensorReadingChangeReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivitySensorReadingChangeReport: IActivitySensorReadingChangeReport}
-RT_ENUM! { enum ActivitySensorReadingConfidence: i32 {
+RT_CLASS!{class ActivitySensorReadingChangeReport: IActivitySensorReadingChangeReport ["Windows.Devices.Sensors.ActivitySensorReadingChangeReport"]}
+RT_ENUM! { enum ActivitySensorReadingConfidence: i32 ["Windows.Devices.Sensors.ActivitySensorReadingConfidence"] {
     High (ActivitySensorReadingConfidence_High) = 0, Low (ActivitySensorReadingConfidence_Low) = 1,
 }}
 DEFINE_IID!(IID_IActivitySensorStatics, 2803764893, 61067, 17873, 178, 91, 8, 204, 13, 249, 42, 182);
@@ -24032,8 +24032,8 @@ impl IActivitySensorTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivitySensorTriggerDetails: IActivitySensorTriggerDetails}
-RT_ENUM! { enum ActivityType: i32 {
+RT_CLASS!{class ActivitySensorTriggerDetails: IActivitySensorTriggerDetails ["Windows.Devices.Sensors.ActivitySensorTriggerDetails"]}
+RT_ENUM! { enum ActivityType: i32 ["Windows.Devices.Sensors.ActivityType"] {
     Unknown (ActivityType_Unknown) = 0, Idle (ActivityType_Idle) = 1, Stationary (ActivityType_Stationary) = 2, Fidgeting (ActivityType_Fidgeting) = 3, Walking (ActivityType_Walking) = 4, Running (ActivityType_Running) = 5, InVehicle (ActivityType_InVehicle) = 6, Biking (ActivityType_Biking) = 7,
 }}
 DEFINE_IID!(IID_IAltimeter, 1928353789, 36612, 18929, 180, 167, 244, 227, 99, 183, 1, 162);
@@ -24081,7 +24081,7 @@ impl IAltimeter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Altimeter: IAltimeter}
+RT_CLASS!{class Altimeter: IAltimeter ["Windows.Devices.Sensors.Altimeter"]}
 impl RtActivatable<IAltimeterStatics> for Altimeter {}
 impl Altimeter {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<Altimeter>>> {
@@ -24128,7 +24128,7 @@ impl IAltimeterReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AltimeterReading: IAltimeterReading}
+RT_CLASS!{class AltimeterReading: IAltimeterReading ["Windows.Devices.Sensors.AltimeterReading"]}
 DEFINE_IID!(IID_IAltimeterReading2, 1413094361, 27915, 17074, 189, 105, 188, 143, 174, 15, 120, 44);
 RT_INTERFACE!{interface IAltimeterReading2(IAltimeterReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IAltimeterReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -24157,7 +24157,7 @@ impl IAltimeterReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AltimeterReadingChangedEventArgs: IAltimeterReadingChangedEventArgs}
+RT_CLASS!{class AltimeterReadingChangedEventArgs: IAltimeterReadingChangedEventArgs ["Windows.Devices.Sensors.AltimeterReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IAltimeterStatics, 2662651843, 58796, 18382, 142, 239, 211, 113, 129, 104, 192, 31);
 RT_INTERFACE!{static interface IAltimeterStatics(IAltimeterStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAltimeterStatics] {
     fn GetDefault(&self, out: *mut *mut Altimeter) -> HRESULT
@@ -24214,7 +24214,7 @@ impl IBarometer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Barometer: IBarometer}
+RT_CLASS!{class Barometer: IBarometer ["Windows.Devices.Sensors.Barometer"]}
 impl RtActivatable<IBarometerStatics> for Barometer {}
 impl RtActivatable<IBarometerStatics2> for Barometer {}
 impl Barometer {
@@ -24268,7 +24268,7 @@ impl IBarometerReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarometerReading: IBarometerReading}
+RT_CLASS!{class BarometerReading: IBarometerReading ["Windows.Devices.Sensors.BarometerReading"]}
 DEFINE_IID!(IID_IBarometerReading2, 2242004203, 37061, 18549, 137, 28, 56, 101, 180, 195, 87, 231);
 RT_INTERFACE!{interface IBarometerReading2(IBarometerReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IBarometerReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -24297,7 +24297,7 @@ impl IBarometerReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BarometerReadingChangedEventArgs: IBarometerReadingChangedEventArgs}
+RT_CLASS!{class BarometerReadingChangedEventArgs: IBarometerReadingChangedEventArgs ["Windows.Devices.Sensors.BarometerReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IBarometerStatics, 678110986, 739, 20358, 132, 252, 253, 216, 146, 181, 148, 15);
 RT_INTERFACE!{static interface IBarometerStatics(IBarometerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBarometerStatics] {
     fn GetDefault(&self, out: *mut *mut Barometer) -> HRESULT
@@ -24365,7 +24365,7 @@ impl ICompass {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Compass: ICompass}
+RT_CLASS!{class Compass: ICompass ["Windows.Devices.Sensors.Compass"]}
 impl RtActivatable<ICompassStatics> for Compass {}
 impl RtActivatable<ICompassStatics2> for Compass {}
 impl Compass {
@@ -24452,7 +24452,7 @@ impl ICompassReading {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompassReading: ICompassReading}
+RT_CLASS!{class CompassReading: ICompassReading ["Windows.Devices.Sensors.CompassReading"]}
 DEFINE_IID!(IID_ICompassReading2, 2973394462, 20923, 18962, 190, 221, 173, 71, 255, 135, 210, 232);
 RT_INTERFACE!{interface ICompassReading2(ICompassReading2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompassReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -24481,7 +24481,7 @@ impl ICompassReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompassReadingChangedEventArgs: ICompassReadingChangedEventArgs}
+RT_CLASS!{class CompassReadingChangedEventArgs: ICompassReadingChangedEventArgs ["Windows.Devices.Sensors.CompassReadingChangedEventArgs"]}
 DEFINE_IID!(IID_ICompassReadingHeadingAccuracy, 3881907534, 35089, 16631, 158, 22, 110, 204, 125, 174, 197, 222);
 RT_INTERFACE!{interface ICompassReadingHeadingAccuracy(ICompassReadingHeadingAccuracyVtbl): IInspectable(IInspectableVtbl) [IID_ICompassReadingHeadingAccuracy] {
     fn get_HeadingAccuracy(&self, out: *mut MagnetometerAccuracy) -> HRESULT
@@ -24560,7 +24560,7 @@ impl IGyrometer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Gyrometer: IGyrometer}
+RT_CLASS!{class Gyrometer: IGyrometer ["Windows.Devices.Sensors.Gyrometer"]}
 impl RtActivatable<IGyrometerStatics> for Gyrometer {}
 impl RtActivatable<IGyrometerStatics2> for Gyrometer {}
 impl Gyrometer {
@@ -24653,7 +24653,7 @@ impl IGyrometerReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GyrometerReading: IGyrometerReading}
+RT_CLASS!{class GyrometerReading: IGyrometerReading ["Windows.Devices.Sensors.GyrometerReading"]}
 DEFINE_IID!(IID_IGyrometerReading2, 380625212, 11145, 17595, 130, 43, 209, 225, 85, 111, 240, 155);
 RT_INTERFACE!{interface IGyrometerReading2(IGyrometerReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IGyrometerReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -24682,7 +24682,7 @@ impl IGyrometerReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GyrometerReadingChangedEventArgs: IGyrometerReadingChangedEventArgs}
+RT_CLASS!{class GyrometerReadingChangedEventArgs: IGyrometerReadingChangedEventArgs ["Windows.Devices.Sensors.GyrometerReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IGyrometerStatics, 2209802185, 58525, 19257, 134, 230, 205, 85, 75, 228, 197, 193);
 RT_INTERFACE!{static interface IGyrometerStatics(IGyrometerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGyrometerStatics] {
     fn GetDefault(&self, out: *mut *mut Gyrometer) -> HRESULT
@@ -24734,7 +24734,7 @@ impl IHingeAngleReading {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HingeAngleReading: IHingeAngleReading}
+RT_CLASS!{class HingeAngleReading: IHingeAngleReading ["Windows.Devices.Sensors.HingeAngleReading"]}
 DEFINE_IID!(IID_IHingeAngleSensor, 3922968066, 49119, 17279, 140, 41, 136, 199, 115, 147, 211, 9);
 RT_INTERFACE!{interface IHingeAngleSensor(IHingeAngleSensorVtbl): IInspectable(IInspectableVtbl) [IID_IHingeAngleSensor] {
     fn GetCurrentReadingAsync(&self, out: *mut *mut foundation::IAsyncOperation<HingeAngleReading>) -> HRESULT,
@@ -24780,7 +24780,7 @@ impl IHingeAngleSensor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HingeAngleSensor: IHingeAngleSensor}
+RT_CLASS!{class HingeAngleSensor: IHingeAngleSensor ["Windows.Devices.Sensors.HingeAngleSensor"]}
 impl RtActivatable<IHingeAngleSensorStatics> for HingeAngleSensor {}
 impl HingeAngleSensor {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -24808,7 +24808,7 @@ impl IHingeAngleSensorReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HingeAngleSensorReadingChangedEventArgs: IHingeAngleSensorReadingChangedEventArgs}
+RT_CLASS!{class HingeAngleSensorReadingChangedEventArgs: IHingeAngleSensorReadingChangedEventArgs ["Windows.Devices.Sensors.HingeAngleSensorReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IHingeAngleSensorStatics, 3082172688, 64433, 16675, 137, 206, 78, 163, 78, 176, 223, 202);
 RT_INTERFACE!{static interface IHingeAngleSensorStatics(IHingeAngleSensorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHingeAngleSensorStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -24877,7 +24877,7 @@ impl IInclinometer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Inclinometer: IInclinometer}
+RT_CLASS!{class Inclinometer: IInclinometer ["Windows.Devices.Sensors.Inclinometer"]}
 impl RtActivatable<IInclinometerStatics> for Inclinometer {}
 impl RtActivatable<IInclinometerStatics2> for Inclinometer {}
 impl RtActivatable<IInclinometerStatics3> for Inclinometer {}
@@ -24986,7 +24986,7 @@ impl IInclinometerReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InclinometerReading: IInclinometerReading}
+RT_CLASS!{class InclinometerReading: IInclinometerReading ["Windows.Devices.Sensors.InclinometerReading"]}
 DEFINE_IID!(IID_IInclinometerReading2, 1326860161, 59659, 18008, 137, 21, 1, 3, 224, 138, 128, 90);
 RT_INTERFACE!{interface IInclinometerReading2(IInclinometerReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IInclinometerReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -25015,7 +25015,7 @@ impl IInclinometerReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InclinometerReadingChangedEventArgs: IInclinometerReadingChangedEventArgs}
+RT_CLASS!{class InclinometerReadingChangedEventArgs: IInclinometerReadingChangedEventArgs ["Windows.Devices.Sensors.InclinometerReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IInclinometerReadingYawAccuracy, 3025397888, 8163, 18822, 162, 87, 230, 236, 226, 114, 57, 73);
 RT_INTERFACE!{interface IInclinometerReadingYawAccuracy(IInclinometerReadingYawAccuracyVtbl): IInspectable(IInspectableVtbl) [IID_IInclinometerReadingYawAccuracy] {
     fn get_YawAccuracy(&self, out: *mut MagnetometerAccuracy) -> HRESULT
@@ -25116,7 +25116,7 @@ impl ILightSensor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LightSensor: ILightSensor}
+RT_CLASS!{class LightSensor: ILightSensor ["Windows.Devices.Sensors.LightSensor"]}
 impl RtActivatable<ILightSensorStatics> for LightSensor {}
 impl RtActivatable<ILightSensorStatics2> for LightSensor {}
 impl LightSensor {
@@ -25181,7 +25181,7 @@ impl ILightSensorReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LightSensorReading: ILightSensorReading}
+RT_CLASS!{class LightSensorReading: ILightSensorReading ["Windows.Devices.Sensors.LightSensorReading"]}
 DEFINE_IID!(IID_ILightSensorReading2, 3075547525, 17571, 17609, 129, 144, 158, 246, 222, 10, 138, 116);
 RT_INTERFACE!{interface ILightSensorReading2(ILightSensorReading2Vtbl): IInspectable(IInspectableVtbl) [IID_ILightSensorReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -25210,7 +25210,7 @@ impl ILightSensorReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LightSensorReadingChangedEventArgs: ILightSensorReadingChangedEventArgs}
+RT_CLASS!{class LightSensorReadingChangedEventArgs: ILightSensorReadingChangedEventArgs ["Windows.Devices.Sensors.LightSensorReadingChangedEventArgs"]}
 DEFINE_IID!(IID_ILightSensorStatics, 1172016260, 50088, 18206, 154, 83, 100, 87, 250, 216, 124, 14);
 RT_INTERFACE!{static interface ILightSensorStatics(ILightSensorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILightSensorStatics] {
     fn GetDefault(&self, out: *mut *mut LightSensor) -> HRESULT
@@ -25278,7 +25278,7 @@ impl IMagnetometer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Magnetometer: IMagnetometer}
+RT_CLASS!{class Magnetometer: IMagnetometer ["Windows.Devices.Sensors.Magnetometer"]}
 impl RtActivatable<IMagnetometerStatics> for Magnetometer {}
 impl RtActivatable<IMagnetometerStatics2> for Magnetometer {}
 impl Magnetometer {
@@ -25331,7 +25331,7 @@ impl IMagnetometer3 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MagnetometerAccuracy: i32 {
+RT_ENUM! { enum MagnetometerAccuracy: i32 ["Windows.Devices.Sensors.MagnetometerAccuracy"] {
     Unknown (MagnetometerAccuracy_Unknown) = 0, Unreliable (MagnetometerAccuracy_Unreliable) = 1, Approximate (MagnetometerAccuracy_Approximate) = 2, High (MagnetometerAccuracy_High) = 3,
 }}
 DEFINE_IID!(IID_IMagnetometerDeviceId, 1488230594, 32331, 16460, 159, 197, 93, 232, 180, 14, 186, 227);
@@ -25380,7 +25380,7 @@ impl IMagnetometerReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagnetometerReading: IMagnetometerReading}
+RT_CLASS!{class MagnetometerReading: IMagnetometerReading ["Windows.Devices.Sensors.MagnetometerReading"]}
 DEFINE_IID!(IID_IMagnetometerReading2, 3569966177, 25049, 16459, 163, 40, 6, 111, 23, 122, 20, 9);
 RT_INTERFACE!{interface IMagnetometerReading2(IMagnetometerReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IMagnetometerReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -25409,7 +25409,7 @@ impl IMagnetometerReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MagnetometerReadingChangedEventArgs: IMagnetometerReadingChangedEventArgs}
+RT_CLASS!{class MagnetometerReadingChangedEventArgs: IMagnetometerReadingChangedEventArgs ["Windows.Devices.Sensors.MagnetometerReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IMagnetometerStatics, 2235327692, 1688, 19930, 166, 223, 156, 185, 204, 74, 180, 10);
 RT_INTERFACE!{static interface IMagnetometerStatics(IMagnetometerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMagnetometerStatics] {
     fn GetDefault(&self, out: *mut *mut Magnetometer) -> HRESULT
@@ -25477,7 +25477,7 @@ impl IOrientationSensor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OrientationSensor: IOrientationSensor}
+RT_CLASS!{class OrientationSensor: IOrientationSensor ["Windows.Devices.Sensors.OrientationSensor"]}
 impl RtActivatable<IOrientationSensorStatics> for OrientationSensor {}
 impl RtActivatable<IOrientationSensorStatics2> for OrientationSensor {}
 impl RtActivatable<IOrientationSensorStatics3> for OrientationSensor {}
@@ -25586,7 +25586,7 @@ impl IOrientationSensorReading {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OrientationSensorReading: IOrientationSensorReading}
+RT_CLASS!{class OrientationSensorReading: IOrientationSensorReading ["Windows.Devices.Sensors.OrientationSensorReading"]}
 DEFINE_IID!(IID_IOrientationSensorReading2, 5729887, 18936, 19461, 158, 7, 36, 250, 199, 148, 8, 195);
 RT_INTERFACE!{interface IOrientationSensorReading2(IOrientationSensorReading2Vtbl): IInspectable(IInspectableVtbl) [IID_IOrientationSensorReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -25615,7 +25615,7 @@ impl IOrientationSensorReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OrientationSensorReadingChangedEventArgs: IOrientationSensorReadingChangedEventArgs}
+RT_CLASS!{class OrientationSensorReadingChangedEventArgs: IOrientationSensorReadingChangedEventArgs ["Windows.Devices.Sensors.OrientationSensorReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IOrientationSensorReadingYawAccuracy, 3517749284, 16218, 18850, 188, 123, 17, 128, 188, 56, 205, 43);
 RT_INTERFACE!{interface IOrientationSensorReadingYawAccuracy(IOrientationSensorReadingYawAccuracyVtbl): IInspectable(IInspectableVtbl) [IID_IOrientationSensorReadingYawAccuracy] {
     fn get_YawAccuracy(&self, out: *mut MagnetometerAccuracy) -> HRESULT
@@ -25734,7 +25734,7 @@ impl IPedometer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Pedometer: IPedometer}
+RT_CLASS!{class Pedometer: IPedometer ["Windows.Devices.Sensors.Pedometer"]}
 impl RtActivatable<IPedometerStatics> for Pedometer {}
 impl RtActivatable<IPedometerStatics2> for Pedometer {}
 impl Pedometer {
@@ -25769,7 +25769,7 @@ impl IPedometer2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PedometerDataThreshold: ISensorDataThreshold}
+RT_CLASS!{class PedometerDataThreshold: ISensorDataThreshold ["Windows.Devices.Sensors.PedometerDataThreshold"]}
 impl RtActivatable<IPedometerDataThresholdFactory> for PedometerDataThreshold {}
 impl PedometerDataThreshold {
     #[inline] pub fn create(sensor: &Pedometer, stepGoal: i32) -> Result<ComPtr<PedometerDataThreshold>> {
@@ -25817,7 +25817,7 @@ impl IPedometerReading {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PedometerReading: IPedometerReading}
+RT_CLASS!{class PedometerReading: IPedometerReading ["Windows.Devices.Sensors.PedometerReading"]}
 DEFINE_IID!(IID_IPedometerReadingChangedEventArgs, 4166378622, 43964, 17494, 134, 168, 37, 207, 43, 51, 55, 66);
 RT_INTERFACE!{interface IPedometerReadingChangedEventArgs(IPedometerReadingChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPedometerReadingChangedEventArgs] {
     fn get_Reading(&self, out: *mut *mut PedometerReading) -> HRESULT
@@ -25829,7 +25829,7 @@ impl IPedometerReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PedometerReadingChangedEventArgs: IPedometerReadingChangedEventArgs}
+RT_CLASS!{class PedometerReadingChangedEventArgs: IPedometerReadingChangedEventArgs ["Windows.Devices.Sensors.PedometerReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IPedometerStatics, 2191002159, 16515, 19963, 180, 17, 147, 142, 160, 244, 185, 70);
 RT_INTERFACE!{static interface IPedometerStatics(IPedometerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPedometerStatics] {
     fn FromIdAsync(&self, deviceId: HSTRING, out: *mut *mut foundation::IAsyncOperation<Pedometer>) -> HRESULT,
@@ -25876,7 +25876,7 @@ impl IPedometerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PedometerStepKind: i32 {
+RT_ENUM! { enum PedometerStepKind: i32 ["Windows.Devices.Sensors.PedometerStepKind"] {
     Unknown (PedometerStepKind_Unknown) = 0, Walking (PedometerStepKind_Walking) = 1, Running (PedometerStepKind_Running) = 2,
 }}
 DEFINE_IID!(IID_IProximitySensor, 1421899448, 60667, 18756, 185, 40, 116, 252, 80, 77, 71, 238);
@@ -25925,7 +25925,7 @@ impl IProximitySensor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProximitySensor: IProximitySensor}
+RT_CLASS!{class ProximitySensor: IProximitySensor ["Windows.Devices.Sensors.ProximitySensor"]}
 impl RtActivatable<IProximitySensorStatics> for ProximitySensor {}
 impl RtActivatable<IProximitySensorStatics2> for ProximitySensor {}
 impl ProximitySensor {
@@ -25940,7 +25940,7 @@ impl ProximitySensor {
     }
 }
 DEFINE_CLSID!(ProximitySensor(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,101,110,115,111,114,115,46,80,114,111,120,105,109,105,116,121,83,101,110,115,111,114,0]) [CLSID_ProximitySensor]);
-RT_CLASS!{class ProximitySensorDataThreshold: ISensorDataThreshold}
+RT_CLASS!{class ProximitySensorDataThreshold: ISensorDataThreshold ["Windows.Devices.Sensors.ProximitySensorDataThreshold"]}
 impl RtActivatable<IProximitySensorDataThresholdFactory> for ProximitySensorDataThreshold {}
 impl ProximitySensorDataThreshold {
     #[inline] pub fn create(sensor: &ProximitySensor) -> Result<ComPtr<ProximitySensorDataThreshold>> {
@@ -25959,7 +25959,7 @@ impl IProximitySensorDataThresholdFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProximitySensorDisplayOnOffController: foundation::IClosable}
+RT_CLASS!{class ProximitySensorDisplayOnOffController: foundation::IClosable ["Windows.Devices.Sensors.ProximitySensorDisplayOnOffController"]}
 DEFINE_IID!(IID_IProximitySensorReading, 1898089817, 4909, 19807, 143, 249, 47, 13, 184, 117, 28, 237);
 RT_INTERFACE!{interface IProximitySensorReading(IProximitySensorReadingVtbl): IInspectable(IInspectableVtbl) [IID_IProximitySensorReading] {
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -25983,7 +25983,7 @@ impl IProximitySensorReading {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProximitySensorReading: IProximitySensorReading}
+RT_CLASS!{class ProximitySensorReading: IProximitySensorReading ["Windows.Devices.Sensors.ProximitySensorReading"]}
 DEFINE_IID!(IID_IProximitySensorReadingChangedEventArgs, 3485660006, 50152, 16637, 140, 195, 103, 226, 137, 0, 73, 56);
 RT_INTERFACE!{interface IProximitySensorReadingChangedEventArgs(IProximitySensorReadingChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IProximitySensorReadingChangedEventArgs] {
     fn get_Reading(&self, out: *mut *mut ProximitySensorReading) -> HRESULT
@@ -25995,7 +25995,7 @@ impl IProximitySensorReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProximitySensorReadingChangedEventArgs: IProximitySensorReadingChangedEventArgs}
+RT_CLASS!{class ProximitySensorReadingChangedEventArgs: IProximitySensorReadingChangedEventArgs ["Windows.Devices.Sensors.ProximitySensorReadingChangedEventArgs"]}
 DEFINE_IID!(IID_IProximitySensorStatics, 689464905, 25193, 20055, 165, 173, 130, 190, 128, 129, 51, 146);
 RT_INTERFACE!{static interface IProximitySensorStatics(IProximitySensorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IProximitySensorStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -26045,8 +26045,8 @@ impl ISensorDataThresholdTriggerDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SensorDataThresholdTriggerDetails: ISensorDataThresholdTriggerDetails}
-RT_ENUM! { enum SensorOptimizationGoal: i32 {
+RT_CLASS!{class SensorDataThresholdTriggerDetails: ISensorDataThresholdTriggerDetails ["Windows.Devices.Sensors.SensorDataThresholdTriggerDetails"]}
+RT_ENUM! { enum SensorOptimizationGoal: i32 ["Windows.Devices.Sensors.SensorOptimizationGoal"] {
     Precision (SensorOptimizationGoal_Precision) = 0, PowerEfficiency (SensorOptimizationGoal_PowerEfficiency) = 1,
 }}
 DEFINE_IID!(IID_ISensorQuaternion, 3385182247, 50972, 18151, 157, 163, 54, 161, 147, 178, 50, 188);
@@ -26078,8 +26078,8 @@ impl ISensorQuaternion {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SensorQuaternion: ISensorQuaternion}
-RT_ENUM! { enum SensorReadingType: i32 {
+RT_CLASS!{class SensorQuaternion: ISensorQuaternion ["Windows.Devices.Sensors.SensorQuaternion"]}
+RT_ENUM! { enum SensorReadingType: i32 ["Windows.Devices.Sensors.SensorReadingType"] {
     Absolute (SensorReadingType_Absolute) = 0, Relative (SensorReadingType_Relative) = 1,
 }}
 DEFINE_IID!(IID_ISensorRotationMatrix, 171792999, 8948, 17298, 149, 56, 101, 208, 189, 6, 74, 166);
@@ -26141,11 +26141,11 @@ impl ISensorRotationMatrix {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SensorRotationMatrix: ISensorRotationMatrix}
-RT_ENUM! { enum SensorType: i32 {
+RT_CLASS!{class SensorRotationMatrix: ISensorRotationMatrix ["Windows.Devices.Sensors.SensorRotationMatrix"]}
+RT_ENUM! { enum SensorType: i32 ["Windows.Devices.Sensors.SensorType"] {
     Accelerometer (SensorType_Accelerometer) = 0, ActivitySensor (SensorType_ActivitySensor) = 1, Barometer (SensorType_Barometer) = 2, Compass (SensorType_Compass) = 3, CustomSensor (SensorType_CustomSensor) = 4, Gyroscope (SensorType_Gyroscope) = 5, ProximitySensor (SensorType_ProximitySensor) = 6, Inclinometer (SensorType_Inclinometer) = 7, LightSensor (SensorType_LightSensor) = 8, OrientationSensor (SensorType_OrientationSensor) = 9, Pedometer (SensorType_Pedometer) = 10, RelativeInclinometer (SensorType_RelativeInclinometer) = 11, RelativeOrientationSensor (SensorType_RelativeOrientationSensor) = 12, SimpleOrientationSensor (SensorType_SimpleOrientationSensor) = 13,
 }}
-RT_ENUM! { enum SimpleOrientation: i32 {
+RT_ENUM! { enum SimpleOrientation: i32 ["Windows.Devices.Sensors.SimpleOrientation"] {
     NotRotated (SimpleOrientation_NotRotated) = 0, Rotated90DegreesCounterclockwise (SimpleOrientation_Rotated90DegreesCounterclockwise) = 1, Rotated180DegreesCounterclockwise (SimpleOrientation_Rotated180DegreesCounterclockwise) = 2, Rotated270DegreesCounterclockwise (SimpleOrientation_Rotated270DegreesCounterclockwise) = 3, Faceup (SimpleOrientation_Faceup) = 4, Facedown (SimpleOrientation_Facedown) = 5,
 }}
 DEFINE_IID!(IID_ISimpleOrientationSensor, 1609906262, 8522, 19950, 163, 249, 97, 111, 26, 176, 111, 253);
@@ -26170,7 +26170,7 @@ impl ISimpleOrientationSensor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SimpleOrientationSensor: ISimpleOrientationSensor}
+RT_CLASS!{class SimpleOrientationSensor: ISimpleOrientationSensor ["Windows.Devices.Sensors.SimpleOrientationSensor"]}
 impl RtActivatable<ISimpleOrientationSensorStatics> for SimpleOrientationSensor {}
 impl RtActivatable<ISimpleOrientationSensorStatics2> for SimpleOrientationSensor {}
 impl SimpleOrientationSensor {
@@ -26229,7 +26229,7 @@ impl ISimpleOrientationSensorOrientationChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SimpleOrientationSensorOrientationChangedEventArgs: ISimpleOrientationSensorOrientationChangedEventArgs}
+RT_CLASS!{class SimpleOrientationSensorOrientationChangedEventArgs: ISimpleOrientationSensorOrientationChangedEventArgs ["Windows.Devices.Sensors.SimpleOrientationSensorOrientationChangedEventArgs"]}
 DEFINE_IID!(IID_ISimpleOrientationSensorStatics, 1928136303, 28842, 16582, 155, 27, 52, 51, 247, 69, 155, 78);
 RT_INTERFACE!{static interface ISimpleOrientationSensorStatics(ISimpleOrientationSensorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISimpleOrientationSensorStatics] {
     fn GetDefault(&self, out: *mut *mut SimpleOrientationSensor) -> HRESULT
@@ -26305,7 +26305,7 @@ impl ICustomSensor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CustomSensor: ICustomSensor}
+RT_CLASS!{class CustomSensor: ICustomSensor ["Windows.Devices.Sensors.Custom.CustomSensor"]}
 impl RtActivatable<ICustomSensorStatics> for CustomSensor {}
 impl CustomSensor {
     #[inline] pub fn get_device_selector(interfaceId: Guid) -> Result<HString> {
@@ -26355,7 +26355,7 @@ impl ICustomSensorReading {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CustomSensorReading: ICustomSensorReading}
+RT_CLASS!{class CustomSensorReading: ICustomSensorReading ["Windows.Devices.Sensors.Custom.CustomSensorReading"]}
 DEFINE_IID!(IID_ICustomSensorReading2, 574396650, 49011, 18834, 154, 72, 211, 200, 151, 89, 76, 203);
 RT_INTERFACE!{interface ICustomSensorReading2(ICustomSensorReading2Vtbl): IInspectable(IInspectableVtbl) [IID_ICustomSensorReading2] {
     fn get_PerformanceCount(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT
@@ -26378,7 +26378,7 @@ impl ICustomSensorReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CustomSensorReadingChangedEventArgs: ICustomSensorReadingChangedEventArgs}
+RT_CLASS!{class CustomSensorReadingChangedEventArgs: ICustomSensorReadingChangedEventArgs ["Windows.Devices.Sensors.Custom.CustomSensorReadingChangedEventArgs"]}
 DEFINE_IID!(IID_ICustomSensorStatics, 2569032399, 62498, 19581, 131, 107, 231, 220, 116, 167, 18, 75);
 RT_INTERFACE!{static interface ICustomSensorStatics(ICustomSensorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICustomSensorStatics] {
     fn GetDeviceSelector(&self, interfaceId: Guid, out: *mut HSTRING) -> HRESULT,
@@ -26411,7 +26411,7 @@ impl IErrorReceivedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ErrorReceivedEventArgs: IErrorReceivedEventArgs}
+RT_CLASS!{class ErrorReceivedEventArgs: IErrorReceivedEventArgs ["Windows.Devices.SerialCommunication.ErrorReceivedEventArgs"]}
 DEFINE_IID!(IID_IPinChangedEventArgs, 2730433968, 64668, 17927, 147, 208, 250, 94, 131, 67, 238, 34);
 RT_INTERFACE!{interface IPinChangedEventArgs(IPinChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPinChangedEventArgs] {
     fn get_PinChange(&self, out: *mut SerialPinChange) -> HRESULT
@@ -26423,7 +26423,7 @@ impl IPinChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PinChangedEventArgs: IPinChangedEventArgs}
+RT_CLASS!{class PinChangedEventArgs: IPinChangedEventArgs ["Windows.Devices.SerialCommunication.PinChangedEventArgs"]}
 DEFINE_IID!(IID_ISerialDevice, 3783773382, 8720, 16719, 182, 90, 245, 85, 58, 3, 55, 42);
 RT_INTERFACE!{interface ISerialDevice(ISerialDeviceVtbl): IInspectable(IInspectableVtbl) [IID_ISerialDevice] {
     fn get_BaudRate(&self, out: *mut u32) -> HRESULT,
@@ -26617,7 +26617,7 @@ impl ISerialDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SerialDevice: ISerialDevice}
+RT_CLASS!{class SerialDevice: ISerialDevice ["Windows.Devices.SerialCommunication.SerialDevice"]}
 impl RtActivatable<ISerialDeviceStatics> for SerialDevice {}
 impl SerialDevice {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -26663,19 +26663,19 @@ impl ISerialDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SerialError: i32 {
+RT_ENUM! { enum SerialError: i32 ["Windows.Devices.SerialCommunication.SerialError"] {
     Frame (SerialError_Frame) = 0, BufferOverrun (SerialError_BufferOverrun) = 1, ReceiveFull (SerialError_ReceiveFull) = 2, ReceiveParity (SerialError_ReceiveParity) = 3, TransmitFull (SerialError_TransmitFull) = 4,
 }}
-RT_ENUM! { enum SerialHandshake: i32 {
+RT_ENUM! { enum SerialHandshake: i32 ["Windows.Devices.SerialCommunication.SerialHandshake"] {
     None (SerialHandshake_None) = 0, RequestToSend (SerialHandshake_RequestToSend) = 1, XOnXOff (SerialHandshake_XOnXOff) = 2, RequestToSendXOnXOff (SerialHandshake_RequestToSendXOnXOff) = 3,
 }}
-RT_ENUM! { enum SerialParity: i32 {
+RT_ENUM! { enum SerialParity: i32 ["Windows.Devices.SerialCommunication.SerialParity"] {
     None (SerialParity_None) = 0, Odd (SerialParity_Odd) = 1, Even (SerialParity_Even) = 2, Mark (SerialParity_Mark) = 3, Space (SerialParity_Space) = 4,
 }}
-RT_ENUM! { enum SerialPinChange: i32 {
+RT_ENUM! { enum SerialPinChange: i32 ["Windows.Devices.SerialCommunication.SerialPinChange"] {
     BreakSignal (SerialPinChange_BreakSignal) = 0, CarrierDetect (SerialPinChange_CarrierDetect) = 1, ClearToSend (SerialPinChange_ClearToSend) = 2, DataSetReady (SerialPinChange_DataSetReady) = 3, RingIndicator (SerialPinChange_RingIndicator) = 4,
 }}
-RT_ENUM! { enum SerialStopBitCount: i32 {
+RT_ENUM! { enum SerialStopBitCount: i32 ["Windows.Devices.SerialCommunication.SerialStopBitCount"] {
     One (SerialStopBitCount_One) = 0, OnePointFive (SerialStopBitCount_OnePointFive) = 1, Two (SerialStopBitCount_Two) = 2,
 }}
 } // Windows.Devices.SerialCommunication
@@ -26692,7 +26692,7 @@ impl ICardAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CardAddedEventArgs: ICardAddedEventArgs}
+RT_CLASS!{class CardAddedEventArgs: ICardAddedEventArgs ["Windows.Devices.SmartCards.CardAddedEventArgs"]}
 DEFINE_IID!(IID_ICardRemovedEventArgs, 355670703, 8919, 18757, 175, 201, 3, 180, 111, 66, 166, 205);
 RT_INTERFACE!{interface ICardRemovedEventArgs(ICardRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICardRemovedEventArgs] {
     fn get_SmartCard(&self, out: *mut *mut SmartCard) -> HRESULT
@@ -26704,7 +26704,7 @@ impl ICardRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CardRemovedEventArgs: ICardRemovedEventArgs}
+RT_CLASS!{class CardRemovedEventArgs: ICardRemovedEventArgs ["Windows.Devices.SmartCards.CardRemovedEventArgs"]}
 DEFINE_IID!(IID_IKnownSmartCardAppletIds, 2063915224, 38324, 19592, 140, 234, 65, 30, 85, 81, 30, 252);
 RT_INTERFACE!{static interface IKnownSmartCardAppletIds(IKnownSmartCardAppletIdsVtbl): IInspectable(IInspectableVtbl) [IID_IKnownSmartCardAppletIds] {
     #[cfg(feature="windows-storage")] fn get_PaymentSystemEnvironment(&self, out: *mut *mut super::super::storage::streams::IBuffer) -> HRESULT,
@@ -26756,8 +26756,8 @@ impl ISmartCard {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCard: ISmartCard}
-RT_ENUM! { enum SmartCardActivationPolicyChangeResult: i32 {
+RT_CLASS!{class SmartCard: ISmartCard ["Windows.Devices.SmartCards.SmartCard"]}
+RT_ENUM! { enum SmartCardActivationPolicyChangeResult: i32 ["Windows.Devices.SmartCards.SmartCardActivationPolicyChangeResult"] {
     Denied (SmartCardActivationPolicyChangeResult_Denied) = 0, Allowed (SmartCardActivationPolicyChangeResult_Allowed) = 1,
 }}
 DEFINE_IID!(IID_ISmartCardAppletIdGroup, 2108777958, 25188, 22260, 94, 3, 200, 99, 133, 57, 94, 177);
@@ -26816,7 +26816,7 @@ impl ISmartCardAppletIdGroup {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardAppletIdGroup: ISmartCardAppletIdGroup}
+RT_CLASS!{class SmartCardAppletIdGroup: ISmartCardAppletIdGroup ["Windows.Devices.SmartCards.SmartCardAppletIdGroup"]}
 impl RtActivatable<ISmartCardAppletIdGroupFactory> for SmartCardAppletIdGroup {}
 impl RtActivatable<ISmartCardAppletIdGroupStatics> for SmartCardAppletIdGroup {}
 impl RtActivatable<IActivationFactory> for SmartCardAppletIdGroup {}
@@ -26875,7 +26875,7 @@ impl ISmartCardAppletIdGroup2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardAppletIdGroupActivationPolicy: i32 {
+RT_ENUM! { enum SmartCardAppletIdGroupActivationPolicy: i32 ["Windows.Devices.SmartCards.SmartCardAppletIdGroupActivationPolicy"] {
     Disabled (SmartCardAppletIdGroupActivationPolicy_Disabled) = 0, ForegroundOverride (SmartCardAppletIdGroupActivationPolicy_ForegroundOverride) = 1, Enabled (SmartCardAppletIdGroupActivationPolicy_Enabled) = 2,
 }}
 DEFINE_IID!(IID_ISmartCardAppletIdGroupFactory, 2433084237, 19045, 20033, 128, 97, 203, 232, 63, 54, 149, 229);
@@ -26924,7 +26924,7 @@ impl ISmartCardAppletIdGroupRegistration {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardAppletIdGroupRegistration: ISmartCardAppletIdGroupRegistration}
+RT_CLASS!{class SmartCardAppletIdGroupRegistration: ISmartCardAppletIdGroupRegistration ["Windows.Devices.SmartCards.SmartCardAppletIdGroupRegistration"]}
 DEFINE_IID!(IID_ISmartCardAppletIdGroupRegistration2, 1599408344, 39079, 20270, 145, 217, 108, 252, 206, 218, 64, 127);
 RT_INTERFACE!{interface ISmartCardAppletIdGroupRegistration2(ISmartCardAppletIdGroupRegistration2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardAppletIdGroupRegistration2] {
     fn get_SmartCardReaderId(&self, out: *mut HSTRING) -> HRESULT,
@@ -27013,7 +27013,7 @@ impl ISmartCardAutomaticResponseApdu {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardAutomaticResponseApdu: ISmartCardAutomaticResponseApdu}
+RT_CLASS!{class SmartCardAutomaticResponseApdu: ISmartCardAutomaticResponseApdu ["Windows.Devices.SmartCards.SmartCardAutomaticResponseApdu"]}
 impl RtActivatable<ISmartCardAutomaticResponseApduFactory> for SmartCardAutomaticResponseApdu {}
 impl SmartCardAutomaticResponseApdu {
     #[cfg(feature="windows-storage")] #[inline] pub fn create(commandApdu: &super::super::storage::streams::IBuffer, responseApdu: &super::super::storage::streams::IBuffer) -> Result<ComPtr<SmartCardAutomaticResponseApdu>> {
@@ -27075,7 +27075,7 @@ impl ISmartCardAutomaticResponseApduFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardAutomaticResponseStatus: i32 {
+RT_ENUM! { enum SmartCardAutomaticResponseStatus: i32 ["Windows.Devices.SmartCards.SmartCardAutomaticResponseStatus"] {
     None (SmartCardAutomaticResponseStatus_None) = 0, Success (SmartCardAutomaticResponseStatus_Success) = 1, UnknownError (SmartCardAutomaticResponseStatus_UnknownError) = 2,
 }}
 DEFINE_IID!(IID_ISmartCardChallengeContext, 422204185, 51652, 18759, 129, 204, 68, 121, 74, 97, 239, 145);
@@ -27113,7 +27113,7 @@ impl ISmartCardChallengeContext {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardChallengeContext: ISmartCardChallengeContext}
+RT_CLASS!{class SmartCardChallengeContext: ISmartCardChallengeContext ["Windows.Devices.SmartCards.SmartCardChallengeContext"]}
 DEFINE_IID!(IID_ISmartCardConnect, 803178469, 653, 18718, 160, 88, 51, 130, 195, 152, 111, 64);
 RT_INTERFACE!{interface ISmartCardConnect(ISmartCardConnectVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardConnect] {
     fn ConnectAsync(&self, out: *mut *mut foundation::IAsyncOperation<SmartCardConnection>) -> HRESULT
@@ -27136,8 +27136,8 @@ impl ISmartCardConnection {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardConnection: ISmartCardConnection}
-RT_ENUM! { enum SmartCardCryptogramAlgorithm: i32 {
+RT_CLASS!{class SmartCardConnection: ISmartCardConnection ["Windows.Devices.SmartCards.SmartCardConnection"]}
+RT_ENUM! { enum SmartCardCryptogramAlgorithm: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramAlgorithm"] {
     None (SmartCardCryptogramAlgorithm_None) = 0, CbcMac (SmartCardCryptogramAlgorithm_CbcMac) = 1, Cvc3Umd (SmartCardCryptogramAlgorithm_Cvc3Umd) = 2, DecimalizedMsd (SmartCardCryptogramAlgorithm_DecimalizedMsd) = 3, Cvc3MD (SmartCardCryptogramAlgorithm_Cvc3MD) = 4, Sha1 (SmartCardCryptogramAlgorithm_Sha1) = 5, SignedDynamicApplicationData (SmartCardCryptogramAlgorithm_SignedDynamicApplicationData) = 6, RsaPkcs1 (SmartCardCryptogramAlgorithm_RsaPkcs1) = 7, Sha256Hmac (SmartCardCryptogramAlgorithm_Sha256Hmac) = 8,
 }}
 DEFINE_IID!(IID_ISmartCardCryptogramGenerator, 3818870907, 60883, 20041, 181, 148, 15, 245, 228, 208, 199, 111);
@@ -27220,7 +27220,7 @@ impl ISmartCardCryptogramGenerator {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramGenerator: ISmartCardCryptogramGenerator}
+RT_CLASS!{class SmartCardCryptogramGenerator: ISmartCardCryptogramGenerator ["Windows.Devices.SmartCards.SmartCardCryptogramGenerator"]}
 impl RtActivatable<ISmartCardCryptogramGeneratorStatics> for SmartCardCryptogramGenerator {}
 impl RtActivatable<ISmartCardCryptogramGeneratorStatics2> for SmartCardCryptogramGenerator {}
 impl SmartCardCryptogramGenerator {
@@ -27268,7 +27268,7 @@ impl ISmartCardCryptogramGenerator2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardCryptogramGeneratorOperationStatus: i32 {
+RT_ENUM! { enum SmartCardCryptogramGeneratorOperationStatus: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramGeneratorOperationStatus"] {
     Success (SmartCardCryptogramGeneratorOperationStatus_Success) = 0, AuthorizationFailed (SmartCardCryptogramGeneratorOperationStatus_AuthorizationFailed) = 1, AuthorizationCanceled (SmartCardCryptogramGeneratorOperationStatus_AuthorizationCanceled) = 2, AuthorizationRequired (SmartCardCryptogramGeneratorOperationStatus_AuthorizationRequired) = 3, CryptogramMaterialPackageStorageKeyExists (SmartCardCryptogramGeneratorOperationStatus_CryptogramMaterialPackageStorageKeyExists) = 4, NoCryptogramMaterialPackageStorageKey (SmartCardCryptogramGeneratorOperationStatus_NoCryptogramMaterialPackageStorageKey) = 5, NoCryptogramMaterialPackage (SmartCardCryptogramGeneratorOperationStatus_NoCryptogramMaterialPackage) = 6, UnsupportedCryptogramMaterialPackage (SmartCardCryptogramGeneratorOperationStatus_UnsupportedCryptogramMaterialPackage) = 7, UnknownCryptogramMaterialName (SmartCardCryptogramGeneratorOperationStatus_UnknownCryptogramMaterialName) = 8, InvalidCryptogramMaterialUsage (SmartCardCryptogramGeneratorOperationStatus_InvalidCryptogramMaterialUsage) = 9, ApduResponseNotSent (SmartCardCryptogramGeneratorOperationStatus_ApduResponseNotSent) = 10, OtherError (SmartCardCryptogramGeneratorOperationStatus_OtherError) = 11, ValidationFailed (SmartCardCryptogramGeneratorOperationStatus_ValidationFailed) = 12, NotSupported (SmartCardCryptogramGeneratorOperationStatus_NotSupported) = 13,
 }}
 DEFINE_IID!(IID_ISmartCardCryptogramGeneratorStatics, 160643344, 52124, 16405, 150, 125, 82, 52, 243, 176, 41, 0);
@@ -27310,7 +27310,7 @@ impl ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult}
+RT_CLASS!{class SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult ["Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {}
 DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,116,65,108,108,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,82,101,115,117,108,116,0]) [CLSID_SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult]);
 DEFINE_IID!(IID_ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult, 1315605084, 38771, 18116, 163, 47, 177, 229, 67, 21, 158, 4);
@@ -27330,7 +27330,7 @@ impl ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult}
+RT_CLASS!{class SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult ["Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {}
 DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,116,65,108,108,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,80,97,99,107,97,103,101,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,82,101,115,117,108,116,0]) [CLSID_SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult]);
 DEFINE_IID!(IID_ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult, 2356996183, 42983, 18589, 185, 214, 54, 128, 97, 81, 80, 18);
@@ -27350,7 +27350,7 @@ impl ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult}
+RT_CLASS!{class SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult: ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult ["Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {}
 DEFINE_CLSID!(SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,71,101,116,65,108,108,67,114,121,112,116,111,103,114,97,109,83,116,111,114,97,103,101,75,101,121,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,82,101,115,117,108,116,0]) [CLSID_SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult]);
 DEFINE_IID!(IID_ISmartCardCryptogramMaterialCharacteristics, 4238001612, 49623, 16723, 146, 59, 162, 212, 60, 108, 141, 73);
@@ -27406,7 +27406,7 @@ impl ISmartCardCryptogramMaterialCharacteristics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramMaterialCharacteristics: ISmartCardCryptogramMaterialCharacteristics}
+RT_CLASS!{class SmartCardCryptogramMaterialCharacteristics: ISmartCardCryptogramMaterialCharacteristics ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialCharacteristics"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramMaterialCharacteristics {}
 DEFINE_CLSID!(SmartCardCryptogramMaterialCharacteristics(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,0]) [CLSID_SmartCardCryptogramMaterialCharacteristics]);
 DEFINE_IID!(IID_ISmartCardCryptogramMaterialPackageCharacteristics, 4290088479, 1682, 19527, 147, 207, 52, 217, 31, 157, 205, 0);
@@ -27438,13 +27438,13 @@ impl ISmartCardCryptogramMaterialPackageCharacteristics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramMaterialPackageCharacteristics: ISmartCardCryptogramMaterialPackageCharacteristics}
+RT_CLASS!{class SmartCardCryptogramMaterialPackageCharacteristics: ISmartCardCryptogramMaterialPackageCharacteristics ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialPackageCharacteristics"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramMaterialPackageCharacteristics {}
 DEFINE_CLSID!(SmartCardCryptogramMaterialPackageCharacteristics(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,77,97,116,101,114,105,97,108,80,97,99,107,97,103,101,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,0]) [CLSID_SmartCardCryptogramMaterialPackageCharacteristics]);
-RT_ENUM! { enum SmartCardCryptogramMaterialPackageConfirmationResponseFormat: i32 {
+RT_ENUM! { enum SmartCardCryptogramMaterialPackageConfirmationResponseFormat: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialPackageConfirmationResponseFormat"] {
     None (SmartCardCryptogramMaterialPackageConfirmationResponseFormat_None) = 0, VisaHmac (SmartCardCryptogramMaterialPackageConfirmationResponseFormat_VisaHmac) = 1,
 }}
-RT_ENUM! { enum SmartCardCryptogramMaterialPackageFormat: i32 {
+RT_ENUM! { enum SmartCardCryptogramMaterialPackageFormat: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialPackageFormat"] {
     None (SmartCardCryptogramMaterialPackageFormat_None) = 0, JweRsaPki (SmartCardCryptogramMaterialPackageFormat_JweRsaPki) = 1,
 }}
 DEFINE_IID!(IID_ISmartCardCryptogramMaterialPossessionProof, 3854150540, 41281, 16693, 154, 221, 176, 210, 227, 170, 31, 201);
@@ -27464,14 +27464,14 @@ impl ISmartCardCryptogramMaterialPossessionProof {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramMaterialPossessionProof: ISmartCardCryptogramMaterialPossessionProof}
-RT_ENUM! { enum SmartCardCryptogramMaterialProtectionMethod: i32 {
+RT_CLASS!{class SmartCardCryptogramMaterialPossessionProof: ISmartCardCryptogramMaterialPossessionProof ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialPossessionProof"]}
+RT_ENUM! { enum SmartCardCryptogramMaterialProtectionMethod: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialProtectionMethod"] {
     None (SmartCardCryptogramMaterialProtectionMethod_None) = 0, WhiteBoxing (SmartCardCryptogramMaterialProtectionMethod_WhiteBoxing) = 1,
 }}
-RT_ENUM! { enum SmartCardCryptogramMaterialType: i32 {
+RT_ENUM! { enum SmartCardCryptogramMaterialType: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramMaterialType"] {
     None (SmartCardCryptogramMaterialType_None) = 0, StaticDataAuthentication (SmartCardCryptogramMaterialType_StaticDataAuthentication) = 1, TripleDes112 (SmartCardCryptogramMaterialType_TripleDes112) = 2, Aes (SmartCardCryptogramMaterialType_Aes) = 3, RsaPkcs1 (SmartCardCryptogramMaterialType_RsaPkcs1) = 4,
 }}
-RT_ENUM! { enum SmartCardCryptogramPlacementOptions: u32 {
+RT_ENUM! { enum SmartCardCryptogramPlacementOptions: u32 ["Windows.Devices.SmartCards.SmartCardCryptogramPlacementOptions"] {
     None (SmartCardCryptogramPlacementOptions_None) = 0, UnitsAreInNibbles (SmartCardCryptogramPlacementOptions_UnitsAreInNibbles) = 1, ChainOutput (SmartCardCryptogramPlacementOptions_ChainOutput) = 2,
 }}
 DEFINE_IID!(IID_ISmartCardCryptogramPlacementStep, 2491089899, 33602, 18322, 162, 229, 146, 86, 54, 55, 138, 83);
@@ -27580,13 +27580,13 @@ impl ISmartCardCryptogramPlacementStep {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramPlacementStep: ISmartCardCryptogramPlacementStep}
+RT_CLASS!{class SmartCardCryptogramPlacementStep: ISmartCardCryptogramPlacementStep ["Windows.Devices.SmartCards.SmartCardCryptogramPlacementStep"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramPlacementStep {}
 DEFINE_CLSID!(SmartCardCryptogramPlacementStep(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,80,108,97,99,101,109,101,110,116,83,116,101,112,0]) [CLSID_SmartCardCryptogramPlacementStep]);
-RT_ENUM! { enum SmartCardCryptogramStorageKeyAlgorithm: i32 {
+RT_ENUM! { enum SmartCardCryptogramStorageKeyAlgorithm: i32 ["Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyAlgorithm"] {
     None (SmartCardCryptogramStorageKeyAlgorithm_None) = 0, Rsa2048 (SmartCardCryptogramStorageKeyAlgorithm_Rsa2048) = 1,
 }}
-RT_ENUM! { enum SmartCardCryptogramStorageKeyCapabilities: u32 {
+RT_ENUM! { enum SmartCardCryptogramStorageKeyCapabilities: u32 ["Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyCapabilities"] {
     None (SmartCardCryptogramStorageKeyCapabilities_None) = 0, HardwareProtection (SmartCardCryptogramStorageKeyCapabilities_HardwareProtection) = 1, UnlockPrompt (SmartCardCryptogramStorageKeyCapabilities_UnlockPrompt) = 2,
 }}
 DEFINE_IID!(IID_ISmartCardCryptogramStorageKeyCharacteristics, 2236765294, 17495, 18469, 180, 100, 99, 84, 113, 163, 159, 92);
@@ -27618,7 +27618,7 @@ impl ISmartCardCryptogramStorageKeyCharacteristics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramStorageKeyCharacteristics: ISmartCardCryptogramStorageKeyCharacteristics}
+RT_CLASS!{class SmartCardCryptogramStorageKeyCharacteristics: ISmartCardCryptogramStorageKeyCharacteristics ["Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyCharacteristics"]}
 impl RtActivatable<IActivationFactory> for SmartCardCryptogramStorageKeyCharacteristics {}
 DEFINE_CLSID!(SmartCardCryptogramStorageKeyCharacteristics(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,67,114,121,112,116,111,103,114,97,109,83,116,111,114,97,103,101,75,101,121,67,104,97,114,97,99,116,101,114,105,115,116,105,99,115,0]) [CLSID_SmartCardCryptogramStorageKeyCharacteristics]);
 DEFINE_IID!(IID_ISmartCardCryptogramStorageKeyInfo, 2008084493, 45207, 20321, 162, 106, 149, 97, 99, 156, 156, 58);
@@ -27672,7 +27672,7 @@ impl ISmartCardCryptogramStorageKeyInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardCryptogramStorageKeyInfo: ISmartCardCryptogramStorageKeyInfo}
+RT_CLASS!{class SmartCardCryptogramStorageKeyInfo: ISmartCardCryptogramStorageKeyInfo ["Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyInfo"]}
 DEFINE_IID!(IID_ISmartCardCryptogramStorageKeyInfo2, 278777, 63485, 16765, 137, 225, 251, 176, 56, 42, 220, 77);
 RT_INTERFACE!{interface ISmartCardCryptogramStorageKeyInfo2(ISmartCardCryptogramStorageKeyInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardCryptogramStorageKeyInfo2] {
     fn get_OperationalRequirements(&self, out: *mut HSTRING) -> HRESULT
@@ -27684,13 +27684,13 @@ impl ISmartCardCryptogramStorageKeyInfo2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardCryptographicKeyAttestationStatus: i32 {
+RT_ENUM! { enum SmartCardCryptographicKeyAttestationStatus: i32 ["Windows.Devices.SmartCards.SmartCardCryptographicKeyAttestationStatus"] {
     NoAttestation (SmartCardCryptographicKeyAttestationStatus_NoAttestation) = 0, SoftwareKeyWithoutTpm (SmartCardCryptographicKeyAttestationStatus_SoftwareKeyWithoutTpm) = 1, SoftwareKeyWithTpm (SmartCardCryptographicKeyAttestationStatus_SoftwareKeyWithTpm) = 2, TpmKeyUnknownAttestationStatus (SmartCardCryptographicKeyAttestationStatus_TpmKeyUnknownAttestationStatus) = 3, TpmKeyWithoutAttestationCapability (SmartCardCryptographicKeyAttestationStatus_TpmKeyWithoutAttestationCapability) = 4, TpmKeyWithTemporaryAttestationFailure (SmartCardCryptographicKeyAttestationStatus_TpmKeyWithTemporaryAttestationFailure) = 5, TpmKeyWithLongTermAttestationFailure (SmartCardCryptographicKeyAttestationStatus_TpmKeyWithLongTermAttestationFailure) = 6, TpmKeyWithAttestation (SmartCardCryptographicKeyAttestationStatus_TpmKeyWithAttestation) = 7,
 }}
-RT_ENUM! { enum SmartCardEmulationCategory: i32 {
+RT_ENUM! { enum SmartCardEmulationCategory: i32 ["Windows.Devices.SmartCards.SmartCardEmulationCategory"] {
     Other (SmartCardEmulationCategory_Other) = 0, Payment (SmartCardEmulationCategory_Payment) = 1,
 }}
-RT_ENUM! { enum SmartCardEmulationType: i32 {
+RT_ENUM! { enum SmartCardEmulationType: i32 ["Windows.Devices.SmartCards.SmartCardEmulationType"] {
     Host (SmartCardEmulationType_Host) = 0, Uicc (SmartCardEmulationType_Uicc) = 1, EmbeddedSE (SmartCardEmulationType_EmbeddedSE) = 2,
 }}
 DEFINE_IID!(IID_ISmartCardEmulator, 3753445042, 34654, 18405, 128, 119, 232, 191, 241, 177, 198, 251);
@@ -27704,7 +27704,7 @@ impl ISmartCardEmulator {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardEmulator: ISmartCardEmulator}
+RT_CLASS!{class SmartCardEmulator: ISmartCardEmulator ["Windows.Devices.SmartCards.SmartCardEmulator"]}
 impl RtActivatable<ISmartCardEmulatorStatics> for SmartCardEmulator {}
 impl RtActivatable<ISmartCardEmulatorStatics2> for SmartCardEmulator {}
 impl RtActivatable<ISmartCardEmulatorStatics3> for SmartCardEmulator {}
@@ -27798,7 +27798,7 @@ impl ISmartCardEmulatorApduReceivedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardEmulatorApduReceivedEventArgs: ISmartCardEmulatorApduReceivedEventArgs}
+RT_CLASS!{class SmartCardEmulatorApduReceivedEventArgs: ISmartCardEmulatorApduReceivedEventArgs ["Windows.Devices.SmartCards.SmartCardEmulatorApduReceivedEventArgs"]}
 DEFINE_IID!(IID_ISmartCardEmulatorApduReceivedEventArgs2, 2348367344, 8929, 16952, 134, 16, 148, 206, 74, 150, 84, 37);
 RT_INTERFACE!{interface ISmartCardEmulatorApduReceivedEventArgs2(ISmartCardEmulatorApduReceivedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardEmulatorApduReceivedEventArgs2] {
     fn get_State(&self, out: *mut u32) -> HRESULT,
@@ -27850,8 +27850,8 @@ impl ISmartCardEmulatorConnectionDeactivatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardEmulatorConnectionDeactivatedEventArgs: ISmartCardEmulatorConnectionDeactivatedEventArgs}
-RT_ENUM! { enum SmartCardEmulatorConnectionDeactivatedReason: i32 {
+RT_CLASS!{class SmartCardEmulatorConnectionDeactivatedEventArgs: ISmartCardEmulatorConnectionDeactivatedEventArgs ["Windows.Devices.SmartCards.SmartCardEmulatorConnectionDeactivatedEventArgs"]}
+RT_ENUM! { enum SmartCardEmulatorConnectionDeactivatedReason: i32 ["Windows.Devices.SmartCards.SmartCardEmulatorConnectionDeactivatedReason"] {
     ConnectionLost (SmartCardEmulatorConnectionDeactivatedReason_ConnectionLost) = 0, ConnectionRedirected (SmartCardEmulatorConnectionDeactivatedReason_ConnectionRedirected) = 1,
 }}
 DEFINE_IID!(IID_ISmartCardEmulatorConnectionProperties, 1311548910, 63849, 20605, 108, 249, 52, 226, 209, 141, 243, 17);
@@ -27871,11 +27871,11 @@ impl ISmartCardEmulatorConnectionProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardEmulatorConnectionProperties: ISmartCardEmulatorConnectionProperties}
-RT_ENUM! { enum SmartCardEmulatorConnectionSource: i32 {
+RT_CLASS!{class SmartCardEmulatorConnectionProperties: ISmartCardEmulatorConnectionProperties ["Windows.Devices.SmartCards.SmartCardEmulatorConnectionProperties"]}
+RT_ENUM! { enum SmartCardEmulatorConnectionSource: i32 ["Windows.Devices.SmartCards.SmartCardEmulatorConnectionSource"] {
     Unknown (SmartCardEmulatorConnectionSource_Unknown) = 0, NfcReader (SmartCardEmulatorConnectionSource_NfcReader) = 1,
 }}
-RT_ENUM! { enum SmartCardEmulatorEnablementPolicy: i32 {
+RT_ENUM! { enum SmartCardEmulatorEnablementPolicy: i32 ["Windows.Devices.SmartCards.SmartCardEmulatorEnablementPolicy"] {
     Never (SmartCardEmulatorEnablementPolicy_Never) = 0, Always (SmartCardEmulatorEnablementPolicy_Always) = 1, ScreenOn (SmartCardEmulatorEnablementPolicy_ScreenOn) = 2, ScreenUnlocked (SmartCardEmulatorEnablementPolicy_ScreenUnlocked) = 3,
 }}
 DEFINE_IID!(IID_ISmartCardEmulatorStatics, 2057043019, 50387, 18767, 184, 162, 98, 21, 216, 30, 133, 178);
@@ -27929,10 +27929,10 @@ impl ISmartCardEmulatorStatics3 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardLaunchBehavior: i32 {
+RT_ENUM! { enum SmartCardLaunchBehavior: i32 ["Windows.Devices.SmartCards.SmartCardLaunchBehavior"] {
     Default (SmartCardLaunchBehavior_Default) = 0, AboveLock (SmartCardLaunchBehavior_AboveLock) = 1,
 }}
-RT_ENUM! { enum SmartCardPinCharacterPolicyOption: i32 {
+RT_ENUM! { enum SmartCardPinCharacterPolicyOption: i32 ["Windows.Devices.SmartCards.SmartCardPinCharacterPolicyOption"] {
     Allow (SmartCardPinCharacterPolicyOption_Allow) = 0, RequireAtLeastOne (SmartCardPinCharacterPolicyOption_RequireAtLeastOne) = 1, Disallow (SmartCardPinCharacterPolicyOption_Disallow) = 2,
 }}
 DEFINE_IID!(IID_ISmartCardPinPolicy, 406643076, 19894, 18497, 172, 158, 42, 193, 243, 155, 115, 4);
@@ -28006,7 +28006,7 @@ impl ISmartCardPinPolicy {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardPinPolicy: ISmartCardPinPolicy}
+RT_CLASS!{class SmartCardPinPolicy: ISmartCardPinPolicy ["Windows.Devices.SmartCards.SmartCardPinPolicy"]}
 impl RtActivatable<IActivationFactory> for SmartCardPinPolicy {}
 DEFINE_CLSID!(SmartCardPinPolicy(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,80,105,110,80,111,108,105,99,121,0]) [CLSID_SmartCardPinPolicy]);
 DEFINE_IID!(IID_ISmartCardPinResetDeferral, 415845036, 30725, 16388, 133, 228, 187, 239, 172, 143, 104, 132);
@@ -28019,7 +28019,7 @@ impl ISmartCardPinResetDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardPinResetDeferral: ISmartCardPinResetDeferral}
+RT_CLASS!{class SmartCardPinResetDeferral: ISmartCardPinResetDeferral ["Windows.Devices.SmartCards.SmartCardPinResetDeferral"]}
 DEFINE_IID!(IID_SmartCardPinResetHandler, 328031808, 62396, 19036, 180, 29, 75, 78, 246, 132, 226, 55);
 RT_DELEGATE!{delegate SmartCardPinResetHandler(SmartCardPinResetHandlerVtbl, SmartCardPinResetHandlerImpl) [IID_SmartCardPinResetHandler] {
     fn Invoke(&self, sender: *mut SmartCardProvisioning, request: *mut SmartCardPinResetRequest) -> HRESULT
@@ -28058,7 +28058,7 @@ impl ISmartCardPinResetRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardPinResetRequest: ISmartCardPinResetRequest}
+RT_CLASS!{class SmartCardPinResetRequest: ISmartCardPinResetRequest ["Windows.Devices.SmartCards.SmartCardPinResetRequest"]}
 DEFINE_IID!(IID_ISmartCardProvisioning, 435088829, 8107, 18300, 183, 18, 26, 44, 90, 241, 253, 110);
 RT_INTERFACE!{interface ISmartCardProvisioning(ISmartCardProvisioningVtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardProvisioning] {
     fn get_SmartCard(&self, out: *mut *mut SmartCard) -> HRESULT,
@@ -28100,7 +28100,7 @@ impl ISmartCardProvisioning {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardProvisioning: ISmartCardProvisioning}
+RT_CLASS!{class SmartCardProvisioning: ISmartCardProvisioning ["Windows.Devices.SmartCards.SmartCardProvisioning"]}
 impl RtActivatable<ISmartCardProvisioningStatics> for SmartCardProvisioning {}
 impl RtActivatable<ISmartCardProvisioningStatics2> for SmartCardProvisioning {}
 impl SmartCardProvisioning {
@@ -28240,7 +28240,7 @@ impl ISmartCardReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardReader: ISmartCardReader}
+RT_CLASS!{class SmartCardReader: ISmartCardReader ["Windows.Devices.SmartCards.SmartCardReader"]}
 impl RtActivatable<ISmartCardReaderStatics> for SmartCardReader {}
 impl SmartCardReader {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -28254,7 +28254,7 @@ impl SmartCardReader {
     }
 }
 DEFINE_CLSID!(SmartCardReader(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,97,114,116,67,97,114,100,115,46,83,109,97,114,116,67,97,114,100,82,101,97,100,101,114,0]) [CLSID_SmartCardReader]);
-RT_ENUM! { enum SmartCardReaderKind: i32 {
+RT_ENUM! { enum SmartCardReaderKind: i32 ["Windows.Devices.SmartCards.SmartCardReaderKind"] {
     Any (SmartCardReaderKind_Any) = 0, Generic (SmartCardReaderKind_Generic) = 1, Tpm (SmartCardReaderKind_Tpm) = 2, Nfc (SmartCardReaderKind_Nfc) = 3, Uicc (SmartCardReaderKind_Uicc) = 4, EmbeddedSE (SmartCardReaderKind_EmbeddedSE) = 5,
 }}
 DEFINE_IID!(IID_ISmartCardReaderStatics, 272368865, 41418, 18674, 162, 129, 91, 111, 102, 154, 241, 7);
@@ -28280,10 +28280,10 @@ impl ISmartCardReaderStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardReaderStatus: i32 {
+RT_ENUM! { enum SmartCardReaderStatus: i32 ["Windows.Devices.SmartCards.SmartCardReaderStatus"] {
     Disconnected (SmartCardReaderStatus_Disconnected) = 0, Ready (SmartCardReaderStatus_Ready) = 1, Exclusive (SmartCardReaderStatus_Exclusive) = 2,
 }}
-RT_ENUM! { enum SmartCardStatus: i32 {
+RT_ENUM! { enum SmartCardStatus: i32 ["Windows.Devices.SmartCards.SmartCardStatus"] {
     Disconnected (SmartCardStatus_Disconnected) = 0, Ready (SmartCardStatus_Ready) = 1, Shared (SmartCardStatus_Shared) = 2, Exclusive (SmartCardStatus_Exclusive) = 3, Unresponsive (SmartCardStatus_Unresponsive) = 4,
 }}
 DEFINE_IID!(IID_ISmartCardTriggerDetails, 1604055326, 14831, 20267, 180, 79, 10, 145, 85, 177, 119, 188);
@@ -28309,7 +28309,7 @@ impl ISmartCardTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmartCardTriggerDetails: ISmartCardTriggerDetails}
+RT_CLASS!{class SmartCardTriggerDetails: ISmartCardTriggerDetails ["Windows.Devices.SmartCards.SmartCardTriggerDetails"]}
 DEFINE_IID!(IID_ISmartCardTriggerDetails2, 692438377, 35189, 19025, 158, 26, 95, 138, 118, 238, 81, 175);
 RT_INTERFACE!{interface ISmartCardTriggerDetails2(ISmartCardTriggerDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmartCardTriggerDetails2] {
     fn get_Emulator(&self, out: *mut *mut SmartCardEmulator) -> HRESULT,
@@ -28344,24 +28344,24 @@ impl ISmartCardTriggerDetails3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmartCardTriggerType: i32 {
+RT_ENUM! { enum SmartCardTriggerType: i32 ["Windows.Devices.SmartCards.SmartCardTriggerType"] {
     EmulatorTransaction (SmartCardTriggerType_EmulatorTransaction) = 0, EmulatorNearFieldEntry (SmartCardTriggerType_EmulatorNearFieldEntry) = 1, EmulatorNearFieldExit (SmartCardTriggerType_EmulatorNearFieldExit) = 2, EmulatorHostApplicationActivated (SmartCardTriggerType_EmulatorHostApplicationActivated) = 3, EmulatorAppletIdGroupRegistrationChanged (SmartCardTriggerType_EmulatorAppletIdGroupRegistrationChanged) = 4, ReaderCardAdded (SmartCardTriggerType_ReaderCardAdded) = 5,
 }}
-RT_ENUM! { enum SmartCardUnlockPromptingBehavior: i32 {
+RT_ENUM! { enum SmartCardUnlockPromptingBehavior: i32 ["Windows.Devices.SmartCards.SmartCardUnlockPromptingBehavior"] {
     AllowUnlockPrompt (SmartCardUnlockPromptingBehavior_AllowUnlockPrompt) = 0, RequireUnlockPrompt (SmartCardUnlockPromptingBehavior_RequireUnlockPrompt) = 1, PreventUnlockPrompt (SmartCardUnlockPromptingBehavior_PreventUnlockPrompt) = 2,
 }}
 } // Windows.Devices.SmartCards
 pub mod sms { // Windows.Devices.Sms
 use ::prelude::*;
-RT_ENUM! { enum CellularClass: i32 {
+RT_ENUM! { enum CellularClass: i32 ["Windows.Devices.Sms.CellularClass"] {
     None (CellularClass_None) = 0, Gsm (CellularClass_Gsm) = 1, Cdma (CellularClass_Cdma) = 2,
 }}
-RT_CLASS!{class DeleteSmsMessageOperation: foundation::IAsyncAction}
-RT_CLASS!{class DeleteSmsMessagesOperation: foundation::IAsyncAction}
-RT_CLASS!{class GetSmsDeviceOperation: foundation::IAsyncOperation<SmsDevice>}
-RT_CLASS!{class GetSmsMessageOperation: foundation::IAsyncOperation<ISmsMessage>}
-RT_CLASS!{class GetSmsMessagesOperation: foundation::IAsyncOperationWithProgress<foundation::collections::IVectorView<ISmsMessage>, i32>}
-RT_CLASS!{class SendSmsMessageOperation: foundation::IAsyncAction}
+RT_CLASS!{class DeleteSmsMessageOperation: foundation::IAsyncAction ["Windows.Devices.Sms.DeleteSmsMessageOperation"]}
+RT_CLASS!{class DeleteSmsMessagesOperation: foundation::IAsyncAction ["Windows.Devices.Sms.DeleteSmsMessagesOperation"]}
+RT_CLASS!{class GetSmsDeviceOperation: foundation::IAsyncOperation<SmsDevice> ["Windows.Devices.Sms.GetSmsDeviceOperation"]}
+RT_CLASS!{class GetSmsMessageOperation: foundation::IAsyncOperation<ISmsMessage> ["Windows.Devices.Sms.GetSmsMessageOperation"]}
+RT_CLASS!{class GetSmsMessagesOperation: foundation::IAsyncOperationWithProgress<foundation::collections::IVectorView<ISmsMessage>, i32> ["Windows.Devices.Sms.GetSmsMessagesOperation"]}
+RT_CLASS!{class SendSmsMessageOperation: foundation::IAsyncAction ["Windows.Devices.Sms.SendSmsMessageOperation"]}
 DEFINE_IID!(IID_ISmsAppMessage, 3904603284, 54176, 18954, 134, 215, 41, 16, 51, 168, 207, 84);
 RT_INTERFACE!{interface ISmsAppMessage(ISmsAppMessageVtbl): IInspectable(IInspectableVtbl) [IID_ISmsAppMessage] {
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -28489,7 +28489,7 @@ impl ISmsAppMessage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsAppMessage: ISmsAppMessage}
+RT_CLASS!{class SmsAppMessage: ISmsAppMessage ["Windows.Devices.Sms.SmsAppMessage"]}
 impl RtActivatable<IActivationFactory> for SmsAppMessage {}
 DEFINE_CLSID!(SmsAppMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,65,112,112,77,101,115,115,97,103,101,0]) [CLSID_SmsAppMessage]);
 DEFINE_IID!(IID_ISmsBinaryMessage, 1542776851, 15187, 19566, 182, 26, 216, 106, 99, 117, 86, 80);
@@ -28519,7 +28519,7 @@ impl ISmsBinaryMessage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsBinaryMessage: ISmsBinaryMessage}
+RT_CLASS!{class SmsBinaryMessage: ISmsBinaryMessage ["Windows.Devices.Sms.SmsBinaryMessage"]}
 impl RtActivatable<IActivationFactory> for SmsBinaryMessage {}
 DEFINE_CLSID!(SmsBinaryMessage(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,66,105,110,97,114,121,77,101,115,115,97,103,101,0]) [CLSID_SmsBinaryMessage]);
 DEFINE_IID!(IID_ISmsBroadcastMessage, 1974385649, 58551, 18548, 160, 156, 41, 86, 229, 146, 249, 87);
@@ -28587,11 +28587,11 @@ impl ISmsBroadcastMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsBroadcastMessage: ISmsBroadcastMessage}
-RT_ENUM! { enum SmsBroadcastType: i32 {
+RT_CLASS!{class SmsBroadcastMessage: ISmsBroadcastMessage ["Windows.Devices.Sms.SmsBroadcastMessage"]}
+RT_ENUM! { enum SmsBroadcastType: i32 ["Windows.Devices.Sms.SmsBroadcastType"] {
     Other (SmsBroadcastType_Other) = 0, CmasPresidential (SmsBroadcastType_CmasPresidential) = 1, CmasExtreme (SmsBroadcastType_CmasExtreme) = 2, CmasSevere (SmsBroadcastType_CmasSevere) = 3, CmasAmber (SmsBroadcastType_CmasAmber) = 4, CmasTest (SmsBroadcastType_CmasTest) = 5, EUAlert1 (SmsBroadcastType_EUAlert1) = 6, EUAlert2 (SmsBroadcastType_EUAlert2) = 7, EUAlert3 (SmsBroadcastType_EUAlert3) = 8, EUAlertAmber (SmsBroadcastType_EUAlertAmber) = 9, EUAlertInfo (SmsBroadcastType_EUAlertInfo) = 10, EtwsEarthquake (SmsBroadcastType_EtwsEarthquake) = 11, EtwsTsunami (SmsBroadcastType_EtwsTsunami) = 12, EtwsTsunamiAndEarthquake (SmsBroadcastType_EtwsTsunamiAndEarthquake) = 13, LatAlertLocal (SmsBroadcastType_LatAlertLocal) = 14,
 }}
-RT_ENUM! { enum SmsDataFormat: i32 {
+RT_ENUM! { enum SmsDataFormat: i32 ["Windows.Devices.Sms.SmsDataFormat"] {
     Unknown (SmsDataFormat_Unknown) = 0, CdmaSubmit (SmsDataFormat_CdmaSubmit) = 1, GsmSubmit (SmsDataFormat_GsmSubmit) = 2, CdmaDeliver (SmsDataFormat_CdmaDeliver) = 3, GsmDeliver (SmsDataFormat_GsmDeliver) = 4,
 }}
 DEFINE_IID!(IID_ISmsDevice, 152539629, 34603, 20204, 156, 114, 171, 17, 98, 123, 52, 236);
@@ -28657,7 +28657,7 @@ impl ISmsDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsDevice: ISmsDevice}
+RT_CLASS!{class SmsDevice: ISmsDevice ["Windows.Devices.Sms.SmsDevice"]}
 impl RtActivatable<ISmsDeviceStatics> for SmsDevice {}
 impl RtActivatable<ISmsDeviceStatics2> for SmsDevice {}
 impl SmsDevice {
@@ -28744,7 +28744,7 @@ impl ISmsDevice2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsDevice2: ISmsDevice2}
+RT_CLASS!{class SmsDevice2: ISmsDevice2 ["Windows.Devices.Sms.SmsDevice2"]}
 impl RtActivatable<ISmsDevice2Statics> for SmsDevice2 {}
 impl SmsDevice2 {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -28825,7 +28825,7 @@ impl ISmsDeviceMessageStore {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsDeviceMessageStore: ISmsDeviceMessageStore}
+RT_CLASS!{class SmsDeviceMessageStore: ISmsDeviceMessageStore ["Windows.Devices.Sms.SmsDeviceMessageStore"]}
 DEFINE_IID!(IID_ISmsDeviceStatics, 4169992170, 55317, 19921, 162, 52, 69, 32, 206, 70, 4, 164);
 RT_INTERFACE!{static interface ISmsDeviceStatics(ISmsDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISmsDeviceStatics] {
     fn GetDeviceSelector(&self, out: *mut HSTRING) -> HRESULT,
@@ -28860,7 +28860,7 @@ impl ISmsDeviceStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmsDeviceStatus: i32 {
+RT_ENUM! { enum SmsDeviceStatus: i32 ["Windows.Devices.Sms.SmsDeviceStatus"] {
     Off (SmsDeviceStatus_Off) = 0, Ready (SmsDeviceStatus_Ready) = 1, SimNotInserted (SmsDeviceStatus_SimNotInserted) = 2, BadSim (SmsDeviceStatus_BadSim) = 3, DeviceFailure (SmsDeviceStatus_DeviceFailure) = 4, SubscriptionNotActivated (SmsDeviceStatus_SubscriptionNotActivated) = 5, DeviceLocked (SmsDeviceStatus_DeviceLocked) = 6, DeviceBlocked (SmsDeviceStatus_DeviceBlocked) = 7,
 }}
 DEFINE_IID!(IID_SmsDeviceStatusChangedEventHandler, 2552959330, 15831, 17944, 175, 137, 12, 39, 45, 93, 6, 216);
@@ -28873,13 +28873,13 @@ impl SmsDeviceStatusChangedEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct SmsEncodedLength {
+RT_STRUCT! { struct SmsEncodedLength ["Windows.Devices.Sms.SmsEncodedLength"] {
     SegmentCount: u32, CharacterCountLastSegment: u32, CharactersPerSegment: u32, ByteCountLastSegment: u32, BytesPerSegment: u32,
 }}
-RT_ENUM! { enum SmsEncoding: i32 {
+RT_ENUM! { enum SmsEncoding: i32 ["Windows.Devices.Sms.SmsEncoding"] {
     Unknown (SmsEncoding_Unknown) = 0, Optimal (SmsEncoding_Optimal) = 1, SevenBitAscii (SmsEncoding_SevenBitAscii) = 2, Unicode (SmsEncoding_Unicode) = 3, GsmSevenBit (SmsEncoding_GsmSevenBit) = 4, EightBit (SmsEncoding_EightBit) = 5, Latin (SmsEncoding_Latin) = 6, Korean (SmsEncoding_Korean) = 7, IA5 (SmsEncoding_IA5) = 8, ShiftJis (SmsEncoding_ShiftJis) = 9, LatinHebrew (SmsEncoding_LatinHebrew) = 10,
 }}
-RT_ENUM! { enum SmsFilterActionType: i32 {
+RT_ENUM! { enum SmsFilterActionType: i32 ["Windows.Devices.Sms.SmsFilterActionType"] {
     AcceptImmediately (SmsFilterActionType_AcceptImmediately) = 0, Drop (SmsFilterActionType_Drop) = 1, Peek (SmsFilterActionType_Peek) = 2, Accept (SmsFilterActionType_Accept) = 3,
 }}
 DEFINE_IID!(IID_ISmsFilterRule, 1088630702, 45129, 20412, 175, 233, 226, 166, 16, 239, 245, 92);
@@ -28970,7 +28970,7 @@ impl ISmsFilterRule {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsFilterRule: ISmsFilterRule}
+RT_CLASS!{class SmsFilterRule: ISmsFilterRule ["Windows.Devices.Sms.SmsFilterRule"]}
 impl RtActivatable<ISmsFilterRuleFactory> for SmsFilterRule {}
 impl SmsFilterRule {
     #[inline] pub fn create_filter_rule(messageType: SmsMessageType) -> Result<ComPtr<SmsFilterRule>> {
@@ -29006,7 +29006,7 @@ impl ISmsFilterRules {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsFilterRules: ISmsFilterRules}
+RT_CLASS!{class SmsFilterRules: ISmsFilterRules ["Windows.Devices.Sms.SmsFilterRules"]}
 impl RtActivatable<ISmsFilterRulesFactory> for SmsFilterRules {}
 impl SmsFilterRules {
     #[inline] pub fn create_filter_rules(actionType: SmsFilterActionType) -> Result<ComPtr<SmsFilterRules>> {
@@ -29025,7 +29025,7 @@ impl ISmsFilterRulesFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmsGeographicalScope: i32 {
+RT_ENUM! { enum SmsGeographicalScope: i32 ["Windows.Devices.Sms.SmsGeographicalScope"] {
     None (SmsGeographicalScope_None) = 0, CellWithImmediateDisplay (SmsGeographicalScope_CellWithImmediateDisplay) = 1, LocationArea (SmsGeographicalScope_LocationArea) = 2, Plmn (SmsGeographicalScope_Plmn) = 3, Cell (SmsGeographicalScope_Cell) = 4,
 }}
 DEFINE_IID!(IID_ISmsMessage, 3980156456, 27012, 19207, 129, 29, 141, 89, 6, 237, 60, 234);
@@ -29080,10 +29080,10 @@ impl ISmsMessageBase {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmsMessageClass: i32 {
+RT_ENUM! { enum SmsMessageClass: i32 ["Windows.Devices.Sms.SmsMessageClass"] {
     None (SmsMessageClass_None) = 0, Class0 (SmsMessageClass_Class0) = 1, Class1 (SmsMessageClass_Class1) = 2, Class2 (SmsMessageClass_Class2) = 3, Class3 (SmsMessageClass_Class3) = 4,
 }}
-RT_ENUM! { enum SmsMessageFilter: i32 {
+RT_ENUM! { enum SmsMessageFilter: i32 ["Windows.Devices.Sms.SmsMessageFilter"] {
     All (SmsMessageFilter_All) = 0, Unread (SmsMessageFilter_Unread) = 1, Read (SmsMessageFilter_Read) = 2, Sent (SmsMessageFilter_Sent) = 3, Draft (SmsMessageFilter_Draft) = 4,
 }}
 DEFINE_IID!(IID_ISmsMessageReceivedEventArgs, 149424792, 47333, 16833, 163, 216, 211, 171, 250, 226, 38, 117);
@@ -29103,7 +29103,7 @@ impl ISmsMessageReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsMessageReceivedEventArgs: ISmsMessageReceivedEventArgs}
+RT_CLASS!{class SmsMessageReceivedEventArgs: ISmsMessageReceivedEventArgs ["Windows.Devices.Sms.SmsMessageReceivedEventArgs"]}
 DEFINE_IID!(IID_SmsMessageReceivedEventHandler, 192599049, 60461, 18382, 162, 83, 115, 43, 238, 235, 202, 205);
 RT_DELEGATE!{delegate SmsMessageReceivedEventHandler(SmsMessageReceivedEventHandlerVtbl, SmsMessageReceivedEventHandlerImpl) [IID_SmsMessageReceivedEventHandler] {
     fn Invoke(&self, sender: *mut SmsDevice, e: *mut SmsMessageReceivedEventArgs) -> HRESULT
@@ -29171,7 +29171,7 @@ impl ISmsMessageReceivedTriggerDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsMessageReceivedTriggerDetails: ISmsMessageReceivedTriggerDetails}
+RT_CLASS!{class SmsMessageReceivedTriggerDetails: ISmsMessageReceivedTriggerDetails ["Windows.Devices.Sms.SmsMessageReceivedTriggerDetails"]}
 DEFINE_IID!(IID_ISmsMessageRegistration, 387993662, 62287, 17515, 131, 179, 15, 241, 153, 35, 180, 9);
 RT_INTERFACE!{interface ISmsMessageRegistration(ISmsMessageRegistrationVtbl): IInspectable(IInspectableVtbl) [IID_ISmsMessageRegistration] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -29199,7 +29199,7 @@ impl ISmsMessageRegistration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsMessageRegistration: ISmsMessageRegistration}
+RT_CLASS!{class SmsMessageRegistration: ISmsMessageRegistration ["Windows.Devices.Sms.SmsMessageRegistration"]}
 impl RtActivatable<ISmsMessageRegistrationStatics> for SmsMessageRegistration {}
 impl SmsMessageRegistration {
     #[inline] pub fn get_all_registrations() -> Result<Option<ComPtr<foundation::collections::IVectorView<SmsMessageRegistration>>>> {
@@ -29227,10 +29227,10 @@ impl ISmsMessageRegistrationStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SmsMessageType: i32 {
+RT_ENUM! { enum SmsMessageType: i32 ["Windows.Devices.Sms.SmsMessageType"] {
     Binary (SmsMessageType_Binary) = 0, Text (SmsMessageType_Text) = 1, Wap (SmsMessageType_Wap) = 2, App (SmsMessageType_App) = 3, Broadcast (SmsMessageType_Broadcast) = 4, Voicemail (SmsMessageType_Voicemail) = 5, Status (SmsMessageType_Status) = 6,
 }}
-RT_ENUM! { enum SmsModemErrorCode: i32 {
+RT_ENUM! { enum SmsModemErrorCode: i32 ["Windows.Devices.Sms.SmsModemErrorCode"] {
     Other (SmsModemErrorCode_Other) = 0, MessagingNetworkError (SmsModemErrorCode_MessagingNetworkError) = 1, SmsOperationNotSupportedByDevice (SmsModemErrorCode_SmsOperationNotSupportedByDevice) = 2, SmsServiceNotSupportedByNetwork (SmsModemErrorCode_SmsServiceNotSupportedByNetwork) = 3, DeviceFailure (SmsModemErrorCode_DeviceFailure) = 4, MessageNotEncodedProperly (SmsModemErrorCode_MessageNotEncodedProperly) = 5, MessageTooLarge (SmsModemErrorCode_MessageTooLarge) = 6, DeviceNotReady (SmsModemErrorCode_DeviceNotReady) = 7, NetworkNotReady (SmsModemErrorCode_NetworkNotReady) = 8, InvalidSmscAddress (SmsModemErrorCode_InvalidSmscAddress) = 9, NetworkFailure (SmsModemErrorCode_NetworkFailure) = 10, FixedDialingNumberRestricted (SmsModemErrorCode_FixedDialingNumberRestricted) = 11,
 }}
 DEFINE_IID!(IID_ISmsReceivedEventDetails, 1538592533, 58477, 19586, 132, 125, 90, 3, 4, 193, 213, 61);
@@ -29250,7 +29250,7 @@ impl ISmsReceivedEventDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsReceivedEventDetails: ISmsReceivedEventDetails}
+RT_CLASS!{class SmsReceivedEventDetails: ISmsReceivedEventDetails ["Windows.Devices.Sms.SmsReceivedEventDetails"]}
 DEFINE_IID!(IID_ISmsReceivedEventDetails2, 1088445574, 42932, 18289, 154, 231, 11, 95, 251, 18, 192, 58);
 RT_INTERFACE!{interface ISmsReceivedEventDetails2(ISmsReceivedEventDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_ISmsReceivedEventDetails2] {
     fn get_MessageClass(&self, out: *mut SmsMessageClass) -> HRESULT,
@@ -29315,7 +29315,7 @@ impl ISmsSendMessageResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsSendMessageResult: ISmsSendMessageResult}
+RT_CLASS!{class SmsSendMessageResult: ISmsSendMessageResult ["Windows.Devices.Sms.SmsSendMessageResult"]}
 DEFINE_IID!(IID_ISmsStatusMessage, 3872555842, 46859, 18039, 147, 121, 201, 120, 63, 223, 248, 244);
 RT_INTERFACE!{interface ISmsStatusMessage(ISmsStatusMessageVtbl): IInspectable(IInspectableVtbl) [IID_ISmsStatusMessage] {
     fn get_To(&self, out: *mut HSTRING) -> HRESULT,
@@ -29363,7 +29363,7 @@ impl ISmsStatusMessage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsStatusMessage: ISmsStatusMessage}
+RT_CLASS!{class SmsStatusMessage: ISmsStatusMessage ["Windows.Devices.Sms.SmsStatusMessage"]}
 DEFINE_IID!(IID_ISmsTextMessage, 3592196172, 42133, 18559, 154, 111, 151, 21, 72, 197, 188, 159);
 RT_INTERFACE!{interface ISmsTextMessage(ISmsTextMessageVtbl): IInspectable(IInspectableVtbl) [IID_ISmsTextMessage] {
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -29443,7 +29443,7 @@ impl ISmsTextMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsTextMessage: ISmsTextMessage}
+RT_CLASS!{class SmsTextMessage: ISmsTextMessage ["Windows.Devices.Sms.SmsTextMessage"]}
 impl RtActivatable<ISmsTextMessageStatics> for SmsTextMessage {}
 impl RtActivatable<IActivationFactory> for SmsTextMessage {}
 impl SmsTextMessage {
@@ -29550,7 +29550,7 @@ impl ISmsTextMessage2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsTextMessage2: ISmsTextMessage2}
+RT_CLASS!{class SmsTextMessage2: ISmsTextMessage2 ["Windows.Devices.Sms.SmsTextMessage2"]}
 impl RtActivatable<IActivationFactory> for SmsTextMessage2 {}
 DEFINE_CLSID!(SmsTextMessage2(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,83,109,115,46,83,109,115,84,101,120,116,77,101,115,115,97,103,101,50,0]) [CLSID_SmsTextMessage2]);
 DEFINE_IID!(IID_ISmsTextMessageStatics, 2137572845, 15564, 18339, 140, 85, 56, 13, 59, 1, 8, 146);
@@ -29599,7 +29599,7 @@ impl ISmsVoicemailMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsVoicemailMessage: ISmsVoicemailMessage}
+RT_CLASS!{class SmsVoicemailMessage: ISmsVoicemailMessage ["Windows.Devices.Sms.SmsVoicemailMessage"]}
 DEFINE_IID!(IID_ISmsWapMessage, 3448993603, 31317, 19771, 144, 33, 242, 46, 2, 45, 9, 197);
 RT_INTERFACE!{interface ISmsWapMessage(ISmsWapMessageVtbl): IInspectable(IInspectableVtbl) [IID_ISmsWapMessage] {
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -29648,7 +29648,7 @@ impl ISmsWapMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SmsWapMessage: ISmsWapMessage}
+RT_CLASS!{class SmsWapMessage: ISmsWapMessage ["Windows.Devices.Sms.SmsWapMessage"]}
 } // Windows.Devices.Sms
 pub mod spi { // Windows.Devices.Spi
 use ::prelude::*;
@@ -29681,7 +29681,7 @@ impl ISpiBusInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpiBusInfo: ISpiBusInfo}
+RT_CLASS!{class SpiBusInfo: ISpiBusInfo ["Windows.Devices.Spi.SpiBusInfo"]}
 DEFINE_IID!(IID_ISpiConnectionSettings, 1384358783, 63797, 19359, 167, 167, 58, 120, 144, 175, 165, 206);
 RT_INTERFACE!{interface ISpiConnectionSettings(ISpiConnectionSettingsVtbl): IInspectable(IInspectableVtbl) [IID_ISpiConnectionSettings] {
     fn get_ChipSelectLine(&self, out: *mut i32) -> HRESULT,
@@ -29742,7 +29742,7 @@ impl ISpiConnectionSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpiConnectionSettings: ISpiConnectionSettings}
+RT_CLASS!{class SpiConnectionSettings: ISpiConnectionSettings ["Windows.Devices.Spi.SpiConnectionSettings"]}
 impl RtActivatable<ISpiConnectionSettingsFactory> for SpiConnectionSettings {}
 impl SpiConnectionSettings {
     #[inline] pub fn create(chipSelectLine: i32) -> Result<ComPtr<SpiConnectionSettings>> {
@@ -29772,7 +29772,7 @@ impl ISpiController {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpiController: ISpiController}
+RT_CLASS!{class SpiController: ISpiController ["Windows.Devices.Spi.SpiController"]}
 impl RtActivatable<ISpiControllerStatics> for SpiController {}
 impl SpiController {
     #[inline] pub fn get_default_async() -> Result<ComPtr<foundation::IAsyncOperation<SpiController>>> {
@@ -29837,7 +29837,7 @@ impl ISpiDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpiDevice: ISpiDevice}
+RT_CLASS!{class SpiDevice: ISpiDevice ["Windows.Devices.Spi.SpiDevice"]}
 impl RtActivatable<ISpiDeviceStatics> for SpiDevice {}
 impl SpiDevice {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -29883,10 +29883,10 @@ impl ISpiDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpiMode: i32 {
+RT_ENUM! { enum SpiMode: i32 ["Windows.Devices.Spi.SpiMode"] {
     Mode0 (SpiMode_Mode0) = 0, Mode1 (SpiMode_Mode1) = 1, Mode2 (SpiMode_Mode2) = 2, Mode3 (SpiMode_Mode3) = 3,
 }}
-RT_ENUM! { enum SpiSharingMode: i32 {
+RT_ENUM! { enum SpiSharingMode: i32 ["Windows.Devices.Spi.SpiSharingMode"] {
     Exclusive (SpiSharingMode_Exclusive) = 0, Shared (SpiSharingMode_Shared) = 1,
 }}
 pub mod provider { // Windows.Devices.Spi.Provider
@@ -29951,7 +29951,7 @@ impl IProviderSpiConnectionSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProviderSpiConnectionSettings: IProviderSpiConnectionSettings}
+RT_CLASS!{class ProviderSpiConnectionSettings: IProviderSpiConnectionSettings ["Windows.Devices.Spi.Provider.ProviderSpiConnectionSettings"]}
 impl RtActivatable<IProviderSpiConnectionSettingsFactory> for ProviderSpiConnectionSettings {}
 impl ProviderSpiConnectionSettings {
     #[inline] pub fn create(chipSelectLine: i32) -> Result<ComPtr<ProviderSpiConnectionSettings>> {
@@ -29970,10 +29970,10 @@ impl IProviderSpiConnectionSettingsFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProviderSpiMode: i32 {
+RT_ENUM! { enum ProviderSpiMode: i32 ["Windows.Devices.Spi.Provider.ProviderSpiMode"] {
     Mode0 (ProviderSpiMode_Mode0) = 0, Mode1 (ProviderSpiMode_Mode1) = 1, Mode2 (ProviderSpiMode_Mode2) = 2, Mode3 (ProviderSpiMode_Mode3) = 3,
 }}
-RT_ENUM! { enum ProviderSpiSharingMode: i32 {
+RT_ENUM! { enum ProviderSpiSharingMode: i32 ["Windows.Devices.Spi.Provider.ProviderSpiSharingMode"] {
     Exclusive (ProviderSpiSharingMode_Exclusive) = 0, Shared (ProviderSpiSharingMode_Shared) = 1,
 }}
 DEFINE_IID!(IID_ISpiControllerProvider, 3244844292, 718, 16934, 163, 133, 79, 17, 251, 4, 180, 27);
@@ -30062,7 +30062,7 @@ impl IUsbBulkInEndpointDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbBulkInEndpointDescriptor: IUsbBulkInEndpointDescriptor}
+RT_CLASS!{class UsbBulkInEndpointDescriptor: IUsbBulkInEndpointDescriptor ["Windows.Devices.Usb.UsbBulkInEndpointDescriptor"]}
 DEFINE_IID!(IID_IUsbBulkInPipe, 4028443963, 17736, 19792, 179, 38, 216, 44, 218, 190, 18, 32);
 RT_INTERFACE!{interface IUsbBulkInPipe(IUsbBulkInPipeVtbl): IInspectable(IInspectableVtbl) [IID_IUsbBulkInPipe] {
     fn get_MaxTransferSizeBytes(&self, out: *mut u32) -> HRESULT,
@@ -30108,7 +30108,7 @@ impl IUsbBulkInPipe {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbBulkInPipe: IUsbBulkInPipe}
+RT_CLASS!{class UsbBulkInPipe: IUsbBulkInPipe ["Windows.Devices.Usb.UsbBulkInPipe"]}
 DEFINE_IID!(IID_IUsbBulkOutEndpointDescriptor, 673219706, 65518, 20320, 155, 225, 149, 108, 172, 62, 203, 101);
 RT_INTERFACE!{interface IUsbBulkOutEndpointDescriptor(IUsbBulkOutEndpointDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IUsbBulkOutEndpointDescriptor] {
     fn get_MaxPacketSize(&self, out: *mut u32) -> HRESULT,
@@ -30132,7 +30132,7 @@ impl IUsbBulkOutEndpointDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbBulkOutEndpointDescriptor: IUsbBulkOutEndpointDescriptor}
+RT_CLASS!{class UsbBulkOutEndpointDescriptor: IUsbBulkOutEndpointDescriptor ["Windows.Devices.Usb.UsbBulkOutEndpointDescriptor"]}
 DEFINE_IID!(IID_IUsbBulkOutPipe, 2833903214, 277, 17834, 139, 33, 55, 178, 37, 188, 206, 231);
 RT_INTERFACE!{interface IUsbBulkOutPipe(IUsbBulkOutPipeVtbl): IInspectable(IInspectableVtbl) [IID_IUsbBulkOutPipe] {
     fn get_EndpointDescriptor(&self, out: *mut *mut UsbBulkOutEndpointDescriptor) -> HRESULT,
@@ -30167,7 +30167,7 @@ impl IUsbBulkOutPipe {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbBulkOutPipe: IUsbBulkOutPipe}
+RT_CLASS!{class UsbBulkOutPipe: IUsbBulkOutPipe ["Windows.Devices.Usb.UsbBulkOutPipe"]}
 DEFINE_IID!(IID_IUsbConfiguration, 1746367529, 13993, 18135, 184, 115, 252, 104, 146, 81, 236, 48);
 RT_INTERFACE!{interface IUsbConfiguration(IUsbConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IUsbConfiguration] {
     fn get_UsbInterfaces(&self, out: *mut *mut foundation::collections::IVectorView<UsbInterface>) -> HRESULT,
@@ -30191,7 +30191,7 @@ impl IUsbConfiguration {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbConfiguration: IUsbConfiguration}
+RT_CLASS!{class UsbConfiguration: IUsbConfiguration ["Windows.Devices.Usb.UsbConfiguration"]}
 DEFINE_IID!(IID_IUsbConfigurationDescriptor, 4061621650, 46146, 16506, 130, 7, 125, 100, 108, 3, 133, 243);
 RT_INTERFACE!{interface IUsbConfigurationDescriptor(IUsbConfigurationDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IUsbConfigurationDescriptor] {
     fn get_ConfigurationValue(&self, out: *mut u8) -> HRESULT,
@@ -30221,7 +30221,7 @@ impl IUsbConfigurationDescriptor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbConfigurationDescriptor: IUsbConfigurationDescriptor}
+RT_CLASS!{class UsbConfigurationDescriptor: IUsbConfigurationDescriptor ["Windows.Devices.Usb.UsbConfigurationDescriptor"]}
 impl RtActivatable<IUsbConfigurationDescriptorStatics> for UsbConfigurationDescriptor {}
 impl UsbConfigurationDescriptor {
     #[inline] pub fn try_parse(descriptor: &UsbDescriptor) -> Result<(Option<ComPtr<UsbConfigurationDescriptor>>, bool)> {
@@ -30249,7 +30249,7 @@ impl IUsbConfigurationDescriptorStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UsbControlRecipient: i32 {
+RT_ENUM! { enum UsbControlRecipient: i32 ["Windows.Devices.Usb.UsbControlRecipient"] {
     Device (UsbControlRecipient_Device) = 0, SpecifiedInterface (UsbControlRecipient_SpecifiedInterface) = 1, Endpoint (UsbControlRecipient_Endpoint) = 2, Other (UsbControlRecipient_Other) = 3, DefaultInterface (UsbControlRecipient_DefaultInterface) = 4,
 }}
 DEFINE_IID!(IID_IUsbControlRequestType, 2392090022, 55101, 18142, 148, 190, 170, 231, 240, 124, 15, 92);
@@ -30301,10 +30301,10 @@ impl IUsbControlRequestType {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbControlRequestType: IUsbControlRequestType}
+RT_CLASS!{class UsbControlRequestType: IUsbControlRequestType ["Windows.Devices.Usb.UsbControlRequestType"]}
 impl RtActivatable<IActivationFactory> for UsbControlRequestType {}
 DEFINE_CLSID!(UsbControlRequestType(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,67,111,110,116,114,111,108,82,101,113,117,101,115,116,84,121,112,101,0]) [CLSID_UsbControlRequestType]);
-RT_ENUM! { enum UsbControlTransferType: i32 {
+RT_ENUM! { enum UsbControlTransferType: i32 ["Windows.Devices.Usb.UsbControlTransferType"] {
     Standard (UsbControlTransferType_Standard) = 0, Class (UsbControlTransferType_Class) = 1, Vendor (UsbControlTransferType_Vendor) = 2,
 }}
 DEFINE_IID!(IID_IUsbDescriptor, 176812566, 24477, 18548, 137, 4, 218, 154, 211, 245, 82, 143);
@@ -30329,7 +30329,7 @@ impl IUsbDescriptor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbDescriptor: IUsbDescriptor}
+RT_CLASS!{class UsbDescriptor: IUsbDescriptor ["Windows.Devices.Usb.UsbDescriptor"]}
 DEFINE_IID!(IID_IUsbDevice, 1380563346, 50262, 17621, 173, 94, 36, 245, 160, 137, 246, 59);
 RT_INTERFACE!{interface IUsbDevice(IUsbDeviceVtbl): IInspectable(IInspectableVtbl) [IID_IUsbDevice] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -30380,7 +30380,7 @@ impl IUsbDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbDevice: IUsbDevice}
+RT_CLASS!{class UsbDevice: IUsbDevice ["Windows.Devices.Usb.UsbDevice"]}
 impl RtActivatable<IUsbDeviceStatics> for UsbDevice {}
 impl UsbDevice {
     #[inline] pub fn get_device_selector(vendorId: u32, productId: u32, winUsbInterfaceClass: Guid) -> Result<HString> {
@@ -30438,14 +30438,14 @@ impl IUsbDeviceClass {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbDeviceClass: IUsbDeviceClass}
+RT_CLASS!{class UsbDeviceClass: IUsbDeviceClass ["Windows.Devices.Usb.UsbDeviceClass"]}
 impl RtActivatable<IActivationFactory> for UsbDeviceClass {}
 DEFINE_CLSID!(UsbDeviceClass(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,85,115,98,46,85,115,98,68,101,118,105,99,101,67,108,97,115,115,0]) [CLSID_UsbDeviceClass]);
 DEFINE_IID!(IID_IUsbDeviceClasses, 1752143197, 39826, 19248, 151, 129, 194, 44, 85, 172, 53, 203);
 RT_INTERFACE!{interface IUsbDeviceClasses(IUsbDeviceClassesVtbl): IInspectable(IInspectableVtbl) [IID_IUsbDeviceClasses] {
     
 }}
-RT_CLASS!{class UsbDeviceClasses: IUsbDeviceClasses}
+RT_CLASS!{class UsbDeviceClasses: IUsbDeviceClasses ["Windows.Devices.Usb.UsbDeviceClasses"]}
 impl RtActivatable<IUsbDeviceClassesStatics> for UsbDeviceClasses {}
 impl UsbDeviceClasses {
     #[inline] pub fn get_cdc_control() -> Result<Option<ComPtr<UsbDeviceClass>>> {
@@ -30577,7 +30577,7 @@ impl IUsbDeviceDescriptor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbDeviceDescriptor: IUsbDeviceDescriptor}
+RT_CLASS!{class UsbDeviceDescriptor: IUsbDeviceDescriptor ["Windows.Devices.Usb.UsbDeviceDescriptor"]}
 DEFINE_IID!(IID_IUsbDeviceStatics, 107709858, 2487, 17478, 133, 2, 111, 230, 220, 170, 115, 9);
 RT_INTERFACE!{static interface IUsbDeviceStatics(IUsbDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUsbDeviceStatics] {
     fn GetDeviceSelector(&self, vendorId: u32, productId: u32, winUsbInterfaceClass: Guid, out: *mut HSTRING) -> HRESULT,
@@ -30660,7 +30660,7 @@ impl IUsbEndpointDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbEndpointDescriptor: IUsbEndpointDescriptor}
+RT_CLASS!{class UsbEndpointDescriptor: IUsbEndpointDescriptor ["Windows.Devices.Usb.UsbEndpointDescriptor"]}
 impl RtActivatable<IUsbEndpointDescriptorStatics> for UsbEndpointDescriptor {}
 impl UsbEndpointDescriptor {
     #[inline] pub fn try_parse(descriptor: &UsbDescriptor) -> Result<(Option<ComPtr<UsbEndpointDescriptor>>, bool)> {
@@ -30688,7 +30688,7 @@ impl IUsbEndpointDescriptorStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UsbEndpointType: i32 {
+RT_ENUM! { enum UsbEndpointType: i32 ["Windows.Devices.Usb.UsbEndpointType"] {
     Control (UsbEndpointType_Control) = 0, Isochronous (UsbEndpointType_Isochronous) = 1, Bulk (UsbEndpointType_Bulk) = 2, Interrupt (UsbEndpointType_Interrupt) = 3,
 }}
 DEFINE_IID!(IID_IUsbInterface, 2687642517, 32583, 18603, 167, 39, 103, 140, 37, 190, 33, 18);
@@ -30738,7 +30738,7 @@ impl IUsbInterface {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterface: IUsbInterface}
+RT_CLASS!{class UsbInterface: IUsbInterface ["Windows.Devices.Usb.UsbInterface"]}
 DEFINE_IID!(IID_IUsbInterfaceDescriptor, 429289671, 47086, 20368, 140, 213, 148, 162, 226, 87, 89, 138);
 RT_INTERFACE!{interface IUsbInterfaceDescriptor(IUsbInterfaceDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterfaceDescriptor] {
     fn get_ClassCode(&self, out: *mut u8) -> HRESULT,
@@ -30774,7 +30774,7 @@ impl IUsbInterfaceDescriptor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterfaceDescriptor: IUsbInterfaceDescriptor}
+RT_CLASS!{class UsbInterfaceDescriptor: IUsbInterfaceDescriptor ["Windows.Devices.Usb.UsbInterfaceDescriptor"]}
 impl RtActivatable<IUsbInterfaceDescriptorStatics> for UsbInterfaceDescriptor {}
 impl UsbInterfaceDescriptor {
     #[inline] pub fn try_parse(descriptor: &UsbDescriptor) -> Result<(Option<ComPtr<UsbInterfaceDescriptor>>, bool)> {
@@ -30855,7 +30855,7 @@ impl IUsbInterfaceSetting {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterfaceSetting: IUsbInterfaceSetting}
+RT_CLASS!{class UsbInterfaceSetting: IUsbInterfaceSetting ["Windows.Devices.Usb.UsbInterfaceSetting"]}
 DEFINE_IID!(IID_IUsbInterruptInEndpointDescriptor, 3226634599, 51473, 19514, 134, 178, 65, 156, 45, 168, 144, 57);
 RT_INTERFACE!{interface IUsbInterruptInEndpointDescriptor(IUsbInterruptInEndpointDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterruptInEndpointDescriptor] {
     fn get_MaxPacketSize(&self, out: *mut u32) -> HRESULT,
@@ -30885,7 +30885,7 @@ impl IUsbInterruptInEndpointDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterruptInEndpointDescriptor: IUsbInterruptInEndpointDescriptor}
+RT_CLASS!{class UsbInterruptInEndpointDescriptor: IUsbInterruptInEndpointDescriptor ["Windows.Devices.Usb.UsbInterruptInEndpointDescriptor"]}
 DEFINE_IID!(IID_IUsbInterruptInEventArgs, 3081781394, 5144, 18742, 130, 9, 41, 156, 245, 96, 85, 131);
 RT_INTERFACE!{interface IUsbInterruptInEventArgs(IUsbInterruptInEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterruptInEventArgs] {
     #[cfg(feature="windows-storage")] fn get_InterruptData(&self, out: *mut *mut super::super::storage::streams::IBuffer) -> HRESULT
@@ -30897,7 +30897,7 @@ impl IUsbInterruptInEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterruptInEventArgs: IUsbInterruptInEventArgs}
+RT_CLASS!{class UsbInterruptInEventArgs: IUsbInterruptInEventArgs ["Windows.Devices.Usb.UsbInterruptInEventArgs"]}
 DEFINE_IID!(IID_IUsbInterruptInPipe, 4194332950, 34007, 18631, 138, 63, 76, 11, 35, 95, 46, 166);
 RT_INTERFACE!{interface IUsbInterruptInPipe(IUsbInterruptInPipeVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterruptInPipe] {
     fn get_EndpointDescriptor(&self, out: *mut *mut UsbInterruptInEndpointDescriptor) -> HRESULT,
@@ -30926,7 +30926,7 @@ impl IUsbInterruptInPipe {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterruptInPipe: IUsbInterruptInPipe}
+RT_CLASS!{class UsbInterruptInPipe: IUsbInterruptInPipe ["Windows.Devices.Usb.UsbInterruptInPipe"]}
 DEFINE_IID!(IID_IUsbInterruptOutEndpointDescriptor, 3433033089, 4298, 17715, 149, 45, 158, 39, 131, 65, 232, 15);
 RT_INTERFACE!{interface IUsbInterruptOutEndpointDescriptor(IUsbInterruptOutEndpointDescriptorVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterruptOutEndpointDescriptor] {
     fn get_MaxPacketSize(&self, out: *mut u32) -> HRESULT,
@@ -30956,7 +30956,7 @@ impl IUsbInterruptOutEndpointDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterruptOutEndpointDescriptor: IUsbInterruptOutEndpointDescriptor}
+RT_CLASS!{class UsbInterruptOutEndpointDescriptor: IUsbInterruptOutEndpointDescriptor ["Windows.Devices.Usb.UsbInterruptOutEndpointDescriptor"]}
 DEFINE_IID!(IID_IUsbInterruptOutPipe, 3917793449, 43769, 18896, 185, 108, 246, 97, 171, 74, 127, 149);
 RT_INTERFACE!{interface IUsbInterruptOutPipe(IUsbInterruptOutPipeVtbl): IInspectable(IInspectableVtbl) [IID_IUsbInterruptOutPipe] {
     fn get_EndpointDescriptor(&self, out: *mut *mut UsbInterruptOutEndpointDescriptor) -> HRESULT,
@@ -30991,8 +30991,8 @@ impl IUsbInterruptOutPipe {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbInterruptOutPipe: IUsbInterruptOutPipe}
-RT_ENUM! { enum UsbReadOptions: u32 {
+RT_CLASS!{class UsbInterruptOutPipe: IUsbInterruptOutPipe ["Windows.Devices.Usb.UsbInterruptOutPipe"]}
+RT_ENUM! { enum UsbReadOptions: u32 ["Windows.Devices.Usb.UsbReadOptions"] {
     None (UsbReadOptions_None) = 0, AutoClearStall (UsbReadOptions_AutoClearStall) = 1, OverrideAutomaticBufferManagement (UsbReadOptions_OverrideAutomaticBufferManagement) = 2, IgnoreShortPacket (UsbReadOptions_IgnoreShortPacket) = 4, AllowPartialReads (UsbReadOptions_AllowPartialReads) = 8,
 }}
 DEFINE_IID!(IID_IUsbSetupPacket, 273391922, 51087, 19537, 182, 84, 228, 157, 2, 242, 203, 3);
@@ -31055,7 +31055,7 @@ impl IUsbSetupPacket {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UsbSetupPacket: IUsbSetupPacket}
+RT_CLASS!{class UsbSetupPacket: IUsbSetupPacket ["Windows.Devices.Usb.UsbSetupPacket"]}
 impl RtActivatable<IUsbSetupPacketFactory> for UsbSetupPacket {}
 impl RtActivatable<IActivationFactory> for UsbSetupPacket {}
 impl UsbSetupPacket {
@@ -31075,16 +31075,16 @@ impl IUsbSetupPacketFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UsbTransferDirection: i32 {
+RT_ENUM! { enum UsbTransferDirection: i32 ["Windows.Devices.Usb.UsbTransferDirection"] {
     Out (UsbTransferDirection_Out) = 0, In (UsbTransferDirection_In) = 1,
 }}
-RT_ENUM! { enum UsbWriteOptions: u32 {
+RT_ENUM! { enum UsbWriteOptions: u32 ["Windows.Devices.Usb.UsbWriteOptions"] {
     None (UsbWriteOptions_None) = 0, AutoClearStall (UsbWriteOptions_AutoClearStall) = 1, ShortPacketTerminate (UsbWriteOptions_ShortPacketTerminate) = 2,
 }}
 } // Windows.Devices.Usb
 pub mod wifi { // Windows.Devices.WiFi
 use ::prelude::*;
-RT_ENUM! { enum WiFiAccessStatus: i32 {
+RT_ENUM! { enum WiFiAccessStatus: i32 ["Windows.Devices.WiFi.WiFiAccessStatus"] {
     Unspecified (WiFiAccessStatus_Unspecified) = 0, Allowed (WiFiAccessStatus_Allowed) = 1, DeniedByUser (WiFiAccessStatus_DeniedByUser) = 2, DeniedBySystem (WiFiAccessStatus_DeniedBySystem) = 3,
 }}
 DEFINE_IID!(IID_IWiFiAdapter, 2797921315, 15733, 17316, 185, 222, 17, 226, 107, 114, 217, 176);
@@ -31147,7 +31147,7 @@ impl IWiFiAdapter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiAdapter: IWiFiAdapter}
+RT_CLASS!{class WiFiAdapter: IWiFiAdapter ["Windows.Devices.WiFi.WiFiAdapter"]}
 impl RtActivatable<IWiFiAdapterStatics> for WiFiAdapter {}
 impl WiFiAdapter {
     #[inline] pub fn find_all_adapters_async() -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<WiFiAdapter>>>> {
@@ -31282,8 +31282,8 @@ impl IWiFiAvailableNetwork {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiAvailableNetwork: IWiFiAvailableNetwork}
-RT_ENUM! { enum WiFiConnectionMethod: i32 {
+RT_CLASS!{class WiFiAvailableNetwork: IWiFiAvailableNetwork ["Windows.Devices.WiFi.WiFiAvailableNetwork"]}
+RT_ENUM! { enum WiFiConnectionMethod: i32 ["Windows.Devices.WiFi.WiFiConnectionMethod"] {
     Default (WiFiConnectionMethod_Default) = 0, WpsPin (WiFiConnectionMethod_WpsPin) = 1, WpsPushButton (WiFiConnectionMethod_WpsPushButton) = 2,
 }}
 DEFINE_IID!(IID_IWiFiConnectionResult, 339468249, 50045, 16574, 165, 200, 133, 123, 206, 133, 169, 49);
@@ -31297,11 +31297,11 @@ impl IWiFiConnectionResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiConnectionResult: IWiFiConnectionResult}
-RT_ENUM! { enum WiFiConnectionStatus: i32 {
+RT_CLASS!{class WiFiConnectionResult: IWiFiConnectionResult ["Windows.Devices.WiFi.WiFiConnectionResult"]}
+RT_ENUM! { enum WiFiConnectionStatus: i32 ["Windows.Devices.WiFi.WiFiConnectionStatus"] {
     UnspecifiedFailure (WiFiConnectionStatus_UnspecifiedFailure) = 0, Success (WiFiConnectionStatus_Success) = 1, AccessRevoked (WiFiConnectionStatus_AccessRevoked) = 2, InvalidCredential (WiFiConnectionStatus_InvalidCredential) = 3, NetworkNotAvailable (WiFiConnectionStatus_NetworkNotAvailable) = 4, Timeout (WiFiConnectionStatus_Timeout) = 5, UnsupportedAuthenticationProtocol (WiFiConnectionStatus_UnsupportedAuthenticationProtocol) = 6,
 }}
-RT_ENUM! { enum WiFiNetworkKind: i32 {
+RT_ENUM! { enum WiFiNetworkKind: i32 ["Windows.Devices.WiFi.WiFiNetworkKind"] {
     Any (WiFiNetworkKind_Any) = 0, Infrastructure (WiFiNetworkKind_Infrastructure) = 1, Adhoc (WiFiNetworkKind_Adhoc) = 2,
 }}
 DEFINE_IID!(IID_IWiFiNetworkReport, 2502221522, 22801, 17502, 129, 148, 190, 79, 26, 112, 72, 149);
@@ -31321,11 +31321,11 @@ impl IWiFiNetworkReport {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiNetworkReport: IWiFiNetworkReport}
-RT_ENUM! { enum WiFiPhyKind: i32 {
+RT_CLASS!{class WiFiNetworkReport: IWiFiNetworkReport ["Windows.Devices.WiFi.WiFiNetworkReport"]}
+RT_ENUM! { enum WiFiPhyKind: i32 ["Windows.Devices.WiFi.WiFiPhyKind"] {
     Unknown (WiFiPhyKind_Unknown) = 0, Fhss (WiFiPhyKind_Fhss) = 1, Dsss (WiFiPhyKind_Dsss) = 2, IRBaseband (WiFiPhyKind_IRBaseband) = 3, Ofdm (WiFiPhyKind_Ofdm) = 4, Hrdsss (WiFiPhyKind_Hrdsss) = 5, Erp (WiFiPhyKind_Erp) = 6, HT (WiFiPhyKind_HT) = 7, Vht (WiFiPhyKind_Vht) = 8, Dmg (WiFiPhyKind_Dmg) = 9, HE (WiFiPhyKind_HE) = 10,
 }}
-RT_ENUM! { enum WiFiReconnectionKind: i32 {
+RT_ENUM! { enum WiFiReconnectionKind: i32 ["Windows.Devices.WiFi.WiFiReconnectionKind"] {
     Automatic (WiFiReconnectionKind_Automatic) = 0, Manual (WiFiReconnectionKind_Manual) = 1,
 }}
 DEFINE_IID!(IID_IWiFiWpsConfigurationResult, 1739888753, 6126, 17105, 177, 79, 90, 17, 241, 34, 111, 181);
@@ -31345,11 +31345,11 @@ impl IWiFiWpsConfigurationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiWpsConfigurationResult: IWiFiWpsConfigurationResult}
-RT_ENUM! { enum WiFiWpsConfigurationStatus: i32 {
+RT_CLASS!{class WiFiWpsConfigurationResult: IWiFiWpsConfigurationResult ["Windows.Devices.WiFi.WiFiWpsConfigurationResult"]}
+RT_ENUM! { enum WiFiWpsConfigurationStatus: i32 ["Windows.Devices.WiFi.WiFiWpsConfigurationStatus"] {
     UnspecifiedFailure (WiFiWpsConfigurationStatus_UnspecifiedFailure) = 0, Success (WiFiWpsConfigurationStatus_Success) = 1, Timeout (WiFiWpsConfigurationStatus_Timeout) = 2,
 }}
-RT_ENUM! { enum WiFiWpsKind: i32 {
+RT_ENUM! { enum WiFiWpsKind: i32 ["Windows.Devices.WiFi.WiFiWpsKind"] {
     Unknown (WiFiWpsKind_Unknown) = 0, Pin (WiFiWpsKind_Pin) = 1, PushButton (WiFiWpsKind_PushButton) = 2, Nfc (WiFiWpsKind_Nfc) = 3, Ethernet (WiFiWpsKind_Ethernet) = 4, Usb (WiFiWpsKind_Usb) = 5,
 }}
 } // Windows.Devices.WiFi
@@ -31399,7 +31399,7 @@ impl IWiFiDirectAdvertisement {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectAdvertisement: IWiFiDirectAdvertisement}
+RT_CLASS!{class WiFiDirectAdvertisement: IWiFiDirectAdvertisement ["Windows.Devices.WiFiDirect.WiFiDirectAdvertisement"]}
 DEFINE_IID!(IID_IWiFiDirectAdvertisement2, 3076106822, 55318, 18715, 145, 122, 180, 13, 125, 196, 3, 162);
 RT_INTERFACE!{interface IWiFiDirectAdvertisement2(IWiFiDirectAdvertisement2Vtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectAdvertisement2] {
     fn get_SupportedConfigurationMethods(&self, out: *mut *mut foundation::collections::IVector<WiFiDirectConfigurationMethod>) -> HRESULT
@@ -31411,7 +31411,7 @@ impl IWiFiDirectAdvertisement2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WiFiDirectAdvertisementListenStateDiscoverability: i32 {
+RT_ENUM! { enum WiFiDirectAdvertisementListenStateDiscoverability: i32 ["Windows.Devices.WiFiDirect.WiFiDirectAdvertisementListenStateDiscoverability"] {
     None (WiFiDirectAdvertisementListenStateDiscoverability_None) = 0, Normal (WiFiDirectAdvertisementListenStateDiscoverability_Normal) = 1, Intensive (WiFiDirectAdvertisementListenStateDiscoverability_Intensive) = 2,
 }}
 DEFINE_IID!(IID_IWiFiDirectAdvertisementPublisher, 3009031450, 39711, 17881, 146, 90, 105, 77, 102, 223, 104, 239);
@@ -31452,10 +31452,10 @@ impl IWiFiDirectAdvertisementPublisher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectAdvertisementPublisher: IWiFiDirectAdvertisementPublisher}
+RT_CLASS!{class WiFiDirectAdvertisementPublisher: IWiFiDirectAdvertisementPublisher ["Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisher"]}
 impl RtActivatable<IActivationFactory> for WiFiDirectAdvertisementPublisher {}
 DEFINE_CLSID!(WiFiDirectAdvertisementPublisher(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,65,100,118,101,114,116,105,115,101,109,101,110,116,80,117,98,108,105,115,104,101,114,0]) [CLSID_WiFiDirectAdvertisementPublisher]);
-RT_ENUM! { enum WiFiDirectAdvertisementPublisherStatus: i32 {
+RT_ENUM! { enum WiFiDirectAdvertisementPublisherStatus: i32 ["Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisherStatus"] {
     Created (WiFiDirectAdvertisementPublisherStatus_Created) = 0, Started (WiFiDirectAdvertisementPublisherStatus_Started) = 1, Stopped (WiFiDirectAdvertisementPublisherStatus_Stopped) = 2, Aborted (WiFiDirectAdvertisementPublisherStatus_Aborted) = 3,
 }}
 DEFINE_IID!(IID_IWiFiDirectAdvertisementPublisherStatusChangedEventArgs, 2868766012, 21633, 18150, 144, 221, 50, 17, 101, 24, 241, 146);
@@ -31475,8 +31475,8 @@ impl IWiFiDirectAdvertisementPublisherStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectAdvertisementPublisherStatusChangedEventArgs: IWiFiDirectAdvertisementPublisherStatusChangedEventArgs}
-RT_ENUM! { enum WiFiDirectConfigurationMethod: i32 {
+RT_CLASS!{class WiFiDirectAdvertisementPublisherStatusChangedEventArgs: IWiFiDirectAdvertisementPublisherStatusChangedEventArgs ["Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisherStatusChangedEventArgs"]}
+RT_ENUM! { enum WiFiDirectConfigurationMethod: i32 ["Windows.Devices.WiFiDirect.WiFiDirectConfigurationMethod"] {
     ProvidePin (WiFiDirectConfigurationMethod_ProvidePin) = 0, DisplayPin (WiFiDirectConfigurationMethod_DisplayPin) = 1, PushButton (WiFiDirectConfigurationMethod_PushButton) = 2,
 }}
 DEFINE_IID!(IID_IWiFiDirectConnectionListener, 1771838221, 36115, 20201, 185, 236, 156, 114, 248, 37, 31, 125);
@@ -31495,7 +31495,7 @@ impl IWiFiDirectConnectionListener {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectConnectionListener: IWiFiDirectConnectionListener}
+RT_CLASS!{class WiFiDirectConnectionListener: IWiFiDirectConnectionListener ["Windows.Devices.WiFiDirect.WiFiDirectConnectionListener"]}
 impl RtActivatable<IActivationFactory> for WiFiDirectConnectionListener {}
 DEFINE_CLSID!(WiFiDirectConnectionListener(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,67,111,110,110,101,99,116,105,111,110,76,105,115,116,101,110,101,114,0]) [CLSID_WiFiDirectConnectionListener]);
 DEFINE_IID!(IID_IWiFiDirectConnectionParameters, 3001373701, 22274, 19222, 160, 44, 187, 205, 33, 239, 96, 152);
@@ -31514,7 +31514,7 @@ impl IWiFiDirectConnectionParameters {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectConnectionParameters: IWiFiDirectConnectionParameters}
+RT_CLASS!{class WiFiDirectConnectionParameters: IWiFiDirectConnectionParameters ["Windows.Devices.WiFiDirect.WiFiDirectConnectionParameters"]}
 impl RtActivatable<IWiFiDirectConnectionParametersStatics> for WiFiDirectConnectionParameters {}
 impl RtActivatable<IActivationFactory> for WiFiDirectConnectionParameters {}
 impl WiFiDirectConnectionParameters {
@@ -31567,7 +31567,7 @@ impl IWiFiDirectConnectionRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectConnectionRequest: IWiFiDirectConnectionRequest}
+RT_CLASS!{class WiFiDirectConnectionRequest: IWiFiDirectConnectionRequest ["Windows.Devices.WiFiDirect.WiFiDirectConnectionRequest"]}
 DEFINE_IID!(IID_IWiFiDirectConnectionRequestedEventArgs, 4187824318, 54157, 18511, 130, 21, 231, 182, 90, 191, 36, 76);
 RT_INTERFACE!{interface IWiFiDirectConnectionRequestedEventArgs(IWiFiDirectConnectionRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectConnectionRequestedEventArgs] {
     fn GetConnectionRequest(&self, out: *mut *mut WiFiDirectConnectionRequest) -> HRESULT
@@ -31579,8 +31579,8 @@ impl IWiFiDirectConnectionRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectConnectionRequestedEventArgs: IWiFiDirectConnectionRequestedEventArgs}
-RT_ENUM! { enum WiFiDirectConnectionStatus: i32 {
+RT_CLASS!{class WiFiDirectConnectionRequestedEventArgs: IWiFiDirectConnectionRequestedEventArgs ["Windows.Devices.WiFiDirect.WiFiDirectConnectionRequestedEventArgs"]}
+RT_ENUM! { enum WiFiDirectConnectionStatus: i32 ["Windows.Devices.WiFiDirect.WiFiDirectConnectionStatus"] {
     Disconnected (WiFiDirectConnectionStatus_Disconnected) = 0, Connected (WiFiDirectConnectionStatus_Connected) = 1,
 }}
 DEFINE_IID!(IID_IWiFiDirectDevice, 1927195304, 29419, 19886, 138, 40, 133, 19, 53, 93, 39, 119);
@@ -31617,7 +31617,7 @@ impl IWiFiDirectDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectDevice: IWiFiDirectDevice}
+RT_CLASS!{class WiFiDirectDevice: IWiFiDirectDevice ["Windows.Devices.WiFiDirect.WiFiDirectDevice"]}
 impl RtActivatable<IWiFiDirectDeviceStatics> for WiFiDirectDevice {}
 impl RtActivatable<IWiFiDirectDeviceStatics2> for WiFiDirectDevice {}
 impl WiFiDirectDevice {
@@ -31635,7 +31635,7 @@ impl WiFiDirectDevice {
     }
 }
 DEFINE_CLSID!(WiFiDirectDevice(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,87,105,70,105,68,105,114,101,99,116,68,101,118,105,99,101,0]) [CLSID_WiFiDirectDevice]);
-RT_ENUM! { enum WiFiDirectDeviceSelectorType: i32 {
+RT_ENUM! { enum WiFiDirectDeviceSelectorType: i32 ["Windows.Devices.WiFiDirect.WiFiDirectDeviceSelectorType"] {
     DeviceInterface (WiFiDirectDeviceSelectorType_DeviceInterface) = 0, AssociationEndpoint (WiFiDirectDeviceSelectorType_AssociationEndpoint) = 1,
 }}
 DEFINE_IID!(IID_IWiFiDirectDeviceStatics, 3899438460, 15020, 18513, 167, 146, 72, 42, 175, 147, 27, 4);
@@ -31672,7 +31672,7 @@ impl IWiFiDirectDeviceStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WiFiDirectError: i32 {
+RT_ENUM! { enum WiFiDirectError: i32 ["Windows.Devices.WiFiDirect.WiFiDirectError"] {
     Success (WiFiDirectError_Success) = 0, RadioNotAvailable (WiFiDirectError_RadioNotAvailable) = 1, ResourceInUse (WiFiDirectError_ResourceInUse) = 2,
 }}
 DEFINE_IID!(IID_IWiFiDirectInformationElement, 2952491734, 30395, 18814, 172, 139, 220, 114, 131, 139, 195, 9);
@@ -31713,7 +31713,7 @@ impl IWiFiDirectInformationElement {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectInformationElement: IWiFiDirectInformationElement}
+RT_CLASS!{class WiFiDirectInformationElement: IWiFiDirectInformationElement ["Windows.Devices.WiFiDirect.WiFiDirectInformationElement"]}
 impl RtActivatable<IWiFiDirectInformationElementStatics> for WiFiDirectInformationElement {}
 impl RtActivatable<IActivationFactory> for WiFiDirectInformationElement {}
 impl WiFiDirectInformationElement {
@@ -31781,8 +31781,8 @@ impl IWiFiDirectLegacySettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectLegacySettings: IWiFiDirectLegacySettings}
-RT_ENUM! { enum WiFiDirectPairingProcedure: i32 {
+RT_CLASS!{class WiFiDirectLegacySettings: IWiFiDirectLegacySettings ["Windows.Devices.WiFiDirect.WiFiDirectLegacySettings"]}
+RT_ENUM! { enum WiFiDirectPairingProcedure: i32 ["Windows.Devices.WiFiDirect.WiFiDirectPairingProcedure"] {
     GroupOwnerNegotiation (WiFiDirectPairingProcedure_GroupOwnerNegotiation) = 0, Invitation (WiFiDirectPairingProcedure_Invitation) = 1,
 }}
 pub mod services { // Windows.Devices.WiFiDirect.Services
@@ -31864,7 +31864,7 @@ impl IWiFiDirectService {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectService: IWiFiDirectService}
+RT_CLASS!{class WiFiDirectService: IWiFiDirectService ["Windows.Devices.WiFiDirect.Services.WiFiDirectService"]}
 impl RtActivatable<IWiFiDirectServiceStatics> for WiFiDirectService {}
 impl WiFiDirectService {
     #[inline] pub fn get_selector(serviceName: &HStringArg) -> Result<HString> {
@@ -31878,7 +31878,7 @@ impl WiFiDirectService {
     }
 }
 DEFINE_CLSID!(WiFiDirectService(&[87,105,110,100,111,119,115,46,68,101,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,46,83,101,114,118,105,99,101,115,46,87,105,70,105,68,105,114,101,99,116,83,101,114,118,105,99,101,0]) [CLSID_WiFiDirectService]);
-RT_ENUM! { enum WiFiDirectServiceAdvertisementStatus: i32 {
+RT_ENUM! { enum WiFiDirectServiceAdvertisementStatus: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertisementStatus"] {
     Created (WiFiDirectServiceAdvertisementStatus_Created) = 0, Started (WiFiDirectServiceAdvertisementStatus_Started) = 1, Stopped (WiFiDirectServiceAdvertisementStatus_Stopped) = 2, Aborted (WiFiDirectServiceAdvertisementStatus_Aborted) = 3,
 }}
 DEFINE_IID!(IID_IWiFiDirectServiceAdvertiser, 2762612449, 40335, 20303, 147, 238, 125, 222, 162, 227, 127, 70);
@@ -32041,7 +32041,7 @@ impl IWiFiDirectServiceAdvertiser {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceAdvertiser: IWiFiDirectServiceAdvertiser}
+RT_CLASS!{class WiFiDirectServiceAdvertiser: IWiFiDirectServiceAdvertiser ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser"]}
 impl RtActivatable<IWiFiDirectServiceAdvertiserFactory> for WiFiDirectServiceAdvertiser {}
 impl WiFiDirectServiceAdvertiser {
     #[inline] pub fn create_wi_fi_direct_service_advertiser(serviceName: &HStringArg) -> Result<ComPtr<WiFiDirectServiceAdvertiser>> {
@@ -32077,14 +32077,14 @@ impl IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceAutoAcceptSessionConnectedEventArgs: IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs}
-RT_ENUM! { enum WiFiDirectServiceConfigurationMethod: i32 {
+RT_CLASS!{class WiFiDirectServiceAutoAcceptSessionConnectedEventArgs: IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAutoAcceptSessionConnectedEventArgs"]}
+RT_ENUM! { enum WiFiDirectServiceConfigurationMethod: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceConfigurationMethod"] {
     Default (WiFiDirectServiceConfigurationMethod_Default) = 0, PinDisplay (WiFiDirectServiceConfigurationMethod_PinDisplay) = 1, PinEntry (WiFiDirectServiceConfigurationMethod_PinEntry) = 2,
 }}
-RT_ENUM! { enum WiFiDirectServiceError: i32 {
+RT_ENUM! { enum WiFiDirectServiceError: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceError"] {
     Success (WiFiDirectServiceError_Success) = 0, RadioNotAvailable (WiFiDirectServiceError_RadioNotAvailable) = 1, ResourceInUse (WiFiDirectServiceError_ResourceInUse) = 2, UnsupportedHardware (WiFiDirectServiceError_UnsupportedHardware) = 3, NoHardware (WiFiDirectServiceError_NoHardware) = 4,
 }}
-RT_ENUM! { enum WiFiDirectServiceIPProtocol: i32 {
+RT_ENUM! { enum WiFiDirectServiceIPProtocol: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceIPProtocol"] {
     Tcp (WiFiDirectServiceIPProtocol_Tcp) = 6, Udp (WiFiDirectServiceIPProtocol_Udp) = 17,
 }}
 DEFINE_IID!(IID_IWiFiDirectServiceProvisioningInfo, 2346417406, 38873, 17826, 142, 153, 219, 80, 145, 15, 182, 166);
@@ -32104,7 +32104,7 @@ impl IWiFiDirectServiceProvisioningInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceProvisioningInfo: IWiFiDirectServiceProvisioningInfo}
+RT_CLASS!{class WiFiDirectServiceProvisioningInfo: IWiFiDirectServiceProvisioningInfo ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceProvisioningInfo"]}
 DEFINE_IID!(IID_IWiFiDirectServiceRemotePortAddedEventArgs, 3570318017, 16339, 20238, 183, 189, 120, 41, 6, 244, 68, 17);
 RT_INTERFACE!{interface IWiFiDirectServiceRemotePortAddedEventArgs(IWiFiDirectServiceRemotePortAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceRemotePortAddedEventArgs] {
     #[cfg(not(feature="windows-networking"))] fn __Dummy0(&self) -> (),
@@ -32123,7 +32123,7 @@ impl IWiFiDirectServiceRemotePortAddedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceRemotePortAddedEventArgs: IWiFiDirectServiceRemotePortAddedEventArgs}
+RT_CLASS!{class WiFiDirectServiceRemotePortAddedEventArgs: IWiFiDirectServiceRemotePortAddedEventArgs ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceRemotePortAddedEventArgs"]}
 DEFINE_IID!(IID_IWiFiDirectServiceSession, 2165580131, 58406, 18379, 134, 64, 225, 179, 88, 139, 242, 111);
 RT_INTERFACE!{interface IWiFiDirectServiceSession(IWiFiDirectServiceSessionVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceSession] {
     fn get_ServiceName(&self, out: *mut HSTRING) -> HRESULT,
@@ -32214,7 +32214,7 @@ impl IWiFiDirectServiceSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceSession: IWiFiDirectServiceSession}
+RT_CLASS!{class WiFiDirectServiceSession: IWiFiDirectServiceSession ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession"]}
 DEFINE_IID!(IID_IWiFiDirectServiceSessionDeferredEventArgs, 2382109055, 4609, 20255, 182, 244, 93, 241, 183, 185, 251, 46);
 RT_INTERFACE!{interface IWiFiDirectServiceSessionDeferredEventArgs(IWiFiDirectServiceSessionDeferredEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceSessionDeferredEventArgs] {
     #[cfg(feature="windows-storage")] fn get_DeferredSessionInfo(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IBuffer) -> HRESULT
@@ -32226,8 +32226,8 @@ impl IWiFiDirectServiceSessionDeferredEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceSessionDeferredEventArgs: IWiFiDirectServiceSessionDeferredEventArgs}
-RT_ENUM! { enum WiFiDirectServiceSessionErrorStatus: i32 {
+RT_CLASS!{class WiFiDirectServiceSessionDeferredEventArgs: IWiFiDirectServiceSessionDeferredEventArgs ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionDeferredEventArgs"]}
+RT_ENUM! { enum WiFiDirectServiceSessionErrorStatus: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionErrorStatus"] {
     Ok (WiFiDirectServiceSessionErrorStatus_Ok) = 0, Disassociated (WiFiDirectServiceSessionErrorStatus_Disassociated) = 1, LocalClose (WiFiDirectServiceSessionErrorStatus_LocalClose) = 2, RemoteClose (WiFiDirectServiceSessionErrorStatus_RemoteClose) = 3, SystemFailure (WiFiDirectServiceSessionErrorStatus_SystemFailure) = 4, NoResponseFromRemote (WiFiDirectServiceSessionErrorStatus_NoResponseFromRemote) = 5,
 }}
 DEFINE_IID!(IID_IWiFiDirectServiceSessionRequest, 2699197579, 20683, 19032, 155, 207, 228, 114, 185, 159, 186, 4);
@@ -32253,7 +32253,7 @@ impl IWiFiDirectServiceSessionRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceSessionRequest: IWiFiDirectServiceSessionRequest}
+RT_CLASS!{class WiFiDirectServiceSessionRequest: IWiFiDirectServiceSessionRequest ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest"]}
 DEFINE_IID!(IID_IWiFiDirectServiceSessionRequestedEventArgs, 1958595601, 21462, 18841, 180, 248, 108, 142, 204, 23, 113, 231);
 RT_INTERFACE!{interface IWiFiDirectServiceSessionRequestedEventArgs(IWiFiDirectServiceSessionRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWiFiDirectServiceSessionRequestedEventArgs] {
     fn GetSessionRequest(&self, out: *mut *mut WiFiDirectServiceSessionRequest) -> HRESULT
@@ -32265,8 +32265,8 @@ impl IWiFiDirectServiceSessionRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WiFiDirectServiceSessionRequestedEventArgs: IWiFiDirectServiceSessionRequestedEventArgs}
-RT_ENUM! { enum WiFiDirectServiceSessionStatus: i32 {
+RT_CLASS!{class WiFiDirectServiceSessionRequestedEventArgs: IWiFiDirectServiceSessionRequestedEventArgs ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequestedEventArgs"]}
+RT_ENUM! { enum WiFiDirectServiceSessionStatus: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionStatus"] {
     Closed (WiFiDirectServiceSessionStatus_Closed) = 0, Initiated (WiFiDirectServiceSessionStatus_Initiated) = 1, Requested (WiFiDirectServiceSessionStatus_Requested) = 2, Open (WiFiDirectServiceSessionStatus_Open) = 3,
 }}
 DEFINE_IID!(IID_IWiFiDirectServiceStatics, 2108948549, 64884, 18056, 183, 37, 93, 206, 134, 172, 242, 51);
@@ -32293,7 +32293,7 @@ impl IWiFiDirectServiceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WiFiDirectServiceStatus: i32 {
+RT_ENUM! { enum WiFiDirectServiceStatus: i32 ["Windows.Devices.WiFiDirect.Services.WiFiDirectServiceStatus"] {
     Available (WiFiDirectServiceStatus_Available) = 0, Busy (WiFiDirectServiceStatus_Busy) = 1, Custom (WiFiDirectServiceStatus_Custom) = 2,
 }}
 } // Windows.Devices.WiFiDirect.Services

--- a/src/rt/gen/windows/foundation.rs
+++ b/src/rt/gen/windows/foundation.rs
@@ -200,7 +200,7 @@ impl<TResult: RtType, TProgress: RtType> AsyncOperationWithProgressCompletedHand
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AsyncStatus: i32 {
+RT_ENUM! { enum AsyncStatus: i32 ["Windows.Foundation.AsyncStatus"] {
     Canceled (AsyncStatus_Canceled) = 2, Completed (AsyncStatus_Completed) = 1, Error (AsyncStatus_Error) = 3, Started (AsyncStatus_Started) = 0,
 }}
 DEFINE_IID!(IID_IClosable, 819308585, 32676, 16422, 131, 187, 215, 91, 174, 78, 169, 158);
@@ -213,7 +213,7 @@ impl IClosable {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct DateTime {
+RT_STRUCT! { struct DateTime ["Windows.Foundation.DateTime"] {
     UniversalTime: i64,
 }}
 DEFINE_IID!(IID_IDeferral, 3592853298, 15231, 18087, 180, 11, 79, 220, 162, 162, 198, 147);
@@ -226,7 +226,7 @@ impl IDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Deferral: IDeferral}
+RT_CLASS!{class Deferral: IDeferral ["Windows.Foundation.Deferral"]}
 impl RtActivatable<IDeferralFactory> for Deferral {}
 impl Deferral {
     #[inline] pub fn create(handler: &DeferralCompletedHandler) -> Result<ComPtr<Deferral>> {
@@ -265,7 +265,7 @@ impl<T: RtType> EventHandler<T> {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct EventRegistrationToken {
+RT_STRUCT! { struct EventRegistrationToken ["Windows.Foundation.EventRegistrationToken"] {
     Value: i64,
 }}
 DEFINE_IID!(IID_IGetActivationFactory, 1323011810, 38621, 18855, 148, 247, 70, 7, 221, 171, 142, 60);
@@ -316,7 +316,7 @@ impl IGuidHelperStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct HResult {
+RT_STRUCT! { struct HResult ["Windows.Foundation.HResult"] {
     Value: i32,
 }}
 DEFINE_IID!(IID_IMemoryBuffer, 4223982890, 9307, 4580, 175, 152, 104, 148, 35, 38, 12, 248);
@@ -330,7 +330,7 @@ impl IMemoryBuffer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MemoryBuffer: IMemoryBuffer}
+RT_CLASS!{class MemoryBuffer: IMemoryBuffer ["Windows.Foundation.MemoryBuffer"]}
 impl RtActivatable<IMemoryBufferFactory> for MemoryBuffer {}
 impl MemoryBuffer {
     #[inline] pub fn create(capacity: u32) -> Result<ComPtr<MemoryBuffer>> {
@@ -371,10 +371,10 @@ impl IMemoryBufferReference {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct Point {
+RT_STRUCT! { struct Point ["Windows.Foundation.Point"] {
     X: f32, Y: f32,
 }}
-RT_ENUM! { enum PropertyType: i32 {
+RT_ENUM! { enum PropertyType: i32 ["Windows.Foundation.PropertyType"] {
     Empty (PropertyType_Empty) = 0, UInt8 (PropertyType_UInt8) = 1, Int16 (PropertyType_Int16) = 2, UInt16 (PropertyType_UInt16) = 3, Int32 (PropertyType_Int32) = 4, UInt32 (PropertyType_UInt32) = 5, Int64 (PropertyType_Int64) = 6, UInt64 (PropertyType_UInt64) = 7, Single (PropertyType_Single) = 8, Double (PropertyType_Double) = 9, Char16 (PropertyType_Char16) = 10, Boolean (PropertyType_Boolean) = 11, String (PropertyType_String) = 12, Inspectable (PropertyType_Inspectable) = 13, DateTime (PropertyType_DateTime) = 14, TimeSpan (PropertyType_TimeSpan) = 15, Guid (PropertyType_Guid) = 16, Point (PropertyType_Point) = 17, Size (PropertyType_Size) = 18, Rect (PropertyType_Rect) = 19, OtherType (PropertyType_OtherType) = 20, UInt8Array (PropertyType_UInt8Array) = 1025, Int16Array (PropertyType_Int16Array) = 1026, UInt16Array (PropertyType_UInt16Array) = 1027, Int32Array (PropertyType_Int32Array) = 1028, UInt32Array (PropertyType_UInt32Array) = 1029, Int64Array (PropertyType_Int64Array) = 1030, UInt64Array (PropertyType_UInt64Array) = 1031, SingleArray (PropertyType_SingleArray) = 1032, DoubleArray (PropertyType_DoubleArray) = 1033, Char16Array (PropertyType_Char16Array) = 1034, BooleanArray (PropertyType_BooleanArray) = 1035, StringArray (PropertyType_StringArray) = 1036, InspectableArray (PropertyType_InspectableArray) = 1037, DateTimeArray (PropertyType_DateTimeArray) = 1038, TimeSpanArray (PropertyType_TimeSpanArray) = 1039, GuidArray (PropertyType_GuidArray) = 1040, PointArray (PropertyType_PointArray) = 1041, SizeArray (PropertyType_SizeArray) = 1042, RectArray (PropertyType_RectArray) = 1043, OtherTypeArray (PropertyType_OtherTypeArray) = 1044,
 }}
 DEFINE_IID!(IID_IPropertyValue, 1272349405, 30036, 16617, 154, 155, 130, 101, 78, 222, 126, 98);
@@ -977,7 +977,7 @@ impl IPropertyValueStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct Rect {
+RT_STRUCT! { struct Rect ["Windows.Foundation.Rect"] {
     X: f32, Y: f32, Width: f32, Height: f32,
 }}
 DEFINE_IID!(IID_IReference, 1640068870, 11621, 4576, 154, 232, 212, 133, 100, 1, 84, 114);
@@ -1002,7 +1002,7 @@ impl<T: RtType> IReferenceArray<T> {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct Size {
+RT_STRUCT! { struct Size ["Windows.Foundation.Size"] {
     Width: f32, Height: f32,
 }}
 DEFINE_IID!(IID_IStringable, 2520162132, 36534, 18672, 171, 206, 193, 178, 17, 230, 39, 195);
@@ -1016,7 +1016,7 @@ impl IStringable {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct TimeSpan {
+RT_STRUCT! { struct TimeSpan ["Windows.Foundation.TimeSpan"] {
     Duration: i64,
 }}
 DEFINE_IID!(IID_TypedEventHandler, 2648818996, 27361, 4576, 132, 225, 24, 169, 5, 188, 197, 63);
@@ -1029,7 +1029,7 @@ impl<TSender: RtType, TResult: RtType> TypedEventHandler<TSender, TResult> {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Uri: IUriRuntimeClass}
+RT_CLASS!{class Uri: IUriRuntimeClass ["Windows.Foundation.Uri"]}
 impl RtActivatable<IUriRuntimeClassFactory> for Uri {}
 impl RtActivatable<IUriEscapeStatics> for Uri {}
 impl Uri {
@@ -1205,7 +1205,7 @@ impl IUriRuntimeClassWithAbsoluteCanonicalUri {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WwwFormUrlDecoder: IWwwFormUrlDecoderRuntimeClass}
+RT_CLASS!{class WwwFormUrlDecoder: IWwwFormUrlDecoderRuntimeClass ["Windows.Foundation.WwwFormUrlDecoder"]}
 impl RtActivatable<IWwwFormUrlDecoderRuntimeClassFactory> for WwwFormUrlDecoder {}
 impl WwwFormUrlDecoder {
     #[inline] pub fn create_www_form_url_decoder(query: &HStringArg) -> Result<ComPtr<WwwFormUrlDecoder>> {
@@ -1230,7 +1230,7 @@ impl IWwwFormUrlDecoderEntry {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WwwFormUrlDecoderEntry: IWwwFormUrlDecoderEntry}
+RT_CLASS!{class WwwFormUrlDecoderEntry: IWwwFormUrlDecoderEntry ["Windows.Foundation.WwwFormUrlDecoderEntry"]}
 DEFINE_IID!(IID_IWwwFormUrlDecoderRuntimeClass, 3562669137, 61989, 17730, 146, 150, 14, 29, 245, 210, 84, 223);
 RT_INTERFACE!{interface IWwwFormUrlDecoderRuntimeClass(IWwwFormUrlDecoderRuntimeClassVtbl): IInspectable(IInspectableVtbl) [IID_IWwwFormUrlDecoderRuntimeClass] {
     fn GetFirstValueByName(&self, name: HSTRING, out: *mut HSTRING) -> HRESULT
@@ -3408,7 +3408,7 @@ RT_PINTERFACE!{ for TypedEventHandler<IMemoryBufferReference, IInspectable> => [
 #[cfg(feature="windows-web")] RT_PINTERFACE!{ for TypedEventHandler<super::web::ui::IWebViewControl, super::web::ui::WebViewControlWebResourceRequestedEventArgs> => [0x3a6ed2bc,0x032b,0x5ec7,0xa2,0x0a,0xc1,0xef,0x49,0x25,0x0c,0x3c] as IID_TypedEventHandler_2_Windows_Web_UI_IWebViewControl_Windows_Web_UI_WebViewControlWebResourceRequestedEventArgs }
 pub mod collections { // Windows.Foundation.Collections
 use ::prelude::*;
-RT_ENUM! { enum CollectionChange: i32 {
+RT_ENUM! { enum CollectionChange: i32 ["Windows.Foundation.Collections.CollectionChange"] {
     Reset (CollectionChange_Reset) = 0, ItemInserted (CollectionChange_ItemInserted) = 1, ItemRemoved (CollectionChange_ItemRemoved) = 2, ItemChanged (CollectionChange_ItemChanged) = 3,
 }}
 DEFINE_IID!(IID_IIterable, 4205151722, 25108, 16919, 175, 218, 127, 70, 222, 88, 105, 179);
@@ -3606,13 +3606,13 @@ DEFINE_IID!(IID_IPropertySet, 2319707551, 62694, 17441, 172, 249, 29, 171, 41, 1
 RT_INTERFACE!{interface IPropertySet(IPropertySetVtbl): IInspectable(IInspectableVtbl) [IID_IPropertySet] {
     
 }}
-RT_CLASS!{class PropertySet: IPropertySet}
+RT_CLASS!{class PropertySet: IPropertySet ["Windows.Foundation.Collections.PropertySet"]}
 impl RtActivatable<IActivationFactory> for PropertySet {}
 DEFINE_CLSID!(PropertySet(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,67,111,108,108,101,99,116,105,111,110,115,46,80,114,111,112,101,114,116,121,83,101,116,0]) [CLSID_PropertySet]);
-RT_CLASS!{class StringMap: IMap<HString, HString>}
+RT_CLASS!{class StringMap: IMap<HString, HString> ["Windows.Foundation.Collections.StringMap"]}
 impl RtActivatable<IActivationFactory> for StringMap {}
 DEFINE_CLSID!(StringMap(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,67,111,108,108,101,99,116,105,111,110,115,46,83,116,114,105,110,103,77,97,112,0]) [CLSID_StringMap]);
-RT_CLASS!{class ValueSet: IPropertySet}
+RT_CLASS!{class ValueSet: IPropertySet ["Windows.Foundation.Collections.ValueSet"]}
 impl RtActivatable<IActivationFactory> for ValueSet {}
 DEFINE_CLSID!(ValueSet(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,67,111,108,108,101,99,116,105,111,110,115,46,86,97,108,117,101,83,101,116,0]) [CLSID_ValueSet]);
 DEFINE_IID!(IID_IVector, 2436052969, 4513, 17221, 163, 162, 78, 127, 149, 110, 34, 45);
@@ -5745,16 +5745,16 @@ impl IAsyncCausalityTracerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CausalityRelation: i32 {
+RT_ENUM! { enum CausalityRelation: i32 ["Windows.Foundation.Diagnostics.CausalityRelation"] {
     AssignDelegate (CausalityRelation_AssignDelegate) = 0, Join (CausalityRelation_Join) = 1, Choice (CausalityRelation_Choice) = 2, Cancel (CausalityRelation_Cancel) = 3, Error (CausalityRelation_Error) = 4,
 }}
-RT_ENUM! { enum CausalitySource: i32 {
+RT_ENUM! { enum CausalitySource: i32 ["Windows.Foundation.Diagnostics.CausalitySource"] {
     Application (CausalitySource_Application) = 0, Library (CausalitySource_Library) = 1, System (CausalitySource_System) = 2,
 }}
-RT_ENUM! { enum CausalitySynchronousWork: i32 {
+RT_ENUM! { enum CausalitySynchronousWork: i32 ["Windows.Foundation.Diagnostics.CausalitySynchronousWork"] {
     CompletionNotification (CausalitySynchronousWork_CompletionNotification) = 0, ProgressNotification (CausalitySynchronousWork_ProgressNotification) = 1, Execution (CausalitySynchronousWork_Execution) = 2,
 }}
-RT_ENUM! { enum CausalityTraceLevel: i32 {
+RT_ENUM! { enum CausalityTraceLevel: i32 ["Windows.Foundation.Diagnostics.CausalityTraceLevel"] {
     Required (CausalityTraceLevel_Required) = 0, Important (CausalityTraceLevel_Important) = 1, Verbose (CausalityTraceLevel_Verbose) = 2,
 }}
 DEFINE_IID!(IID_IErrorDetails, 931969793, 11465, 17039, 140, 85, 44, 153, 13, 70, 62, 143);
@@ -5780,7 +5780,7 @@ impl IErrorDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ErrorDetails: IErrorDetails}
+RT_CLASS!{class ErrorDetails: IErrorDetails ["Windows.Foundation.Diagnostics.ErrorDetails"]}
 impl RtActivatable<IErrorDetailsStatics> for ErrorDetails {}
 impl ErrorDetails {
     #[inline] pub fn create_from_hresult_async(errorCode: i32) -> Result<ComPtr<super::IAsyncOperation<ErrorDetails>>> {
@@ -5799,7 +5799,7 @@ impl IErrorDetailsStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ErrorOptions: u32 {
+RT_ENUM! { enum ErrorOptions: u32 ["Windows.Foundation.Diagnostics.ErrorOptions"] {
     None (ErrorOptions_None) = 0, SuppressExceptions (ErrorOptions_SuppressExceptions) = 1, ForceExceptions (ErrorOptions_ForceExceptions) = 2, UseSetErrorInfo (ErrorOptions_UseSetErrorInfo) = 4, SuppressSetErrorInfo (ErrorOptions_SuppressSetErrorInfo) = 8,
 }}
 DEFINE_IID!(IID_IErrorReportingSettings, 372676498, 45118, 19361, 139, 184, 210, 143, 74, 180, 210, 192);
@@ -5862,7 +5862,7 @@ impl IFileLoggingSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileLoggingSession: IFileLoggingSession}
+RT_CLASS!{class FileLoggingSession: IFileLoggingSession ["Windows.Foundation.Diagnostics.FileLoggingSession"]}
 impl RtActivatable<IFileLoggingSessionFactory> for FileLoggingSession {}
 impl FileLoggingSession {
     #[inline] pub fn create(name: &HStringArg) -> Result<ComPtr<FileLoggingSession>> {
@@ -5892,7 +5892,7 @@ impl ILogFileGeneratedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LogFileGeneratedEventArgs: ILogFileGeneratedEventArgs}
+RT_CLASS!{class LogFileGeneratedEventArgs: ILogFileGeneratedEventArgs ["Windows.Foundation.Diagnostics.LogFileGeneratedEventArgs"]}
 DEFINE_IID!(IID_ILoggingActivity, 3154323777, 46950, 19637, 152, 72, 151, 172, 107, 166, 214, 12);
 RT_INTERFACE!{interface ILoggingActivity(ILoggingActivityVtbl): IInspectable(IInspectableVtbl) [IID_ILoggingActivity] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -5910,7 +5910,7 @@ impl ILoggingActivity {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LoggingActivity: ILoggingActivity}
+RT_CLASS!{class LoggingActivity: ILoggingActivity ["Windows.Foundation.Diagnostics.LoggingActivity"]}
 impl RtActivatable<ILoggingActivityFactory> for LoggingActivity {}
 impl LoggingActivity {
     #[inline] pub fn create_logging_activity(activityName: &HStringArg, loggingChannel: &ILoggingChannel) -> Result<ComPtr<LoggingActivity>> {
@@ -6018,7 +6018,7 @@ impl ILoggingChannel {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LoggingChannel: ILoggingChannel}
+RT_CLASS!{class LoggingChannel: ILoggingChannel ["Windows.Foundation.Diagnostics.LoggingChannel"]}
 impl RtActivatable<ILoggingChannelFactory> for LoggingChannel {}
 impl RtActivatable<ILoggingChannelFactory2> for LoggingChannel {}
 impl LoggingChannel {
@@ -6088,7 +6088,7 @@ impl ILoggingChannelOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LoggingChannelOptions: ILoggingChannelOptions}
+RT_CLASS!{class LoggingChannelOptions: ILoggingChannelOptions ["Windows.Foundation.Diagnostics.LoggingChannelOptions"]}
 impl RtActivatable<ILoggingChannelOptionsFactory> for LoggingChannelOptions {}
 impl RtActivatable<IActivationFactory> for LoggingChannelOptions {}
 impl LoggingChannelOptions {
@@ -6108,7 +6108,7 @@ impl ILoggingChannelOptionsFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LoggingFieldFormat: i32 {
+RT_ENUM! { enum LoggingFieldFormat: i32 ["Windows.Foundation.Diagnostics.LoggingFieldFormat"] {
     Default (LoggingFieldFormat_Default) = 0, Hidden (LoggingFieldFormat_Hidden) = 1, String (LoggingFieldFormat_String) = 2, Boolean (LoggingFieldFormat_Boolean) = 3, Hexadecimal (LoggingFieldFormat_Hexadecimal) = 4, ProcessId (LoggingFieldFormat_ProcessId) = 5, ThreadId (LoggingFieldFormat_ThreadId) = 6, Port (LoggingFieldFormat_Port) = 7, Ipv4Address (LoggingFieldFormat_Ipv4Address) = 8, Ipv6Address (LoggingFieldFormat_Ipv6Address) = 9, SocketAddress (LoggingFieldFormat_SocketAddress) = 10, Xml (LoggingFieldFormat_Xml) = 11, Json (LoggingFieldFormat_Json) = 12, Win32Error (LoggingFieldFormat_Win32Error) = 13, NTStatus (LoggingFieldFormat_NTStatus) = 14, HResult (LoggingFieldFormat_HResult) = 15, FileTime (LoggingFieldFormat_FileTime) = 16, Signed (LoggingFieldFormat_Signed) = 17, Unsigned (LoggingFieldFormat_Unsigned) = 18,
 }}
 DEFINE_IID!(IID_ILoggingFields, 3623270319, 30253, 17785, 131, 189, 82, 194, 59, 195, 51, 188);
@@ -6691,13 +6691,13 @@ impl ILoggingFields {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LoggingFields: ILoggingFields}
+RT_CLASS!{class LoggingFields: ILoggingFields ["Windows.Foundation.Diagnostics.LoggingFields"]}
 impl RtActivatable<IActivationFactory> for LoggingFields {}
 DEFINE_CLSID!(LoggingFields(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,76,111,103,103,105,110,103,70,105,101,108,100,115,0]) [CLSID_LoggingFields]);
-RT_ENUM! { enum LoggingLevel: i32 {
+RT_ENUM! { enum LoggingLevel: i32 ["Windows.Foundation.Diagnostics.LoggingLevel"] {
     Verbose (LoggingLevel_Verbose) = 0, Information (LoggingLevel_Information) = 1, Warning (LoggingLevel_Warning) = 2, Error (LoggingLevel_Error) = 3, Critical (LoggingLevel_Critical) = 4,
 }}
-RT_ENUM! { enum LoggingOpcode: i32 {
+RT_ENUM! { enum LoggingOpcode: i32 ["Windows.Foundation.Diagnostics.LoggingOpcode"] {
     Info (LoggingOpcode_Info) = 0, Start (LoggingOpcode_Start) = 1, Stop (LoggingOpcode_Stop) = 2, Reply (LoggingOpcode_Reply) = 6, Resume (LoggingOpcode_Resume) = 7, Suspend (LoggingOpcode_Suspend) = 8, Send (LoggingOpcode_Send) = 9,
 }}
 DEFINE_IID!(IID_ILoggingOptions, 2428270672, 402, 20317, 172, 38, 0, 106, 218, 202, 18, 216);
@@ -6771,7 +6771,7 @@ impl ILoggingOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LoggingOptions: ILoggingOptions}
+RT_CLASS!{class LoggingOptions: ILoggingOptions ["Windows.Foundation.Diagnostics.LoggingOptions"]}
 impl RtActivatable<ILoggingOptionsFactory> for LoggingOptions {}
 impl RtActivatable<IActivationFactory> for LoggingOptions {}
 impl LoggingOptions {
@@ -6824,7 +6824,7 @@ impl ILoggingSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LoggingSession: ILoggingSession}
+RT_CLASS!{class LoggingSession: ILoggingSession ["Windows.Foundation.Diagnostics.LoggingSession"]}
 impl RtActivatable<ILoggingSessionFactory> for LoggingSession {}
 impl LoggingSession {
     #[inline] pub fn create(name: &HStringArg) -> Result<ComPtr<LoggingSession>> {
@@ -6910,7 +6910,7 @@ impl ILoggingTarget {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RuntimeBrokerErrorSettings: IErrorReportingSettings}
+RT_CLASS!{class RuntimeBrokerErrorSettings: IErrorReportingSettings ["Windows.Foundation.Diagnostics.RuntimeBrokerErrorSettings"]}
 impl RtActivatable<IActivationFactory> for RuntimeBrokerErrorSettings {}
 DEFINE_CLSID!(RuntimeBrokerErrorSettings(&[87,105,110,100,111,119,115,46,70,111,117,110,100,97,116,105,111,110,46,68,105,97,103,110,111,115,116,105,99,115,46,82,117,110,116,105,109,101,66,114,111,107,101,114,69,114,114,111,114,83,101,116,116,105,110,103,115,0]) [CLSID_RuntimeBrokerErrorSettings]);
 DEFINE_IID!(IID_ITracingStatusChangedEventArgs, 1091270417, 65339, 18303, 156, 154, 210, 239, 218, 48, 45, 195);
@@ -6930,7 +6930,7 @@ impl ITracingStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TracingStatusChangedEventArgs: ITracingStatusChangedEventArgs}
+RT_CLASS!{class TracingStatusChangedEventArgs: ITracingStatusChangedEventArgs ["Windows.Foundation.Diagnostics.TracingStatusChangedEventArgs"]}
 } // Windows.Foundation.Diagnostics
 pub mod metadata { // Windows.Foundation.Metadata
 use ::prelude::*;
@@ -7034,55 +7034,55 @@ impl IApiInformationStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AttributeTargets: u32 {
+RT_ENUM! { enum AttributeTargets: u32 ["Windows.Foundation.Metadata.AttributeTargets"] {
     All (AttributeTargets_All) = 4294967295, Delegate (AttributeTargets_Delegate) = 1, Enum (AttributeTargets_Enum) = 2, Event (AttributeTargets_Event) = 4, Field (AttributeTargets_Field) = 8, Interface (AttributeTargets_Interface) = 16, Method (AttributeTargets_Method) = 64, Parameter (AttributeTargets_Parameter) = 128, Property (AttributeTargets_Property) = 256, RuntimeClass (AttributeTargets_RuntimeClass) = 512, Struct (AttributeTargets_Struct) = 1024, InterfaceImpl (AttributeTargets_InterfaceImpl) = 2048, ApiContract (AttributeTargets_ApiContract) = 8192,
 }}
-RT_ENUM! { enum CompositionType: i32 {
+RT_ENUM! { enum CompositionType: i32 ["Windows.Foundation.Metadata.CompositionType"] {
     Protected (CompositionType_Protected) = 1, Public (CompositionType_Public) = 2,
 }}
-RT_ENUM! { enum DeprecationType: i32 {
+RT_ENUM! { enum DeprecationType: i32 ["Windows.Foundation.Metadata.DeprecationType"] {
     Deprecate (DeprecationType_Deprecate) = 0, Remove (DeprecationType_Remove) = 1,
 }}
-RT_ENUM! { enum FeatureStage: i32 {
+RT_ENUM! { enum FeatureStage: i32 ["Windows.Foundation.Metadata.FeatureStage"] {
     AlwaysDisabled (FeatureStage_AlwaysDisabled) = 0, DisabledByDefault (FeatureStage_DisabledByDefault) = 1, EnabledByDefault (FeatureStage_EnabledByDefault) = 2, AlwaysEnabled (FeatureStage_AlwaysEnabled) = 3,
 }}
-RT_ENUM! { enum GCPressureAmount: i32 {
+RT_ENUM! { enum GCPressureAmount: i32 ["Windows.Foundation.Metadata.GCPressureAmount"] {
     Low (GCPressureAmount_Low) = 0, Medium (GCPressureAmount_Medium) = 1, High (GCPressureAmount_High) = 2,
 }}
-RT_ENUM! { enum MarshalingType: i32 {
+RT_ENUM! { enum MarshalingType: i32 ["Windows.Foundation.Metadata.MarshalingType"] {
     None (MarshalingType_None) = 1, Agile (MarshalingType_Agile) = 2, Standard (MarshalingType_Standard) = 3, InvalidMarshaling (MarshalingType_InvalidMarshaling) = 0,
 }}
-RT_ENUM! { enum Platform: i32 {
+RT_ENUM! { enum Platform: i32 ["Windows.Foundation.Metadata.Platform"] {
     Windows (Platform_Windows) = 0, WindowsPhone (Platform_WindowsPhone) = 1,
 }}
-RT_ENUM! { enum ThreadingModel: i32 {
+RT_ENUM! { enum ThreadingModel: i32 ["Windows.Foundation.Metadata.ThreadingModel"] {
     STA (ThreadingModel_STA) = 1, MTA (ThreadingModel_MTA) = 2, Both (ThreadingModel_Both) = 3, InvalidThreading (ThreadingModel_InvalidThreading) = 0,
 }}
 } // Windows.Foundation.Metadata
 pub mod numerics { // Windows.Foundation.Numerics
 use ::prelude::*;
-RT_STRUCT! { struct Matrix3x2 {
+RT_STRUCT! { struct Matrix3x2 ["Windows.Foundation.Numerics.Matrix3x2"] {
     M11: f32, M12: f32, M21: f32, M22: f32, M31: f32, M32: f32,
 }}
-RT_STRUCT! { struct Matrix4x4 {
+RT_STRUCT! { struct Matrix4x4 ["Windows.Foundation.Numerics.Matrix4x4"] {
     M11: f32, M12: f32, M13: f32, M14: f32, M21: f32, M22: f32, M23: f32, M24: f32, M31: f32, M32: f32, M33: f32, M34: f32, M41: f32, M42: f32, M43: f32, M44: f32,
 }}
-RT_STRUCT! { struct Plane {
+RT_STRUCT! { struct Plane ["Windows.Foundation.Numerics.Plane"] {
     Normal: Vector3, D: f32,
 }}
-RT_STRUCT! { struct Quaternion {
+RT_STRUCT! { struct Quaternion ["Windows.Foundation.Numerics.Quaternion"] {
     X: f32, Y: f32, Z: f32, W: f32,
 }}
-RT_STRUCT! { struct Rational {
+RT_STRUCT! { struct Rational ["Windows.Foundation.Numerics.Rational"] {
     Numerator: u32, Denominator: u32,
 }}
-RT_STRUCT! { struct Vector2 {
+RT_STRUCT! { struct Vector2 ["Windows.Foundation.Numerics.Vector2"] {
     X: f32, Y: f32,
 }}
-RT_STRUCT! { struct Vector3 {
+RT_STRUCT! { struct Vector3 ["Windows.Foundation.Numerics.Vector3"] {
     X: f32, Y: f32, Z: f32,
 }}
-RT_STRUCT! { struct Vector4 {
+RT_STRUCT! { struct Vector4 ["Windows.Foundation.Numerics.Vector4"] {
     X: f32, Y: f32, Z: f32, W: f32,
 }}
 } // Windows.Foundation.Numerics

--- a/src/rt/gen/windows/gaming.rs
+++ b/src/rt/gen/windows/gaming.rs
@@ -17,7 +17,7 @@ impl IArcadeStick {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ArcadeStick: IArcadeStick}
+RT_CLASS!{class ArcadeStick: IArcadeStick ["Windows.Gaming.Input.ArcadeStick"]}
 impl RtActivatable<IArcadeStickStatics> for ArcadeStick {}
 impl RtActivatable<IArcadeStickStatics2> for ArcadeStick {}
 impl ArcadeStick {
@@ -41,10 +41,10 @@ impl ArcadeStick {
     }
 }
 DEFINE_CLSID!(ArcadeStick(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,65,114,99,97,100,101,83,116,105,99,107,0]) [CLSID_ArcadeStick]);
-RT_ENUM! { enum ArcadeStickButtons: u32 {
+RT_ENUM! { enum ArcadeStickButtons: u32 ["Windows.Gaming.Input.ArcadeStickButtons"] {
     None (ArcadeStickButtons_None) = 0, StickUp (ArcadeStickButtons_StickUp) = 1, StickDown (ArcadeStickButtons_StickDown) = 2, StickLeft (ArcadeStickButtons_StickLeft) = 4, StickRight (ArcadeStickButtons_StickRight) = 8, Action1 (ArcadeStickButtons_Action1) = 16, Action2 (ArcadeStickButtons_Action2) = 32, Action3 (ArcadeStickButtons_Action3) = 64, Action4 (ArcadeStickButtons_Action4) = 128, Action5 (ArcadeStickButtons_Action5) = 256, Action6 (ArcadeStickButtons_Action6) = 512, Special1 (ArcadeStickButtons_Special1) = 1024, Special2 (ArcadeStickButtons_Special2) = 2048,
 }}
-RT_STRUCT! { struct ArcadeStickReading {
+RT_STRUCT! { struct ArcadeStickReading ["Windows.Gaming.Input.ArcadeStickReading"] {
     Timestamp: u64, Buttons: ArcadeStickButtons,
 }}
 DEFINE_IID!(IID_IArcadeStickStatics, 1547155656, 14257, 19160, 148, 88, 32, 15, 26, 48, 1, 142);
@@ -114,7 +114,7 @@ impl IFlightStick {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FlightStick: IFlightStick}
+RT_CLASS!{class FlightStick: IFlightStick ["Windows.Gaming.Input.FlightStick"]}
 impl RtActivatable<IFlightStickStatics> for FlightStick {}
 impl FlightStick {
     #[inline] pub fn add_flight_stick_added(value: &foundation::EventHandler<FlightStick>) -> Result<foundation::EventRegistrationToken> {
@@ -137,10 +137,10 @@ impl FlightStick {
     }
 }
 DEFINE_CLSID!(FlightStick(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,108,105,103,104,116,83,116,105,99,107,0]) [CLSID_FlightStick]);
-RT_ENUM! { enum FlightStickButtons: u32 {
+RT_ENUM! { enum FlightStickButtons: u32 ["Windows.Gaming.Input.FlightStickButtons"] {
     None (FlightStickButtons_None) = 0, FirePrimary (FlightStickButtons_FirePrimary) = 1, FireSecondary (FlightStickButtons_FireSecondary) = 2,
 }}
-RT_STRUCT! { struct FlightStickReading {
+RT_STRUCT! { struct FlightStickReading ["Windows.Gaming.Input.FlightStickReading"] {
     Timestamp: u64, Buttons: FlightStickButtons, HatSwitch: GameControllerSwitchPosition, Roll: f64, Pitch: f64, Yaw: f64, Throttle: f64,
 }}
 DEFINE_IID!(IID_IFlightStickStatics, 1427411530, 65228, 17246, 131, 220, 92, 236, 138, 24, 165, 32);
@@ -249,13 +249,13 @@ impl IGameControllerBatteryInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GameControllerButtonLabel: i32 {
+RT_ENUM! { enum GameControllerButtonLabel: i32 ["Windows.Gaming.Input.GameControllerButtonLabel"] {
     None (GameControllerButtonLabel_None) = 0, XboxBack (GameControllerButtonLabel_XboxBack) = 1, XboxStart (GameControllerButtonLabel_XboxStart) = 2, XboxMenu (GameControllerButtonLabel_XboxMenu) = 3, XboxView (GameControllerButtonLabel_XboxView) = 4, XboxUp (GameControllerButtonLabel_XboxUp) = 5, XboxDown (GameControllerButtonLabel_XboxDown) = 6, XboxLeft (GameControllerButtonLabel_XboxLeft) = 7, XboxRight (GameControllerButtonLabel_XboxRight) = 8, XboxA (GameControllerButtonLabel_XboxA) = 9, XboxB (GameControllerButtonLabel_XboxB) = 10, XboxX (GameControllerButtonLabel_XboxX) = 11, XboxY (GameControllerButtonLabel_XboxY) = 12, XboxLeftBumper (GameControllerButtonLabel_XboxLeftBumper) = 13, XboxLeftTrigger (GameControllerButtonLabel_XboxLeftTrigger) = 14, XboxLeftStickButton (GameControllerButtonLabel_XboxLeftStickButton) = 15, XboxRightBumper (GameControllerButtonLabel_XboxRightBumper) = 16, XboxRightTrigger (GameControllerButtonLabel_XboxRightTrigger) = 17, XboxRightStickButton (GameControllerButtonLabel_XboxRightStickButton) = 18, XboxPaddle1 (GameControllerButtonLabel_XboxPaddle1) = 19, XboxPaddle2 (GameControllerButtonLabel_XboxPaddle2) = 20, XboxPaddle3 (GameControllerButtonLabel_XboxPaddle3) = 21, XboxPaddle4 (GameControllerButtonLabel_XboxPaddle4) = 22, Mode (GameControllerButtonLabel_Mode) = 23, Select (GameControllerButtonLabel_Select) = 24, Menu (GameControllerButtonLabel_Menu) = 25, View (GameControllerButtonLabel_View) = 26, Back (GameControllerButtonLabel_Back) = 27, Start (GameControllerButtonLabel_Start) = 28, Options (GameControllerButtonLabel_Options) = 29, Share (GameControllerButtonLabel_Share) = 30, Up (GameControllerButtonLabel_Up) = 31, Down (GameControllerButtonLabel_Down) = 32, Left (GameControllerButtonLabel_Left) = 33, Right (GameControllerButtonLabel_Right) = 34, LetterA (GameControllerButtonLabel_LetterA) = 35, LetterB (GameControllerButtonLabel_LetterB) = 36, LetterC (GameControllerButtonLabel_LetterC) = 37, LetterL (GameControllerButtonLabel_LetterL) = 38, LetterR (GameControllerButtonLabel_LetterR) = 39, LetterX (GameControllerButtonLabel_LetterX) = 40, LetterY (GameControllerButtonLabel_LetterY) = 41, LetterZ (GameControllerButtonLabel_LetterZ) = 42, Cross (GameControllerButtonLabel_Cross) = 43, Circle (GameControllerButtonLabel_Circle) = 44, Square (GameControllerButtonLabel_Square) = 45, Triangle (GameControllerButtonLabel_Triangle) = 46, LeftBumper (GameControllerButtonLabel_LeftBumper) = 47, LeftTrigger (GameControllerButtonLabel_LeftTrigger) = 48, LeftStickButton (GameControllerButtonLabel_LeftStickButton) = 49, Left1 (GameControllerButtonLabel_Left1) = 50, Left2 (GameControllerButtonLabel_Left2) = 51, Left3 (GameControllerButtonLabel_Left3) = 52, RightBumper (GameControllerButtonLabel_RightBumper) = 53, RightTrigger (GameControllerButtonLabel_RightTrigger) = 54, RightStickButton (GameControllerButtonLabel_RightStickButton) = 55, Right1 (GameControllerButtonLabel_Right1) = 56, Right2 (GameControllerButtonLabel_Right2) = 57, Right3 (GameControllerButtonLabel_Right3) = 58, Paddle1 (GameControllerButtonLabel_Paddle1) = 59, Paddle2 (GameControllerButtonLabel_Paddle2) = 60, Paddle3 (GameControllerButtonLabel_Paddle3) = 61, Paddle4 (GameControllerButtonLabel_Paddle4) = 62, Plus (GameControllerButtonLabel_Plus) = 63, Minus (GameControllerButtonLabel_Minus) = 64, DownLeftArrow (GameControllerButtonLabel_DownLeftArrow) = 65, DialLeft (GameControllerButtonLabel_DialLeft) = 66, DialRight (GameControllerButtonLabel_DialRight) = 67, Suspension (GameControllerButtonLabel_Suspension) = 68,
 }}
-RT_ENUM! { enum GameControllerSwitchKind: i32 {
+RT_ENUM! { enum GameControllerSwitchKind: i32 ["Windows.Gaming.Input.GameControllerSwitchKind"] {
     TwoWay (GameControllerSwitchKind_TwoWay) = 0, FourWay (GameControllerSwitchKind_FourWay) = 1, EightWay (GameControllerSwitchKind_EightWay) = 2,
 }}
-RT_ENUM! { enum GameControllerSwitchPosition: i32 {
+RT_ENUM! { enum GameControllerSwitchPosition: i32 ["Windows.Gaming.Input.GameControllerSwitchPosition"] {
     Center (GameControllerSwitchPosition_Center) = 0, Up (GameControllerSwitchPosition_Up) = 1, UpRight (GameControllerSwitchPosition_UpRight) = 2, Right (GameControllerSwitchPosition_Right) = 3, DownRight (GameControllerSwitchPosition_DownRight) = 4, Down (GameControllerSwitchPosition_Down) = 5, DownLeft (GameControllerSwitchPosition_DownLeft) = 6, Left (GameControllerSwitchPosition_Left) = 7, UpLeft (GameControllerSwitchPosition_UpLeft) = 8,
 }}
 DEFINE_IID!(IID_IGamepad, 3162223676, 2665, 14595, 158, 157, 165, 15, 134, 164, 93, 229);
@@ -280,7 +280,7 @@ impl IGamepad {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Gamepad: IGamepad}
+RT_CLASS!{class Gamepad: IGamepad ["Windows.Gaming.Input.Gamepad"]}
 impl RtActivatable<IGamepadStatics> for Gamepad {}
 impl RtActivatable<IGamepadStatics2> for Gamepad {}
 impl Gamepad {
@@ -315,10 +315,10 @@ impl IGamepad2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GamepadButtons: u32 {
+RT_ENUM! { enum GamepadButtons: u32 ["Windows.Gaming.Input.GamepadButtons"] {
     None (GamepadButtons_None) = 0, Menu (GamepadButtons_Menu) = 1, View (GamepadButtons_View) = 2, A (GamepadButtons_A) = 4, B (GamepadButtons_B) = 8, X (GamepadButtons_X) = 16, Y (GamepadButtons_Y) = 32, DPadUp (GamepadButtons_DPadUp) = 64, DPadDown (GamepadButtons_DPadDown) = 128, DPadLeft (GamepadButtons_DPadLeft) = 256, DPadRight (GamepadButtons_DPadRight) = 512, LeftShoulder (GamepadButtons_LeftShoulder) = 1024, RightShoulder (GamepadButtons_RightShoulder) = 2048, LeftThumbstick (GamepadButtons_LeftThumbstick) = 4096, RightThumbstick (GamepadButtons_RightThumbstick) = 8192, Paddle1 (GamepadButtons_Paddle1) = 16384, Paddle2 (GamepadButtons_Paddle2) = 32768, Paddle3 (GamepadButtons_Paddle3) = 65536, Paddle4 (GamepadButtons_Paddle4) = 131072,
 }}
-RT_STRUCT! { struct GamepadReading {
+RT_STRUCT! { struct GamepadReading ["Windows.Gaming.Input.GamepadReading"] {
     Timestamp: u64, Buttons: GamepadButtons, LeftTrigger: f64, RightTrigger: f64, LeftThumbstickX: f64, LeftThumbstickY: f64, RightThumbstickX: f64, RightThumbstickY: f64,
 }}
 DEFINE_IID!(IID_IGamepadStatics, 2344412457, 54428, 14825, 149, 96, 228, 125, 222, 150, 183, 200);
@@ -365,7 +365,7 @@ impl IGamepadStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct GamepadVibration {
+RT_STRUCT! { struct GamepadVibration ["Windows.Gaming.Input.GamepadVibration"] {
     LeftMotor: f64, RightMotor: f64, LeftTrigger: f64, RightTrigger: f64,
 }}
 DEFINE_IID!(IID_IHeadset, 1070683887, 26917, 16296, 145, 129, 2, 156, 82, 35, 174, 59);
@@ -385,8 +385,8 @@ impl IHeadset {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Headset: IHeadset}
-RT_ENUM! { enum OptionalUINavigationButtons: u32 {
+RT_CLASS!{class Headset: IHeadset ["Windows.Gaming.Input.Headset"]}
+RT_ENUM! { enum OptionalUINavigationButtons: u32 ["Windows.Gaming.Input.OptionalUINavigationButtons"] {
     None (OptionalUINavigationButtons_None) = 0, Context1 (OptionalUINavigationButtons_Context1) = 1, Context2 (OptionalUINavigationButtons_Context2) = 2, Context3 (OptionalUINavigationButtons_Context3) = 4, Context4 (OptionalUINavigationButtons_Context4) = 8, PageUp (OptionalUINavigationButtons_PageUp) = 16, PageDown (OptionalUINavigationButtons_PageDown) = 32, PageLeft (OptionalUINavigationButtons_PageLeft) = 64, PageRight (OptionalUINavigationButtons_PageRight) = 128, ScrollUp (OptionalUINavigationButtons_ScrollUp) = 256, ScrollDown (OptionalUINavigationButtons_ScrollDown) = 512, ScrollLeft (OptionalUINavigationButtons_ScrollLeft) = 1024, ScrollRight (OptionalUINavigationButtons_ScrollRight) = 2048,
 }}
 DEFINE_IID!(IID_IRacingWheel, 4115031407, 57606, 19586, 169, 15, 85, 64, 18, 144, 75, 133);
@@ -442,7 +442,7 @@ impl IRacingWheel {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RacingWheel: IRacingWheel}
+RT_CLASS!{class RacingWheel: IRacingWheel ["Windows.Gaming.Input.RacingWheel"]}
 impl RtActivatable<IRacingWheelStatics> for RacingWheel {}
 impl RtActivatable<IRacingWheelStatics2> for RacingWheel {}
 impl RacingWheel {
@@ -466,10 +466,10 @@ impl RacingWheel {
     }
 }
 DEFINE_CLSID!(RacingWheel(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,82,97,99,105,110,103,87,104,101,101,108,0]) [CLSID_RacingWheel]);
-RT_ENUM! { enum RacingWheelButtons: u32 {
+RT_ENUM! { enum RacingWheelButtons: u32 ["Windows.Gaming.Input.RacingWheelButtons"] {
     None (RacingWheelButtons_None) = 0, PreviousGear (RacingWheelButtons_PreviousGear) = 1, NextGear (RacingWheelButtons_NextGear) = 2, DPadUp (RacingWheelButtons_DPadUp) = 4, DPadDown (RacingWheelButtons_DPadDown) = 8, DPadLeft (RacingWheelButtons_DPadLeft) = 16, DPadRight (RacingWheelButtons_DPadRight) = 32, Button1 (RacingWheelButtons_Button1) = 64, Button2 (RacingWheelButtons_Button2) = 128, Button3 (RacingWheelButtons_Button3) = 256, Button4 (RacingWheelButtons_Button4) = 512, Button5 (RacingWheelButtons_Button5) = 1024, Button6 (RacingWheelButtons_Button6) = 2048, Button7 (RacingWheelButtons_Button7) = 4096, Button8 (RacingWheelButtons_Button8) = 8192, Button9 (RacingWheelButtons_Button9) = 16384, Button10 (RacingWheelButtons_Button10) = 32768, Button11 (RacingWheelButtons_Button11) = 65536, Button12 (RacingWheelButtons_Button12) = 131072, Button13 (RacingWheelButtons_Button13) = 262144, Button14 (RacingWheelButtons_Button14) = 524288, Button15 (RacingWheelButtons_Button15) = 1048576, Button16 (RacingWheelButtons_Button16) = 2097152,
 }}
-RT_STRUCT! { struct RacingWheelReading {
+RT_STRUCT! { struct RacingWheelReading ["Windows.Gaming.Input.RacingWheelReading"] {
     Timestamp: u64, Buttons: RacingWheelButtons, PatternShifterGear: i32, Wheel: f64, Throttle: f64, Brake: f64, Clutch: f64, Handbrake: f64,
 }}
 DEFINE_IID!(IID_IRacingWheelStatics, 985738453, 22555, 18742, 159, 148, 105, 241, 230, 81, 76, 125);
@@ -575,7 +575,7 @@ impl IRawGameController {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RawGameController: IRawGameController}
+RT_CLASS!{class RawGameController: IRawGameController ["Windows.Gaming.Input.RawGameController"]}
 impl RtActivatable<IRawGameControllerStatics> for RawGameController {}
 impl RawGameController {
     #[inline] pub fn add_raw_game_controller_added(value: &foundation::EventHandler<RawGameController>) -> Result<foundation::EventRegistrationToken> {
@@ -661,7 +661,7 @@ impl IRawGameControllerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RequiredUINavigationButtons: u32 {
+RT_ENUM! { enum RequiredUINavigationButtons: u32 ["Windows.Gaming.Input.RequiredUINavigationButtons"] {
     None (RequiredUINavigationButtons_None) = 0, Menu (RequiredUINavigationButtons_Menu) = 1, View (RequiredUINavigationButtons_View) = 2, Accept (RequiredUINavigationButtons_Accept) = 4, Cancel (RequiredUINavigationButtons_Cancel) = 8, Up (RequiredUINavigationButtons_Up) = 16, Down (RequiredUINavigationButtons_Down) = 32, Left (RequiredUINavigationButtons_Left) = 64, Right (RequiredUINavigationButtons_Right) = 128,
 }}
 DEFINE_IID!(IID_IUINavigationController, 3853447133, 62734, 19029, 140, 220, 211, 50, 41, 84, 129, 117);
@@ -687,7 +687,7 @@ impl IUINavigationController {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UINavigationController: IUINavigationController}
+RT_CLASS!{class UINavigationController: IUINavigationController ["Windows.Gaming.Input.UINavigationController"]}
 impl RtActivatable<IUINavigationControllerStatics> for UINavigationController {}
 impl RtActivatable<IUINavigationControllerStatics2> for UINavigationController {}
 impl UINavigationController {
@@ -755,7 +755,7 @@ impl IUINavigationControllerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct UINavigationReading {
+RT_STRUCT! { struct UINavigationReading ["Windows.Gaming.Input.UINavigationReading"] {
     Timestamp: u64, RequiredButtons: RequiredUINavigationButtons, OptionalButtons: OptionalUINavigationButtons,
 }}
 pub mod custom { // Windows.Gaming.Input.Custom
@@ -880,10 +880,10 @@ impl IGameControllerProvider {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct GameControllerVersionInfo {
+RT_STRUCT! { struct GameControllerVersionInfo ["Windows.Gaming.Input.Custom.GameControllerVersionInfo"] {
     Major: u16, Minor: u16, Build: u16, Revision: u16,
 }}
-RT_STRUCT! { struct GipFirmwareUpdateProgress {
+RT_STRUCT! { struct GipFirmwareUpdateProgress ["Windows.Gaming.Input.Custom.GipFirmwareUpdateProgress"] {
     PercentCompleted: f64, CurrentComponentId: u32,
 }}
 DEFINE_IID!(IID_IGipFirmwareUpdateResult, 1803111730, 34131, 17042, 142, 3, 225, 102, 81, 162, 248, 188);
@@ -909,8 +909,8 @@ impl IGipFirmwareUpdateResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GipFirmwareUpdateResult: IGipFirmwareUpdateResult}
-RT_ENUM! { enum GipFirmwareUpdateStatus: i32 {
+RT_CLASS!{class GipFirmwareUpdateResult: IGipFirmwareUpdateResult ["Windows.Gaming.Input.Custom.GipFirmwareUpdateResult"]}
+RT_ENUM! { enum GipFirmwareUpdateStatus: i32 ["Windows.Gaming.Input.Custom.GipFirmwareUpdateStatus"] {
     Completed (GipFirmwareUpdateStatus_Completed) = 0, UpToDate (GipFirmwareUpdateStatus_UpToDate) = 1, Failed (GipFirmwareUpdateStatus_Failed) = 2,
 }}
 DEFINE_IID!(IID_IGipGameControllerInputSink, 2718993087, 2545, 17340, 161, 64, 128, 248, 153, 236, 54, 251);
@@ -949,8 +949,8 @@ impl IGipGameControllerProvider {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GipGameControllerProvider: IGipGameControllerProvider}
-RT_ENUM! { enum GipMessageClass: i32 {
+RT_CLASS!{class GipGameControllerProvider: IGipGameControllerProvider ["Windows.Gaming.Input.Custom.GipGameControllerProvider"]}
+RT_ENUM! { enum GipMessageClass: i32 ["Windows.Gaming.Input.Custom.GipMessageClass"] {
     Command (GipMessageClass_Command) = 0, LowLatency (GipMessageClass_LowLatency) = 1, StandardLatency (GipMessageClass_StandardLatency) = 2,
 }}
 DEFINE_IID!(IID_IHidGameControllerInputSink, 4149527330, 6189, 16612, 161, 38, 252, 238, 79, 250, 30, 49);
@@ -995,11 +995,11 @@ impl IHidGameControllerProvider {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HidGameControllerProvider: IHidGameControllerProvider}
-RT_ENUM! { enum XusbDeviceSubtype: i32 {
+RT_CLASS!{class HidGameControllerProvider: IHidGameControllerProvider ["Windows.Gaming.Input.Custom.HidGameControllerProvider"]}
+RT_ENUM! { enum XusbDeviceSubtype: i32 ["Windows.Gaming.Input.Custom.XusbDeviceSubtype"] {
     Unknown (XusbDeviceSubtype_Unknown) = 0, Gamepad (XusbDeviceSubtype_Gamepad) = 1, ArcadePad (XusbDeviceSubtype_ArcadePad) = 2, ArcadeStick (XusbDeviceSubtype_ArcadeStick) = 3, FlightStick (XusbDeviceSubtype_FlightStick) = 4, Wheel (XusbDeviceSubtype_Wheel) = 5, Guitar (XusbDeviceSubtype_Guitar) = 6, GuitarAlternate (XusbDeviceSubtype_GuitarAlternate) = 7, GuitarBass (XusbDeviceSubtype_GuitarBass) = 8, DrumKit (XusbDeviceSubtype_DrumKit) = 9, DancePad (XusbDeviceSubtype_DancePad) = 10,
 }}
-RT_ENUM! { enum XusbDeviceType: i32 {
+RT_ENUM! { enum XusbDeviceType: i32 ["Windows.Gaming.Input.Custom.XusbDeviceType"] {
     Unknown (XusbDeviceType_Unknown) = 0, Gamepad (XusbDeviceType_Gamepad) = 1,
 }}
 DEFINE_IID!(IID_IXusbGameControllerInputSink, 2997624213, 28363, 17075, 138, 171, 2, 84, 1, 202, 71, 18);
@@ -1022,7 +1022,7 @@ impl IXusbGameControllerProvider {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XusbGameControllerProvider: IXusbGameControllerProvider}
+RT_CLASS!{class XusbGameControllerProvider: IXusbGameControllerProvider ["Windows.Gaming.Input.Custom.XusbGameControllerProvider"]}
 } // Windows.Gaming.Input.Custom
 pub mod forcefeedback { // Windows.Gaming.Input.ForceFeedback
 use ::prelude::*;
@@ -1042,7 +1042,7 @@ impl IConditionForceEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConditionForceEffect: IForceFeedbackEffect}
+RT_CLASS!{class ConditionForceEffect: IForceFeedbackEffect ["Windows.Gaming.Input.ForceFeedback.ConditionForceEffect"]}
 impl RtActivatable<IConditionForceEffectFactory> for ConditionForceEffect {}
 impl ConditionForceEffect {
     #[inline] pub fn create_instance(effectKind: ConditionForceEffectKind) -> Result<ComPtr<ConditionForceEffect>> {
@@ -1061,7 +1061,7 @@ impl IConditionForceEffectFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ConditionForceEffectKind: i32 {
+RT_ENUM! { enum ConditionForceEffectKind: i32 ["Windows.Gaming.Input.ForceFeedback.ConditionForceEffectKind"] {
     Spring (ConditionForceEffectKind_Spring) = 0, Damper (ConditionForceEffectKind_Damper) = 1, Inertia (ConditionForceEffectKind_Inertia) = 2, Friction (ConditionForceEffectKind_Friction) = 3,
 }}
 DEFINE_IID!(IID_IConstantForceEffect, 2616852800, 62407, 16732, 176, 104, 15, 6, 135, 52, 188, 224);
@@ -1079,7 +1079,7 @@ impl IConstantForceEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConstantForceEffect: IForceFeedbackEffect}
+RT_CLASS!{class ConstantForceEffect: IForceFeedbackEffect ["Windows.Gaming.Input.ForceFeedback.ConstantForceEffect"]}
 impl RtActivatable<IActivationFactory> for ConstantForceEffect {}
 DEFINE_CLSID!(ConstantForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,67,111,110,115,116,97,110,116,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_ConstantForceEffect]);
 DEFINE_IID!(IID_IForceFeedbackEffect, 2709502476, 10980, 18626, 128, 99, 234, 189, 7, 119, 203, 137);
@@ -1114,13 +1114,13 @@ impl IForceFeedbackEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ForceFeedbackEffectAxes: u32 {
+RT_ENUM! { enum ForceFeedbackEffectAxes: u32 ["Windows.Gaming.Input.ForceFeedback.ForceFeedbackEffectAxes"] {
     None (ForceFeedbackEffectAxes_None) = 0, X (ForceFeedbackEffectAxes_X) = 1, Y (ForceFeedbackEffectAxes_Y) = 2, Z (ForceFeedbackEffectAxes_Z) = 4,
 }}
-RT_ENUM! { enum ForceFeedbackEffectState: i32 {
+RT_ENUM! { enum ForceFeedbackEffectState: i32 ["Windows.Gaming.Input.ForceFeedback.ForceFeedbackEffectState"] {
     Stopped (ForceFeedbackEffectState_Stopped) = 0, Running (ForceFeedbackEffectState_Running) = 1, Paused (ForceFeedbackEffectState_Paused) = 2, Faulted (ForceFeedbackEffectState_Faulted) = 3,
 }}
-RT_ENUM! { enum ForceFeedbackLoadEffectResult: i32 {
+RT_ENUM! { enum ForceFeedbackLoadEffectResult: i32 ["Windows.Gaming.Input.ForceFeedback.ForceFeedbackLoadEffectResult"] {
     Succeeded (ForceFeedbackLoadEffectResult_Succeeded) = 0, EffectStorageFull (ForceFeedbackLoadEffectResult_EffectStorageFull) = 1, EffectNotSupported (ForceFeedbackLoadEffectResult_EffectNotSupported) = 2,
 }}
 DEFINE_IID!(IID_IForceFeedbackMotor, 2369601916, 42474, 17686, 128, 38, 43, 0, 247, 78, 246, 229);
@@ -1202,7 +1202,7 @@ impl IForceFeedbackMotor {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ForceFeedbackMotor: IForceFeedbackMotor}
+RT_CLASS!{class ForceFeedbackMotor: IForceFeedbackMotor ["Windows.Gaming.Input.ForceFeedback.ForceFeedbackMotor"]}
 DEFINE_IID!(IID_IPeriodicForceEffect, 1548826839, 64629, 19794, 154, 10, 239, 228, 202, 181, 254, 100);
 RT_INTERFACE!{interface IPeriodicForceEffect(IPeriodicForceEffectVtbl): IInspectable(IInspectableVtbl) [IID_IPeriodicForceEffect] {
     fn get_Kind(&self, out: *mut PeriodicForceEffectKind) -> HRESULT,
@@ -1224,7 +1224,7 @@ impl IPeriodicForceEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PeriodicForceEffect: IForceFeedbackEffect}
+RT_CLASS!{class PeriodicForceEffect: IForceFeedbackEffect ["Windows.Gaming.Input.ForceFeedback.PeriodicForceEffect"]}
 impl RtActivatable<IPeriodicForceEffectFactory> for PeriodicForceEffect {}
 impl PeriodicForceEffect {
     #[inline] pub fn create_instance(effectKind: PeriodicForceEffectKind) -> Result<ComPtr<PeriodicForceEffect>> {
@@ -1243,7 +1243,7 @@ impl IPeriodicForceEffectFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PeriodicForceEffectKind: i32 {
+RT_ENUM! { enum PeriodicForceEffectKind: i32 ["Windows.Gaming.Input.ForceFeedback.PeriodicForceEffectKind"] {
     SquareWave (PeriodicForceEffectKind_SquareWave) = 0, SineWave (PeriodicForceEffectKind_SineWave) = 1, TriangleWave (PeriodicForceEffectKind_TriangleWave) = 2, SawtoothWaveUp (PeriodicForceEffectKind_SawtoothWaveUp) = 3, SawtoothWaveDown (PeriodicForceEffectKind_SawtoothWaveDown) = 4,
 }}
 DEFINE_IID!(IID_IRampForceEffect, 4059566681, 7334, 16512, 181, 109, 180, 63, 51, 84, 208, 82);
@@ -1261,7 +1261,7 @@ impl IRampForceEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RampForceEffect: IForceFeedbackEffect}
+RT_CLASS!{class RampForceEffect: IForceFeedbackEffect ["Windows.Gaming.Input.ForceFeedback.RampForceEffect"]}
 impl RtActivatable<IActivationFactory> for RampForceEffect {}
 DEFINE_CLSID!(RampForceEffect(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,73,110,112,117,116,46,70,111,114,99,101,70,101,101,100,98,97,99,107,46,82,97,109,112,70,111,114,99,101,69,102,102,101,99,116,0]) [CLSID_RampForceEffect]);
 } // Windows.Gaming.Input.ForceFeedback
@@ -1336,7 +1336,7 @@ impl GameList {
     }
 }
 DEFINE_CLSID!(GameList(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,80,114,101,118,105,101,119,46,71,97,109,101,115,69,110,117,109,101,114,97,116,105,111,110,46,71,97,109,101,76,105,115,116,0]) [CLSID_GameList]);
-RT_ENUM! { enum GameListCategory: i32 {
+RT_ENUM! { enum GameListCategory: i32 ["Windows.Gaming.Preview.GamesEnumeration.GameListCategory"] {
     Candidate (GameListCategory_Candidate) = 0, ConfirmedBySystem (GameListCategory_ConfirmedBySystem) = 1, ConfirmedByUser (GameListCategory_ConfirmedByUser) = 2,
 }}
 DEFINE_IID!(IID_GameListChangedEventHandler, 636920865, 55541, 19857, 180, 14, 83, 213, 232, 111, 222, 100);
@@ -1385,7 +1385,7 @@ impl IGameListEntry {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameListEntry: IGameListEntry}
+RT_CLASS!{class GameListEntry: IGameListEntry ["Windows.Gaming.Preview.GamesEnumeration.GameListEntry"]}
 DEFINE_IID!(IID_IGameListEntry2, 3628765067, 34633, 18981, 144, 211, 246, 197, 164, 39, 136, 109);
 RT_INTERFACE!{interface IGameListEntry2(IGameListEntry2Vtbl): IInspectable(IInspectableVtbl) [IID_IGameListEntry2] {
     fn get_LaunchableState(&self, out: *mut GameListEntryLaunchableState) -> HRESULT,
@@ -1442,7 +1442,7 @@ impl IGameListEntry2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GameListEntryLaunchableState: i32 {
+RT_ENUM! { enum GameListEntryLaunchableState: i32 ["Windows.Gaming.Preview.GamesEnumeration.GameListEntryLaunchableState"] {
     NotLaunchable (GameListEntryLaunchableState_NotLaunchable) = 0, ByLastRunningFullPath (GameListEntryLaunchableState_ByLastRunningFullPath) = 1, ByUserProvidedPath (GameListEntryLaunchableState_ByUserProvidedPath) = 2, ByTile (GameListEntryLaunchableState_ByTile) = 3,
 }}
 DEFINE_IID!(IID_GameListRemovedEventHandler, 281371791, 27791, 18194, 155, 56, 71, 75, 194, 46, 118, 216);
@@ -1627,7 +1627,7 @@ impl IGameModeConfiguration {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameModeConfiguration: IGameModeConfiguration}
+RT_CLASS!{class GameModeConfiguration: IGameModeConfiguration ["Windows.Gaming.Preview.GamesEnumeration.GameModeConfiguration"]}
 DEFINE_IID!(IID_IGameModeUserConfiguration, 1926449908, 30059, 18191, 160, 194, 186, 98, 169, 7, 149, 219);
 RT_INTERFACE!{interface IGameModeUserConfiguration(IGameModeUserConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IGameModeUserConfiguration] {
     fn get_GamingRelatedProcessNames(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT,
@@ -1645,7 +1645,7 @@ impl IGameModeUserConfiguration {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameModeUserConfiguration: IGameModeUserConfiguration}
+RT_CLASS!{class GameModeUserConfiguration: IGameModeUserConfiguration ["Windows.Gaming.Preview.GamesEnumeration.GameModeUserConfiguration"]}
 impl RtActivatable<IGameModeUserConfigurationStatics> for GameModeUserConfiguration {}
 impl GameModeUserConfiguration {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<GameModeUserConfiguration>>> {
@@ -1730,7 +1730,7 @@ impl IGameBarStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GameChatMessageOrigin: i32 {
+RT_ENUM! { enum GameChatMessageOrigin: i32 ["Windows.Gaming.UI.GameChatMessageOrigin"] {
     Voice (GameChatMessageOrigin_Voice) = 0, Text (GameChatMessageOrigin_Text) = 1,
 }}
 DEFINE_IID!(IID_IGameChatMessageReceivedEventArgs, 2726429169, 16313, 20034, 164, 3, 122, 252, 226, 2, 59, 30);
@@ -1768,7 +1768,7 @@ impl IGameChatMessageReceivedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameChatMessageReceivedEventArgs: IGameChatMessageReceivedEventArgs}
+RT_CLASS!{class GameChatMessageReceivedEventArgs: IGameChatMessageReceivedEventArgs ["Windows.Gaming.UI.GameChatMessageReceivedEventArgs"]}
 DEFINE_IID!(IID_IGameChatOverlay, 4224075877, 63228, 19016, 174, 7, 3, 172, 110, 212, 55, 4);
 RT_INTERFACE!{interface IGameChatOverlay(IGameChatOverlayVtbl): IInspectable(IInspectableVtbl) [IID_IGameChatOverlay] {
     fn get_DesiredPosition(&self, out: *mut GameChatOverlayPosition) -> HRESULT,
@@ -1790,7 +1790,7 @@ impl IGameChatOverlay {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameChatOverlay: IGameChatOverlay}
+RT_CLASS!{class GameChatOverlay: IGameChatOverlay ["Windows.Gaming.UI.GameChatOverlay"]}
 impl RtActivatable<IGameChatOverlayStatics> for GameChatOverlay {}
 impl GameChatOverlay {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<GameChatOverlay>>> {
@@ -1819,10 +1819,10 @@ impl IGameChatOverlayMessageSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameChatOverlayMessageSource: IGameChatOverlayMessageSource}
+RT_CLASS!{class GameChatOverlayMessageSource: IGameChatOverlayMessageSource ["Windows.Gaming.UI.GameChatOverlayMessageSource"]}
 impl RtActivatable<IActivationFactory> for GameChatOverlayMessageSource {}
 DEFINE_CLSID!(GameChatOverlayMessageSource(&[87,105,110,100,111,119,115,46,71,97,109,105,110,103,46,85,73,46,71,97,109,101,67,104,97,116,79,118,101,114,108,97,121,77,101,115,115,97,103,101,83,111,117,114,99,101,0]) [CLSID_GameChatOverlayMessageSource]);
-RT_ENUM! { enum GameChatOverlayPosition: i32 {
+RT_ENUM! { enum GameChatOverlayPosition: i32 ["Windows.Gaming.UI.GameChatOverlayPosition"] {
     BottomCenter (GameChatOverlayPosition_BottomCenter) = 0, BottomLeft (GameChatOverlayPosition_BottomLeft) = 1, BottomRight (GameChatOverlayPosition_BottomRight) = 2, MiddleRight (GameChatOverlayPosition_MiddleRight) = 3, MiddleLeft (GameChatOverlayPosition_MiddleLeft) = 4, TopCenter (GameChatOverlayPosition_TopCenter) = 5, TopLeft (GameChatOverlayPosition_TopLeft) = 6, TopRight (GameChatOverlayPosition_TopRight) = 7,
 }}
 DEFINE_IID!(IID_IGameChatOverlayStatics, 2309813780, 30823, 18935, 150, 135, 37, 217, 219, 244, 68, 209);
@@ -1852,7 +1852,7 @@ impl IGameUIProviderActivatedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameUIProviderActivatedEventArgs: IGameUIProviderActivatedEventArgs}
+RT_CLASS!{class GameUIProviderActivatedEventArgs: IGameUIProviderActivatedEventArgs ["Windows.Gaming.UI.GameUIProviderActivatedEventArgs"]}
 } // Windows.Gaming.UI
 pub mod xboxlive { // Windows.Gaming.XboxLive
 pub mod storage { // Windows.Gaming.XboxLive.Storage
@@ -1874,7 +1874,7 @@ impl IGameSaveBlobGetResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveBlobGetResult: IGameSaveBlobGetResult}
+RT_CLASS!{class GameSaveBlobGetResult: IGameSaveBlobGetResult ["Windows.Gaming.XboxLive.Storage.GameSaveBlobGetResult"]}
 DEFINE_IID!(IID_IGameSaveBlobInfo, 2916319284, 47856, 17989, 182, 208, 70, 237, 175, 251, 60, 43);
 RT_INTERFACE!{interface IGameSaveBlobInfo(IGameSaveBlobInfoVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveBlobInfo] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -1892,7 +1892,7 @@ impl IGameSaveBlobInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveBlobInfo: IGameSaveBlobInfo}
+RT_CLASS!{class GameSaveBlobInfo: IGameSaveBlobInfo ["Windows.Gaming.XboxLive.Storage.GameSaveBlobInfo"]}
 DEFINE_IID!(IID_IGameSaveBlobInfoGetResult, 3344401794, 13975, 17087, 152, 156, 102, 93, 146, 59, 82, 49);
 RT_INTERFACE!{interface IGameSaveBlobInfoGetResult(IGameSaveBlobInfoGetResultVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveBlobInfoGetResult] {
     fn get_Status(&self, out: *mut GameSaveErrorStatus) -> HRESULT,
@@ -1910,7 +1910,7 @@ impl IGameSaveBlobInfoGetResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveBlobInfoGetResult: IGameSaveBlobInfoGetResult}
+RT_CLASS!{class GameSaveBlobInfoGetResult: IGameSaveBlobInfoGetResult ["Windows.Gaming.XboxLive.Storage.GameSaveBlobInfoGetResult"]}
 DEFINE_IID!(IID_IGameSaveBlobInfoQuery, 2682090674, 61166, 17531, 169, 210, 127, 150, 192, 248, 50, 8);
 RT_INTERFACE!{interface IGameSaveBlobInfoQuery(IGameSaveBlobInfoQueryVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveBlobInfoQuery] {
     fn GetBlobInfoAsync(&self, out: *mut *mut foundation::IAsyncOperation<GameSaveBlobInfoGetResult>) -> HRESULT,
@@ -1934,7 +1934,7 @@ impl IGameSaveBlobInfoQuery {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveBlobInfoQuery: IGameSaveBlobInfoQuery}
+RT_CLASS!{class GameSaveBlobInfoQuery: IGameSaveBlobInfoQuery ["Windows.Gaming.XboxLive.Storage.GameSaveBlobInfoQuery"]}
 DEFINE_IID!(IID_IGameSaveContainer, 3284176777, 22079, 20173, 156, 111, 51, 253, 14, 50, 61, 16);
 RT_INTERFACE!{interface IGameSaveContainer(IGameSaveContainerVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveContainer] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -1984,7 +1984,7 @@ impl IGameSaveContainer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveContainer: IGameSaveContainer}
+RT_CLASS!{class GameSaveContainer: IGameSaveContainer ["Windows.Gaming.XboxLive.Storage.GameSaveContainer"]}
 DEFINE_IID!(IID_IGameSaveContainerInfo, 3085071104, 5469, 19380, 178, 186, 147, 3, 6, 243, 145, 181);
 RT_INTERFACE!{interface IGameSaveContainerInfo(IGameSaveContainerInfoVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveContainerInfo] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -2020,7 +2020,7 @@ impl IGameSaveContainerInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveContainerInfo: IGameSaveContainerInfo}
+RT_CLASS!{class GameSaveContainerInfo: IGameSaveContainerInfo ["Windows.Gaming.XboxLive.Storage.GameSaveContainerInfo"]}
 DEFINE_IID!(IID_IGameSaveContainerInfoGetResult, 4291104116, 50561, 20381, 158, 57, 48, 161, 12, 30, 76, 80);
 RT_INTERFACE!{interface IGameSaveContainerInfoGetResult(IGameSaveContainerInfoGetResultVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveContainerInfoGetResult] {
     fn get_Status(&self, out: *mut GameSaveErrorStatus) -> HRESULT,
@@ -2038,7 +2038,7 @@ impl IGameSaveContainerInfoGetResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveContainerInfoGetResult: IGameSaveContainerInfoGetResult}
+RT_CLASS!{class GameSaveContainerInfoGetResult: IGameSaveContainerInfoGetResult ["Windows.Gaming.XboxLive.Storage.GameSaveContainerInfoGetResult"]}
 DEFINE_IID!(IID_IGameSaveContainerInfoQuery, 1016391779, 28544, 17191, 147, 39, 255, 193, 26, 253, 66, 179);
 RT_INTERFACE!{interface IGameSaveContainerInfoQuery(IGameSaveContainerInfoQueryVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveContainerInfoQuery] {
     fn GetContainerInfoAsync(&self, out: *mut *mut foundation::IAsyncOperation<GameSaveContainerInfoGetResult>) -> HRESULT,
@@ -2062,8 +2062,8 @@ impl IGameSaveContainerInfoQuery {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveContainerInfoQuery: IGameSaveContainerInfoQuery}
-RT_ENUM! { enum GameSaveErrorStatus: i32 {
+RT_CLASS!{class GameSaveContainerInfoQuery: IGameSaveContainerInfoQuery ["Windows.Gaming.XboxLive.Storage.GameSaveContainerInfoQuery"]}
+RT_ENUM! { enum GameSaveErrorStatus: i32 ["Windows.Gaming.XboxLive.Storage.GameSaveErrorStatus"] {
     Ok (GameSaveErrorStatus_Ok) = 0, Abort (GameSaveErrorStatus_Abort) = -2147467260, InvalidContainerName (GameSaveErrorStatus_InvalidContainerName) = -2138898431, NoAccess (GameSaveErrorStatus_NoAccess) = -2138898430, OutOfLocalStorage (GameSaveErrorStatus_OutOfLocalStorage) = -2138898429, UserCanceled (GameSaveErrorStatus_UserCanceled) = -2138898428, UpdateTooBig (GameSaveErrorStatus_UpdateTooBig) = -2138898427, QuotaExceeded (GameSaveErrorStatus_QuotaExceeded) = -2138898426, ProvidedBufferTooSmall (GameSaveErrorStatus_ProvidedBufferTooSmall) = -2138898425, BlobNotFound (GameSaveErrorStatus_BlobNotFound) = -2138898424, NoXboxLiveInfo (GameSaveErrorStatus_NoXboxLiveInfo) = -2138898423, ContainerNotInSync (GameSaveErrorStatus_ContainerNotInSync) = -2138898422, ContainerSyncFailed (GameSaveErrorStatus_ContainerSyncFailed) = -2138898421, UserHasNoXboxLiveInfo (GameSaveErrorStatus_UserHasNoXboxLiveInfo) = -2138898420, ObjectExpired (GameSaveErrorStatus_ObjectExpired) = -2138898419,
 }}
 DEFINE_IID!(IID_IGameSaveOperationResult, 3473873413, 9376, 17794, 154, 85, 177, 187, 187, 147, 136, 216);
@@ -2077,7 +2077,7 @@ impl IGameSaveOperationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveOperationResult: IGameSaveOperationResult}
+RT_CLASS!{class GameSaveOperationResult: IGameSaveOperationResult ["Windows.Gaming.XboxLive.Storage.GameSaveOperationResult"]}
 DEFINE_IID!(IID_IGameSaveProvider, 2426798996, 33022, 16913, 151, 248, 165, 222, 20, 221, 149, 210);
 RT_INTERFACE!{interface IGameSaveProvider(IGameSaveProviderVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveProvider] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -2126,7 +2126,7 @@ impl IGameSaveProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveProvider: IGameSaveProvider}
+RT_CLASS!{class GameSaveProvider: IGameSaveProvider ["Windows.Gaming.XboxLive.Storage.GameSaveProvider"]}
 impl RtActivatable<IGameSaveProviderStatics> for GameSaveProvider {}
 impl GameSaveProvider {
     #[cfg(feature="windows-system")] #[inline] pub fn get_for_user_async(user: &::rt::gen::windows::system::User, serviceConfigId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<GameSaveProviderGetResult>>> {
@@ -2154,7 +2154,7 @@ impl IGameSaveProviderGetResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameSaveProviderGetResult: IGameSaveProviderGetResult}
+RT_CLASS!{class GameSaveProviderGetResult: IGameSaveProviderGetResult ["Windows.Gaming.XboxLive.Storage.GameSaveProviderGetResult"]}
 DEFINE_IID!(IID_IGameSaveProviderStatics, 3491577552, 31491, 17565, 140, 189, 52, 2, 132, 42, 16, 72);
 RT_INTERFACE!{static interface IGameSaveProviderStatics(IGameSaveProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameSaveProviderStatics] {
     #[cfg(feature="windows-system")] fn GetForUserAsync(&self, user: *mut ::rt::gen::windows::system::User, serviceConfigId: HSTRING, out: *mut *mut foundation::IAsyncOperation<GameSaveProviderGetResult>) -> HRESULT,

--- a/src/rt/gen/windows/globalization.rs
+++ b/src/rt/gen/windows/globalization.rs
@@ -625,7 +625,7 @@ impl ICalendar {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Calendar: ICalendar}
+RT_CLASS!{class Calendar: ICalendar ["Windows.Globalization.Calendar"]}
 impl RtActivatable<ICalendarFactory> for Calendar {}
 impl RtActivatable<ICalendarFactory2> for Calendar {}
 impl RtActivatable<IActivationFactory> for Calendar {}
@@ -2334,7 +2334,7 @@ impl ICurrencyIdentifiersStatics3 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DayOfWeek: i32 {
+RT_ENUM! { enum DayOfWeek: i32 ["Windows.Globalization.DayOfWeek"] {
     Sunday (DayOfWeek_Sunday) = 0, Monday (DayOfWeek_Monday) = 1, Tuesday (DayOfWeek_Tuesday) = 2, Wednesday (DayOfWeek_Wednesday) = 3, Thursday (DayOfWeek_Thursday) = 4, Friday (DayOfWeek_Friday) = 5, Saturday (DayOfWeek_Saturday) = 6,
 }}
 DEFINE_IID!(IID_IGeographicRegion, 32089633, 19044, 20185, 149, 79, 158, 222, 176, 123, 217, 3);
@@ -2384,7 +2384,7 @@ impl IGeographicRegion {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GeographicRegion: IGeographicRegion}
+RT_CLASS!{class GeographicRegion: IGeographicRegion ["Windows.Globalization.GeographicRegion"]}
 impl RtActivatable<IGeographicRegionFactory> for GeographicRegion {}
 impl RtActivatable<IGeographicRegionStatics> for GeographicRegion {}
 impl RtActivatable<IActivationFactory> for GeographicRegion {}
@@ -2442,7 +2442,7 @@ impl IJapanesePhoneme {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class JapanesePhoneme: IJapanesePhoneme}
+RT_CLASS!{class JapanesePhoneme: IJapanesePhoneme ["Windows.Globalization.JapanesePhoneme"]}
 RT_CLASS!{static class JapanesePhoneticAnalyzer}
 impl RtActivatable<IJapanesePhoneticAnalyzerStatics> for JapanesePhoneticAnalyzer {}
 impl JapanesePhoneticAnalyzer {
@@ -2500,7 +2500,7 @@ impl ILanguage {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Language: ILanguage}
+RT_CLASS!{class Language: ILanguage ["Windows.Globalization.Language"]}
 impl RtActivatable<ILanguageFactory> for Language {}
 impl RtActivatable<ILanguageStatics> for Language {}
 impl RtActivatable<ILanguageStatics2> for Language {}
@@ -2552,7 +2552,7 @@ impl ILanguageFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LanguageLayoutDirection: i32 {
+RT_ENUM! { enum LanguageLayoutDirection: i32 ["Windows.Globalization.LanguageLayoutDirection"] {
     Ltr (LanguageLayoutDirection_Ltr) = 0, Rtl (LanguageLayoutDirection_Rtl) = 1, TtbLtr (LanguageLayoutDirection_TtbLtr) = 2, TtbRtl (LanguageLayoutDirection_TtbRtl) = 3,
 }}
 DEFINE_IID!(IID_ILanguageStatics, 2990331223, 2149, 18132, 137, 184, 213, 155, 232, 153, 15, 13);
@@ -3078,7 +3078,7 @@ impl ICharacterGrouping {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CharacterGrouping: ICharacterGrouping}
+RT_CLASS!{class CharacterGrouping: ICharacterGrouping ["Windows.Globalization.Collation.CharacterGrouping"]}
 DEFINE_IID!(IID_ICharacterGroupings, 3100772981, 54479, 16469, 128, 229, 206, 22, 156, 34, 100, 150);
 RT_INTERFACE!{interface ICharacterGroupings(ICharacterGroupingsVtbl): IInspectable(IInspectableVtbl) [IID_ICharacterGroupings] {
     fn Lookup(&self, text: HSTRING, out: *mut HSTRING) -> HRESULT
@@ -3090,7 +3090,7 @@ impl ICharacterGroupings {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CharacterGroupings: ICharacterGroupings}
+RT_CLASS!{class CharacterGroupings: ICharacterGroupings ["Windows.Globalization.Collation.CharacterGroupings"]}
 impl RtActivatable<ICharacterGroupingsFactory> for CharacterGroupings {}
 impl RtActivatable<IActivationFactory> for CharacterGroupings {}
 impl CharacterGroupings {
@@ -3225,7 +3225,7 @@ impl IDateTimeFormatter {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DateTimeFormatter: IDateTimeFormatter}
+RT_CLASS!{class DateTimeFormatter: IDateTimeFormatter ["Windows.Globalization.DateTimeFormatting.DateTimeFormatter"]}
 impl RtActivatable<IDateTimeFormatterFactory> for DateTimeFormatter {}
 impl RtActivatable<IDateTimeFormatterStatics> for DateTimeFormatter {}
 impl DateTimeFormatter {
@@ -3351,25 +3351,25 @@ impl IDateTimeFormatterStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DayFormat: i32 {
+RT_ENUM! { enum DayFormat: i32 ["Windows.Globalization.DateTimeFormatting.DayFormat"] {
     None (DayFormat_None) = 0, Default (DayFormat_Default) = 1,
 }}
-RT_ENUM! { enum DayOfWeekFormat: i32 {
+RT_ENUM! { enum DayOfWeekFormat: i32 ["Windows.Globalization.DateTimeFormatting.DayOfWeekFormat"] {
     None (DayOfWeekFormat_None) = 0, Default (DayOfWeekFormat_Default) = 1, Abbreviated (DayOfWeekFormat_Abbreviated) = 2, Full (DayOfWeekFormat_Full) = 3,
 }}
-RT_ENUM! { enum HourFormat: i32 {
+RT_ENUM! { enum HourFormat: i32 ["Windows.Globalization.DateTimeFormatting.HourFormat"] {
     None (HourFormat_None) = 0, Default (HourFormat_Default) = 1,
 }}
-RT_ENUM! { enum MinuteFormat: i32 {
+RT_ENUM! { enum MinuteFormat: i32 ["Windows.Globalization.DateTimeFormatting.MinuteFormat"] {
     None (MinuteFormat_None) = 0, Default (MinuteFormat_Default) = 1,
 }}
-RT_ENUM! { enum MonthFormat: i32 {
+RT_ENUM! { enum MonthFormat: i32 ["Windows.Globalization.DateTimeFormatting.MonthFormat"] {
     None (MonthFormat_None) = 0, Default (MonthFormat_Default) = 1, Abbreviated (MonthFormat_Abbreviated) = 2, Full (MonthFormat_Full) = 3, Numeric (MonthFormat_Numeric) = 4,
 }}
-RT_ENUM! { enum SecondFormat: i32 {
+RT_ENUM! { enum SecondFormat: i32 ["Windows.Globalization.DateTimeFormatting.SecondFormat"] {
     None (SecondFormat_None) = 0, Default (SecondFormat_Default) = 1,
 }}
-RT_ENUM! { enum YearFormat: i32 {
+RT_ENUM! { enum YearFormat: i32 ["Windows.Globalization.DateTimeFormatting.YearFormat"] {
     None (YearFormat_None) = 0, Default (YearFormat_Default) = 1, Abbreviated (YearFormat_Abbreviated) = 2, Full (YearFormat_Full) = 3,
 }}
 } // Windows.Globalization.DateTimeFormatting
@@ -3413,7 +3413,7 @@ impl ILanguageFont {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LanguageFont: ILanguageFont}
+RT_CLASS!{class LanguageFont: ILanguageFont ["Windows.Globalization.Fonts.LanguageFont"]}
 DEFINE_IID!(IID_ILanguageFontGroup, 4080697283, 14940, 19178, 185, 255, 179, 159, 178, 66, 247, 246);
 RT_INTERFACE!{interface ILanguageFontGroup(ILanguageFontGroupVtbl): IInspectable(IInspectableVtbl) [IID_ILanguageFontGroup] {
     fn get_UITextFont(&self, out: *mut *mut LanguageFont) -> HRESULT,
@@ -3485,7 +3485,7 @@ impl ILanguageFontGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LanguageFontGroup: ILanguageFontGroup}
+RT_CLASS!{class LanguageFontGroup: ILanguageFontGroup ["Windows.Globalization.Fonts.LanguageFontGroup"]}
 impl RtActivatable<ILanguageFontGroupFactory> for LanguageFontGroup {}
 impl LanguageFontGroup {
     #[inline] pub fn create_language_font_group(languageTag: &HStringArg) -> Result<ComPtr<LanguageFontGroup>> {
@@ -3523,7 +3523,7 @@ impl ICurrencyFormatter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CurrencyFormatter: ICurrencyFormatter}
+RT_CLASS!{class CurrencyFormatter: ICurrencyFormatter ["Windows.Globalization.NumberFormatting.CurrencyFormatter"]}
 impl RtActivatable<ICurrencyFormatterFactory> for CurrencyFormatter {}
 impl CurrencyFormatter {
     #[inline] pub fn create_currency_formatter_code(currencyCode: &HStringArg) -> Result<ComPtr<CurrencyFormatter>> {
@@ -3572,10 +3572,10 @@ impl ICurrencyFormatterFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CurrencyFormatterMode: i32 {
+RT_ENUM! { enum CurrencyFormatterMode: i32 ["Windows.Globalization.NumberFormatting.CurrencyFormatterMode"] {
     UseSymbol (CurrencyFormatterMode_UseSymbol) = 0, UseCurrencyCode (CurrencyFormatterMode_UseCurrencyCode) = 1,
 }}
-RT_CLASS!{class DecimalFormatter: INumberFormatter}
+RT_CLASS!{class DecimalFormatter: INumberFormatter ["Windows.Globalization.NumberFormatting.DecimalFormatter"]}
 impl RtActivatable<IDecimalFormatterFactory> for DecimalFormatter {}
 impl RtActivatable<IActivationFactory> for DecimalFormatter {}
 impl DecimalFormatter {
@@ -3622,7 +3622,7 @@ impl IIncrementNumberRounder {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class IncrementNumberRounder: INumberRounder}
+RT_CLASS!{class IncrementNumberRounder: INumberRounder ["Windows.Globalization.NumberFormatting.IncrementNumberRounder"]}
 impl RtActivatable<IActivationFactory> for IncrementNumberRounder {}
 DEFINE_CLSID!(IncrementNumberRounder(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,73,110,99,114,101,109,101,110,116,78,117,109,98,101,114,82,111,117,110,100,101,114,0]) [CLSID_IncrementNumberRounder]);
 DEFINE_IID!(IID_INumberFormatter, 2768272457, 30326, 19895, 134, 49, 27, 111, 242, 101, 202, 169);
@@ -3869,7 +3869,7 @@ impl INumeralSystemTranslator {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NumeralSystemTranslator: INumeralSystemTranslator}
+RT_CLASS!{class NumeralSystemTranslator: INumeralSystemTranslator ["Windows.Globalization.NumberFormatting.NumeralSystemTranslator"]}
 impl RtActivatable<INumeralSystemTranslatorFactory> for NumeralSystemTranslator {}
 impl RtActivatable<IActivationFactory> for NumeralSystemTranslator {}
 impl NumeralSystemTranslator {
@@ -3889,7 +3889,7 @@ impl INumeralSystemTranslatorFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PercentFormatter: INumberFormatter}
+RT_CLASS!{class PercentFormatter: INumberFormatter ["Windows.Globalization.NumberFormatting.PercentFormatter"]}
 impl RtActivatable<IPercentFormatterFactory> for PercentFormatter {}
 impl RtActivatable<IActivationFactory> for PercentFormatter {}
 impl PercentFormatter {
@@ -3909,7 +3909,7 @@ impl IPercentFormatterFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PermilleFormatter: INumberFormatter}
+RT_CLASS!{class PermilleFormatter: INumberFormatter ["Windows.Globalization.NumberFormatting.PermilleFormatter"]}
 impl RtActivatable<IPermilleFormatterFactory> for PermilleFormatter {}
 impl RtActivatable<IActivationFactory> for PermilleFormatter {}
 impl PermilleFormatter {
@@ -3929,7 +3929,7 @@ impl IPermilleFormatterFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RoundingAlgorithm: i32 {
+RT_ENUM! { enum RoundingAlgorithm: i32 ["Windows.Globalization.NumberFormatting.RoundingAlgorithm"] {
     None (RoundingAlgorithm_None) = 0, RoundDown (RoundingAlgorithm_RoundDown) = 1, RoundUp (RoundingAlgorithm_RoundUp) = 2, RoundTowardsZero (RoundingAlgorithm_RoundTowardsZero) = 3, RoundAwayFromZero (RoundingAlgorithm_RoundAwayFromZero) = 4, RoundHalfDown (RoundingAlgorithm_RoundHalfDown) = 5, RoundHalfUp (RoundingAlgorithm_RoundHalfUp) = 6, RoundHalfTowardsZero (RoundingAlgorithm_RoundHalfTowardsZero) = 7, RoundHalfAwayFromZero (RoundingAlgorithm_RoundHalfAwayFromZero) = 8, RoundHalfToEven (RoundingAlgorithm_RoundHalfToEven) = 9, RoundHalfToOdd (RoundingAlgorithm_RoundHalfToOdd) = 10,
 }}
 DEFINE_IID!(IID_ISignedZeroOption, 4246527281, 2620, 18884, 166, 66, 150, 161, 86, 79, 79, 48);
@@ -3975,7 +3975,7 @@ impl ISignificantDigitsNumberRounder {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SignificantDigitsNumberRounder: INumberRounder}
+RT_CLASS!{class SignificantDigitsNumberRounder: INumberRounder ["Windows.Globalization.NumberFormatting.SignificantDigitsNumberRounder"]}
 impl RtActivatable<IActivationFactory> for SignificantDigitsNumberRounder {}
 DEFINE_CLSID!(SignificantDigitsNumberRounder(&[87,105,110,100,111,119,115,46,71,108,111,98,97,108,105,122,97,116,105,111,110,46,78,117,109,98,101,114,70,111,114,109,97,116,116,105,110,103,46,83,105,103,110,105,102,105,99,97,110,116,68,105,103,105,116,115,78,117,109,98,101,114,82,111,117,110,100,101,114,0]) [CLSID_SignificantDigitsNumberRounder]);
 DEFINE_IID!(IID_ISignificantDigitsOption, 491650269, 11587, 20200, 187, 241, 193, 178, 106, 113, 26, 88);
@@ -3997,7 +3997,7 @@ impl ISignificantDigitsOption {
 } // Windows.Globalization.NumberFormatting
 pub mod phonenumberformatting { // Windows.Globalization.PhoneNumberFormatting
 use ::prelude::*;
-RT_ENUM! { enum PhoneNumberFormat: i32 {
+RT_ENUM! { enum PhoneNumberFormat: i32 ["Windows.Globalization.PhoneNumberFormatting.PhoneNumberFormat"] {
     E164 (PhoneNumberFormat_E164) = 0, International (PhoneNumberFormat_International) = 1, National (PhoneNumberFormat_National) = 2, Rfc3966 (PhoneNumberFormat_Rfc3966) = 3,
 }}
 DEFINE_IID!(IID_IPhoneNumberFormatter, 358003870, 47828, 19274, 144, 13, 68, 7, 173, 183, 201, 129);
@@ -4035,7 +4035,7 @@ impl IPhoneNumberFormatter {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneNumberFormatter: IPhoneNumberFormatter}
+RT_CLASS!{class PhoneNumberFormatter: IPhoneNumberFormatter ["Windows.Globalization.PhoneNumberFormatting.PhoneNumberFormatter"]}
 impl RtActivatable<IPhoneNumberFormatterStatics> for PhoneNumberFormatter {}
 impl RtActivatable<IActivationFactory> for PhoneNumberFormatter {}
 impl PhoneNumberFormatter {
@@ -4135,7 +4135,7 @@ impl IPhoneNumberInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhoneNumberInfo: IPhoneNumberInfo}
+RT_CLASS!{class PhoneNumberInfo: IPhoneNumberInfo ["Windows.Globalization.PhoneNumberFormatting.PhoneNumberInfo"]}
 impl RtActivatable<IPhoneNumberInfoFactory> for PhoneNumberInfo {}
 impl RtActivatable<IPhoneNumberInfoStatics> for PhoneNumberInfo {}
 impl PhoneNumberInfo {
@@ -4178,13 +4178,13 @@ impl IPhoneNumberInfoStatics {
         if hr == S_OK { Ok((ComPtr::wrap_optional(phoneNumber), out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PhoneNumberMatchResult: i32 {
+RT_ENUM! { enum PhoneNumberMatchResult: i32 ["Windows.Globalization.PhoneNumberFormatting.PhoneNumberMatchResult"] {
     NoMatch (PhoneNumberMatchResult_NoMatch) = 0, ShortNationalSignificantNumberMatch (PhoneNumberMatchResult_ShortNationalSignificantNumberMatch) = 1, NationalSignificantNumberMatch (PhoneNumberMatchResult_NationalSignificantNumberMatch) = 2, ExactMatch (PhoneNumberMatchResult_ExactMatch) = 3,
 }}
-RT_ENUM! { enum PhoneNumberParseResult: i32 {
+RT_ENUM! { enum PhoneNumberParseResult: i32 ["Windows.Globalization.PhoneNumberFormatting.PhoneNumberParseResult"] {
     Valid (PhoneNumberParseResult_Valid) = 0, NotANumber (PhoneNumberParseResult_NotANumber) = 1, InvalidCountryCode (PhoneNumberParseResult_InvalidCountryCode) = 2, TooShort (PhoneNumberParseResult_TooShort) = 3, TooLong (PhoneNumberParseResult_TooLong) = 4,
 }}
-RT_ENUM! { enum PredictedPhoneNumberKind: i32 {
+RT_ENUM! { enum PredictedPhoneNumberKind: i32 ["Windows.Globalization.PhoneNumberFormatting.PredictedPhoneNumberKind"] {
     FixedLine (PredictedPhoneNumberKind_FixedLine) = 0, Mobile (PredictedPhoneNumberKind_Mobile) = 1, FixedLineOrMobile (PredictedPhoneNumberKind_FixedLineOrMobile) = 2, TollFree (PredictedPhoneNumberKind_TollFree) = 3, PremiumRate (PredictedPhoneNumberKind_PremiumRate) = 4, SharedCost (PredictedPhoneNumberKind_SharedCost) = 5, Voip (PredictedPhoneNumberKind_Voip) = 6, PersonalNumber (PredictedPhoneNumberKind_PersonalNumber) = 7, Pager (PredictedPhoneNumberKind_Pager) = 8, UniversalAccountNumber (PredictedPhoneNumberKind_UniversalAccountNumber) = 9, Voicemail (PredictedPhoneNumberKind_Voicemail) = 10, Unknown (PredictedPhoneNumberKind_Unknown) = 11,
 }}
 } // Windows.Globalization.PhoneNumberFormatting

--- a/src/rt/gen/windows/graphics.rs
+++ b/src/rt/gen/windows/graphics.rs
@@ -1,18 +1,18 @@
 use ::prelude::*;
-RT_STRUCT! { struct DisplayAdapterId {
+RT_STRUCT! { struct DisplayAdapterId ["Windows.Graphics.DisplayAdapterId"] {
     LowPart: u32, HighPart: i32,
 }}
 DEFINE_IID!(IID_IGeometrySource2D, 3405740290, 26380, 16769, 166, 36, 218, 151, 114, 3, 184, 69);
 RT_INTERFACE!{interface IGeometrySource2D(IGeometrySource2DVtbl): IInspectable(IInspectableVtbl) [IID_IGeometrySource2D] {
     
 }}
-RT_STRUCT! { struct PointInt32 {
+RT_STRUCT! { struct PointInt32 ["Windows.Graphics.PointInt32"] {
     X: i32, Y: i32,
 }}
-RT_STRUCT! { struct RectInt32 {
+RT_STRUCT! { struct RectInt32 ["Windows.Graphics.RectInt32"] {
     X: i32, Y: i32, Width: i32, Height: i32,
 }}
-RT_STRUCT! { struct SizeInt32 {
+RT_STRUCT! { struct SizeInt32 ["Windows.Graphics.SizeInt32"] {
     Width: i32, Height: i32,
 }}
 pub mod capture { // Windows.Graphics.Capture
@@ -40,7 +40,7 @@ impl IDirect3D11CaptureFrame {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Direct3D11CaptureFrame: IDirect3D11CaptureFrame}
+RT_CLASS!{class Direct3D11CaptureFrame: IDirect3D11CaptureFrame ["Windows.Graphics.Capture.Direct3D11CaptureFrame"]}
 DEFINE_IID!(IID_IDirect3D11CaptureFramePool, 619408674, 6517, 16942, 130, 231, 120, 13, 189, 141, 223, 36);
 RT_INTERFACE!{interface IDirect3D11CaptureFramePool(IDirect3D11CaptureFramePoolVtbl): IInspectable(IInspectableVtbl) [IID_IDirect3D11CaptureFramePool] {
     fn Recreate(&self, device: *mut super::directx::direct3d11::IDirect3DDevice, pixelFormat: super::directx::DirectXPixelFormat, numberOfBuffers: i32, size: super::SizeInt32) -> HRESULT,
@@ -80,7 +80,7 @@ impl IDirect3D11CaptureFramePool {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Direct3D11CaptureFramePool: IDirect3D11CaptureFramePool}
+RT_CLASS!{class Direct3D11CaptureFramePool: IDirect3D11CaptureFramePool ["Windows.Graphics.Capture.Direct3D11CaptureFramePool"]}
 impl RtActivatable<IDirect3D11CaptureFramePoolStatics> for Direct3D11CaptureFramePool {}
 impl RtActivatable<IDirect3D11CaptureFramePoolStatics2> for Direct3D11CaptureFramePool {}
 impl Direct3D11CaptureFramePool {
@@ -142,7 +142,7 @@ impl IGraphicsCaptureItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GraphicsCaptureItem: IGraphicsCaptureItem}
+RT_CLASS!{class GraphicsCaptureItem: IGraphicsCaptureItem ["Windows.Graphics.Capture.GraphicsCaptureItem"]}
 impl RtActivatable<IGraphicsCaptureItemStatics> for GraphicsCaptureItem {}
 impl GraphicsCaptureItem {
     #[cfg(feature="windows-ui")] #[inline] pub fn create_from_visual(visual: &super::super::ui::composition::Visual) -> Result<Option<ComPtr<GraphicsCaptureItem>>> {
@@ -172,7 +172,7 @@ impl IGraphicsCapturePicker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GraphicsCapturePicker: IGraphicsCapturePicker}
+RT_CLASS!{class GraphicsCapturePicker: IGraphicsCapturePicker ["Windows.Graphics.Capture.GraphicsCapturePicker"]}
 impl RtActivatable<IActivationFactory> for GraphicsCapturePicker {}
 DEFINE_CLSID!(GraphicsCapturePicker(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,67,97,112,116,117,114,101,46,71,114,97,112,104,105,99,115,67,97,112,116,117,114,101,80,105,99,107,101,114,0]) [CLSID_GraphicsCapturePicker]);
 DEFINE_IID!(IID_IGraphicsCaptureSession, 2169389737, 63247, 19159, 147, 155, 253, 220, 198, 235, 136, 13);
@@ -185,7 +185,7 @@ impl IGraphicsCaptureSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GraphicsCaptureSession: IGraphicsCaptureSession}
+RT_CLASS!{class GraphicsCaptureSession: IGraphicsCaptureSession ["Windows.Graphics.Capture.GraphicsCaptureSession"]}
 impl RtActivatable<IGraphicsCaptureSessionStatics> for GraphicsCaptureSession {}
 impl GraphicsCaptureSession {
     #[inline] pub fn is_supported() -> Result<bool> {
@@ -207,18 +207,18 @@ impl IGraphicsCaptureSessionStatics {
 } // Windows.Graphics.Capture
 pub mod directx { // Windows.Graphics.DirectX
 use ::prelude::*;
-RT_ENUM! { enum DirectXAlphaMode: i32 {
+RT_ENUM! { enum DirectXAlphaMode: i32 ["Windows.Graphics.DirectX.DirectXAlphaMode"] {
     Unspecified (DirectXAlphaMode_Unspecified) = 0, Premultiplied (DirectXAlphaMode_Premultiplied) = 1, Straight (DirectXAlphaMode_Straight) = 2, Ignore (DirectXAlphaMode_Ignore) = 3,
 }}
-RT_ENUM! { enum DirectXColorSpace: i32 {
+RT_ENUM! { enum DirectXColorSpace: i32 ["Windows.Graphics.DirectX.DirectXColorSpace"] {
     RgbFullG22NoneP709 (DirectXColorSpace_RgbFullG22NoneP709) = 0, RgbFullG10NoneP709 (DirectXColorSpace_RgbFullG10NoneP709) = 1, RgbStudioG22NoneP709 (DirectXColorSpace_RgbStudioG22NoneP709) = 2, RgbStudioG22NoneP2020 (DirectXColorSpace_RgbStudioG22NoneP2020) = 3, Reserved (DirectXColorSpace_Reserved) = 4, YccFullG22NoneP709X601 (DirectXColorSpace_YccFullG22NoneP709X601) = 5, YccStudioG22LeftP601 (DirectXColorSpace_YccStudioG22LeftP601) = 6, YccFullG22LeftP601 (DirectXColorSpace_YccFullG22LeftP601) = 7, YccStudioG22LeftP709 (DirectXColorSpace_YccStudioG22LeftP709) = 8, YccFullG22LeftP709 (DirectXColorSpace_YccFullG22LeftP709) = 9, YccStudioG22LeftP2020 (DirectXColorSpace_YccStudioG22LeftP2020) = 10, YccFullG22LeftP2020 (DirectXColorSpace_YccFullG22LeftP2020) = 11, RgbFullG2084NoneP2020 (DirectXColorSpace_RgbFullG2084NoneP2020) = 12, YccStudioG2084LeftP2020 (DirectXColorSpace_YccStudioG2084LeftP2020) = 13, RgbStudioG2084NoneP2020 (DirectXColorSpace_RgbStudioG2084NoneP2020) = 14, YccStudioG22TopLeftP2020 (DirectXColorSpace_YccStudioG22TopLeftP2020) = 15, YccStudioG2084TopLeftP2020 (DirectXColorSpace_YccStudioG2084TopLeftP2020) = 16, RgbFullG22NoneP2020 (DirectXColorSpace_RgbFullG22NoneP2020) = 17, YccStudioGHlgTopLeftP2020 (DirectXColorSpace_YccStudioGHlgTopLeftP2020) = 18, YccFullGHlgTopLeftP2020 (DirectXColorSpace_YccFullGHlgTopLeftP2020) = 19, RgbStudioG24NoneP709 (DirectXColorSpace_RgbStudioG24NoneP709) = 20, RgbStudioG24NoneP2020 (DirectXColorSpace_RgbStudioG24NoneP2020) = 21, YccStudioG24LeftP709 (DirectXColorSpace_YccStudioG24LeftP709) = 22, YccStudioG24LeftP2020 (DirectXColorSpace_YccStudioG24LeftP2020) = 23, YccStudioG24TopLeftP2020 (DirectXColorSpace_YccStudioG24TopLeftP2020) = 24,
 }}
-RT_ENUM! { enum DirectXPixelFormat: i32 {
+RT_ENUM! { enum DirectXPixelFormat: i32 ["Windows.Graphics.DirectX.DirectXPixelFormat"] {
     Unknown (DirectXPixelFormat_Unknown) = 0, R32G32B32A32Typeless (DirectXPixelFormat_R32G32B32A32Typeless) = 1, R32G32B32A32Float (DirectXPixelFormat_R32G32B32A32Float) = 2, R32G32B32A32UInt (DirectXPixelFormat_R32G32B32A32UInt) = 3, R32G32B32A32Int (DirectXPixelFormat_R32G32B32A32Int) = 4, R32G32B32Typeless (DirectXPixelFormat_R32G32B32Typeless) = 5, R32G32B32Float (DirectXPixelFormat_R32G32B32Float) = 6, R32G32B32UInt (DirectXPixelFormat_R32G32B32UInt) = 7, R32G32B32Int (DirectXPixelFormat_R32G32B32Int) = 8, R16G16B16A16Typeless (DirectXPixelFormat_R16G16B16A16Typeless) = 9, R16G16B16A16Float (DirectXPixelFormat_R16G16B16A16Float) = 10, R16G16B16A16UIntNormalized (DirectXPixelFormat_R16G16B16A16UIntNormalized) = 11, R16G16B16A16UInt (DirectXPixelFormat_R16G16B16A16UInt) = 12, R16G16B16A16IntNormalized (DirectXPixelFormat_R16G16B16A16IntNormalized) = 13, R16G16B16A16Int (DirectXPixelFormat_R16G16B16A16Int) = 14, R32G32Typeless (DirectXPixelFormat_R32G32Typeless) = 15, R32G32Float (DirectXPixelFormat_R32G32Float) = 16, R32G32UInt (DirectXPixelFormat_R32G32UInt) = 17, R32G32Int (DirectXPixelFormat_R32G32Int) = 18, R32G8X24Typeless (DirectXPixelFormat_R32G8X24Typeless) = 19, D32FloatS8X24UInt (DirectXPixelFormat_D32FloatS8X24UInt) = 20, R32FloatX8X24Typeless (DirectXPixelFormat_R32FloatX8X24Typeless) = 21, X32TypelessG8X24UInt (DirectXPixelFormat_X32TypelessG8X24UInt) = 22, R10G10B10A2Typeless (DirectXPixelFormat_R10G10B10A2Typeless) = 23, R10G10B10A2UIntNormalized (DirectXPixelFormat_R10G10B10A2UIntNormalized) = 24, R10G10B10A2UInt (DirectXPixelFormat_R10G10B10A2UInt) = 25, R11G11B10Float (DirectXPixelFormat_R11G11B10Float) = 26, R8G8B8A8Typeless (DirectXPixelFormat_R8G8B8A8Typeless) = 27, R8G8B8A8UIntNormalized (DirectXPixelFormat_R8G8B8A8UIntNormalized) = 28, R8G8B8A8UIntNormalizedSrgb (DirectXPixelFormat_R8G8B8A8UIntNormalizedSrgb) = 29, R8G8B8A8UInt (DirectXPixelFormat_R8G8B8A8UInt) = 30, R8G8B8A8IntNormalized (DirectXPixelFormat_R8G8B8A8IntNormalized) = 31, R8G8B8A8Int (DirectXPixelFormat_R8G8B8A8Int) = 32, R16G16Typeless (DirectXPixelFormat_R16G16Typeless) = 33, R16G16Float (DirectXPixelFormat_R16G16Float) = 34, R16G16UIntNormalized (DirectXPixelFormat_R16G16UIntNormalized) = 35, R16G16UInt (DirectXPixelFormat_R16G16UInt) = 36, R16G16IntNormalized (DirectXPixelFormat_R16G16IntNormalized) = 37, R16G16Int (DirectXPixelFormat_R16G16Int) = 38, R32Typeless (DirectXPixelFormat_R32Typeless) = 39, D32Float (DirectXPixelFormat_D32Float) = 40, R32Float (DirectXPixelFormat_R32Float) = 41, R32UInt (DirectXPixelFormat_R32UInt) = 42, R32Int (DirectXPixelFormat_R32Int) = 43, R24G8Typeless (DirectXPixelFormat_R24G8Typeless) = 44, D24UIntNormalizedS8UInt (DirectXPixelFormat_D24UIntNormalizedS8UInt) = 45, R24UIntNormalizedX8Typeless (DirectXPixelFormat_R24UIntNormalizedX8Typeless) = 46, X24TypelessG8UInt (DirectXPixelFormat_X24TypelessG8UInt) = 47, R8G8Typeless (DirectXPixelFormat_R8G8Typeless) = 48, R8G8UIntNormalized (DirectXPixelFormat_R8G8UIntNormalized) = 49, R8G8UInt (DirectXPixelFormat_R8G8UInt) = 50, R8G8IntNormalized (DirectXPixelFormat_R8G8IntNormalized) = 51, R8G8Int (DirectXPixelFormat_R8G8Int) = 52, R16Typeless (DirectXPixelFormat_R16Typeless) = 53, R16Float (DirectXPixelFormat_R16Float) = 54, D16UIntNormalized (DirectXPixelFormat_D16UIntNormalized) = 55, R16UIntNormalized (DirectXPixelFormat_R16UIntNormalized) = 56, R16UInt (DirectXPixelFormat_R16UInt) = 57, R16IntNormalized (DirectXPixelFormat_R16IntNormalized) = 58, R16Int (DirectXPixelFormat_R16Int) = 59, R8Typeless (DirectXPixelFormat_R8Typeless) = 60, R8UIntNormalized (DirectXPixelFormat_R8UIntNormalized) = 61, R8UInt (DirectXPixelFormat_R8UInt) = 62, R8IntNormalized (DirectXPixelFormat_R8IntNormalized) = 63, R8Int (DirectXPixelFormat_R8Int) = 64, A8UIntNormalized (DirectXPixelFormat_A8UIntNormalized) = 65, R1UIntNormalized (DirectXPixelFormat_R1UIntNormalized) = 66, R9G9B9E5SharedExponent (DirectXPixelFormat_R9G9B9E5SharedExponent) = 67, R8G8B8G8UIntNormalized (DirectXPixelFormat_R8G8B8G8UIntNormalized) = 68, G8R8G8B8UIntNormalized (DirectXPixelFormat_G8R8G8B8UIntNormalized) = 69, BC1Typeless (DirectXPixelFormat_BC1Typeless) = 70, BC1UIntNormalized (DirectXPixelFormat_BC1UIntNormalized) = 71, BC1UIntNormalizedSrgb (DirectXPixelFormat_BC1UIntNormalizedSrgb) = 72, BC2Typeless (DirectXPixelFormat_BC2Typeless) = 73, BC2UIntNormalized (DirectXPixelFormat_BC2UIntNormalized) = 74, BC2UIntNormalizedSrgb (DirectXPixelFormat_BC2UIntNormalizedSrgb) = 75, BC3Typeless (DirectXPixelFormat_BC3Typeless) = 76, BC3UIntNormalized (DirectXPixelFormat_BC3UIntNormalized) = 77, BC3UIntNormalizedSrgb (DirectXPixelFormat_BC3UIntNormalizedSrgb) = 78, BC4Typeless (DirectXPixelFormat_BC4Typeless) = 79, BC4UIntNormalized (DirectXPixelFormat_BC4UIntNormalized) = 80, BC4IntNormalized (DirectXPixelFormat_BC4IntNormalized) = 81, BC5Typeless (DirectXPixelFormat_BC5Typeless) = 82, BC5UIntNormalized (DirectXPixelFormat_BC5UIntNormalized) = 83, BC5IntNormalized (DirectXPixelFormat_BC5IntNormalized) = 84, B5G6R5UIntNormalized (DirectXPixelFormat_B5G6R5UIntNormalized) = 85, B5G5R5A1UIntNormalized (DirectXPixelFormat_B5G5R5A1UIntNormalized) = 86, B8G8R8A8UIntNormalized (DirectXPixelFormat_B8G8R8A8UIntNormalized) = 87, B8G8R8X8UIntNormalized (DirectXPixelFormat_B8G8R8X8UIntNormalized) = 88, R10G10B10XRBiasA2UIntNormalized (DirectXPixelFormat_R10G10B10XRBiasA2UIntNormalized) = 89, B8G8R8A8Typeless (DirectXPixelFormat_B8G8R8A8Typeless) = 90, B8G8R8A8UIntNormalizedSrgb (DirectXPixelFormat_B8G8R8A8UIntNormalizedSrgb) = 91, B8G8R8X8Typeless (DirectXPixelFormat_B8G8R8X8Typeless) = 92, B8G8R8X8UIntNormalizedSrgb (DirectXPixelFormat_B8G8R8X8UIntNormalizedSrgb) = 93, BC6HTypeless (DirectXPixelFormat_BC6HTypeless) = 94, BC6H16UnsignedFloat (DirectXPixelFormat_BC6H16UnsignedFloat) = 95, BC6H16Float (DirectXPixelFormat_BC6H16Float) = 96, BC7Typeless (DirectXPixelFormat_BC7Typeless) = 97, BC7UIntNormalized (DirectXPixelFormat_BC7UIntNormalized) = 98, BC7UIntNormalizedSrgb (DirectXPixelFormat_BC7UIntNormalizedSrgb) = 99, Ayuv (DirectXPixelFormat_Ayuv) = 100, Y410 (DirectXPixelFormat_Y410) = 101, Y416 (DirectXPixelFormat_Y416) = 102, NV12 (DirectXPixelFormat_NV12) = 103, P010 (DirectXPixelFormat_P010) = 104, P016 (DirectXPixelFormat_P016) = 105, Opaque420 (DirectXPixelFormat_Opaque420) = 106, Yuy2 (DirectXPixelFormat_Yuy2) = 107, Y210 (DirectXPixelFormat_Y210) = 108, Y216 (DirectXPixelFormat_Y216) = 109, NV11 (DirectXPixelFormat_NV11) = 110, AI44 (DirectXPixelFormat_AI44) = 111, IA44 (DirectXPixelFormat_IA44) = 112, P8 (DirectXPixelFormat_P8) = 113, A8P8 (DirectXPixelFormat_A8P8) = 114, B4G4R4A4UIntNormalized (DirectXPixelFormat_B4G4R4A4UIntNormalized) = 115, P208 (DirectXPixelFormat_P208) = 130, V208 (DirectXPixelFormat_V208) = 131, V408 (DirectXPixelFormat_V408) = 132,
 }}
 pub mod direct3d11 { // Windows.Graphics.DirectX.Direct3D11
 use ::prelude::*;
-RT_ENUM! { enum Direct3DBindings: u32 {
+RT_ENUM! { enum Direct3DBindings: u32 ["Windows.Graphics.DirectX.Direct3D11.Direct3DBindings"] {
     VertexBuffer (Direct3DBindings_VertexBuffer) = 1, IndexBuffer (Direct3DBindings_IndexBuffer) = 2, ConstantBuffer (Direct3DBindings_ConstantBuffer) = 4, ShaderResource (Direct3DBindings_ShaderResource) = 8, StreamOutput (Direct3DBindings_StreamOutput) = 16, RenderTarget (Direct3DBindings_RenderTarget) = 32, DepthStencil (Direct3DBindings_DepthStencil) = 64, UnorderedAccess (Direct3DBindings_UnorderedAccess) = 128, Decoder (Direct3DBindings_Decoder) = 512, VideoEncoder (Direct3DBindings_VideoEncoder) = 1024,
 }}
 DEFINE_IID!(IID_IDirect3DDevice, 2742428843, 36191, 18000, 157, 62, 158, 174, 61, 155, 198, 112);
@@ -231,7 +231,7 @@ impl IDirect3DDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct Direct3DMultisampleDescription {
+RT_STRUCT! { struct Direct3DMultisampleDescription ["Windows.Graphics.DirectX.Direct3D11.Direct3DMultisampleDescription"] {
     Count: i32, Quality: i32,
 }}
 DEFINE_IID!(IID_IDirect3DSurface, 200581446, 5057, 18068, 190, 227, 122, 191, 21, 234, 245, 134);
@@ -245,10 +245,10 @@ impl IDirect3DSurface {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct Direct3DSurfaceDescription {
+RT_STRUCT! { struct Direct3DSurfaceDescription ["Windows.Graphics.DirectX.Direct3D11.Direct3DSurfaceDescription"] {
     Width: i32, Height: i32, Format: super::DirectXPixelFormat, MultisampleDescription: Direct3DMultisampleDescription,
 }}
-RT_ENUM! { enum Direct3DUsage: i32 {
+RT_ENUM! { enum Direct3DUsage: i32 ["Windows.Graphics.DirectX.Direct3D11.Direct3DUsage"] {
     Default (Direct3DUsage_Default) = 0, Immutable (Direct3DUsage_Immutable) = 1, Dynamic (Direct3DUsage_Dynamic) = 2, Staging (Direct3DUsage_Staging) = 3,
 }}
 } // Windows.Graphics.DirectX.Direct3D11
@@ -326,8 +326,8 @@ impl IAdvancedColorInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdvancedColorInfo: IAdvancedColorInfo}
-RT_ENUM! { enum AdvancedColorKind: i32 {
+RT_CLASS!{class AdvancedColorInfo: IAdvancedColorInfo ["Windows.Graphics.Display.AdvancedColorInfo"]}
+RT_ENUM! { enum AdvancedColorKind: i32 ["Windows.Graphics.Display.AdvancedColorKind"] {
     StandardDynamicRange (AdvancedColorKind_StandardDynamicRange) = 0, WideColorGamut (AdvancedColorKind_WideColorGamut) = 1, HighDynamicRange (AdvancedColorKind_HighDynamicRange) = 2,
 }}
 DEFINE_IID!(IID_IBrightnessOverride, 2529780250, 49475, 17298, 190, 221, 74, 126, 149, 116, 200, 253);
@@ -412,7 +412,7 @@ impl IBrightnessOverride {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BrightnessOverride: IBrightnessOverride}
+RT_CLASS!{class BrightnessOverride: IBrightnessOverride ["Windows.Graphics.Display.BrightnessOverride"]}
 impl RtActivatable<IBrightnessOverrideStatics> for BrightnessOverride {}
 impl BrightnessOverride {
     #[inline] pub fn get_default_for_system() -> Result<Option<ComPtr<BrightnessOverride>>> {
@@ -443,7 +443,7 @@ impl IBrightnessOverrideSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BrightnessOverrideSettings: IBrightnessOverrideSettings}
+RT_CLASS!{class BrightnessOverrideSettings: IBrightnessOverrideSettings ["Windows.Graphics.Display.BrightnessOverrideSettings"]}
 impl RtActivatable<IBrightnessOverrideSettingsStatics> for BrightnessOverrideSettings {}
 impl BrightnessOverrideSettings {
     #[inline] pub fn create_from_level(level: f64) -> Result<Option<ComPtr<BrightnessOverrideSettings>>> {
@@ -514,7 +514,7 @@ impl IColorOverrideSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ColorOverrideSettings: IColorOverrideSettings}
+RT_CLASS!{class ColorOverrideSettings: IColorOverrideSettings ["Windows.Graphics.Display.ColorOverrideSettings"]}
 impl RtActivatable<IColorOverrideSettingsStatics> for ColorOverrideSettings {}
 impl ColorOverrideSettings {
     #[inline] pub fn create_from_display_color_override_scenario(overrideScenario: DisplayColorOverrideScenario) -> Result<Option<ComPtr<ColorOverrideSettings>>> {
@@ -533,16 +533,16 @@ impl IColorOverrideSettingsStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DisplayBrightnessOverrideOptions: u32 {
+RT_ENUM! { enum DisplayBrightnessOverrideOptions: u32 ["Windows.Graphics.Display.DisplayBrightnessOverrideOptions"] {
     None (DisplayBrightnessOverrideOptions_None) = 0, UseDimmedPolicyWhenBatteryIsLow (DisplayBrightnessOverrideOptions_UseDimmedPolicyWhenBatteryIsLow) = 1,
 }}
-RT_ENUM! { enum DisplayBrightnessOverrideScenario: i32 {
+RT_ENUM! { enum DisplayBrightnessOverrideScenario: i32 ["Windows.Graphics.Display.DisplayBrightnessOverrideScenario"] {
     IdleBrightness (DisplayBrightnessOverrideScenario_IdleBrightness) = 0, BarcodeReadingBrightness (DisplayBrightnessOverrideScenario_BarcodeReadingBrightness) = 1, FullBrightness (DisplayBrightnessOverrideScenario_FullBrightness) = 2,
 }}
-RT_ENUM! { enum DisplayBrightnessScenario: i32 {
+RT_ENUM! { enum DisplayBrightnessScenario: i32 ["Windows.Graphics.Display.DisplayBrightnessScenario"] {
     DefaultBrightness (DisplayBrightnessScenario_DefaultBrightness) = 0, IdleBrightness (DisplayBrightnessScenario_IdleBrightness) = 1, BarcodeReadingBrightness (DisplayBrightnessScenario_BarcodeReadingBrightness) = 2, FullBrightness (DisplayBrightnessScenario_FullBrightness) = 3,
 }}
-RT_ENUM! { enum DisplayColorOverrideScenario: i32 {
+RT_ENUM! { enum DisplayColorOverrideScenario: i32 ["Windows.Graphics.Display.DisplayColorOverrideScenario"] {
     Accurate (DisplayColorOverrideScenario_Accurate) = 0,
 }}
 DEFINE_IID!(IID_IDisplayEnhancementOverride, 1117099215, 55674, 19202, 164, 40, 92, 66, 146, 247, 245, 34);
@@ -633,7 +633,7 @@ impl IDisplayEnhancementOverride {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayEnhancementOverride: IDisplayEnhancementOverride}
+RT_CLASS!{class DisplayEnhancementOverride: IDisplayEnhancementOverride ["Windows.Graphics.Display.DisplayEnhancementOverride"]}
 impl RtActivatable<IDisplayEnhancementOverrideStatics> for DisplayEnhancementOverride {}
 impl DisplayEnhancementOverride {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<DisplayEnhancementOverride>>> {
@@ -664,7 +664,7 @@ impl IDisplayEnhancementOverrideCapabilities {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayEnhancementOverrideCapabilities: IDisplayEnhancementOverrideCapabilities}
+RT_CLASS!{class DisplayEnhancementOverrideCapabilities: IDisplayEnhancementOverrideCapabilities ["Windows.Graphics.Display.DisplayEnhancementOverrideCapabilities"]}
 DEFINE_IID!(IID_IDisplayEnhancementOverrideCapabilitiesChangedEventArgs, 3680626276, 5626, 18906, 139, 119, 7, 219, 210, 175, 88, 93);
 RT_INTERFACE!{interface IDisplayEnhancementOverrideCapabilitiesChangedEventArgs(IDisplayEnhancementOverrideCapabilitiesChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayEnhancementOverrideCapabilitiesChangedEventArgs] {
     fn get_Capabilities(&self, out: *mut *mut DisplayEnhancementOverrideCapabilities) -> HRESULT
@@ -676,7 +676,7 @@ impl IDisplayEnhancementOverrideCapabilitiesChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayEnhancementOverrideCapabilitiesChangedEventArgs: IDisplayEnhancementOverrideCapabilitiesChangedEventArgs}
+RT_CLASS!{class DisplayEnhancementOverrideCapabilitiesChangedEventArgs: IDisplayEnhancementOverrideCapabilitiesChangedEventArgs ["Windows.Graphics.Display.DisplayEnhancementOverrideCapabilitiesChangedEventArgs"]}
 DEFINE_IID!(IID_IDisplayEnhancementOverrideStatics, 3478879937, 38801, 17491, 176, 19, 41, 182, 247, 120, 229, 25);
 RT_INTERFACE!{static interface IDisplayEnhancementOverrideStatics(IDisplayEnhancementOverrideStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDisplayEnhancementOverrideStatics] {
     fn GetForCurrentView(&self, out: *mut *mut DisplayEnhancementOverride) -> HRESULT
@@ -786,7 +786,7 @@ impl IDisplayInformation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayInformation: IDisplayInformation}
+RT_CLASS!{class DisplayInformation: IDisplayInformation ["Windows.Graphics.Display.DisplayInformation"]}
 impl RtActivatable<IDisplayInformationStatics> for DisplayInformation {}
 impl DisplayInformation {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<DisplayInformation>>> {
@@ -900,7 +900,7 @@ impl IDisplayInformationStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DisplayOrientations: u32 {
+RT_ENUM! { enum DisplayOrientations: u32 ["Windows.Graphics.Display.DisplayOrientations"] {
     None (DisplayOrientations_None) = 0, Landscape (DisplayOrientations_Landscape) = 1, Portrait (DisplayOrientations_Portrait) = 2, LandscapeFlipped (DisplayOrientations_LandscapeFlipped) = 4, PortraitFlipped (DisplayOrientations_PortraitFlipped) = 8,
 }}
 RT_CLASS!{static class DisplayProperties}
@@ -1080,24 +1080,24 @@ impl IDisplayPropertiesStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HdrMetadataFormat: i32 {
+RT_ENUM! { enum HdrMetadataFormat: i32 ["Windows.Graphics.Display.HdrMetadataFormat"] {
     Hdr10 (HdrMetadataFormat_Hdr10) = 0, Hdr10Plus (HdrMetadataFormat_Hdr10Plus) = 1,
 }}
-RT_STRUCT! { struct NitRange {
+RT_STRUCT! { struct NitRange ["Windows.Graphics.Display.NitRange"] {
     MinNits: f32, MaxNits: f32, StepSizeNits: f32,
 }}
-RT_ENUM! { enum ResolutionScale: i32 {
+RT_ENUM! { enum ResolutionScale: i32 ["Windows.Graphics.Display.ResolutionScale"] {
     Invalid (ResolutionScale_Invalid) = 0, Scale100Percent (ResolutionScale_Scale100Percent) = 100, Scale120Percent (ResolutionScale_Scale120Percent) = 120, Scale125Percent (ResolutionScale_Scale125Percent) = 125, Scale140Percent (ResolutionScale_Scale140Percent) = 140, Scale150Percent (ResolutionScale_Scale150Percent) = 150, Scale160Percent (ResolutionScale_Scale160Percent) = 160, Scale175Percent (ResolutionScale_Scale175Percent) = 175, Scale180Percent (ResolutionScale_Scale180Percent) = 180, Scale200Percent (ResolutionScale_Scale200Percent) = 200, Scale225Percent (ResolutionScale_Scale225Percent) = 225, Scale250Percent (ResolutionScale_Scale250Percent) = 250, Scale300Percent (ResolutionScale_Scale300Percent) = 300, Scale350Percent (ResolutionScale_Scale350Percent) = 350, Scale400Percent (ResolutionScale_Scale400Percent) = 400, Scale450Percent (ResolutionScale_Scale450Percent) = 450, Scale500Percent (ResolutionScale_Scale500Percent) = 500,
 }}
 pub mod core { // Windows.Graphics.Display.Core
 use ::prelude::*;
-RT_ENUM! { enum HdmiDisplayColorSpace: i32 {
+RT_ENUM! { enum HdmiDisplayColorSpace: i32 ["Windows.Graphics.Display.Core.HdmiDisplayColorSpace"] {
     RgbLimited (HdmiDisplayColorSpace_RgbLimited) = 0, RgbFull (HdmiDisplayColorSpace_RgbFull) = 1, BT2020 (HdmiDisplayColorSpace_BT2020) = 2, BT709 (HdmiDisplayColorSpace_BT709) = 3,
 }}
-RT_STRUCT! { struct HdmiDisplayHdr2086Metadata {
+RT_STRUCT! { struct HdmiDisplayHdr2086Metadata ["Windows.Graphics.Display.Core.HdmiDisplayHdr2086Metadata"] {
     RedPrimaryX: u16, RedPrimaryY: u16, GreenPrimaryX: u16, GreenPrimaryY: u16, BluePrimaryX: u16, BluePrimaryY: u16, WhitePointX: u16, WhitePointY: u16, MaxMasteringLuminance: u16, MinMasteringLuminance: u16, MaxContentLightLevel: u16, MaxFrameAverageLightLevel: u16,
 }}
-RT_ENUM! { enum HdmiDisplayHdrOption: i32 {
+RT_ENUM! { enum HdmiDisplayHdrOption: i32 ["Windows.Graphics.Display.Core.HdmiDisplayHdrOption"] {
     None (HdmiDisplayHdrOption_None) = 0, EotfSdr (HdmiDisplayHdrOption_EotfSdr) = 1, Eotf2084 (HdmiDisplayHdrOption_Eotf2084) = 2, DolbyVisionLowLatency (HdmiDisplayHdrOption_DolbyVisionLowLatency) = 3,
 }}
 DEFINE_IID!(IID_IHdmiDisplayInformation, 319503370, 62821, 18286, 171, 213, 234, 5, 174, 231, 76, 105);
@@ -1152,7 +1152,7 @@ impl IHdmiDisplayInformation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HdmiDisplayInformation: IHdmiDisplayInformation}
+RT_CLASS!{class HdmiDisplayInformation: IHdmiDisplayInformation ["Windows.Graphics.Display.Core.HdmiDisplayInformation"]}
 impl RtActivatable<IHdmiDisplayInformationStatics> for HdmiDisplayInformation {}
 impl HdmiDisplayInformation {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<HdmiDisplayInformation>>> {
@@ -1242,7 +1242,7 @@ impl IHdmiDisplayMode {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HdmiDisplayMode: IHdmiDisplayMode}
+RT_CLASS!{class HdmiDisplayMode: IHdmiDisplayMode ["Windows.Graphics.Display.Core.HdmiDisplayMode"]}
 DEFINE_IID!(IID_IHdmiDisplayMode2, 130895519, 19260, 17080, 132, 231, 137, 83, 104, 113, 138, 242);
 RT_INTERFACE!{interface IHdmiDisplayMode2(IHdmiDisplayMode2Vtbl): IInspectable(IInspectableVtbl) [IID_IHdmiDisplayMode2] {
     fn get_IsDolbyVisionLowLatencySupported(&self, out: *mut bool) -> HRESULT
@@ -1254,7 +1254,7 @@ impl IHdmiDisplayMode2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HdmiDisplayPixelEncoding: i32 {
+RT_ENUM! { enum HdmiDisplayPixelEncoding: i32 ["Windows.Graphics.Display.Core.HdmiDisplayPixelEncoding"] {
     Rgb444 (HdmiDisplayPixelEncoding_Rgb444) = 0, Ycc444 (HdmiDisplayPixelEncoding_Ycc444) = 1, Ycc422 (HdmiDisplayPixelEncoding_Ycc422) = 2, Ycc420 (HdmiDisplayPixelEncoding_Ycc420) = 3,
 }}
 } // Windows.Graphics.Display.Core
@@ -1284,7 +1284,7 @@ RT_INTERFACE!{interface IGraphicsEffectSource(IGraphicsEffectSourceVtbl): IInspe
 } // Windows.Graphics.Effects
 pub mod holographic { // Windows.Graphics.Holographic
 use ::prelude::*;
-RT_STRUCT! { struct HolographicAdapterId {
+RT_STRUCT! { struct HolographicAdapterId ["Windows.Graphics.Holographic.HolographicAdapterId"] {
     LowPart: u32, HighPart: i32,
 }}
 DEFINE_IID!(IID_IHolographicCamera, 3840508997, 39917, 18816, 155, 160, 232, 118, 128, 209, 203, 116);
@@ -1331,7 +1331,7 @@ impl IHolographicCamera {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicCamera: IHolographicCamera}
+RT_CLASS!{class HolographicCamera: IHolographicCamera ["Windows.Graphics.Holographic.HolographicCamera"]}
 DEFINE_IID!(IID_IHolographicCamera2, 3042680602, 47756, 20356, 173, 121, 46, 126, 30, 36, 80, 243);
 RT_INTERFACE!{interface IHolographicCamera2(IHolographicCamera2Vtbl): IInspectable(IInspectableVtbl) [IID_IHolographicCamera2] {
     fn get_LeftViewportParameters(&self, out: *mut *mut HolographicCameraViewportParameters) -> HRESULT,
@@ -1472,7 +1472,7 @@ impl IHolographicCameraPose {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicCameraPose: IHolographicCameraPose}
+RT_CLASS!{class HolographicCameraPose: IHolographicCameraPose ["Windows.Graphics.Holographic.HolographicCameraPose"]}
 DEFINE_IID!(IID_IHolographicCameraPose2, 590078067, 23853, 17760, 129, 78, 38, 151, 196, 252, 225, 107);
 RT_INTERFACE!{interface IHolographicCameraPose2(IHolographicCameraPose2Vtbl): IInspectable(IInspectableVtbl) [IID_IHolographicCameraPose2] {
     #[cfg(not(feature="windows-perception"))] fn __Dummy0(&self) -> (),
@@ -1529,7 +1529,7 @@ impl IHolographicCameraRenderingParameters {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicCameraRenderingParameters: IHolographicCameraRenderingParameters}
+RT_CLASS!{class HolographicCameraRenderingParameters: IHolographicCameraRenderingParameters ["Windows.Graphics.Holographic.HolographicCameraRenderingParameters"]}
 DEFINE_IID!(IID_IHolographicCameraRenderingParameters2, 638742755, 46742, 17972, 148, 214, 190, 6, 129, 100, 53, 153);
 RT_INTERFACE!{interface IHolographicCameraRenderingParameters2(IHolographicCameraRenderingParameters2Vtbl): IInspectable(IInspectableVtbl) [IID_IHolographicCameraRenderingParameters2] {
     fn get_ReprojectionMode(&self, out: *mut HolographicReprojectionMode) -> HRESULT,
@@ -1584,7 +1584,7 @@ impl IHolographicCameraViewportParameters {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicCameraViewportParameters: IHolographicCameraViewportParameters}
+RT_CLASS!{class HolographicCameraViewportParameters: IHolographicCameraViewportParameters ["Windows.Graphics.Holographic.HolographicCameraViewportParameters"]}
 DEFINE_IID!(IID_IHolographicDisplay, 2597233684, 7583, 16528, 163, 136, 144, 192, 111, 110, 174, 156);
 RT_INTERFACE!{interface IHolographicDisplay(IHolographicDisplayVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicDisplay] {
     fn get_DisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1626,7 +1626,7 @@ impl IHolographicDisplay {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicDisplay: IHolographicDisplay}
+RT_CLASS!{class HolographicDisplay: IHolographicDisplay ["Windows.Graphics.Holographic.HolographicDisplay"]}
 impl RtActivatable<IHolographicDisplayStatics> for HolographicDisplay {}
 impl HolographicDisplay {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<HolographicDisplay>>> {
@@ -1713,7 +1713,7 @@ impl IHolographicFrame {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicFrame: IHolographicFrame}
+RT_CLASS!{class HolographicFrame: IHolographicFrame ["Windows.Graphics.Holographic.HolographicFrame"]}
 DEFINE_IID!(IID_IHolographicFrame2, 675231679, 15346, 24209, 102, 51, 135, 5, 116, 230, 242, 23);
 RT_INTERFACE!{interface IHolographicFrame2(IHolographicFrame2Vtbl): IInspectable(IInspectableVtbl) [IID_IHolographicFrame2] {
     fn GetQuadLayerUpdateParameters(&self, layer: *mut HolographicQuadLayer, out: *mut *mut HolographicQuadLayerUpdateParameters) -> HRESULT
@@ -1742,7 +1742,7 @@ impl IHolographicFramePrediction {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicFramePrediction: IHolographicFramePrediction}
+RT_CLASS!{class HolographicFramePrediction: IHolographicFramePrediction ["Windows.Graphics.Holographic.HolographicFramePrediction"]}
 DEFINE_IID!(IID_IHolographicFramePresentationMonitor, 3397854572, 28590, 17038, 187, 131, 37, 223, 238, 81, 19, 107);
 RT_INTERFACE!{interface IHolographicFramePresentationMonitor(IHolographicFramePresentationMonitorVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicFramePresentationMonitor] {
     fn ReadReports(&self, out: *mut *mut foundation::collections::IVectorView<HolographicFramePresentationReport>) -> HRESULT
@@ -1754,7 +1754,7 @@ impl IHolographicFramePresentationMonitor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicFramePresentationMonitor: IHolographicFramePresentationMonitor}
+RT_CLASS!{class HolographicFramePresentationMonitor: IHolographicFramePresentationMonitor ["Windows.Graphics.Holographic.HolographicFramePresentationMonitor"]}
 DEFINE_IID!(IID_IHolographicFramePresentationReport, 2159736340, 62196, 19594, 141, 227, 6, 92, 120, 246, 213, 222);
 RT_INTERFACE!{interface IHolographicFramePresentationReport(IHolographicFramePresentationReportVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicFramePresentationReport] {
     fn get_CompositorGpuDuration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -1790,11 +1790,11 @@ impl IHolographicFramePresentationReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicFramePresentationReport: IHolographicFramePresentationReport}
-RT_ENUM! { enum HolographicFramePresentResult: i32 {
+RT_CLASS!{class HolographicFramePresentationReport: IHolographicFramePresentationReport ["Windows.Graphics.Holographic.HolographicFramePresentationReport"]}
+RT_ENUM! { enum HolographicFramePresentResult: i32 ["Windows.Graphics.Holographic.HolographicFramePresentResult"] {
     Success (HolographicFramePresentResult_Success) = 0, DeviceRemoved (HolographicFramePresentResult_DeviceRemoved) = 1,
 }}
-RT_ENUM! { enum HolographicFramePresentWaitBehavior: i32 {
+RT_ENUM! { enum HolographicFramePresentWaitBehavior: i32 ["Windows.Graphics.Holographic.HolographicFramePresentWaitBehavior"] {
     WaitForFrameToFinish (HolographicFramePresentWaitBehavior_WaitForFrameToFinish) = 0, DoNotWaitForFrameToFinish (HolographicFramePresentWaitBehavior_DoNotWaitForFrameToFinish) = 1,
 }}
 DEFINE_IID!(IID_IHolographicQuadLayer, 2419351753, 51673, 23900, 65, 172, 162, 213, 171, 15, 211, 49);
@@ -1814,7 +1814,7 @@ impl IHolographicQuadLayer {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicQuadLayer: IHolographicQuadLayer}
+RT_CLASS!{class HolographicQuadLayer: IHolographicQuadLayer ["Windows.Graphics.Holographic.HolographicQuadLayer"]}
 impl RtActivatable<IHolographicQuadLayerFactory> for HolographicQuadLayer {}
 impl HolographicQuadLayer {
     #[inline] pub fn create(size: foundation::Size) -> Result<ComPtr<HolographicQuadLayer>> {
@@ -1879,7 +1879,7 @@ impl IHolographicQuadLayerUpdateParameters {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicQuadLayerUpdateParameters: IHolographicQuadLayerUpdateParameters}
+RT_CLASS!{class HolographicQuadLayerUpdateParameters: IHolographicQuadLayerUpdateParameters ["Windows.Graphics.Holographic.HolographicQuadLayerUpdateParameters"]}
 DEFINE_IID!(IID_IHolographicQuadLayerUpdateParameters2, 1328796461, 33473, 18113, 137, 128, 60, 183, 13, 152, 24, 43);
 RT_INTERFACE!{interface IHolographicQuadLayerUpdateParameters2(IHolographicQuadLayerUpdateParameters2Vtbl): IInspectable(IInspectableVtbl) [IID_IHolographicQuadLayerUpdateParameters2] {
     fn get_CanAcquireWithHardwareProtection(&self, out: *mut bool) -> HRESULT,
@@ -1897,7 +1897,7 @@ impl IHolographicQuadLayerUpdateParameters2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HolographicReprojectionMode: i32 {
+RT_ENUM! { enum HolographicReprojectionMode: i32 ["Windows.Graphics.Holographic.HolographicReprojectionMode"] {
     PositionAndOrientation (HolographicReprojectionMode_PositionAndOrientation) = 0, OrientationOnly (HolographicReprojectionMode_OrientationOnly) = 1, Disabled (HolographicReprojectionMode_Disabled) = 2,
 }}
 DEFINE_IID!(IID_IHolographicSpace, 1132518310, 24184, 17231, 128, 124, 52, 51, 209, 239, 232, 183);
@@ -1944,7 +1944,7 @@ impl IHolographicSpace {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicSpace: IHolographicSpace}
+RT_CLASS!{class HolographicSpace: IHolographicSpace ["Windows.Graphics.Holographic.HolographicSpace"]}
 impl RtActivatable<IHolographicSpaceStatics> for HolographicSpace {}
 impl RtActivatable<IHolographicSpaceStatics2> for HolographicSpace {}
 impl RtActivatable<IHolographicSpaceStatics3> for HolographicSpace {}
@@ -2024,7 +2024,7 @@ impl IHolographicSpaceCameraAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicSpaceCameraAddedEventArgs: IHolographicSpaceCameraAddedEventArgs}
+RT_CLASS!{class HolographicSpaceCameraAddedEventArgs: IHolographicSpaceCameraAddedEventArgs ["Windows.Graphics.Holographic.HolographicSpaceCameraAddedEventArgs"]}
 DEFINE_IID!(IID_IHolographicSpaceCameraRemovedEventArgs, 2153006248, 62126, 12846, 141, 169, 131, 106, 10, 149, 164, 193);
 RT_INTERFACE!{interface IHolographicSpaceCameraRemovedEventArgs(IHolographicSpaceCameraRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicSpaceCameraRemovedEventArgs] {
     fn get_Camera(&self, out: *mut *mut HolographicCamera) -> HRESULT
@@ -2036,7 +2036,7 @@ impl IHolographicSpaceCameraRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HolographicSpaceCameraRemovedEventArgs: IHolographicSpaceCameraRemovedEventArgs}
+RT_CLASS!{class HolographicSpaceCameraRemovedEventArgs: IHolographicSpaceCameraRemovedEventArgs ["Windows.Graphics.Holographic.HolographicSpaceCameraRemovedEventArgs"]}
 DEFINE_IID!(IID_IHolographicSpaceStatics, 911106148, 51442, 15265, 131, 145, 102, 184, 72, 158, 103, 253);
 RT_INTERFACE!{static interface IHolographicSpaceStatics(IHolographicSpaceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHolographicSpaceStatics] {
     #[cfg(feature="windows-ui")] fn CreateForCoreWindow(&self, window: *mut super::super::ui::core::CoreWindow, out: *mut *mut HolographicSpace) -> HRESULT
@@ -2087,19 +2087,19 @@ impl IHolographicSpaceStatics3 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HolographicSpaceUserPresence: i32 {
+RT_ENUM! { enum HolographicSpaceUserPresence: i32 ["Windows.Graphics.Holographic.HolographicSpaceUserPresence"] {
     Absent (HolographicSpaceUserPresence_Absent) = 0, PresentPassive (HolographicSpaceUserPresence_PresentPassive) = 1, PresentActive (HolographicSpaceUserPresence_PresentActive) = 2,
 }}
-RT_STRUCT! { struct HolographicStereoTransform {
+RT_STRUCT! { struct HolographicStereoTransform ["Windows.Graphics.Holographic.HolographicStereoTransform"] {
     Left: foundation::numerics::Matrix4x4, Right: foundation::numerics::Matrix4x4,
 }}
 } // Windows.Graphics.Holographic
 pub mod imaging { // Windows.Graphics.Imaging
 use ::prelude::*;
-RT_ENUM! { enum BitmapAlphaMode: i32 {
+RT_ENUM! { enum BitmapAlphaMode: i32 ["Windows.Graphics.Imaging.BitmapAlphaMode"] {
     Premultiplied (BitmapAlphaMode_Premultiplied) = 0, Straight (BitmapAlphaMode_Straight) = 1, Ignore (BitmapAlphaMode_Ignore) = 2,
 }}
-RT_STRUCT! { struct BitmapBounds {
+RT_STRUCT! { struct BitmapBounds ["Windows.Graphics.Imaging.BitmapBounds"] {
     X: u32, Y: u32, Width: u32, Height: u32,
 }}
 DEFINE_IID!(IID_IBitmapBuffer, 2772305092, 14748, 17292, 178, 143, 166, 58, 107, 131, 209, 161);
@@ -2119,8 +2119,8 @@ impl IBitmapBuffer {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapBuffer: IBitmapBuffer}
-RT_ENUM! { enum BitmapBufferAccessMode: i32 {
+RT_CLASS!{class BitmapBuffer: IBitmapBuffer ["Windows.Graphics.Imaging.BitmapBuffer"]}
+RT_ENUM! { enum BitmapBufferAccessMode: i32 ["Windows.Graphics.Imaging.BitmapBufferAccessMode"] {
     Read (BitmapBufferAccessMode_Read) = 0, ReadWrite (BitmapBufferAccessMode_ReadWrite) = 1, Write (BitmapBufferAccessMode_Write) = 2,
 }}
 DEFINE_IID!(IID_IBitmapCodecInformation, 1074572018, 50352, 17298, 163, 176, 111, 111, 155, 169, 92, 180);
@@ -2152,7 +2152,7 @@ impl IBitmapCodecInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapCodecInformation: IBitmapCodecInformation}
+RT_CLASS!{class BitmapCodecInformation: IBitmapCodecInformation ["Windows.Graphics.Imaging.BitmapCodecInformation"]}
 DEFINE_IID!(IID_IBitmapDecoder, 2901353146, 7540, 19601, 157, 252, 150, 32, 116, 82, 51, 230);
 RT_INTERFACE!{interface IBitmapDecoder(IBitmapDecoderVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapDecoder] {
     fn get_BitmapContainerProperties(&self, out: *mut *mut BitmapPropertiesView) -> HRESULT,
@@ -2188,7 +2188,7 @@ impl IBitmapDecoder {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapDecoder: IBitmapDecoder}
+RT_CLASS!{class BitmapDecoder: IBitmapDecoder ["Windows.Graphics.Imaging.BitmapDecoder"]}
 impl RtActivatable<IBitmapDecoderStatics> for BitmapDecoder {}
 impl RtActivatable<IBitmapDecoderStatics2> for BitmapDecoder {}
 impl BitmapDecoder {
@@ -2397,7 +2397,7 @@ impl IBitmapEncoder {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapEncoder: IBitmapEncoder}
+RT_CLASS!{class BitmapEncoder: IBitmapEncoder ["Windows.Graphics.Imaging.BitmapEncoder"]}
 impl RtActivatable<IBitmapEncoderStatics> for BitmapEncoder {}
 impl RtActivatable<IBitmapEncoderStatics2> for BitmapEncoder {}
 impl BitmapEncoder {
@@ -2534,7 +2534,7 @@ impl IBitmapEncoderWithSoftwareBitmap {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BitmapFlip: i32 {
+RT_ENUM! { enum BitmapFlip: i32 ["Windows.Graphics.Imaging.BitmapFlip"] {
     None (BitmapFlip_None) = 0, Horizontal (BitmapFlip_Horizontal) = 1, Vertical (BitmapFlip_Vertical) = 2,
 }}
 DEFINE_IID!(IID_IBitmapFrame, 1923389980, 32897, 17293, 145, 188, 148, 236, 252, 129, 133, 198);
@@ -2614,7 +2614,7 @@ impl IBitmapFrame {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapFrame: IBitmapFrame}
+RT_CLASS!{class BitmapFrame: IBitmapFrame ["Windows.Graphics.Imaging.BitmapFrame"]}
 DEFINE_IID!(IID_IBitmapFrameWithSoftwareBitmap, 4264066202, 16908, 18787, 135, 173, 105, 20, 54, 224, 131, 131);
 RT_INTERFACE!{interface IBitmapFrameWithSoftwareBitmap(IBitmapFrameWithSoftwareBitmapVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapFrameWithSoftwareBitmap] {
     fn GetSoftwareBitmapAsync(&self, out: *mut *mut foundation::IAsyncOperation<SoftwareBitmap>) -> HRESULT,
@@ -2638,13 +2638,13 @@ impl IBitmapFrameWithSoftwareBitmap {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BitmapInterpolationMode: i32 {
+RT_ENUM! { enum BitmapInterpolationMode: i32 ["Windows.Graphics.Imaging.BitmapInterpolationMode"] {
     NearestNeighbor (BitmapInterpolationMode_NearestNeighbor) = 0, Linear (BitmapInterpolationMode_Linear) = 1, Cubic (BitmapInterpolationMode_Cubic) = 2, Fant (BitmapInterpolationMode_Fant) = 3,
 }}
-RT_ENUM! { enum BitmapPixelFormat: i32 {
+RT_ENUM! { enum BitmapPixelFormat: i32 ["Windows.Graphics.Imaging.BitmapPixelFormat"] {
     Unknown (BitmapPixelFormat_Unknown) = 0, Rgba16 (BitmapPixelFormat_Rgba16) = 12, Rgba8 (BitmapPixelFormat_Rgba8) = 30, Gray16 (BitmapPixelFormat_Gray16) = 57, Gray8 (BitmapPixelFormat_Gray8) = 62, Bgra8 (BitmapPixelFormat_Bgra8) = 87, Nv12 (BitmapPixelFormat_Nv12) = 103, P010 (BitmapPixelFormat_P010) = 104, Yuy2 (BitmapPixelFormat_Yuy2) = 107,
 }}
-RT_STRUCT! { struct BitmapPlaneDescription {
+RT_STRUCT! { struct BitmapPlaneDescription ["Windows.Graphics.Imaging.BitmapPlaneDescription"] {
     StartIndex: i32, Width: i32, Height: i32, Stride: i32,
 }}
 DEFINE_IID!(IID_IBitmapProperties, 3936309019, 46341, 17488, 164, 209, 232, 202, 148, 82, 157, 141);
@@ -2658,7 +2658,7 @@ impl IBitmapProperties {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapProperties: IBitmapProperties}
+RT_CLASS!{class BitmapProperties: IBitmapProperties ["Windows.Graphics.Imaging.BitmapProperties"]}
 DEFINE_IID!(IID_IBitmapPropertiesView, 2114971770, 14960, 18680, 156, 85, 25, 108, 245, 165, 69, 245);
 RT_INTERFACE!{interface IBitmapPropertiesView(IBitmapPropertiesViewVtbl): IInspectable(IInspectableVtbl) [IID_IBitmapPropertiesView] {
     fn GetPropertiesAsync(&self, propertiesToRetrieve: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncOperation<BitmapPropertySet>) -> HRESULT
@@ -2670,14 +2670,14 @@ impl IBitmapPropertiesView {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapPropertiesView: IBitmapPropertiesView}
-RT_CLASS!{class BitmapPropertySet: foundation::collections::IMap<HString, BitmapTypedValue>}
+RT_CLASS!{class BitmapPropertiesView: IBitmapPropertiesView ["Windows.Graphics.Imaging.BitmapPropertiesView"]}
+RT_CLASS!{class BitmapPropertySet: foundation::collections::IMap<HString, BitmapTypedValue> ["Windows.Graphics.Imaging.BitmapPropertySet"]}
 impl RtActivatable<IActivationFactory> for BitmapPropertySet {}
 DEFINE_CLSID!(BitmapPropertySet(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,80,114,111,112,101,114,116,121,83,101,116,0]) [CLSID_BitmapPropertySet]);
-RT_ENUM! { enum BitmapRotation: i32 {
+RT_ENUM! { enum BitmapRotation: i32 ["Windows.Graphics.Imaging.BitmapRotation"] {
     None (BitmapRotation_None) = 0, Clockwise90Degrees (BitmapRotation_Clockwise90Degrees) = 1, Clockwise180Degrees (BitmapRotation_Clockwise180Degrees) = 2, Clockwise270Degrees (BitmapRotation_Clockwise270Degrees) = 3,
 }}
-RT_STRUCT! { struct BitmapSize {
+RT_STRUCT! { struct BitmapSize ["Windows.Graphics.Imaging.BitmapSize"] {
     Width: u32, Height: u32,
 }}
 DEFINE_IID!(IID_IBitmapTransform, 2926924612, 57960, 19765, 173, 207, 233, 149, 211, 26, 141, 52);
@@ -2751,7 +2751,7 @@ impl IBitmapTransform {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapTransform: IBitmapTransform}
+RT_CLASS!{class BitmapTransform: IBitmapTransform ["Windows.Graphics.Imaging.BitmapTransform"]}
 impl RtActivatable<IActivationFactory> for BitmapTransform {}
 DEFINE_CLSID!(BitmapTransform(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,73,109,97,103,105,110,103,46,66,105,116,109,97,112,84,114,97,110,115,102,111,114,109,0]) [CLSID_BitmapTransform]);
 DEFINE_IID!(IID_IBitmapTypedValue, 3447735465, 9283, 16384, 176, 205, 121, 49, 108, 86, 245, 137);
@@ -2771,7 +2771,7 @@ impl IBitmapTypedValue {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BitmapTypedValue: IBitmapTypedValue}
+RT_CLASS!{class BitmapTypedValue: IBitmapTypedValue ["Windows.Graphics.Imaging.BitmapTypedValue"]}
 impl RtActivatable<IBitmapTypedValueFactory> for BitmapTypedValue {}
 impl BitmapTypedValue {
     #[inline] pub fn create(value: &IInspectable, type_: foundation::PropertyType) -> Result<ComPtr<BitmapTypedValue>> {
@@ -2790,15 +2790,15 @@ impl IBitmapTypedValueFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ColorManagementMode: i32 {
+RT_ENUM! { enum ColorManagementMode: i32 ["Windows.Graphics.Imaging.ColorManagementMode"] {
     DoNotColorManage (ColorManagementMode_DoNotColorManage) = 0, ColorManageToSRgb (ColorManagementMode_ColorManageToSRgb) = 1,
 }}
-RT_ENUM! { enum ExifOrientationMode: i32 {
+RT_ENUM! { enum ExifOrientationMode: i32 ["Windows.Graphics.Imaging.ExifOrientationMode"] {
     IgnoreExifOrientation (ExifOrientationMode_IgnoreExifOrientation) = 0, RespectExifOrientation (ExifOrientationMode_RespectExifOrientation) = 1,
 }}
-#[cfg(feature="windows-storage")] RT_CLASS!{class ImageStream: super::super::storage::streams::IRandomAccessStreamWithContentType}
-#[cfg(not(feature="windows-storage"))] RT_CLASS!{class ImageStream: IInspectable}
-RT_ENUM! { enum JpegSubsamplingMode: i32 {
+#[cfg(feature="windows-storage")] RT_CLASS!{class ImageStream: super::super::storage::streams::IRandomAccessStreamWithContentType ["Windows.Graphics.Imaging.ImageStream"]}
+#[cfg(not(feature="windows-storage"))] RT_CLASS!{class ImageStream: IInspectable ["Windows.Graphics.Imaging.ImageStream"]}
+RT_ENUM! { enum JpegSubsamplingMode: i32 ["Windows.Graphics.Imaging.JpegSubsamplingMode"] {
     Default (JpegSubsamplingMode_Default) = 0, Y4Cb2Cr0 (JpegSubsamplingMode_Y4Cb2Cr0) = 1, Y4Cb2Cr2 (JpegSubsamplingMode_Y4Cb2Cr2) = 2, Y4Cb4Cr4 (JpegSubsamplingMode_Y4Cb4Cr4) = 3,
 }}
 DEFINE_IID!(IID_IPixelDataProvider, 3716357925, 6236, 17813, 159, 185, 204, 190, 110, 193, 138, 111);
@@ -2812,8 +2812,8 @@ impl IPixelDataProvider {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PixelDataProvider: IPixelDataProvider}
-RT_ENUM! { enum PngFilterMode: i32 {
+RT_CLASS!{class PixelDataProvider: IPixelDataProvider ["Windows.Graphics.Imaging.PixelDataProvider"]}
+RT_ENUM! { enum PngFilterMode: i32 ["Windows.Graphics.Imaging.PngFilterMode"] {
     Automatic (PngFilterMode_Automatic) = 0, None (PngFilterMode_None) = 1, Sub (PngFilterMode_Sub) = 2, Up (PngFilterMode_Up) = 3, Average (PngFilterMode_Average) = 4, Paeth (PngFilterMode_Paeth) = 5, Adaptive (PngFilterMode_Adaptive) = 6,
 }}
 DEFINE_IID!(IID_ISoftwareBitmap, 1755186952, 32495, 18495, 150, 63, 218, 147, 136, 24, 224, 115);
@@ -2902,7 +2902,7 @@ impl ISoftwareBitmap {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SoftwareBitmap: ISoftwareBitmap}
+RT_CLASS!{class SoftwareBitmap: ISoftwareBitmap ["Windows.Graphics.Imaging.SoftwareBitmap"]}
 impl RtActivatable<ISoftwareBitmapFactory> for SoftwareBitmap {}
 impl RtActivatable<ISoftwareBitmapStatics> for SoftwareBitmap {}
 impl SoftwareBitmap {
@@ -3001,32 +3001,32 @@ impl ISoftwareBitmapStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TiffCompressionMode: i32 {
+RT_ENUM! { enum TiffCompressionMode: i32 ["Windows.Graphics.Imaging.TiffCompressionMode"] {
     Automatic (TiffCompressionMode_Automatic) = 0, None (TiffCompressionMode_None) = 1, Ccitt3 (TiffCompressionMode_Ccitt3) = 2, Ccitt4 (TiffCompressionMode_Ccitt4) = 3, Lzw (TiffCompressionMode_Lzw) = 4, Rle (TiffCompressionMode_Rle) = 5, Zip (TiffCompressionMode_Zip) = 6, LzwhDifferencing (TiffCompressionMode_LzwhDifferencing) = 7,
 }}
 } // Windows.Graphics.Imaging
 pub mod printing { // Windows.Graphics.Printing
 use ::prelude::*;
-RT_ENUM! { enum PrintBinding: i32 {
+RT_ENUM! { enum PrintBinding: i32 ["Windows.Graphics.Printing.PrintBinding"] {
     Default (PrintBinding_Default) = 0, NotAvailable (PrintBinding_NotAvailable) = 1, PrinterCustom (PrintBinding_PrinterCustom) = 2, None (PrintBinding_None) = 3, Bale (PrintBinding_Bale) = 4, BindBottom (PrintBinding_BindBottom) = 5, BindLeft (PrintBinding_BindLeft) = 6, BindRight (PrintBinding_BindRight) = 7, BindTop (PrintBinding_BindTop) = 8, Booklet (PrintBinding_Booklet) = 9, EdgeStitchBottom (PrintBinding_EdgeStitchBottom) = 10, EdgeStitchLeft (PrintBinding_EdgeStitchLeft) = 11, EdgeStitchRight (PrintBinding_EdgeStitchRight) = 12, EdgeStitchTop (PrintBinding_EdgeStitchTop) = 13, Fold (PrintBinding_Fold) = 14, JogOffset (PrintBinding_JogOffset) = 15, Trim (PrintBinding_Trim) = 16,
 }}
-RT_ENUM! { enum PrintBordering: i32 {
+RT_ENUM! { enum PrintBordering: i32 ["Windows.Graphics.Printing.PrintBordering"] {
     Default (PrintBordering_Default) = 0, NotAvailable (PrintBordering_NotAvailable) = 1, PrinterCustom (PrintBordering_PrinterCustom) = 2, Bordered (PrintBordering_Bordered) = 3, Borderless (PrintBordering_Borderless) = 4,
 }}
-RT_ENUM! { enum PrintCollation: i32 {
+RT_ENUM! { enum PrintCollation: i32 ["Windows.Graphics.Printing.PrintCollation"] {
     Default (PrintCollation_Default) = 0, NotAvailable (PrintCollation_NotAvailable) = 1, PrinterCustom (PrintCollation_PrinterCustom) = 2, Collated (PrintCollation_Collated) = 3, Uncollated (PrintCollation_Uncollated) = 4,
 }}
-RT_ENUM! { enum PrintColorMode: i32 {
+RT_ENUM! { enum PrintColorMode: i32 ["Windows.Graphics.Printing.PrintColorMode"] {
     Default (PrintColorMode_Default) = 0, NotAvailable (PrintColorMode_NotAvailable) = 1, PrinterCustom (PrintColorMode_PrinterCustom) = 2, Color (PrintColorMode_Color) = 3, Grayscale (PrintColorMode_Grayscale) = 4, Monochrome (PrintColorMode_Monochrome) = 5,
 }}
 DEFINE_IID!(IID_IPrintDocumentSource, 3738962992, 61931, 18399, 170, 230, 237, 84, 39, 81, 31, 1);
 RT_INTERFACE!{interface IPrintDocumentSource(IPrintDocumentSourceVtbl): IInspectable(IInspectableVtbl) [IID_IPrintDocumentSource] {
     
 }}
-RT_ENUM! { enum PrintDuplex: i32 {
+RT_ENUM! { enum PrintDuplex: i32 ["Windows.Graphics.Printing.PrintDuplex"] {
     Default (PrintDuplex_Default) = 0, NotAvailable (PrintDuplex_NotAvailable) = 1, PrinterCustom (PrintDuplex_PrinterCustom) = 2, OneSided (PrintDuplex_OneSided) = 3, TwoSidedShortEdge (PrintDuplex_TwoSidedShortEdge) = 4, TwoSidedLongEdge (PrintDuplex_TwoSidedLongEdge) = 5,
 }}
-RT_ENUM! { enum PrintHolePunch: i32 {
+RT_ENUM! { enum PrintHolePunch: i32 ["Windows.Graphics.Printing.PrintHolePunch"] {
     Default (PrintHolePunch_Default) = 0, NotAvailable (PrintHolePunch_NotAvailable) = 1, PrinterCustom (PrintHolePunch_PrinterCustom) = 2, None (PrintHolePunch_None) = 3, LeftEdge (PrintHolePunch_LeftEdge) = 4, RightEdge (PrintHolePunch_RightEdge) = 5, TopEdge (PrintHolePunch_TopEdge) = 6, BottomEdge (PrintHolePunch_BottomEdge) = 7,
 }}
 DEFINE_IID!(IID_IPrintManager, 4280981140, 35993, 17661, 174, 74, 25, 217, 170, 154, 15, 10);
@@ -3045,7 +3045,7 @@ impl IPrintManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintManager: IPrintManager}
+RT_CLASS!{class PrintManager: IPrintManager ["Windows.Graphics.Printing.PrintManager"]}
 impl RtActivatable<IPrintManagerStatic> for PrintManager {}
 impl RtActivatable<IPrintManagerStatic2> for PrintManager {}
 impl PrintManager {
@@ -3088,16 +3088,16 @@ impl IPrintManagerStatic2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PrintMediaSize: i32 {
+RT_ENUM! { enum PrintMediaSize: i32 ["Windows.Graphics.Printing.PrintMediaSize"] {
     Default (PrintMediaSize_Default) = 0, NotAvailable (PrintMediaSize_NotAvailable) = 1, PrinterCustom (PrintMediaSize_PrinterCustom) = 2, BusinessCard (PrintMediaSize_BusinessCard) = 3, CreditCard (PrintMediaSize_CreditCard) = 4, IsoA0 (PrintMediaSize_IsoA0) = 5, IsoA1 (PrintMediaSize_IsoA1) = 6, IsoA10 (PrintMediaSize_IsoA10) = 7, IsoA2 (PrintMediaSize_IsoA2) = 8, IsoA3 (PrintMediaSize_IsoA3) = 9, IsoA3Extra (PrintMediaSize_IsoA3Extra) = 10, IsoA3Rotated (PrintMediaSize_IsoA3Rotated) = 11, IsoA4 (PrintMediaSize_IsoA4) = 12, IsoA4Extra (PrintMediaSize_IsoA4Extra) = 13, IsoA4Rotated (PrintMediaSize_IsoA4Rotated) = 14, IsoA5 (PrintMediaSize_IsoA5) = 15, IsoA5Extra (PrintMediaSize_IsoA5Extra) = 16, IsoA5Rotated (PrintMediaSize_IsoA5Rotated) = 17, IsoA6 (PrintMediaSize_IsoA6) = 18, IsoA6Rotated (PrintMediaSize_IsoA6Rotated) = 19, IsoA7 (PrintMediaSize_IsoA7) = 20, IsoA8 (PrintMediaSize_IsoA8) = 21, IsoA9 (PrintMediaSize_IsoA9) = 22, IsoB0 (PrintMediaSize_IsoB0) = 23, IsoB1 (PrintMediaSize_IsoB1) = 24, IsoB10 (PrintMediaSize_IsoB10) = 25, IsoB2 (PrintMediaSize_IsoB2) = 26, IsoB3 (PrintMediaSize_IsoB3) = 27, IsoB4 (PrintMediaSize_IsoB4) = 28, IsoB4Envelope (PrintMediaSize_IsoB4Envelope) = 29, IsoB5Envelope (PrintMediaSize_IsoB5Envelope) = 30, IsoB5Extra (PrintMediaSize_IsoB5Extra) = 31, IsoB7 (PrintMediaSize_IsoB7) = 32, IsoB8 (PrintMediaSize_IsoB8) = 33, IsoB9 (PrintMediaSize_IsoB9) = 34, IsoC0 (PrintMediaSize_IsoC0) = 35, IsoC1 (PrintMediaSize_IsoC1) = 36, IsoC10 (PrintMediaSize_IsoC10) = 37, IsoC2 (PrintMediaSize_IsoC2) = 38, IsoC3 (PrintMediaSize_IsoC3) = 39, IsoC3Envelope (PrintMediaSize_IsoC3Envelope) = 40, IsoC4 (PrintMediaSize_IsoC4) = 41, IsoC4Envelope (PrintMediaSize_IsoC4Envelope) = 42, IsoC5 (PrintMediaSize_IsoC5) = 43, IsoC5Envelope (PrintMediaSize_IsoC5Envelope) = 44, IsoC6 (PrintMediaSize_IsoC6) = 45, IsoC6C5Envelope (PrintMediaSize_IsoC6C5Envelope) = 46, IsoC6Envelope (PrintMediaSize_IsoC6Envelope) = 47, IsoC7 (PrintMediaSize_IsoC7) = 48, IsoC8 (PrintMediaSize_IsoC8) = 49, IsoC9 (PrintMediaSize_IsoC9) = 50, IsoDLEnvelope (PrintMediaSize_IsoDLEnvelope) = 51, IsoDLEnvelopeRotated (PrintMediaSize_IsoDLEnvelopeRotated) = 52, IsoSRA3 (PrintMediaSize_IsoSRA3) = 53, Japan2LPhoto (PrintMediaSize_Japan2LPhoto) = 54, JapanChou3Envelope (PrintMediaSize_JapanChou3Envelope) = 55, JapanChou3EnvelopeRotated (PrintMediaSize_JapanChou3EnvelopeRotated) = 56, JapanChou4Envelope (PrintMediaSize_JapanChou4Envelope) = 57, JapanChou4EnvelopeRotated (PrintMediaSize_JapanChou4EnvelopeRotated) = 58, JapanDoubleHagakiPostcard (PrintMediaSize_JapanDoubleHagakiPostcard) = 59, JapanDoubleHagakiPostcardRotated (PrintMediaSize_JapanDoubleHagakiPostcardRotated) = 60, JapanHagakiPostcard (PrintMediaSize_JapanHagakiPostcard) = 61, JapanHagakiPostcardRotated (PrintMediaSize_JapanHagakiPostcardRotated) = 62, JapanKaku2Envelope (PrintMediaSize_JapanKaku2Envelope) = 63, JapanKaku2EnvelopeRotated (PrintMediaSize_JapanKaku2EnvelopeRotated) = 64, JapanKaku3Envelope (PrintMediaSize_JapanKaku3Envelope) = 65, JapanKaku3EnvelopeRotated (PrintMediaSize_JapanKaku3EnvelopeRotated) = 66, JapanLPhoto (PrintMediaSize_JapanLPhoto) = 67, JapanQuadrupleHagakiPostcard (PrintMediaSize_JapanQuadrupleHagakiPostcard) = 68, JapanYou1Envelope (PrintMediaSize_JapanYou1Envelope) = 69, JapanYou2Envelope (PrintMediaSize_JapanYou2Envelope) = 70, JapanYou3Envelope (PrintMediaSize_JapanYou3Envelope) = 71, JapanYou4Envelope (PrintMediaSize_JapanYou4Envelope) = 72, JapanYou4EnvelopeRotated (PrintMediaSize_JapanYou4EnvelopeRotated) = 73, JapanYou6Envelope (PrintMediaSize_JapanYou6Envelope) = 74, JapanYou6EnvelopeRotated (PrintMediaSize_JapanYou6EnvelopeRotated) = 75, JisB0 (PrintMediaSize_JisB0) = 76, JisB1 (PrintMediaSize_JisB1) = 77, JisB10 (PrintMediaSize_JisB10) = 78, JisB2 (PrintMediaSize_JisB2) = 79, JisB3 (PrintMediaSize_JisB3) = 80, JisB4 (PrintMediaSize_JisB4) = 81, JisB4Rotated (PrintMediaSize_JisB4Rotated) = 82, JisB5 (PrintMediaSize_JisB5) = 83, JisB5Rotated (PrintMediaSize_JisB5Rotated) = 84, JisB6 (PrintMediaSize_JisB6) = 85, JisB6Rotated (PrintMediaSize_JisB6Rotated) = 86, JisB7 (PrintMediaSize_JisB7) = 87, JisB8 (PrintMediaSize_JisB8) = 88, JisB9 (PrintMediaSize_JisB9) = 89, NorthAmerica10x11 (PrintMediaSize_NorthAmerica10x11) = 90, NorthAmerica10x12 (PrintMediaSize_NorthAmerica10x12) = 91, NorthAmerica10x14 (PrintMediaSize_NorthAmerica10x14) = 92, NorthAmerica11x17 (PrintMediaSize_NorthAmerica11x17) = 93, NorthAmerica14x17 (PrintMediaSize_NorthAmerica14x17) = 94, NorthAmerica4x6 (PrintMediaSize_NorthAmerica4x6) = 95, NorthAmerica4x8 (PrintMediaSize_NorthAmerica4x8) = 96, NorthAmerica5x7 (PrintMediaSize_NorthAmerica5x7) = 97, NorthAmerica8x10 (PrintMediaSize_NorthAmerica8x10) = 98, NorthAmerica9x11 (PrintMediaSize_NorthAmerica9x11) = 99, NorthAmericaArchitectureASheet (PrintMediaSize_NorthAmericaArchitectureASheet) = 100, NorthAmericaArchitectureBSheet (PrintMediaSize_NorthAmericaArchitectureBSheet) = 101, NorthAmericaArchitectureCSheet (PrintMediaSize_NorthAmericaArchitectureCSheet) = 102, NorthAmericaArchitectureDSheet (PrintMediaSize_NorthAmericaArchitectureDSheet) = 103, NorthAmericaArchitectureESheet (PrintMediaSize_NorthAmericaArchitectureESheet) = 104, NorthAmericaCSheet (PrintMediaSize_NorthAmericaCSheet) = 105, NorthAmericaDSheet (PrintMediaSize_NorthAmericaDSheet) = 106, NorthAmericaESheet (PrintMediaSize_NorthAmericaESheet) = 107, NorthAmericaExecutive (PrintMediaSize_NorthAmericaExecutive) = 108, NorthAmericaGermanLegalFanfold (PrintMediaSize_NorthAmericaGermanLegalFanfold) = 109, NorthAmericaGermanStandardFanfold (PrintMediaSize_NorthAmericaGermanStandardFanfold) = 110, NorthAmericaLegal (PrintMediaSize_NorthAmericaLegal) = 111, NorthAmericaLegalExtra (PrintMediaSize_NorthAmericaLegalExtra) = 112, NorthAmericaLetter (PrintMediaSize_NorthAmericaLetter) = 113, NorthAmericaLetterExtra (PrintMediaSize_NorthAmericaLetterExtra) = 114, NorthAmericaLetterPlus (PrintMediaSize_NorthAmericaLetterPlus) = 115, NorthAmericaLetterRotated (PrintMediaSize_NorthAmericaLetterRotated) = 116, NorthAmericaMonarchEnvelope (PrintMediaSize_NorthAmericaMonarchEnvelope) = 117, NorthAmericaNote (PrintMediaSize_NorthAmericaNote) = 118, NorthAmericaNumber10Envelope (PrintMediaSize_NorthAmericaNumber10Envelope) = 119, NorthAmericaNumber10EnvelopeRotated (PrintMediaSize_NorthAmericaNumber10EnvelopeRotated) = 120, NorthAmericaNumber11Envelope (PrintMediaSize_NorthAmericaNumber11Envelope) = 121, NorthAmericaNumber12Envelope (PrintMediaSize_NorthAmericaNumber12Envelope) = 122, NorthAmericaNumber14Envelope (PrintMediaSize_NorthAmericaNumber14Envelope) = 123, NorthAmericaNumber9Envelope (PrintMediaSize_NorthAmericaNumber9Envelope) = 124, NorthAmericaPersonalEnvelope (PrintMediaSize_NorthAmericaPersonalEnvelope) = 125, NorthAmericaQuarto (PrintMediaSize_NorthAmericaQuarto) = 126, NorthAmericaStatement (PrintMediaSize_NorthAmericaStatement) = 127, NorthAmericaSuperA (PrintMediaSize_NorthAmericaSuperA) = 128, NorthAmericaSuperB (PrintMediaSize_NorthAmericaSuperB) = 129, NorthAmericaTabloid (PrintMediaSize_NorthAmericaTabloid) = 130, NorthAmericaTabloidExtra (PrintMediaSize_NorthAmericaTabloidExtra) = 131, OtherMetricA3Plus (PrintMediaSize_OtherMetricA3Plus) = 132, OtherMetricA4Plus (PrintMediaSize_OtherMetricA4Plus) = 133, OtherMetricFolio (PrintMediaSize_OtherMetricFolio) = 134, OtherMetricInviteEnvelope (PrintMediaSize_OtherMetricInviteEnvelope) = 135, OtherMetricItalianEnvelope (PrintMediaSize_OtherMetricItalianEnvelope) = 136, Prc10Envelope (PrintMediaSize_Prc10Envelope) = 137, Prc10EnvelopeRotated (PrintMediaSize_Prc10EnvelopeRotated) = 138, Prc16K (PrintMediaSize_Prc16K) = 139, Prc16KRotated (PrintMediaSize_Prc16KRotated) = 140, Prc1Envelope (PrintMediaSize_Prc1Envelope) = 141, Prc1EnvelopeRotated (PrintMediaSize_Prc1EnvelopeRotated) = 142, Prc2Envelope (PrintMediaSize_Prc2Envelope) = 143, Prc2EnvelopeRotated (PrintMediaSize_Prc2EnvelopeRotated) = 144, Prc32K (PrintMediaSize_Prc32K) = 145, Prc32KBig (PrintMediaSize_Prc32KBig) = 146, Prc32KRotated (PrintMediaSize_Prc32KRotated) = 147, Prc3Envelope (PrintMediaSize_Prc3Envelope) = 148, Prc3EnvelopeRotated (PrintMediaSize_Prc3EnvelopeRotated) = 149, Prc4Envelope (PrintMediaSize_Prc4Envelope) = 150, Prc4EnvelopeRotated (PrintMediaSize_Prc4EnvelopeRotated) = 151, Prc5Envelope (PrintMediaSize_Prc5Envelope) = 152, Prc5EnvelopeRotated (PrintMediaSize_Prc5EnvelopeRotated) = 153, Prc6Envelope (PrintMediaSize_Prc6Envelope) = 154, Prc6EnvelopeRotated (PrintMediaSize_Prc6EnvelopeRotated) = 155, Prc7Envelope (PrintMediaSize_Prc7Envelope) = 156, Prc7EnvelopeRotated (PrintMediaSize_Prc7EnvelopeRotated) = 157, Prc8Envelope (PrintMediaSize_Prc8Envelope) = 158, Prc8EnvelopeRotated (PrintMediaSize_Prc8EnvelopeRotated) = 159, Prc9Envelope (PrintMediaSize_Prc9Envelope) = 160, Prc9EnvelopeRotated (PrintMediaSize_Prc9EnvelopeRotated) = 161, Roll04Inch (PrintMediaSize_Roll04Inch) = 162, Roll06Inch (PrintMediaSize_Roll06Inch) = 163, Roll08Inch (PrintMediaSize_Roll08Inch) = 164, Roll12Inch (PrintMediaSize_Roll12Inch) = 165, Roll15Inch (PrintMediaSize_Roll15Inch) = 166, Roll18Inch (PrintMediaSize_Roll18Inch) = 167, Roll22Inch (PrintMediaSize_Roll22Inch) = 168, Roll24Inch (PrintMediaSize_Roll24Inch) = 169, Roll30Inch (PrintMediaSize_Roll30Inch) = 170, Roll36Inch (PrintMediaSize_Roll36Inch) = 171, Roll54Inch (PrintMediaSize_Roll54Inch) = 172,
 }}
-RT_ENUM! { enum PrintMediaType: i32 {
+RT_ENUM! { enum PrintMediaType: i32 ["Windows.Graphics.Printing.PrintMediaType"] {
     Default (PrintMediaType_Default) = 0, NotAvailable (PrintMediaType_NotAvailable) = 1, PrinterCustom (PrintMediaType_PrinterCustom) = 2, AutoSelect (PrintMediaType_AutoSelect) = 3, Archival (PrintMediaType_Archival) = 4, BackPrintFilm (PrintMediaType_BackPrintFilm) = 5, Bond (PrintMediaType_Bond) = 6, CardStock (PrintMediaType_CardStock) = 7, Continuous (PrintMediaType_Continuous) = 8, EnvelopePlain (PrintMediaType_EnvelopePlain) = 9, EnvelopeWindow (PrintMediaType_EnvelopeWindow) = 10, Fabric (PrintMediaType_Fabric) = 11, HighResolution (PrintMediaType_HighResolution) = 12, Label (PrintMediaType_Label) = 13, MultiLayerForm (PrintMediaType_MultiLayerForm) = 14, MultiPartForm (PrintMediaType_MultiPartForm) = 15, Photographic (PrintMediaType_Photographic) = 16, PhotographicFilm (PrintMediaType_PhotographicFilm) = 17, PhotographicGlossy (PrintMediaType_PhotographicGlossy) = 18, PhotographicHighGloss (PrintMediaType_PhotographicHighGloss) = 19, PhotographicMatte (PrintMediaType_PhotographicMatte) = 20, PhotographicSatin (PrintMediaType_PhotographicSatin) = 21, PhotographicSemiGloss (PrintMediaType_PhotographicSemiGloss) = 22, Plain (PrintMediaType_Plain) = 23, Screen (PrintMediaType_Screen) = 24, ScreenPaged (PrintMediaType_ScreenPaged) = 25, Stationery (PrintMediaType_Stationery) = 26, TabStockFull (PrintMediaType_TabStockFull) = 27, TabStockPreCut (PrintMediaType_TabStockPreCut) = 28, Transparency (PrintMediaType_Transparency) = 29, TShirtTransfer (PrintMediaType_TShirtTransfer) = 30, None (PrintMediaType_None) = 31,
 }}
-RT_ENUM! { enum PrintOrientation: i32 {
+RT_ENUM! { enum PrintOrientation: i32 ["Windows.Graphics.Printing.PrintOrientation"] {
     Default (PrintOrientation_Default) = 0, NotAvailable (PrintOrientation_NotAvailable) = 1, PrinterCustom (PrintOrientation_PrinterCustom) = 2, Portrait (PrintOrientation_Portrait) = 3, PortraitFlipped (PrintOrientation_PortraitFlipped) = 4, Landscape (PrintOrientation_Landscape) = 5, LandscapeFlipped (PrintOrientation_LandscapeFlipped) = 6,
 }}
-RT_STRUCT! { struct PrintPageDescription {
+RT_STRUCT! { struct PrintPageDescription ["Windows.Graphics.Printing.PrintPageDescription"] {
     PageSize: foundation::Size, ImageableRect: foundation::Rect, DpiX: u32, DpiY: u32,
 }}
 DEFINE_IID!(IID_IPrintPageInfo, 3712739785, 42657, 19162, 147, 14, 218, 135, 42, 79, 35, 211);
@@ -3160,7 +3160,7 @@ impl IPrintPageInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintPageInfo: IPrintPageInfo}
+RT_CLASS!{class PrintPageInfo: IPrintPageInfo ["Windows.Graphics.Printing.PrintPageInfo"]}
 impl RtActivatable<IActivationFactory> for PrintPageInfo {}
 DEFINE_CLSID!(PrintPageInfo(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,46,80,114,105,110,116,80,97,103,101,73,110,102,111,0]) [CLSID_PrintPageInfo]);
 DEFINE_IID!(IID_IPrintPageRange, 4171263060, 28284, 20933, 87, 253, 6, 96, 194, 215, 21, 19);
@@ -3180,7 +3180,7 @@ impl IPrintPageRange {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintPageRange: IPrintPageRange}
+RT_CLASS!{class PrintPageRange: IPrintPageRange ["Windows.Graphics.Printing.PrintPageRange"]}
 impl RtActivatable<IPrintPageRangeFactory> for PrintPageRange {}
 impl PrintPageRange {
     #[inline] pub fn create(firstPage: i32, lastPage: i32) -> Result<ComPtr<PrintPageRange>> {
@@ -3246,11 +3246,11 @@ impl IPrintPageRangeOptions {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintPageRangeOptions: IPrintPageRangeOptions}
-RT_ENUM! { enum PrintQuality: i32 {
+RT_CLASS!{class PrintPageRangeOptions: IPrintPageRangeOptions ["Windows.Graphics.Printing.PrintPageRangeOptions"]}
+RT_ENUM! { enum PrintQuality: i32 ["Windows.Graphics.Printing.PrintQuality"] {
     Default (PrintQuality_Default) = 0, NotAvailable (PrintQuality_NotAvailable) = 1, PrinterCustom (PrintQuality_PrinterCustom) = 2, Automatic (PrintQuality_Automatic) = 3, Draft (PrintQuality_Draft) = 4, Fax (PrintQuality_Fax) = 5, High (PrintQuality_High) = 6, Normal (PrintQuality_Normal) = 7, Photographic (PrintQuality_Photographic) = 8, Text (PrintQuality_Text) = 9,
 }}
-RT_ENUM! { enum PrintStaple: i32 {
+RT_ENUM! { enum PrintStaple: i32 ["Windows.Graphics.Printing.PrintStaple"] {
     Default (PrintStaple_Default) = 0, NotAvailable (PrintStaple_NotAvailable) = 1, PrinterCustom (PrintStaple_PrinterCustom) = 2, None (PrintStaple_None) = 3, StapleTopLeft (PrintStaple_StapleTopLeft) = 4, StapleTopRight (PrintStaple_StapleTopRight) = 5, StapleBottomLeft (PrintStaple_StapleBottomLeft) = 6, StapleBottomRight (PrintStaple_StapleBottomRight) = 7, StapleDualLeft (PrintStaple_StapleDualLeft) = 8, StapleDualRight (PrintStaple_StapleDualRight) = 9, StapleDualTop (PrintStaple_StapleDualTop) = 10, StapleDualBottom (PrintStaple_StapleDualBottom) = 11, SaddleStitch (PrintStaple_SaddleStitch) = 12,
 }}
 DEFINE_IID!(IID_IPrintTask, 1641546311, 27894, 20397, 132, 226, 165, 232, 46, 45, 76, 235);
@@ -3321,7 +3321,7 @@ impl IPrintTask {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTask: IPrintTask}
+RT_CLASS!{class PrintTask: IPrintTask ["Windows.Graphics.Printing.PrintTask"]}
 DEFINE_IID!(IID_IPrintTask2, 908281975, 15955, 19869, 143, 94, 49, 106, 200, 222, 218, 225);
 RT_INTERFACE!{interface IPrintTask2(IPrintTask2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrintTask2] {
     fn put_IsPreviewEnabled(&self, value: bool) -> HRESULT,
@@ -3349,8 +3349,8 @@ impl IPrintTaskCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskCompletedEventArgs: IPrintTaskCompletedEventArgs}
-RT_ENUM! { enum PrintTaskCompletion: i32 {
+RT_CLASS!{class PrintTaskCompletedEventArgs: IPrintTaskCompletedEventArgs ["Windows.Graphics.Printing.PrintTaskCompletedEventArgs"]}
+RT_ENUM! { enum PrintTaskCompletion: i32 ["Windows.Graphics.Printing.PrintTaskCompletion"] {
     Abandoned (PrintTaskCompletion_Abandoned) = 0, Canceled (PrintTaskCompletion_Canceled) = 1, Failed (PrintTaskCompletion_Failed) = 2, Submitted (PrintTaskCompletion_Submitted) = 3,
 }}
 DEFINE_IID!(IID_IPrintTaskOptions, 1510631099, 53897, 16827, 150, 221, 87, 226, 131, 56, 174, 63);
@@ -3375,7 +3375,7 @@ impl IPrintTaskOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskOptions: IPrintTaskOptionsCore}
+RT_CLASS!{class PrintTaskOptions: IPrintTaskOptionsCore ["Windows.Graphics.Printing.PrintTaskOptions"]}
 DEFINE_IID!(IID_IPrintTaskOptions2, 3952809478, 39478, 19289, 134, 23, 178, 23, 132, 146, 98, 225);
 RT_INTERFACE!{interface IPrintTaskOptions2(IPrintTaskOptions2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskOptions2] {
     fn get_PageRangeOptions(&self, out: *mut *mut PrintPageRangeOptions) -> HRESULT,
@@ -3564,7 +3564,7 @@ impl IPrintTaskProgressingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskProgressingEventArgs: IPrintTaskProgressingEventArgs}
+RT_CLASS!{class PrintTaskProgressingEventArgs: IPrintTaskProgressingEventArgs ["Windows.Graphics.Printing.PrintTaskProgressingEventArgs"]}
 DEFINE_IID!(IID_IPrintTaskRequest, 1878400558, 10018, 16960, 166, 124, 243, 100, 132, 154, 23, 243);
 RT_INTERFACE!{interface IPrintTaskRequest(IPrintTaskRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskRequest] {
     fn get_Deadline(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -3588,7 +3588,7 @@ impl IPrintTaskRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskRequest: IPrintTaskRequest}
+RT_CLASS!{class PrintTaskRequest: IPrintTaskRequest ["Windows.Graphics.Printing.PrintTaskRequest"]}
 DEFINE_IID!(IID_IPrintTaskRequestedDeferral, 3488592880, 52798, 17095, 148, 150, 100, 128, 12, 98, 44, 68);
 RT_INTERFACE!{interface IPrintTaskRequestedDeferral(IPrintTaskRequestedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskRequestedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -3599,7 +3599,7 @@ impl IPrintTaskRequestedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskRequestedDeferral: IPrintTaskRequestedDeferral}
+RT_CLASS!{class PrintTaskRequestedDeferral: IPrintTaskRequestedDeferral ["Windows.Graphics.Printing.PrintTaskRequestedDeferral"]}
 DEFINE_IID!(IID_IPrintTaskRequestedEventArgs, 3501193508, 41755, 17740, 167, 182, 93, 12, 197, 34, 252, 22);
 RT_INTERFACE!{interface IPrintTaskRequestedEventArgs(IPrintTaskRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut PrintTaskRequest) -> HRESULT
@@ -3611,7 +3611,7 @@ impl IPrintTaskRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskRequestedEventArgs: IPrintTaskRequestedEventArgs}
+RT_CLASS!{class PrintTaskRequestedEventArgs: IPrintTaskRequestedEventArgs ["Windows.Graphics.Printing.PrintTaskRequestedEventArgs"]}
 DEFINE_IID!(IID_IPrintTaskSourceRequestedArgs, 4193281982, 62550, 16880, 156, 152, 92, 231, 62, 133, 20, 16);
 RT_INTERFACE!{interface IPrintTaskSourceRequestedArgs(IPrintTaskSourceRequestedArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskSourceRequestedArgs] {
     fn get_Deadline(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -3634,7 +3634,7 @@ impl IPrintTaskSourceRequestedArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskSourceRequestedArgs: IPrintTaskSourceRequestedArgs}
+RT_CLASS!{class PrintTaskSourceRequestedArgs: IPrintTaskSourceRequestedArgs ["Windows.Graphics.Printing.PrintTaskSourceRequestedArgs"]}
 DEFINE_IID!(IID_IPrintTaskSourceRequestedDeferral, 1242915025, 27026, 19869, 133, 85, 76, 164, 86, 63, 177, 102);
 RT_INTERFACE!{interface IPrintTaskSourceRequestedDeferral(IPrintTaskSourceRequestedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskSourceRequestedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -3645,7 +3645,7 @@ impl IPrintTaskSourceRequestedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskSourceRequestedDeferral: IPrintTaskSourceRequestedDeferral}
+RT_CLASS!{class PrintTaskSourceRequestedDeferral: IPrintTaskSourceRequestedDeferral ["Windows.Graphics.Printing.PrintTaskSourceRequestedDeferral"]}
 DEFINE_IID!(IID_PrintTaskSourceRequestedHandler, 1813028776, 23734, 19258, 134, 99, 243, 156, 176, 45, 201, 180);
 RT_DELEGATE!{delegate PrintTaskSourceRequestedHandler(PrintTaskSourceRequestedHandlerVtbl, PrintTaskSourceRequestedHandlerImpl) [IID_PrintTaskSourceRequestedHandler] {
     fn Invoke(&self, args: *mut PrintTaskSourceRequestedArgs) -> HRESULT
@@ -3869,7 +3869,7 @@ impl IPrintBindingOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintBindingOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintBindingOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintBindingOptionDetails"]}
 DEFINE_IID!(IID_IPrintBorderingOptionDetails, 1299430543, 64339, 20146, 152, 95, 29, 145, 222, 11, 118, 57);
 RT_INTERFACE!{interface IPrintBorderingOptionDetails(IPrintBorderingOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintBorderingOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -3897,7 +3897,7 @@ impl IPrintBorderingOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintBorderingOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintBorderingOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintBorderingOptionDetails"]}
 DEFINE_IID!(IID_IPrintCollationOptionDetails, 3601576294, 42406, 16604, 172, 195, 115, 159, 40, 241, 229, 211);
 RT_INTERFACE!{interface IPrintCollationOptionDetails(IPrintCollationOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintCollationOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -3925,7 +3925,7 @@ impl IPrintCollationOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintCollationOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintCollationOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintCollationOptionDetails"]}
 DEFINE_IID!(IID_IPrintColorModeOptionDetails, 3685316356, 61910, 18499, 164, 132, 155, 68, 124, 220, 243, 182);
 RT_INTERFACE!{interface IPrintColorModeOptionDetails(IPrintColorModeOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintColorModeOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -3953,7 +3953,7 @@ impl IPrintColorModeOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintColorModeOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintColorModeOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintColorModeOptionDetails"]}
 DEFINE_IID!(IID_IPrintCopiesOptionDetails, 1107636377, 17209, 17219, 137, 141, 44, 71, 181, 224, 195, 65);
 RT_INTERFACE!{interface IPrintCopiesOptionDetails(IPrintCopiesOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintCopiesOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -3981,7 +3981,7 @@ impl IPrintCopiesOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintCopiesOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintCopiesOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintCopiesOptionDetails"]}
 DEFINE_IID!(IID_IPrintCustomItemDetails, 1459926583, 23610, 17562, 170, 54, 179, 41, 27, 17, 146, 253);
 RT_INTERFACE!{interface IPrintCustomItemDetails(IPrintCustomItemDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintCustomItemDetails] {
     fn get_ItemId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4004,7 +4004,7 @@ impl IPrintCustomItemDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintCustomItemDetails: IPrintCustomItemDetails}
+RT_CLASS!{class PrintCustomItemDetails: IPrintCustomItemDetails ["Windows.Graphics.Printing.OptionDetails.PrintCustomItemDetails"]}
 DEFINE_IID!(IID_IPrintCustomItemListOptionDetails, 2784689544, 22770, 20157, 185, 15, 81, 228, 242, 148, 76, 93);
 RT_INTERFACE!{interface IPrintCustomItemListOptionDetails(IPrintCustomItemListOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintCustomItemListOptionDetails] {
     fn AddItem(&self, itemId: HSTRING, displayName: HSTRING) -> HRESULT
@@ -4015,7 +4015,7 @@ impl IPrintCustomItemListOptionDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintCustomItemListOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintCustomItemListOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintCustomItemListOptionDetails"]}
 DEFINE_IID!(IID_IPrintCustomItemListOptionDetails2, 3386258749, 25884, 19001, 144, 110, 16, 145, 161, 128, 27, 241);
 RT_INTERFACE!{interface IPrintCustomItemListOptionDetails2(IPrintCustomItemListOptionDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrintCustomItemListOptionDetails2] {
     #[cfg(feature="windows-storage")] fn AddItem(&self, itemId: HSTRING, displayName: HSTRING, description: HSTRING, icon: *mut ::rt::gen::windows::storage::streams::IRandomAccessStreamWithContentType) -> HRESULT
@@ -4085,7 +4085,7 @@ impl IPrintCustomTextOptionDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintCustomTextOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintCustomTextOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintCustomTextOptionDetails"]}
 DEFINE_IID!(IID_IPrintCustomTextOptionDetails2, 3467053908, 47479, 18200, 131, 56, 126, 210, 176, 216, 111, 227);
 RT_INTERFACE!{interface IPrintCustomTextOptionDetails2(IPrintCustomTextOptionDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IPrintCustomTextOptionDetails2] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4140,7 +4140,7 @@ impl IPrintCustomToggleOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintCustomToggleOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintCustomToggleOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintCustomToggleOptionDetails"]}
 DEFINE_IID!(IID_IPrintDuplexOptionDetails, 4242097553, 54436, 17658, 179, 254, 66, 224, 186, 40, 213, 173);
 RT_INTERFACE!{interface IPrintDuplexOptionDetails(IPrintDuplexOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintDuplexOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4168,7 +4168,7 @@ impl IPrintDuplexOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintDuplexOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintDuplexOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintDuplexOptionDetails"]}
 DEFINE_IID!(IID_IPrintHolePunchOptionDetails, 2799574808, 18476, 18007, 157, 113, 141, 221, 219, 234, 30, 30);
 RT_INTERFACE!{interface IPrintHolePunchOptionDetails(IPrintHolePunchOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintHolePunchOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4196,7 +4196,7 @@ impl IPrintHolePunchOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintHolePunchOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintHolePunchOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintHolePunchOptionDetails"]}
 DEFINE_IID!(IID_IPrintItemListOptionDetails, 2585941951, 65121, 17368, 162, 79, 163, 246, 171, 115, 32, 231);
 RT_INTERFACE!{interface IPrintItemListOptionDetails(IPrintItemListOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintItemListOptionDetails] {
     fn get_Items(&self, out: *mut *mut foundation::collections::IVectorView<IInspectable>) -> HRESULT
@@ -4235,7 +4235,7 @@ impl IPrintMediaSizeOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintMediaSizeOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintMediaSizeOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintMediaSizeOptionDetails"]}
 DEFINE_IID!(IID_IPrintMediaTypeOptionDetails, 4173791243, 44019, 19132, 142, 134, 34, 171, 197, 116, 74, 67);
 RT_INTERFACE!{interface IPrintMediaTypeOptionDetails(IPrintMediaTypeOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintMediaTypeOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4263,7 +4263,7 @@ impl IPrintMediaTypeOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintMediaTypeOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintMediaTypeOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintMediaTypeOptionDetails"]}
 DEFINE_IID!(IID_IPrintNumberOptionDetails, 1291959215, 25692, 19945, 150, 95, 111, 198, 187, 196, 124, 171);
 RT_INTERFACE!{interface IPrintNumberOptionDetails(IPrintNumberOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintNumberOptionDetails] {
     fn get_MinValue(&self, out: *mut u32) -> HRESULT,
@@ -4332,10 +4332,10 @@ impl IPrintOptionDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PrintOptionStates: u32 {
+RT_ENUM! { enum PrintOptionStates: u32 ["Windows.Graphics.Printing.OptionDetails.PrintOptionStates"] {
     None (PrintOptionStates_None) = 0, Enabled (PrintOptionStates_Enabled) = 1, Constrained (PrintOptionStates_Constrained) = 2,
 }}
-RT_ENUM! { enum PrintOptionType: i32 {
+RT_ENUM! { enum PrintOptionType: i32 ["Windows.Graphics.Printing.OptionDetails.PrintOptionType"] {
     Unknown (PrintOptionType_Unknown) = 0, Number (PrintOptionType_Number) = 1, Text (PrintOptionType_Text) = 2, ItemList (PrintOptionType_ItemList) = 3, Toggle (PrintOptionType_Toggle) = 4,
 }}
 DEFINE_IID!(IID_IPrintOrientationOptionDetails, 1187219577, 26336, 19872, 135, 180, 210, 84, 87, 130, 78, 183);
@@ -4365,7 +4365,7 @@ impl IPrintOrientationOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintOrientationOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintOrientationOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintOrientationOptionDetails"]}
 DEFINE_IID!(IID_IPrintPageRangeOptionDetails, 1511646391, 11240, 19111, 158, 165, 222, 251, 232, 113, 59, 78);
 RT_INTERFACE!{interface IPrintPageRangeOptionDetails(IPrintPageRangeOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintPageRangeOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4393,7 +4393,7 @@ impl IPrintPageRangeOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintPageRangeOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintPageRangeOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintPageRangeOptionDetails"]}
 DEFINE_IID!(IID_IPrintQualityOptionDetails, 768633761, 52762, 17638, 132, 249, 58, 146, 234, 30, 48, 68);
 RT_INTERFACE!{interface IPrintQualityOptionDetails(IPrintQualityOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintQualityOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4421,7 +4421,7 @@ impl IPrintQualityOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintQualityOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintQualityOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintQualityOptionDetails"]}
 DEFINE_IID!(IID_IPrintStapleOptionDetails, 3560011197, 39947, 17632, 132, 246, 206, 235, 206, 101, 56, 0);
 RT_INTERFACE!{interface IPrintStapleOptionDetails(IPrintStapleOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintStapleOptionDetails] {
     fn put_WarningText(&self, value: HSTRING) -> HRESULT,
@@ -4449,7 +4449,7 @@ impl IPrintStapleOptionDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintStapleOptionDetails: IPrintOptionDetails}
+RT_CLASS!{class PrintStapleOptionDetails: IPrintOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintStapleOptionDetails"]}
 DEFINE_IID!(IID_IPrintTaskOptionChangedEventArgs, 1696169221, 42478, 17159, 148, 7, 154, 202, 209, 71, 103, 156);
 RT_INTERFACE!{interface IPrintTaskOptionChangedEventArgs(IPrintTaskOptionChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskOptionChangedEventArgs] {
     fn get_OptionId(&self, out: *mut *mut IInspectable) -> HRESULT
@@ -4461,7 +4461,7 @@ impl IPrintTaskOptionChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskOptionChangedEventArgs: IPrintTaskOptionChangedEventArgs}
+RT_CLASS!{class PrintTaskOptionChangedEventArgs: IPrintTaskOptionChangedEventArgs ["Windows.Graphics.Printing.OptionDetails.PrintTaskOptionChangedEventArgs"]}
 DEFINE_IID!(IID_IPrintTaskOptionDetails, 4117891825, 43166, 17062, 129, 175, 248, 224, 16, 179, 138, 104);
 RT_INTERFACE!{interface IPrintTaskOptionDetails(IPrintTaskOptionDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTaskOptionDetails] {
     fn get_Options(&self, out: *mut *mut foundation::collections::IMapView<HString, IPrintOptionDetails>) -> HRESULT,
@@ -4507,7 +4507,7 @@ impl IPrintTaskOptionDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTaskOptionDetails: IPrintTaskOptionDetails}
+RT_CLASS!{class PrintTaskOptionDetails: IPrintTaskOptionDetails ["Windows.Graphics.Printing.OptionDetails.PrintTaskOptionDetails"]}
 impl RtActivatable<IPrintTaskOptionDetailsStatic> for PrintTaskOptionDetails {}
 impl PrintTaskOptionDetails {
     #[inline] pub fn get_from_print_task_options(printTaskOptions: &super::PrintTaskOptions) -> Result<Option<ComPtr<PrintTaskOptionDetails>>> {
@@ -4677,7 +4677,7 @@ impl IPrintTicketCapabilities {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTicketCapabilities: IPrintTicketCapabilities}
+RT_CLASS!{class PrintTicketCapabilities: IPrintTicketCapabilities ["Windows.Graphics.Printing.PrintTicket.PrintTicketCapabilities"]}
 DEFINE_IID!(IID_IPrintTicketFeature, 3881860458, 23029, 16643, 136, 88, 185, 119, 16, 150, 61, 57);
 RT_INTERFACE!{interface IPrintTicketFeature(IPrintTicketFeatureVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTicketFeature] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -4737,8 +4737,8 @@ impl IPrintTicketFeature {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTicketFeature: IPrintTicketFeature}
-RT_ENUM! { enum PrintTicketFeatureSelectionType: i32 {
+RT_CLASS!{class PrintTicketFeature: IPrintTicketFeature ["Windows.Graphics.Printing.PrintTicket.PrintTicketFeature"]}
+RT_ENUM! { enum PrintTicketFeatureSelectionType: i32 ["Windows.Graphics.Printing.PrintTicket.PrintTicketFeatureSelectionType"] {
     PickOne (PrintTicketFeatureSelectionType_PickOne) = 0, PickMany (PrintTicketFeatureSelectionType_PickMany) = 1,
 }}
 DEFINE_IID!(IID_IPrintTicketOption, 2961624976, 45927, 20043, 189, 72, 156, 120, 160, 187, 49, 206);
@@ -4797,8 +4797,8 @@ impl IPrintTicketOption {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTicketOption: IPrintTicketOption}
-RT_ENUM! { enum PrintTicketParameterDataType: i32 {
+RT_CLASS!{class PrintTicketOption: IPrintTicketOption ["Windows.Graphics.Printing.PrintTicket.PrintTicketOption"]}
+RT_ENUM! { enum PrintTicketParameterDataType: i32 ["Windows.Graphics.Printing.PrintTicket.PrintTicketParameterDataType"] {
     Integer (PrintTicketParameterDataType_Integer) = 0, NumericString (PrintTicketParameterDataType_NumericString) = 1, String (PrintTicketParameterDataType_String) = 2,
 }}
 DEFINE_IID!(IID_IPrintTicketParameterDefinition, 3602560228, 10594, 19457, 183, 243, 154, 146, 148, 235, 131, 53);
@@ -4849,7 +4849,7 @@ impl IPrintTicketParameterDefinition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTicketParameterDefinition: IPrintTicketParameterDefinition}
+RT_CLASS!{class PrintTicketParameterDefinition: IPrintTicketParameterDefinition ["Windows.Graphics.Printing.PrintTicket.PrintTicketParameterDefinition"]}
 DEFINE_IID!(IID_IPrintTicketParameterInitializer, 1580414395, 41125, 18609, 157, 92, 7, 17, 109, 220, 89, 122);
 RT_INTERFACE!{interface IPrintTicketParameterInitializer(IPrintTicketParameterInitializerVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTicketParameterInitializer] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -4885,7 +4885,7 @@ impl IPrintTicketParameterInitializer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTicketParameterInitializer: IPrintTicketParameterInitializer}
+RT_CLASS!{class PrintTicketParameterInitializer: IPrintTicketParameterInitializer ["Windows.Graphics.Printing.PrintTicket.PrintTicketParameterInitializer"]}
 DEFINE_IID!(IID_IPrintTicketValue, 1723009586, 9293, 20002, 169, 139, 187, 60, 241, 242, 221, 145);
 RT_INTERFACE!{interface IPrintTicketValue(IPrintTicketValueVtbl): IInspectable(IInspectableVtbl) [IID_IPrintTicketValue] {
     fn get_Type(&self, out: *mut PrintTicketValueType) -> HRESULT,
@@ -4909,8 +4909,8 @@ impl IPrintTicketValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintTicketValue: IPrintTicketValue}
-RT_ENUM! { enum PrintTicketValueType: i32 {
+RT_CLASS!{class PrintTicketValue: IPrintTicketValue ["Windows.Graphics.Printing.PrintTicket.PrintTicketValue"]}
+RT_ENUM! { enum PrintTicketValueType: i32 ["Windows.Graphics.Printing.PrintTicket.PrintTicketValueType"] {
     Integer (PrintTicketValueType_Integer) = 0, String (PrintTicketValueType_String) = 1, Unknown (PrintTicketValueType_Unknown) = 2,
 }}
 DEFINE_IID!(IID_IWorkflowPrintTicket, 1104487045, 13800, 17550, 168, 197, 228, 182, 162, 207, 130, 108);
@@ -5075,7 +5075,7 @@ impl IWorkflowPrintTicket {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WorkflowPrintTicket: IWorkflowPrintTicket}
+RT_CLASS!{class WorkflowPrintTicket: IWorkflowPrintTicket ["Windows.Graphics.Printing.PrintTicket.WorkflowPrintTicket"]}
 DEFINE_IID!(IID_IWorkflowPrintTicketValidationResult, 181531538, 55931, 18998, 191, 54, 106, 153, 166, 46, 32, 89);
 RT_INTERFACE!{interface IWorkflowPrintTicketValidationResult(IWorkflowPrintTicketValidationResultVtbl): IInspectable(IInspectableVtbl) [IID_IWorkflowPrintTicketValidationResult] {
     fn get_Validated(&self, out: *mut bool) -> HRESULT,
@@ -5093,7 +5093,7 @@ impl IWorkflowPrintTicketValidationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WorkflowPrintTicketValidationResult: IWorkflowPrintTicketValidationResult}
+RT_CLASS!{class WorkflowPrintTicketValidationResult: IWorkflowPrintTicketValidationResult ["Windows.Graphics.Printing.PrintTicket.WorkflowPrintTicketValidationResult"]}
 } // Windows.Graphics.Printing.PrintTicket
 pub mod workflow { // Windows.Graphics.Printing.Workflow
 use ::prelude::*;
@@ -5135,7 +5135,7 @@ impl IPrintWorkflowBackgroundSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowBackgroundSession: IPrintWorkflowBackgroundSession}
+RT_CLASS!{class PrintWorkflowBackgroundSession: IPrintWorkflowBackgroundSession ["Windows.Graphics.Printing.Workflow.PrintWorkflowBackgroundSession"]}
 DEFINE_IID!(IID_IPrintWorkflowBackgroundSetupRequestedEventArgs, 1139372866, 5968, 22985, 97, 251, 56, 55, 72, 162, 3, 98);
 RT_INTERFACE!{interface IPrintWorkflowBackgroundSetupRequestedEventArgs(IPrintWorkflowBackgroundSetupRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowBackgroundSetupRequestedEventArgs] {
     fn GetUserPrintTicketAsync(&self, out: *mut *mut foundation::IAsyncOperation<super::printticket::WorkflowPrintTicket>) -> HRESULT,
@@ -5164,7 +5164,7 @@ impl IPrintWorkflowBackgroundSetupRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowBackgroundSetupRequestedEventArgs: IPrintWorkflowBackgroundSetupRequestedEventArgs}
+RT_CLASS!{class PrintWorkflowBackgroundSetupRequestedEventArgs: IPrintWorkflowBackgroundSetupRequestedEventArgs ["Windows.Graphics.Printing.Workflow.PrintWorkflowBackgroundSetupRequestedEventArgs"]}
 DEFINE_IID!(IID_IPrintWorkflowConfiguration, 3500852461, 64843, 24053, 75, 182, 141, 13, 21, 158, 190, 63);
 RT_INTERFACE!{interface IPrintWorkflowConfiguration(IPrintWorkflowConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowConfiguration] {
     fn get_SourceAppDisplayName(&self, out: *mut HSTRING) -> HRESULT,
@@ -5188,7 +5188,7 @@ impl IPrintWorkflowConfiguration {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowConfiguration: IPrintWorkflowConfiguration}
+RT_CLASS!{class PrintWorkflowConfiguration: IPrintWorkflowConfiguration ["Windows.Graphics.Printing.Workflow.PrintWorkflowConfiguration"]}
 DEFINE_IID!(IID_IPrintWorkflowForegroundSession, 3348849616, 63724, 19691, 149, 58, 200, 135, 97, 87, 221, 51);
 RT_INTERFACE!{interface IPrintWorkflowForegroundSession(IPrintWorkflowForegroundSessionVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowForegroundSession] {
     fn add_SetupRequested(&self, setupEventHandler: *mut foundation::TypedEventHandler<PrintWorkflowForegroundSession, PrintWorkflowForegroundSetupRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5227,7 +5227,7 @@ impl IPrintWorkflowForegroundSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowForegroundSession: IPrintWorkflowForegroundSession}
+RT_CLASS!{class PrintWorkflowForegroundSession: IPrintWorkflowForegroundSession ["Windows.Graphics.Printing.Workflow.PrintWorkflowForegroundSession"]}
 DEFINE_IID!(IID_IPrintWorkflowForegroundSetupRequestedEventArgs, 3152249415, 39963, 19923, 155, 43, 200, 4, 104, 217, 65, 179);
 RT_INTERFACE!{interface IPrintWorkflowForegroundSetupRequestedEventArgs(IPrintWorkflowForegroundSetupRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowForegroundSetupRequestedEventArgs] {
     fn GetUserPrintTicketAsync(&self, out: *mut *mut foundation::IAsyncOperation<super::printticket::WorkflowPrintTicket>) -> HRESULT,
@@ -5251,18 +5251,18 @@ impl IPrintWorkflowForegroundSetupRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowForegroundSetupRequestedEventArgs: IPrintWorkflowForegroundSetupRequestedEventArgs}
+RT_CLASS!{class PrintWorkflowForegroundSetupRequestedEventArgs: IPrintWorkflowForegroundSetupRequestedEventArgs ["Windows.Graphics.Printing.Workflow.PrintWorkflowForegroundSetupRequestedEventArgs"]}
 DEFINE_IID!(IID_IPrintWorkflowObjectModelSourceFileContent, 3278670442, 35370, 16794, 179, 195, 32, 144, 230, 191, 171, 47);
 RT_INTERFACE!{interface IPrintWorkflowObjectModelSourceFileContent(IPrintWorkflowObjectModelSourceFileContentVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowObjectModelSourceFileContent] {
     
 }}
-RT_CLASS!{class PrintWorkflowObjectModelSourceFileContent: IPrintWorkflowObjectModelSourceFileContent}
+RT_CLASS!{class PrintWorkflowObjectModelSourceFileContent: IPrintWorkflowObjectModelSourceFileContent ["Windows.Graphics.Printing.Workflow.PrintWorkflowObjectModelSourceFileContent"]}
 DEFINE_IID!(IID_IPrintWorkflowObjectModelTargetPackage, 2107030644, 39764, 19617, 173, 58, 151, 156, 61, 68, 221, 172);
 RT_INTERFACE!{interface IPrintWorkflowObjectModelTargetPackage(IPrintWorkflowObjectModelTargetPackageVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowObjectModelTargetPackage] {
     
 }}
-RT_CLASS!{class PrintWorkflowObjectModelTargetPackage: IPrintWorkflowObjectModelTargetPackage}
-RT_ENUM! { enum PrintWorkflowSessionStatus: i32 {
+RT_CLASS!{class PrintWorkflowObjectModelTargetPackage: IPrintWorkflowObjectModelTargetPackage ["Windows.Graphics.Printing.Workflow.PrintWorkflowObjectModelTargetPackage"]}
+RT_ENUM! { enum PrintWorkflowSessionStatus: i32 ["Windows.Graphics.Printing.Workflow.PrintWorkflowSessionStatus"] {
     Started (PrintWorkflowSessionStatus_Started) = 0, Completed (PrintWorkflowSessionStatus_Completed) = 1, Aborted (PrintWorkflowSessionStatus_Aborted) = 2, Closed (PrintWorkflowSessionStatus_Closed) = 3,
 }}
 DEFINE_IID!(IID_IPrintWorkflowSourceContent, 438879809, 52913, 17715, 187, 115, 251, 230, 62, 239, 219, 24);
@@ -5288,7 +5288,7 @@ impl IPrintWorkflowSourceContent {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowSourceContent: IPrintWorkflowSourceContent}
+RT_CLASS!{class PrintWorkflowSourceContent: IPrintWorkflowSourceContent ["Windows.Graphics.Printing.Workflow.PrintWorkflowSourceContent"]}
 DEFINE_IID!(IID_IPrintWorkflowSpoolStreamContent, 1927634638, 58374, 19316, 132, 225, 63, 243, 253, 205, 175, 112);
 RT_INTERFACE!{interface IPrintWorkflowSpoolStreamContent(IPrintWorkflowSpoolStreamContentVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowSpoolStreamContent] {
     #[cfg(feature="windows-storage")] fn GetInputStream(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IInputStream) -> HRESULT
@@ -5300,7 +5300,7 @@ impl IPrintWorkflowSpoolStreamContent {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowSpoolStreamContent: IPrintWorkflowSpoolStreamContent}
+RT_CLASS!{class PrintWorkflowSpoolStreamContent: IPrintWorkflowSpoolStreamContent ["Windows.Graphics.Printing.Workflow.PrintWorkflowSpoolStreamContent"]}
 DEFINE_IID!(IID_IPrintWorkflowStreamTarget, 2990258820, 34149, 18571, 152, 57, 28, 158, 124, 122, 169, 22);
 RT_INTERFACE!{interface IPrintWorkflowStreamTarget(IPrintWorkflowStreamTargetVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowStreamTarget] {
     #[cfg(feature="windows-storage")] fn GetOutputStream(&self, out: *mut *mut ::rt::gen::windows::storage::streams::IOutputStream) -> HRESULT
@@ -5312,7 +5312,7 @@ impl IPrintWorkflowStreamTarget {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowStreamTarget: IPrintWorkflowStreamTarget}
+RT_CLASS!{class PrintWorkflowStreamTarget: IPrintWorkflowStreamTarget ["Windows.Graphics.Printing.Workflow.PrintWorkflowStreamTarget"]}
 DEFINE_IID!(IID_IPrintWorkflowSubmittedEventArgs, 987564609, 14228, 21865, 92, 135, 64, 232, 255, 114, 15, 131);
 RT_INTERFACE!{interface IPrintWorkflowSubmittedEventArgs(IPrintWorkflowSubmittedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowSubmittedEventArgs] {
     fn get_Operation(&self, out: *mut *mut PrintWorkflowSubmittedOperation) -> HRESULT,
@@ -5336,7 +5336,7 @@ impl IPrintWorkflowSubmittedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowSubmittedEventArgs: IPrintWorkflowSubmittedEventArgs}
+RT_CLASS!{class PrintWorkflowSubmittedEventArgs: IPrintWorkflowSubmittedEventArgs ["Windows.Graphics.Printing.Workflow.PrintWorkflowSubmittedEventArgs"]}
 DEFINE_IID!(IID_IPrintWorkflowSubmittedOperation, 776888854, 15329, 24335, 92, 129, 165, 162, 189, 78, 171, 14);
 RT_INTERFACE!{interface IPrintWorkflowSubmittedOperation(IPrintWorkflowSubmittedOperationVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowSubmittedOperation] {
     fn Complete(&self, status: PrintWorkflowSubmittedStatus) -> HRESULT,
@@ -5359,8 +5359,8 @@ impl IPrintWorkflowSubmittedOperation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowSubmittedOperation: IPrintWorkflowSubmittedOperation}
-RT_ENUM! { enum PrintWorkflowSubmittedStatus: i32 {
+RT_CLASS!{class PrintWorkflowSubmittedOperation: IPrintWorkflowSubmittedOperation ["Windows.Graphics.Printing.Workflow.PrintWorkflowSubmittedOperation"]}
+RT_ENUM! { enum PrintWorkflowSubmittedStatus: i32 ["Windows.Graphics.Printing.Workflow.PrintWorkflowSubmittedStatus"] {
     Succeeded (PrintWorkflowSubmittedStatus_Succeeded) = 0, Canceled (PrintWorkflowSubmittedStatus_Canceled) = 1, Failed (PrintWorkflowSubmittedStatus_Failed) = 2,
 }}
 DEFINE_IID!(IID_IPrintWorkflowTarget, 702162796, 2675, 23277, 79, 61, 151, 13, 50, 81, 240, 87);
@@ -5380,7 +5380,7 @@ impl IPrintWorkflowTarget {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowTarget: IPrintWorkflowTarget}
+RT_CLASS!{class PrintWorkflowTarget: IPrintWorkflowTarget ["Windows.Graphics.Printing.Workflow.PrintWorkflowTarget"]}
 DEFINE_IID!(IID_IPrintWorkflowTriggerDetails, 1463408744, 40326, 16466, 176, 203, 243, 16, 190, 205, 89, 187);
 RT_INTERFACE!{interface IPrintWorkflowTriggerDetails(IPrintWorkflowTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowTriggerDetails] {
     fn get_PrintWorkflowSession(&self, out: *mut *mut PrintWorkflowBackgroundSession) -> HRESULT
@@ -5392,7 +5392,7 @@ impl IPrintWorkflowTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowTriggerDetails: IPrintWorkflowTriggerDetails}
+RT_CLASS!{class PrintWorkflowTriggerDetails: IPrintWorkflowTriggerDetails ["Windows.Graphics.Printing.Workflow.PrintWorkflowTriggerDetails"]}
 DEFINE_IID!(IID_IPrintWorkflowUIActivatedEventArgs, 3163194445, 2539, 22342, 114, 166, 141, 200, 181, 237, 190, 155);
 RT_INTERFACE!{interface IPrintWorkflowUIActivatedEventArgs(IPrintWorkflowUIActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowUIActivatedEventArgs] {
     fn get_PrintWorkflowSession(&self, out: *mut *mut PrintWorkflowForegroundSession) -> HRESULT
@@ -5404,7 +5404,7 @@ impl IPrintWorkflowUIActivatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowUIActivatedEventArgs: IPrintWorkflowUIActivatedEventArgs}
+RT_CLASS!{class PrintWorkflowUIActivatedEventArgs: IPrintWorkflowUIActivatedEventArgs ["Windows.Graphics.Printing.Workflow.PrintWorkflowUIActivatedEventArgs"]}
 DEFINE_IID!(IID_IPrintWorkflowXpsDataAvailableEventArgs, 1293009713, 21713, 17230, 190, 14, 130, 197, 250, 88, 229, 178);
 RT_INTERFACE!{interface IPrintWorkflowXpsDataAvailableEventArgs(IPrintWorkflowXpsDataAvailableEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrintWorkflowXpsDataAvailableEventArgs] {
     fn get_Operation(&self, out: *mut *mut PrintWorkflowSubmittedOperation) -> HRESULT,
@@ -5422,7 +5422,7 @@ impl IPrintWorkflowXpsDataAvailableEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrintWorkflowXpsDataAvailableEventArgs: IPrintWorkflowXpsDataAvailableEventArgs}
+RT_CLASS!{class PrintWorkflowXpsDataAvailableEventArgs: IPrintWorkflowXpsDataAvailableEventArgs ["Windows.Graphics.Printing.Workflow.PrintWorkflowXpsDataAvailableEventArgs"]}
 } // Windows.Graphics.Printing.Workflow
 } // Windows.Graphics.Printing
 pub mod printing3d { // Windows.Graphics.Printing3D
@@ -5443,7 +5443,7 @@ impl IPrint3DManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DManager: IPrint3DManager}
+RT_CLASS!{class Print3DManager: IPrint3DManager ["Windows.Graphics.Printing3D.Print3DManager"]}
 impl RtActivatable<IPrint3DManagerStatics> for Print3DManager {}
 impl Print3DManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<Print3DManager>>> {
@@ -5515,7 +5515,7 @@ impl IPrint3DTask {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DTask: IPrint3DTask}
+RT_CLASS!{class Print3DTask: IPrint3DTask ["Windows.Graphics.Printing3D.Print3DTask"]}
 DEFINE_IID!(IID_IPrint3DTaskCompletedEventArgs, 3424195759, 9748, 20253, 172, 204, 214, 252, 79, 218, 84, 85);
 RT_INTERFACE!{interface IPrint3DTaskCompletedEventArgs(IPrint3DTaskCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DTaskCompletedEventArgs] {
     fn get_Completion(&self, out: *mut Print3DTaskCompletion) -> HRESULT,
@@ -5533,11 +5533,11 @@ impl IPrint3DTaskCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DTaskCompletedEventArgs: IPrint3DTaskCompletedEventArgs}
-RT_ENUM! { enum Print3DTaskCompletion: i32 {
+RT_CLASS!{class Print3DTaskCompletedEventArgs: IPrint3DTaskCompletedEventArgs ["Windows.Graphics.Printing3D.Print3DTaskCompletedEventArgs"]}
+RT_ENUM! { enum Print3DTaskCompletion: i32 ["Windows.Graphics.Printing3D.Print3DTaskCompletion"] {
     Abandoned (Print3DTaskCompletion_Abandoned) = 0, Canceled (Print3DTaskCompletion_Canceled) = 1, Failed (Print3DTaskCompletion_Failed) = 2, Slicing (Print3DTaskCompletion_Slicing) = 3, Submitted (Print3DTaskCompletion_Submitted) = 4,
 }}
-RT_ENUM! { enum Print3DTaskDetail: i32 {
+RT_ENUM! { enum Print3DTaskDetail: i32 ["Windows.Graphics.Printing3D.Print3DTaskDetail"] {
     Unknown (Print3DTaskDetail_Unknown) = 0, ModelExceedsPrintBed (Print3DTaskDetail_ModelExceedsPrintBed) = 1, UploadFailed (Print3DTaskDetail_UploadFailed) = 2, InvalidMaterialSelection (Print3DTaskDetail_InvalidMaterialSelection) = 3, InvalidModel (Print3DTaskDetail_InvalidModel) = 4, ModelNotManifold (Print3DTaskDetail_ModelNotManifold) = 5, InvalidPrintTicket (Print3DTaskDetail_InvalidPrintTicket) = 6,
 }}
 DEFINE_IID!(IID_IPrint3DTaskRequest, 630572143, 8773, 19546, 135, 49, 13, 96, 77, 198, 188, 60);
@@ -5551,7 +5551,7 @@ impl IPrint3DTaskRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DTaskRequest: IPrint3DTaskRequest}
+RT_CLASS!{class Print3DTaskRequest: IPrint3DTaskRequest ["Windows.Graphics.Printing3D.Print3DTaskRequest"]}
 DEFINE_IID!(IID_IPrint3DTaskRequestedEventArgs, 353154943, 6341, 16599, 159, 64, 250, 179, 9, 110, 5, 169);
 RT_INTERFACE!{interface IPrint3DTaskRequestedEventArgs(IPrint3DTaskRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DTaskRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut Print3DTaskRequest) -> HRESULT
@@ -5563,7 +5563,7 @@ impl IPrint3DTaskRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DTaskRequestedEventArgs: IPrint3DTaskRequestedEventArgs}
+RT_CLASS!{class Print3DTaskRequestedEventArgs: IPrint3DTaskRequestedEventArgs ["Windows.Graphics.Printing3D.Print3DTaskRequestedEventArgs"]}
 DEFINE_IID!(IID_IPrint3DTaskSourceChangedEventArgs, 1540175023, 9449, 19472, 141, 7, 20, 195, 70, 186, 63, 207);
 RT_INTERFACE!{interface IPrint3DTaskSourceChangedEventArgs(IPrint3DTaskSourceChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DTaskSourceChangedEventArgs] {
     fn get_Source(&self, out: *mut *mut Printing3D3MFPackage) -> HRESULT
@@ -5575,7 +5575,7 @@ impl IPrint3DTaskSourceChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DTaskSourceChangedEventArgs: IPrint3DTaskSourceChangedEventArgs}
+RT_CLASS!{class Print3DTaskSourceChangedEventArgs: IPrint3DTaskSourceChangedEventArgs ["Windows.Graphics.Printing3D.Print3DTaskSourceChangedEventArgs"]}
 DEFINE_IID!(IID_IPrint3DTaskSourceRequestedArgs, 3346832058, 9391, 16973, 163, 191, 146, 37, 12, 53, 86, 2);
 RT_INTERFACE!{interface IPrint3DTaskSourceRequestedArgs(IPrint3DTaskSourceRequestedArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPrint3DTaskSourceRequestedArgs] {
     fn SetSource(&self, source: *mut Printing3D3MFPackage) -> HRESULT
@@ -5586,7 +5586,7 @@ impl IPrint3DTaskSourceRequestedArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Print3DTaskSourceRequestedArgs: IPrint3DTaskSourceRequestedArgs}
+RT_CLASS!{class Print3DTaskSourceRequestedArgs: IPrint3DTaskSourceRequestedArgs ["Windows.Graphics.Printing3D.Print3DTaskSourceRequestedArgs"]}
 DEFINE_IID!(IID_Print3DTaskSourceRequestedHandler, 3910622832, 51479, 18142, 187, 81, 217, 169, 77, 179, 113, 31);
 RT_DELEGATE!{delegate Print3DTaskSourceRequestedHandler(Print3DTaskSourceRequestedHandlerVtbl, Print3DTaskSourceRequestedHandlerImpl) [IID_Print3DTaskSourceRequestedHandler] {
     fn Invoke(&self, args: *mut Print3DTaskSourceRequestedArgs) -> HRESULT
@@ -5665,7 +5665,7 @@ impl IPrinting3D3MFPackage {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3D3MFPackage: IPrinting3D3MFPackage}
+RT_CLASS!{class Printing3D3MFPackage: IPrinting3D3MFPackage ["Windows.Graphics.Printing3D.Printing3D3MFPackage"]}
 impl RtActivatable<IPrinting3D3MFPackageStatics> for Printing3D3MFPackage {}
 impl RtActivatable<IActivationFactory> for Printing3D3MFPackage {}
 impl Printing3D3MFPackage {
@@ -5728,7 +5728,7 @@ impl IPrinting3DBaseMaterial {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DBaseMaterial: IPrinting3DBaseMaterial}
+RT_CLASS!{class Printing3DBaseMaterial: IPrinting3DBaseMaterial ["Windows.Graphics.Printing3D.Printing3DBaseMaterial"]}
 impl RtActivatable<IPrinting3DBaseMaterialStatics> for Printing3DBaseMaterial {}
 impl RtActivatable<IActivationFactory> for Printing3DBaseMaterial {}
 impl Printing3DBaseMaterial {
@@ -5757,7 +5757,7 @@ impl IPrinting3DBaseMaterialGroup {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DBaseMaterialGroup: IPrinting3DBaseMaterialGroup}
+RT_CLASS!{class Printing3DBaseMaterialGroup: IPrinting3DBaseMaterialGroup ["Windows.Graphics.Printing3D.Printing3DBaseMaterialGroup"]}
 impl RtActivatable<IPrinting3DBaseMaterialGroupFactory> for Printing3DBaseMaterialGroup {}
 impl Printing3DBaseMaterialGroup {
     #[inline] pub fn create(materialGroupId: u32) -> Result<ComPtr<Printing3DBaseMaterialGroup>> {
@@ -5793,10 +5793,10 @@ impl IPrinting3DBaseMaterialStatics {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct Printing3DBufferDescription {
+RT_STRUCT! { struct Printing3DBufferDescription ["Windows.Graphics.Printing3D.Printing3DBufferDescription"] {
     Format: Printing3DBufferFormat, Stride: u32,
 }}
-RT_ENUM! { enum Printing3DBufferFormat: i32 {
+RT_ENUM! { enum Printing3DBufferFormat: i32 ["Windows.Graphics.Printing3D.Printing3DBufferFormat"] {
     Unknown (Printing3DBufferFormat_Unknown) = 0, R32G32B32A32Float (Printing3DBufferFormat_R32G32B32A32Float) = 2, R32G32B32A32UInt (Printing3DBufferFormat_R32G32B32A32UInt) = 3, R32G32B32Float (Printing3DBufferFormat_R32G32B32Float) = 6, R32G32B32UInt (Printing3DBufferFormat_R32G32B32UInt) = 7, Printing3DDouble (Printing3DBufferFormat_Printing3DDouble) = 500, Printing3DUInt (Printing3DBufferFormat_Printing3DUInt) = 501,
 }}
 DEFINE_IID!(IID_IPrinting3DColorMaterial, 3783891240, 31975, 17029, 163, 93, 241, 69, 201, 81, 12, 123);
@@ -5815,7 +5815,7 @@ impl IPrinting3DColorMaterial {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DColorMaterial: IPrinting3DColorMaterial}
+RT_CLASS!{class Printing3DColorMaterial: IPrinting3DColorMaterial ["Windows.Graphics.Printing3D.Printing3DColorMaterial"]}
 impl RtActivatable<IActivationFactory> for Printing3DColorMaterial {}
 DEFINE_CLSID!(Printing3DColorMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,108,111,114,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DColorMaterial]);
 DEFINE_IID!(IID_IPrinting3DColorMaterial2, 4205897810, 2799, 17641, 157, 221, 54, 238, 234, 90, 205, 68);
@@ -5851,7 +5851,7 @@ impl IPrinting3DColorMaterialGroup {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DColorMaterialGroup: IPrinting3DColorMaterialGroup}
+RT_CLASS!{class Printing3DColorMaterialGroup: IPrinting3DColorMaterialGroup ["Windows.Graphics.Printing3D.Printing3DColorMaterialGroup"]}
 impl RtActivatable<IPrinting3DColorMaterialGroupFactory> for Printing3DColorMaterialGroup {}
 impl Printing3DColorMaterialGroup {
     #[inline] pub fn create(materialGroupId: u32) -> Result<ComPtr<Printing3DColorMaterialGroup>> {
@@ -5936,7 +5936,7 @@ impl IPrinting3DComponent {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DComponent: IPrinting3DComponent}
+RT_CLASS!{class Printing3DComponent: IPrinting3DComponent ["Windows.Graphics.Printing3D.Printing3DComponent"]}
 impl RtActivatable<IActivationFactory> for Printing3DComponent {}
 DEFINE_CLSID!(Printing3DComponent(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,110,101,110,116,0]) [CLSID_Printing3DComponent]);
 DEFINE_IID!(IID_IPrinting3DComponentWithMatrix, 846852917, 3824, 17771, 154, 33, 73, 190, 190, 139, 81, 194);
@@ -5966,7 +5966,7 @@ impl IPrinting3DComponentWithMatrix {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DComponentWithMatrix: IPrinting3DComponentWithMatrix}
+RT_CLASS!{class Printing3DComponentWithMatrix: IPrinting3DComponentWithMatrix ["Windows.Graphics.Printing3D.Printing3DComponentWithMatrix"]}
 impl RtActivatable<IActivationFactory> for Printing3DComponentWithMatrix {}
 DEFINE_CLSID!(Printing3DComponentWithMatrix(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,110,101,110,116,87,105,116,104,77,97,116,114,105,120,0]) [CLSID_Printing3DComponentWithMatrix]);
 DEFINE_IID!(IID_IPrinting3DCompositeMaterial, 1176647901, 22062, 20332, 136, 45, 244, 216, 65, 253, 99, 199);
@@ -5980,7 +5980,7 @@ impl IPrinting3DCompositeMaterial {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DCompositeMaterial: IPrinting3DCompositeMaterial}
+RT_CLASS!{class Printing3DCompositeMaterial: IPrinting3DCompositeMaterial ["Windows.Graphics.Printing3D.Printing3DCompositeMaterial"]}
 impl RtActivatable<IActivationFactory> for Printing3DCompositeMaterial {}
 DEFINE_CLSID!(Printing3DCompositeMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,67,111,109,112,111,115,105,116,101,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DCompositeMaterial]);
 DEFINE_IID!(IID_IPrinting3DCompositeMaterialGroup, 2375314011, 16625, 18797, 165, 251, 52, 10, 90, 103, 142, 48);
@@ -6006,7 +6006,7 @@ impl IPrinting3DCompositeMaterialGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DCompositeMaterialGroup: IPrinting3DCompositeMaterialGroup}
+RT_CLASS!{class Printing3DCompositeMaterialGroup: IPrinting3DCompositeMaterialGroup ["Windows.Graphics.Printing3D.Printing3DCompositeMaterialGroup"]}
 impl RtActivatable<IPrinting3DCompositeMaterialGroupFactory> for Printing3DCompositeMaterialGroup {}
 impl Printing3DCompositeMaterialGroup {
     #[inline] pub fn create(materialGroupId: u32) -> Result<ComPtr<Printing3DCompositeMaterialGroup>> {
@@ -6079,7 +6079,7 @@ impl IPrinting3DFaceReductionOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DFaceReductionOptions: IPrinting3DFaceReductionOptions}
+RT_CLASS!{class Printing3DFaceReductionOptions: IPrinting3DFaceReductionOptions ["Windows.Graphics.Printing3D.Printing3DFaceReductionOptions"]}
 impl RtActivatable<IActivationFactory> for Printing3DFaceReductionOptions {}
 DEFINE_CLSID!(Printing3DFaceReductionOptions(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,70,97,99,101,82,101,100,117,99,116,105,111,110,79,112,116,105,111,110,115,0]) [CLSID_Printing3DFaceReductionOptions]);
 DEFINE_IID!(IID_IPrinting3DMaterial, 932033110, 60770, 18770, 184, 91, 3, 86, 125, 124, 70, 94);
@@ -6117,7 +6117,7 @@ impl IPrinting3DMaterial {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DMaterial: IPrinting3DMaterial}
+RT_CLASS!{class Printing3DMaterial: IPrinting3DMaterial ["Windows.Graphics.Printing3D.Printing3DMaterial"]}
 impl RtActivatable<IActivationFactory> for Printing3DMaterial {}
 DEFINE_CLSID!(Printing3DMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DMaterial]);
 DEFINE_IID!(IID_IPrinting3DMesh, 422482140, 552, 11777, 188, 32, 197, 41, 12, 191, 50, 196);
@@ -6257,10 +6257,10 @@ impl IPrinting3DMesh {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DMesh: IPrinting3DMesh}
+RT_CLASS!{class Printing3DMesh: IPrinting3DMesh ["Windows.Graphics.Printing3D.Printing3DMesh"]}
 impl RtActivatable<IActivationFactory> for Printing3DMesh {}
 DEFINE_CLSID!(Printing3DMesh(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,101,115,104,0]) [CLSID_Printing3DMesh]);
-RT_ENUM! { enum Printing3DMeshVerificationMode: i32 {
+RT_ENUM! { enum Printing3DMeshVerificationMode: i32 ["Windows.Graphics.Printing3D.Printing3DMeshVerificationMode"] {
     FindFirstError (Printing3DMeshVerificationMode_FindFirstError) = 0, FindAllErrors (Printing3DMeshVerificationMode_FindAllErrors) = 1,
 }}
 DEFINE_IID!(IID_IPrinting3DMeshVerificationResult, 425095610, 59706, 20106, 164, 111, 222, 168, 232, 82, 25, 126);
@@ -6286,7 +6286,7 @@ impl IPrinting3DMeshVerificationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DMeshVerificationResult: IPrinting3DMeshVerificationResult}
+RT_CLASS!{class Printing3DMeshVerificationResult: IPrinting3DMeshVerificationResult ["Windows.Graphics.Printing3D.Printing3DMeshVerificationResult"]}
 DEFINE_IID!(IID_IPrinting3DModel, 755052272, 21243, 37274, 119, 176, 75, 26, 59, 128, 50, 79);
 RT_INTERFACE!{interface IPrinting3DModel(IPrinting3DModelVtbl): IInspectable(IInspectableVtbl) [IID_IPrinting3DModel] {
     fn get_Unit(&self, out: *mut Printing3DModelUnit) -> HRESULT,
@@ -6378,7 +6378,7 @@ impl IPrinting3DModel {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DModel: IPrinting3DModel}
+RT_CLASS!{class Printing3DModel: IPrinting3DModel ["Windows.Graphics.Printing3D.Printing3DModel"]}
 impl RtActivatable<IActivationFactory> for Printing3DModel {}
 DEFINE_CLSID!(Printing3DModel(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,111,100,101,108,0]) [CLSID_Printing3DModel]);
 DEFINE_IID!(IID_IPrinting3DModel2, 3374344647, 51265, 18419, 168, 78, 161, 73, 253, 8, 182, 87);
@@ -6460,10 +6460,10 @@ impl IPrinting3DModelTexture {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DModelTexture: IPrinting3DModelTexture}
+RT_CLASS!{class Printing3DModelTexture: IPrinting3DModelTexture ["Windows.Graphics.Printing3D.Printing3DModelTexture"]}
 impl RtActivatable<IActivationFactory> for Printing3DModelTexture {}
 DEFINE_CLSID!(Printing3DModelTexture(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,111,100,101,108,84,101,120,116,117,114,101,0]) [CLSID_Printing3DModelTexture]);
-RT_ENUM! { enum Printing3DModelUnit: i32 {
+RT_ENUM! { enum Printing3DModelUnit: i32 ["Windows.Graphics.Printing3D.Printing3DModelUnit"] {
     Meter (Printing3DModelUnit_Meter) = 0, Micron (Printing3DModelUnit_Micron) = 1, Millimeter (Printing3DModelUnit_Millimeter) = 2, Centimeter (Printing3DModelUnit_Centimeter) = 3, Inch (Printing3DModelUnit_Inch) = 4, Foot (Printing3DModelUnit_Foot) = 5,
 }}
 DEFINE_IID!(IID_IPrinting3DMultiplePropertyMaterial, 631645515, 50921, 18509, 162, 20, 162, 94, 87, 118, 186, 98);
@@ -6477,7 +6477,7 @@ impl IPrinting3DMultiplePropertyMaterial {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DMultiplePropertyMaterial: IPrinting3DMultiplePropertyMaterial}
+RT_CLASS!{class Printing3DMultiplePropertyMaterial: IPrinting3DMultiplePropertyMaterial ["Windows.Graphics.Printing3D.Printing3DMultiplePropertyMaterial"]}
 impl RtActivatable<IActivationFactory> for Printing3DMultiplePropertyMaterial {}
 DEFINE_CLSID!(Printing3DMultiplePropertyMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,77,117,108,116,105,112,108,101,80,114,111,112,101,114,116,121,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DMultiplePropertyMaterial]);
 DEFINE_IID!(IID_IPrinting3DMultiplePropertyMaterialGroup, 4036298009, 44729, 17685, 163, 155, 160, 136, 251, 187, 39, 124);
@@ -6503,7 +6503,7 @@ impl IPrinting3DMultiplePropertyMaterialGroup {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DMultiplePropertyMaterialGroup: IPrinting3DMultiplePropertyMaterialGroup}
+RT_CLASS!{class Printing3DMultiplePropertyMaterialGroup: IPrinting3DMultiplePropertyMaterialGroup ["Windows.Graphics.Printing3D.Printing3DMultiplePropertyMaterialGroup"]}
 impl RtActivatable<IPrinting3DMultiplePropertyMaterialGroupFactory> for Printing3DMultiplePropertyMaterialGroup {}
 impl Printing3DMultiplePropertyMaterialGroup {
     #[inline] pub fn create(materialGroupId: u32) -> Result<ComPtr<Printing3DMultiplePropertyMaterialGroup>> {
@@ -6522,10 +6522,10 @@ impl IPrinting3DMultiplePropertyMaterialGroupFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum Printing3DObjectType: i32 {
+RT_ENUM! { enum Printing3DObjectType: i32 ["Windows.Graphics.Printing3D.Printing3DObjectType"] {
     Model (Printing3DObjectType_Model) = 0, Support (Printing3DObjectType_Support) = 1, Others (Printing3DObjectType_Others) = 2,
 }}
-RT_ENUM! { enum Printing3DPackageCompression: i32 {
+RT_ENUM! { enum Printing3DPackageCompression: i32 ["Windows.Graphics.Printing3D.Printing3DPackageCompression"] {
     Low (Printing3DPackageCompression_Low) = 0, Medium (Printing3DPackageCompression_Medium) = 1, High (Printing3DPackageCompression_High) = 2,
 }}
 DEFINE_IID!(IID_IPrinting3DTexture2CoordMaterial, 2374257659, 2025, 18822, 152, 51, 141, 211, 212, 140, 104, 89);
@@ -6566,7 +6566,7 @@ impl IPrinting3DTexture2CoordMaterial {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DTexture2CoordMaterial: IPrinting3DTexture2CoordMaterial}
+RT_CLASS!{class Printing3DTexture2CoordMaterial: IPrinting3DTexture2CoordMaterial ["Windows.Graphics.Printing3D.Printing3DTexture2CoordMaterial"]}
 impl RtActivatable<IActivationFactory> for Printing3DTexture2CoordMaterial {}
 DEFINE_CLSID!(Printing3DTexture2CoordMaterial(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,84,101,120,116,117,114,101,50,67,111,111,114,100,77,97,116,101,114,105,97,108,0]) [CLSID_Printing3DTexture2CoordMaterial]);
 DEFINE_IID!(IID_IPrinting3DTexture2CoordMaterialGroup, 1652391079, 28048, 20409, 159, 196, 159, 239, 243, 223, 168, 146);
@@ -6586,7 +6586,7 @@ impl IPrinting3DTexture2CoordMaterialGroup {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DTexture2CoordMaterialGroup: IPrinting3DTexture2CoordMaterialGroup}
+RT_CLASS!{class Printing3DTexture2CoordMaterialGroup: IPrinting3DTexture2CoordMaterialGroup ["Windows.Graphics.Printing3D.Printing3DTexture2CoordMaterialGroup"]}
 impl RtActivatable<IPrinting3DTexture2CoordMaterialGroupFactory> for Printing3DTexture2CoordMaterialGroup {}
 impl Printing3DTexture2CoordMaterialGroup {
     #[inline] pub fn create(materialGroupId: u32) -> Result<ComPtr<Printing3DTexture2CoordMaterialGroup>> {
@@ -6621,7 +6621,7 @@ impl IPrinting3DTexture2CoordMaterialGroupFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum Printing3DTextureEdgeBehavior: i32 {
+RT_ENUM! { enum Printing3DTextureEdgeBehavior: i32 ["Windows.Graphics.Printing3D.Printing3DTextureEdgeBehavior"] {
     None (Printing3DTextureEdgeBehavior_None) = 0, Wrap (Printing3DTextureEdgeBehavior_Wrap) = 1, Mirror (Printing3DTextureEdgeBehavior_Mirror) = 2, Clamp (Printing3DTextureEdgeBehavior_Clamp) = 3,
 }}
 DEFINE_IID!(IID_IPrinting3DTextureResource, 2802709293, 27313, 17582, 188, 69, 162, 115, 130, 192, 211, 140);
@@ -6653,7 +6653,7 @@ impl IPrinting3DTextureResource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Printing3DTextureResource: IPrinting3DTextureResource}
+RT_CLASS!{class Printing3DTextureResource: IPrinting3DTextureResource ["Windows.Graphics.Printing3D.Printing3DTextureResource"]}
 impl RtActivatable<IActivationFactory> for Printing3DTextureResource {}
 DEFINE_CLSID!(Printing3DTextureResource(&[87,105,110,100,111,119,115,46,71,114,97,112,104,105,99,115,46,80,114,105,110,116,105,110,103,51,68,46,80,114,105,110,116,105,110,103,51,68,84,101,120,116,117,114,101,82,101,115,111,117,114,99,101,0]) [CLSID_Printing3DTextureResource]);
 } // Windows.Graphics.Printing3D

--- a/src/rt/gen/windows/management.rs
+++ b/src/rt/gen/windows/management.rs
@@ -76,13 +76,13 @@ impl IMdmAlert {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MdmAlert: IMdmAlert}
+RT_CLASS!{class MdmAlert: IMdmAlert ["Windows.Management.MdmAlert"]}
 impl RtActivatable<IActivationFactory> for MdmAlert {}
 DEFINE_CLSID!(MdmAlert(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,77,100,109,65,108,101,114,116,0]) [CLSID_MdmAlert]);
-RT_ENUM! { enum MdmAlertDataType: i32 {
+RT_ENUM! { enum MdmAlertDataType: i32 ["Windows.Management.MdmAlertDataType"] {
     String (MdmAlertDataType_String) = 0, Base64 (MdmAlertDataType_Base64) = 1, Boolean (MdmAlertDataType_Boolean) = 2, Integer (MdmAlertDataType_Integer) = 3,
 }}
-RT_ENUM! { enum MdmAlertMark: i32 {
+RT_ENUM! { enum MdmAlertMark: i32 ["Windows.Management.MdmAlertMark"] {
     None (MdmAlertMark_None) = 0, Fatal (MdmAlertMark_Fatal) = 1, Critical (MdmAlertMark_Critical) = 2, Warning (MdmAlertMark_Warning) = 3, Informational (MdmAlertMark_Informational) = 4,
 }}
 DEFINE_IID!(IID_IMdmSession, 4270403916, 36708, 18327, 169, 215, 157, 136, 248, 106, 225, 102);
@@ -137,7 +137,7 @@ impl IMdmSession {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MdmSession: IMdmSession}
+RT_CLASS!{class MdmSession: IMdmSession ["Windows.Management.MdmSession"]}
 RT_CLASS!{static class MdmSessionManager}
 impl RtActivatable<IMdmSessionManagerStatics> for MdmSessionManager {}
 impl MdmSessionManager {
@@ -183,7 +183,7 @@ impl IMdmSessionManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MdmSessionState: i32 {
+RT_ENUM! { enum MdmSessionState: i32 ["Windows.Management.MdmSessionState"] {
     NotStarted (MdmSessionState_NotStarted) = 0, Starting (MdmSessionState_Starting) = 1, Connecting (MdmSessionState_Connecting) = 2, Communicating (MdmSessionState_Communicating) = 3, AlertStatusAvailable (MdmSessionState_AlertStatusAvailable) = 4, Retrying (MdmSessionState_Retrying) = 5, Completed (MdmSessionState_Completed) = 6,
 }}
 pub mod core { // Windows.Management.Core
@@ -192,7 +192,7 @@ DEFINE_IID!(IID_IApplicationDataManager, 1959855154, 11929, 16384, 154, 58, 100,
 RT_INTERFACE!{interface IApplicationDataManager(IApplicationDataManagerVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationDataManager] {
     
 }}
-RT_CLASS!{class ApplicationDataManager: IApplicationDataManager}
+RT_CLASS!{class ApplicationDataManager: IApplicationDataManager ["Windows.Management.Core.ApplicationDataManager"]}
 impl RtActivatable<IApplicationDataManagerStatics> for ApplicationDataManager {}
 impl ApplicationDataManager {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_for_package_family(packageFamilyName: &HStringArg) -> Result<Option<ComPtr<super::super::storage::ApplicationData>>> {
@@ -214,16 +214,16 @@ impl IApplicationDataManagerStatics {
 } // Windows.Management.Core
 pub mod deployment { // Windows.Management.Deployment
 use ::prelude::*;
-RT_ENUM! { enum AddPackageByAppInstallerOptions: u32 {
+RT_ENUM! { enum AddPackageByAppInstallerOptions: u32 ["Windows.Management.Deployment.AddPackageByAppInstallerOptions"] {
     None (AddPackageByAppInstallerOptions_None) = 0, InstallAllResources (AddPackageByAppInstallerOptions_InstallAllResources) = 32, ForceTargetAppShutdown (AddPackageByAppInstallerOptions_ForceTargetAppShutdown) = 64, RequiredContentGroupOnly (AddPackageByAppInstallerOptions_RequiredContentGroupOnly) = 256,
 }}
-RT_ENUM! { enum DeploymentOptions: u32 {
+RT_ENUM! { enum DeploymentOptions: u32 ["Windows.Management.Deployment.DeploymentOptions"] {
     None (DeploymentOptions_None) = 0, ForceApplicationShutdown (DeploymentOptions_ForceApplicationShutdown) = 1, DevelopmentMode (DeploymentOptions_DevelopmentMode) = 2, InstallAllResources (DeploymentOptions_InstallAllResources) = 32, ForceTargetApplicationShutdown (DeploymentOptions_ForceTargetApplicationShutdown) = 64, RequiredContentGroupOnly (DeploymentOptions_RequiredContentGroupOnly) = 256, ForceUpdateFromAnyVersion (DeploymentOptions_ForceUpdateFromAnyVersion) = 262144,
 }}
-RT_STRUCT! { struct DeploymentProgress {
+RT_STRUCT! { struct DeploymentProgress ["Windows.Management.Deployment.DeploymentProgress"] {
     state: DeploymentProgressState, percentage: u32,
 }}
-RT_ENUM! { enum DeploymentProgressState: i32 {
+RT_ENUM! { enum DeploymentProgressState: i32 ["Windows.Management.Deployment.DeploymentProgressState"] {
     Queued (DeploymentProgressState_Queued) = 0, Processing (DeploymentProgressState_Processing) = 1,
 }}
 DEFINE_IID!(IID_IDeploymentResult, 627292590, 46973, 19487, 138, 123, 32, 230, 173, 81, 94, 243);
@@ -249,7 +249,7 @@ impl IDeploymentResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DeploymentResult: IDeploymentResult}
+RT_CLASS!{class DeploymentResult: IDeploymentResult ["Windows.Management.Deployment.DeploymentResult"]}
 DEFINE_IID!(IID_IDeploymentResult2, 4228804956, 23041, 19415, 188, 241, 56, 28, 140, 130, 224, 74);
 RT_INTERFACE!{interface IDeploymentResult2(IDeploymentResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IDeploymentResult2] {
     fn get_IsRegistered(&self, out: *mut bool) -> HRESULT
@@ -261,7 +261,7 @@ impl IDeploymentResult2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PackageInstallState: i32 {
+RT_ENUM! { enum PackageInstallState: i32 ["Windows.Management.Deployment.PackageInstallState"] {
     NotInstalled (PackageInstallState_NotInstalled) = 0, Staged (PackageInstallState_Staged) = 1, Installed (PackageInstallState_Installed) = 2, Paused (PackageInstallState_Paused) = 6,
 }}
 DEFINE_IID!(IID_IPackageManager, 2591902565, 24207, 20423, 162, 229, 127, 105, 37, 203, 139, 83);
@@ -364,7 +364,7 @@ impl IPackageManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageManager: IPackageManager}
+RT_CLASS!{class PackageManager: IPackageManager ["Windows.Management.Deployment.PackageManager"]}
 impl RtActivatable<IActivationFactory> for PackageManager {}
 DEFINE_CLSID!(PackageManager(&[87,105,110,100,111,119,115,46,77,97,110,97,103,101,109,101,110,116,46,68,101,112,108,111,121,109,101,110,116,46,80,97,99,107,97,103,101,77,97,110,97,103,101,114,0]) [CLSID_PackageManager]);
 DEFINE_IID!(IID_IPackageManager2, 4155166861, 2112, 18162, 181, 216, 202, 212, 118, 147, 160, 149);
@@ -650,14 +650,14 @@ impl IPackageManagerDebugSettings {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageManagerDebugSettings: IPackageManagerDebugSettings}
-RT_ENUM! { enum PackageState: i32 {
+RT_CLASS!{class PackageManagerDebugSettings: IPackageManagerDebugSettings ["Windows.Management.Deployment.PackageManagerDebugSettings"]}
+RT_ENUM! { enum PackageState: i32 ["Windows.Management.Deployment.PackageState"] {
     Normal (PackageState_Normal) = 0, LicenseInvalid (PackageState_LicenseInvalid) = 1, Modified (PackageState_Modified) = 2, Tampered (PackageState_Tampered) = 3,
 }}
-RT_ENUM! { enum PackageStatus: u32 {
+RT_ENUM! { enum PackageStatus: u32 ["Windows.Management.Deployment.PackageStatus"] {
     OK (PackageStatus_OK) = 0, LicenseIssue (PackageStatus_LicenseIssue) = 1, Modified (PackageStatus_Modified) = 2, Tampered (PackageStatus_Tampered) = 4, Disabled (PackageStatus_Disabled) = 8,
 }}
-RT_ENUM! { enum PackageTypes: u32 {
+RT_ENUM! { enum PackageTypes: u32 ["Windows.Management.Deployment.PackageTypes"] {
     None (PackageTypes_None) = 0, Main (PackageTypes_Main) = 1, Framework (PackageTypes_Framework) = 2, Resource (PackageTypes_Resource) = 4, Bundle (PackageTypes_Bundle) = 8, Xap (PackageTypes_Xap) = 16, Optional (PackageTypes_Optional) = 32,
 }}
 DEFINE_IID!(IID_IPackageUserInformation, 4130878499, 64009, 19644, 144, 85, 21, 202, 39, 94, 46, 126);
@@ -677,7 +677,7 @@ impl IPackageUserInformation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageUserInformation: IPackageUserInformation}
+RT_CLASS!{class PackageUserInformation: IPackageUserInformation ["Windows.Management.Deployment.PackageUserInformation"]}
 DEFINE_IID!(IID_IPackageVolume, 3475403459, 6720, 17488, 151, 57, 42, 206, 46, 137, 136, 83);
 RT_INTERFACE!{interface IPackageVolume(IPackageVolumeVtbl): IInspectable(IInspectableVtbl) [IID_IPackageVolume] {
     fn get_IsOffline(&self, out: *mut bool) -> HRESULT,
@@ -803,7 +803,7 @@ impl IPackageVolume {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PackageVolume: IPackageVolume}
+RT_CLASS!{class PackageVolume: IPackageVolume ["Windows.Management.Deployment.PackageVolume"]}
 DEFINE_IID!(IID_IPackageVolume2, 1185664814, 40404, 18338, 171, 140, 198, 64, 131, 73, 188, 216);
 RT_INTERFACE!{interface IPackageVolume2(IPackageVolume2Vtbl): IInspectable(IInspectableVtbl) [IID_IPackageVolume2] {
     fn get_IsFullTrustPackageSupported(&self, out: *mut bool) -> HRESULT,
@@ -827,7 +827,7 @@ impl IPackageVolume2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemovalOptions: u32 {
+RT_ENUM! { enum RemovalOptions: u32 ["Windows.Management.Deployment.RemovalOptions"] {
     None (RemovalOptions_None) = 0, PreserveApplicationData (RemovalOptions_PreserveApplicationData) = 4096, RemoveForAllUsers (RemovalOptions_RemoveForAllUsers) = 524288,
 }}
 pub mod preview { // Windows.Management.Deployment.Preview
@@ -868,7 +868,7 @@ impl IInstalledClassicAppInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InstalledClassicAppInfo: IInstalledClassicAppInfo}
+RT_CLASS!{class InstalledClassicAppInfo: IInstalledClassicAppInfo ["Windows.Management.Deployment.Preview.InstalledClassicAppInfo"]}
 } // Windows.Management.Deployment.Preview
 } // Windows.Management.Deployment
 pub mod policies { // Windows.Management.Policies
@@ -968,8 +968,8 @@ impl INamedPolicyData {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NamedPolicyData: INamedPolicyData}
-RT_ENUM! { enum NamedPolicyKind: i32 {
+RT_CLASS!{class NamedPolicyData: INamedPolicyData ["Windows.Management.Policies.NamedPolicyData"]}
+RT_ENUM! { enum NamedPolicyKind: i32 ["Windows.Management.Policies.NamedPolicyKind"] {
     Invalid (NamedPolicyKind_Invalid) = 0, Binary (NamedPolicyKind_Binary) = 1, Boolean (NamedPolicyKind_Boolean) = 2, Int32 (NamedPolicyKind_Int32) = 3, Int64 (NamedPolicyKind_Int64) = 4, String (NamedPolicyKind_String) = 5,
 }}
 DEFINE_IID!(IID_INamedPolicyStatics, 2138651623, 30404, 16472, 140, 173, 103, 102, 44, 208, 95, 13);
@@ -1020,7 +1020,7 @@ impl IPreviewBuildsManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PreviewBuildsManager: IPreviewBuildsManager}
+RT_CLASS!{class PreviewBuildsManager: IPreviewBuildsManager ["Windows.Management.Update.PreviewBuildsManager"]}
 impl RtActivatable<IPreviewBuildsManagerStatics> for PreviewBuildsManager {}
 impl PreviewBuildsManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<PreviewBuildsManager>>> {
@@ -1059,7 +1059,7 @@ impl IPreviewBuildsState {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PreviewBuildsState: IPreviewBuildsState}
+RT_CLASS!{class PreviewBuildsState: IPreviewBuildsState ["Windows.Management.Update.PreviewBuildsState"]}
 } // Windows.Management.Update
 pub mod workplace { // Windows.Management.Workplace
 use ::prelude::*;
@@ -1124,7 +1124,7 @@ impl IMdmPolicyStatics2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MessagingSyncPolicy: i32 {
+RT_ENUM! { enum MessagingSyncPolicy: i32 ["Windows.Management.Workplace.MessagingSyncPolicy"] {
     Disallowed (MessagingSyncPolicy_Disallowed) = 0, Allowed (MessagingSyncPolicy_Allowed) = 1, Required (MessagingSyncPolicy_Required) = 2,
 }}
 RT_CLASS!{static class WorkplaceSettings}

--- a/src/rt/gen/windows/media.rs
+++ b/src/rt/gen/windows/media.rs
@@ -21,8 +21,8 @@ impl IAudioBuffer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioBuffer: IAudioBuffer}
-RT_ENUM! { enum AudioBufferAccessMode: i32 {
+RT_CLASS!{class AudioBuffer: IAudioBuffer ["Windows.Media.AudioBuffer"]}
+RT_ENUM! { enum AudioBufferAccessMode: i32 ["Windows.Media.AudioBufferAccessMode"] {
     Read (AudioBufferAccessMode_Read) = 0, ReadWrite (AudioBufferAccessMode_ReadWrite) = 1, Write (AudioBufferAccessMode_Write) = 2,
 }}
 DEFINE_IID!(IID_IAudioFrame, 3815424772, 43698, 17015, 158, 208, 67, 206, 223, 142, 41, 198);
@@ -36,7 +36,7 @@ impl IAudioFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioFrame: IAudioFrame}
+RT_CLASS!{class AudioFrame: IAudioFrame ["Windows.Media.AudioFrame"]}
 impl RtActivatable<IAudioFrameFactory> for AudioFrame {}
 impl AudioFrame {
     #[inline] pub fn create(capacity: u32) -> Result<ComPtr<AudioFrame>> {
@@ -55,7 +55,7 @@ impl IAudioFrameFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AudioProcessing: i32 {
+RT_ENUM! { enum AudioProcessing: i32 ["Windows.Media.AudioProcessing"] {
     Default (AudioProcessing_Default) = 0, Raw (AudioProcessing_Raw) = 1,
 }}
 DEFINE_IID!(IID_IAutoRepeatModeChangeRequestedEventArgs, 3927146234, 55378, 17294, 136, 43, 201, 144, 16, 154, 120, 244);
@@ -69,7 +69,7 @@ impl IAutoRepeatModeChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AutoRepeatModeChangeRequestedEventArgs: IAutoRepeatModeChangeRequestedEventArgs}
+RT_CLASS!{class AutoRepeatModeChangeRequestedEventArgs: IAutoRepeatModeChangeRequestedEventArgs ["Windows.Media.AutoRepeatModeChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IImageDisplayProperties, 3440101359, 21735, 16671, 153, 51, 240, 233, 139, 10, 150, 210);
 RT_INTERFACE!{interface IImageDisplayProperties(IImageDisplayPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IImageDisplayProperties] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -97,7 +97,7 @@ impl IImageDisplayProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageDisplayProperties: IImageDisplayProperties}
+RT_CLASS!{class ImageDisplayProperties: IImageDisplayProperties ["Windows.Media.ImageDisplayProperties"]}
 DEFINE_IID!(IID_IMediaControl, 2565995489, 31373, 17099, 182, 254, 143, 230, 152, 38, 79, 19);
 RT_INTERFACE!{static interface IMediaControl(IMediaControlVtbl): IInspectable(IInspectableVtbl) [IID_IMediaControl] {
     fn add_SoundLevelChanged(&self, handler: *mut foundation::EventHandler<IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -464,7 +464,7 @@ impl IMediaExtensionManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaExtensionManager: IMediaExtensionManager}
+RT_CLASS!{class MediaExtensionManager: IMediaExtensionManager ["Windows.Media.MediaExtensionManager"]}
 impl RtActivatable<IActivationFactory> for MediaExtensionManager {}
 DEFINE_CLSID!(MediaExtensionManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,69,120,116,101,110,115,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MediaExtensionManager]);
 DEFINE_IID!(IID_IMediaExtensionManager2, 1540276039, 16451, 20461, 172, 175, 84, 236, 41, 223, 177, 247);
@@ -597,13 +597,13 @@ impl IMediaMarkerTypesStatics {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaPlaybackAutoRepeatMode: i32 {
+RT_ENUM! { enum MediaPlaybackAutoRepeatMode: i32 ["Windows.Media.MediaPlaybackAutoRepeatMode"] {
     None (MediaPlaybackAutoRepeatMode_None) = 0, Track (MediaPlaybackAutoRepeatMode_Track) = 1, List (MediaPlaybackAutoRepeatMode_List) = 2,
 }}
-RT_ENUM! { enum MediaPlaybackStatus: i32 {
+RT_ENUM! { enum MediaPlaybackStatus: i32 ["Windows.Media.MediaPlaybackStatus"] {
     Closed (MediaPlaybackStatus_Closed) = 0, Changing (MediaPlaybackStatus_Changing) = 1, Stopped (MediaPlaybackStatus_Stopped) = 2, Playing (MediaPlaybackStatus_Playing) = 3, Paused (MediaPlaybackStatus_Paused) = 4,
 }}
-RT_ENUM! { enum MediaPlaybackType: i32 {
+RT_ENUM! { enum MediaPlaybackType: i32 ["Windows.Media.MediaPlaybackType"] {
     Unknown (MediaPlaybackType_Unknown) = 0, Music (MediaPlaybackType_Music) = 1, Video (MediaPlaybackType_Video) = 2, Image (MediaPlaybackType_Image) = 3,
 }}
 DEFINE_IID!(IID_IMediaProcessingTriggerDetails, 3951387820, 41809, 20302, 180, 240, 155, 242, 64, 137, 147, 219);
@@ -617,7 +617,7 @@ impl IMediaProcessingTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaProcessingTriggerDetails: IMediaProcessingTriggerDetails}
+RT_CLASS!{class MediaProcessingTriggerDetails: IMediaProcessingTriggerDetails ["Windows.Media.MediaProcessingTriggerDetails"]}
 DEFINE_IID!(IID_IMediaTimelineController, 2396217843, 2936, 17248, 191, 113, 12, 132, 25, 153, 234, 27);
 RT_INTERFACE!{interface IMediaTimelineController(IMediaTimelineControllerVtbl): IInspectable(IInspectableVtbl) [IID_IMediaTimelineController] {
     fn Start(&self) -> HRESULT,
@@ -688,7 +688,7 @@ impl IMediaTimelineController {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaTimelineController: IMediaTimelineController}
+RT_CLASS!{class MediaTimelineController: IMediaTimelineController ["Windows.Media.MediaTimelineController"]}
 impl RtActivatable<IActivationFactory> for MediaTimelineController {}
 DEFINE_CLSID!(MediaTimelineController(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,84,105,109,101,108,105,110,101,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_MediaTimelineController]);
 DEFINE_IID!(IID_IMediaTimelineController2, 4017416760, 40562, 19961, 131, 85, 110, 144, 200, 27, 186, 221);
@@ -751,11 +751,11 @@ impl IMediaTimelineControllerFailedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaTimelineControllerFailedEventArgs: IMediaTimelineControllerFailedEventArgs}
-RT_ENUM! { enum MediaTimelineControllerState: i32 {
+RT_CLASS!{class MediaTimelineControllerFailedEventArgs: IMediaTimelineControllerFailedEventArgs ["Windows.Media.MediaTimelineControllerFailedEventArgs"]}
+RT_ENUM! { enum MediaTimelineControllerState: i32 ["Windows.Media.MediaTimelineControllerState"] {
     Paused (MediaTimelineControllerState_Paused) = 0, Running (MediaTimelineControllerState_Running) = 1, Stalled (MediaTimelineControllerState_Stalled) = 2, Error (MediaTimelineControllerState_Error) = 3,
 }}
-RT_STRUCT! { struct MediaTimeRange {
+RT_STRUCT! { struct MediaTimeRange ["Windows.Media.MediaTimeRange"] {
     Start: foundation::TimeSpan, End: foundation::TimeSpan,
 }}
 DEFINE_IID!(IID_IMusicDisplayProperties, 1807682649, 53408, 19750, 146, 160, 249, 120, 225, 209, 142, 123);
@@ -796,7 +796,7 @@ impl IMusicDisplayProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MusicDisplayProperties: IMusicDisplayProperties}
+RT_CLASS!{class MusicDisplayProperties: IMusicDisplayProperties ["Windows.Media.MusicDisplayProperties"]}
 DEFINE_IID!(IID_IMusicDisplayProperties2, 3572834, 38867, 17593, 176, 15, 0, 138, 252, 239, 175, 24);
 RT_INTERFACE!{interface IMusicDisplayProperties2(IMusicDisplayProperties2Vtbl): IInspectable(IInspectableVtbl) [IID_IMusicDisplayProperties2] {
     fn get_AlbumTitle(&self, out: *mut HSTRING) -> HRESULT,
@@ -857,7 +857,7 @@ impl IPlaybackPositionChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaybackPositionChangeRequestedEventArgs: IPlaybackPositionChangeRequestedEventArgs}
+RT_CLASS!{class PlaybackPositionChangeRequestedEventArgs: IPlaybackPositionChangeRequestedEventArgs ["Windows.Media.PlaybackPositionChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IPlaybackRateChangeRequestedEventArgs, 753058847, 15574, 20343, 155, 167, 235, 39, 194, 106, 33, 64);
 RT_INTERFACE!{interface IPlaybackRateChangeRequestedEventArgs(IPlaybackRateChangeRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPlaybackRateChangeRequestedEventArgs] {
     fn get_RequestedPlaybackRate(&self, out: *mut f64) -> HRESULT
@@ -869,7 +869,7 @@ impl IPlaybackRateChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaybackRateChangeRequestedEventArgs: IPlaybackRateChangeRequestedEventArgs}
+RT_CLASS!{class PlaybackRateChangeRequestedEventArgs: IPlaybackRateChangeRequestedEventArgs ["Windows.Media.PlaybackRateChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IShuffleEnabledChangeRequestedEventArgs, 1236636670, 20432, 18022, 163, 20, 192, 224, 25, 64, 211, 2);
 RT_INTERFACE!{interface IShuffleEnabledChangeRequestedEventArgs(IShuffleEnabledChangeRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IShuffleEnabledChangeRequestedEventArgs] {
     fn get_RequestedShuffleEnabled(&self, out: *mut bool) -> HRESULT
@@ -881,8 +881,8 @@ impl IShuffleEnabledChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShuffleEnabledChangeRequestedEventArgs: IShuffleEnabledChangeRequestedEventArgs}
-RT_ENUM! { enum SoundLevel: i32 {
+RT_CLASS!{class ShuffleEnabledChangeRequestedEventArgs: IShuffleEnabledChangeRequestedEventArgs ["Windows.Media.ShuffleEnabledChangeRequestedEventArgs"]}
+RT_ENUM! { enum SoundLevel: i32 ["Windows.Media.SoundLevel"] {
     Muted (SoundLevel_Muted) = 0, Low (SoundLevel_Low) = 1, Full (SoundLevel_Full) = 2,
 }}
 DEFINE_IID!(IID_ISystemMediaTransportControls, 2583314420, 5954, 17062, 144, 46, 8, 125, 65, 249, 101, 236);
@@ -1056,7 +1056,7 @@ impl ISystemMediaTransportControls {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMediaTransportControls: ISystemMediaTransportControls}
+RT_CLASS!{class SystemMediaTransportControls: ISystemMediaTransportControls ["Windows.Media.SystemMediaTransportControls"]}
 impl RtActivatable<ISystemMediaTransportControlsStatics> for SystemMediaTransportControls {}
 impl SystemMediaTransportControls {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<SystemMediaTransportControls>>> {
@@ -1151,7 +1151,7 @@ impl ISystemMediaTransportControls2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SystemMediaTransportControlsButton: i32 {
+RT_ENUM! { enum SystemMediaTransportControlsButton: i32 ["Windows.Media.SystemMediaTransportControlsButton"] {
     Play (SystemMediaTransportControlsButton_Play) = 0, Pause (SystemMediaTransportControlsButton_Pause) = 1, Stop (SystemMediaTransportControlsButton_Stop) = 2, Record (SystemMediaTransportControlsButton_Record) = 3, FastForward (SystemMediaTransportControlsButton_FastForward) = 4, Rewind (SystemMediaTransportControlsButton_Rewind) = 5, Next (SystemMediaTransportControlsButton_Next) = 6, Previous (SystemMediaTransportControlsButton_Previous) = 7, ChannelUp (SystemMediaTransportControlsButton_ChannelUp) = 8, ChannelDown (SystemMediaTransportControlsButton_ChannelDown) = 9,
 }}
 DEFINE_IID!(IID_ISystemMediaTransportControlsButtonPressedEventArgs, 3086250262, 42351, 19912, 158, 17, 146, 3, 31, 74, 135, 194);
@@ -1165,7 +1165,7 @@ impl ISystemMediaTransportControlsButtonPressedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMediaTransportControlsButtonPressedEventArgs: ISystemMediaTransportControlsButtonPressedEventArgs}
+RT_CLASS!{class SystemMediaTransportControlsButtonPressedEventArgs: ISystemMediaTransportControlsButtonPressedEventArgs ["Windows.Media.SystemMediaTransportControlsButtonPressedEventArgs"]}
 DEFINE_IID!(IID_ISystemMediaTransportControlsDisplayUpdater, 2327561534, 64085, 20175, 173, 142, 201, 132, 229, 221, 21, 80);
 RT_INTERFACE!{interface ISystemMediaTransportControlsDisplayUpdater(ISystemMediaTransportControlsDisplayUpdaterVtbl): IInspectable(IInspectableVtbl) [IID_ISystemMediaTransportControlsDisplayUpdater] {
     fn get_Type(&self, out: *mut MediaPlaybackType) -> HRESULT,
@@ -1241,8 +1241,8 @@ impl ISystemMediaTransportControlsDisplayUpdater {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMediaTransportControlsDisplayUpdater: ISystemMediaTransportControlsDisplayUpdater}
-RT_ENUM! { enum SystemMediaTransportControlsProperty: i32 {
+RT_CLASS!{class SystemMediaTransportControlsDisplayUpdater: ISystemMediaTransportControlsDisplayUpdater ["Windows.Media.SystemMediaTransportControlsDisplayUpdater"]}
+RT_ENUM! { enum SystemMediaTransportControlsProperty: i32 ["Windows.Media.SystemMediaTransportControlsProperty"] {
     SoundLevel (SystemMediaTransportControlsProperty_SoundLevel) = 0,
 }}
 DEFINE_IID!(IID_ISystemMediaTransportControlsPropertyChangedEventArgs, 3502901558, 13211, 19635, 142, 235, 115, 118, 7, 245, 110, 8);
@@ -1256,7 +1256,7 @@ impl ISystemMediaTransportControlsPropertyChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMediaTransportControlsPropertyChangedEventArgs: ISystemMediaTransportControlsPropertyChangedEventArgs}
+RT_CLASS!{class SystemMediaTransportControlsPropertyChangedEventArgs: ISystemMediaTransportControlsPropertyChangedEventArgs ["Windows.Media.SystemMediaTransportControlsPropertyChangedEventArgs"]}
 DEFINE_IID!(IID_ISystemMediaTransportControlsStatics, 1136277514, 60580, 18482, 145, 171, 212, 21, 250, 228, 132, 198);
 RT_INTERFACE!{static interface ISystemMediaTransportControlsStatics(ISystemMediaTransportControlsStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemMediaTransportControlsStatics] {
     fn GetForCurrentView(&self, out: *mut *mut SystemMediaTransportControls) -> HRESULT
@@ -1328,7 +1328,7 @@ impl ISystemMediaTransportControlsTimelineProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMediaTransportControlsTimelineProperties: ISystemMediaTransportControlsTimelineProperties}
+RT_CLASS!{class SystemMediaTransportControlsTimelineProperties: ISystemMediaTransportControlsTimelineProperties ["Windows.Media.SystemMediaTransportControlsTimelineProperties"]}
 impl RtActivatable<IActivationFactory> for SystemMediaTransportControlsTimelineProperties {}
 DEFINE_CLSID!(SystemMediaTransportControlsTimelineProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,83,121,115,116,101,109,77,101,100,105,97,84,114,97,110,115,112,111,114,116,67,111,110,116,114,111,108,115,84,105,109,101,108,105,110,101,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_SystemMediaTransportControlsTimelineProperties]);
 DEFINE_IID!(IID_IVideoDisplayProperties, 1443495345, 23853, 18546, 129, 112, 69, 222, 229, 188, 47, 92);
@@ -1358,7 +1358,7 @@ impl IVideoDisplayProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoDisplayProperties: IVideoDisplayProperties}
+RT_CLASS!{class VideoDisplayProperties: IVideoDisplayProperties ["Windows.Media.VideoDisplayProperties"]}
 DEFINE_IID!(IID_IVideoDisplayProperties2, 3021005262, 43858, 16811, 164, 134, 204, 16, 250, 177, 82, 249);
 RT_INTERFACE!{interface IVideoDisplayProperties2(IVideoDisplayProperties2Vtbl): IInspectable(IInspectableVtbl) [IID_IVideoDisplayProperties2] {
     fn get_Genres(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT
@@ -1412,7 +1412,7 @@ impl IVideoFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoFrame: IVideoFrame}
+RT_CLASS!{class VideoFrame: IVideoFrame ["Windows.Media.VideoFrame"]}
 impl RtActivatable<IVideoFrameFactory> for VideoFrame {}
 impl RtActivatable<IVideoFrameStatics> for VideoFrame {}
 impl VideoFrame {
@@ -1517,7 +1517,7 @@ impl IAppBroadcastingMonitor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastingMonitor: IAppBroadcastingMonitor}
+RT_CLASS!{class AppBroadcastingMonitor: IAppBroadcastingMonitor ["Windows.Media.AppBroadcasting.AppBroadcastingMonitor"]}
 impl RtActivatable<IActivationFactory> for AppBroadcastingMonitor {}
 DEFINE_CLSID!(AppBroadcastingMonitor(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,112,112,66,114,111,97,100,99,97,115,116,105,110,103,46,65,112,112,66,114,111,97,100,99,97,115,116,105,110,103,77,111,110,105,116,111,114,0]) [CLSID_AppBroadcastingMonitor]);
 DEFINE_IID!(IID_IAppBroadcastingStatus, 304473311, 929, 17144, 139, 128, 201, 34, 140, 217, 207, 46);
@@ -1537,7 +1537,7 @@ impl IAppBroadcastingStatus {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastingStatus: IAppBroadcastingStatus}
+RT_CLASS!{class AppBroadcastingStatus: IAppBroadcastingStatus ["Windows.Media.AppBroadcasting.AppBroadcastingStatus"]}
 DEFINE_IID!(IID_IAppBroadcastingStatusDetails, 110996900, 46451, 20028, 142, 25, 27, 175, 172, 208, 151, 19);
 RT_INTERFACE!{interface IAppBroadcastingStatusDetails(IAppBroadcastingStatusDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastingStatusDetails] {
     fn get_IsAnyAppBroadcasting(&self, out: *mut bool) -> HRESULT,
@@ -1591,7 +1591,7 @@ impl IAppBroadcastingStatusDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastingStatusDetails: IAppBroadcastingStatusDetails}
+RT_CLASS!{class AppBroadcastingStatusDetails: IAppBroadcastingStatusDetails ["Windows.Media.AppBroadcasting.AppBroadcastingStatusDetails"]}
 DEFINE_IID!(IID_IAppBroadcastingUI, 3849297807, 61081, 19914, 163, 195, 112, 175, 61, 180, 79, 95);
 RT_INTERFACE!{interface IAppBroadcastingUI(IAppBroadcastingUIVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastingUI] {
     fn GetStatus(&self, out: *mut *mut AppBroadcastingStatus) -> HRESULT,
@@ -1608,7 +1608,7 @@ impl IAppBroadcastingUI {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastingUI: IAppBroadcastingUI}
+RT_CLASS!{class AppBroadcastingUI: IAppBroadcastingUI ["Windows.Media.AppBroadcasting.AppBroadcastingUI"]}
 impl RtActivatable<IAppBroadcastingUIStatics> for AppBroadcastingUI {}
 impl AppBroadcastingUI {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<AppBroadcastingUI>>> {
@@ -1674,7 +1674,7 @@ impl IAppRecordingManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppRecordingManager: IAppRecordingManager}
+RT_CLASS!{class AppRecordingManager: IAppRecordingManager ["Windows.Media.AppRecording.AppRecordingManager"]}
 impl RtActivatable<IAppRecordingManagerStatics> for AppRecordingManager {}
 impl AppRecordingManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<AppRecordingManager>>> {
@@ -1722,7 +1722,7 @@ impl IAppRecordingResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppRecordingResult: IAppRecordingResult}
+RT_CLASS!{class AppRecordingResult: IAppRecordingResult ["Windows.Media.AppRecording.AppRecordingResult"]}
 DEFINE_IID!(IID_IAppRecordingSavedScreenshotInfo, 2607033610, 6298, 19712, 191, 37, 225, 187, 18, 73, 213, 148);
 RT_INTERFACE!{interface IAppRecordingSavedScreenshotInfo(IAppRecordingSavedScreenshotInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAppRecordingSavedScreenshotInfo] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -1741,8 +1741,8 @@ impl IAppRecordingSavedScreenshotInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppRecordingSavedScreenshotInfo: IAppRecordingSavedScreenshotInfo}
-RT_ENUM! { enum AppRecordingSaveScreenshotOption: i32 {
+RT_CLASS!{class AppRecordingSavedScreenshotInfo: IAppRecordingSavedScreenshotInfo ["Windows.Media.AppRecording.AppRecordingSavedScreenshotInfo"]}
+RT_ENUM! { enum AppRecordingSaveScreenshotOption: i32 ["Windows.Media.AppRecording.AppRecordingSaveScreenshotOption"] {
     None (AppRecordingSaveScreenshotOption_None) = 0, HdrContentVisible (AppRecordingSaveScreenshotOption_HdrContentVisible) = 1,
 }}
 DEFINE_IID!(IID_IAppRecordingSaveScreenshotResult, 2623245578, 2747, 17495, 170, 238, 36, 249, 193, 46, 199, 120);
@@ -1768,7 +1768,7 @@ impl IAppRecordingSaveScreenshotResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppRecordingSaveScreenshotResult: IAppRecordingSaveScreenshotResult}
+RT_CLASS!{class AppRecordingSaveScreenshotResult: IAppRecordingSaveScreenshotResult ["Windows.Media.AppRecording.AppRecordingSaveScreenshotResult"]}
 DEFINE_IID!(IID_IAppRecordingStatus, 487376940, 48152, 19338, 166, 239, 18, 126, 250, 179, 181, 217);
 RT_INTERFACE!{interface IAppRecordingStatus(IAppRecordingStatusVtbl): IInspectable(IInspectableVtbl) [IID_IAppRecordingStatus] {
     fn get_CanRecord(&self, out: *mut bool) -> HRESULT,
@@ -1798,7 +1798,7 @@ impl IAppRecordingStatus {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppRecordingStatus: IAppRecordingStatus}
+RT_CLASS!{class AppRecordingStatus: IAppRecordingStatus ["Windows.Media.AppRecording.AppRecordingStatus"]}
 DEFINE_IID!(IID_IAppRecordingStatusDetails, 3040389552, 5357, 17426, 172, 69, 109, 103, 44, 156, 153, 73);
 RT_INTERFACE!{interface IAppRecordingStatusDetails(IAppRecordingStatusDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IAppRecordingStatusDetails] {
     fn get_IsAnyAppBroadcasting(&self, out: *mut bool) -> HRESULT,
@@ -1858,7 +1858,7 @@ impl IAppRecordingStatusDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppRecordingStatusDetails: IAppRecordingStatusDetails}
+RT_CLASS!{class AppRecordingStatusDetails: IAppRecordingStatusDetails ["Windows.Media.AppRecording.AppRecordingStatusDetails"]}
 } // Windows.Media.AppRecording
 pub mod audio { // Windows.Media.Audio
 use ::prelude::*;
@@ -1873,8 +1873,8 @@ impl IAudioDeviceInputNode {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioDeviceInputNode: IAudioDeviceInputNode}
-RT_ENUM! { enum AudioDeviceNodeCreationStatus: i32 {
+RT_CLASS!{class AudioDeviceInputNode: IAudioDeviceInputNode ["Windows.Media.Audio.AudioDeviceInputNode"]}
+RT_ENUM! { enum AudioDeviceNodeCreationStatus: i32 ["Windows.Media.Audio.AudioDeviceNodeCreationStatus"] {
     Success (AudioDeviceNodeCreationStatus_Success) = 0, DeviceNotAvailable (AudioDeviceNodeCreationStatus_DeviceNotAvailable) = 1, FormatNotSupported (AudioDeviceNodeCreationStatus_FormatNotSupported) = 2, UnknownFailure (AudioDeviceNodeCreationStatus_UnknownFailure) = 3, AccessDenied (AudioDeviceNodeCreationStatus_AccessDenied) = 4,
 }}
 DEFINE_IID!(IID_IAudioDeviceOutputNode, 909040639, 65308, 17460, 158, 15, 189, 46, 245, 34, 172, 130);
@@ -1888,7 +1888,7 @@ impl IAudioDeviceOutputNode {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioDeviceOutputNode: IAudioDeviceOutputNode}
+RT_CLASS!{class AudioDeviceOutputNode: IAudioDeviceOutputNode ["Windows.Media.Audio.AudioDeviceOutputNode"]}
 DEFINE_IID!(IID_IAudioFileInputNode, 2421909448, 28517, 19668, 136, 144, 70, 148, 132, 60, 39, 109);
 RT_INTERFACE!{interface IAudioFileInputNode(IAudioFileInputNodeVtbl): IInspectable(IInspectableVtbl) [IID_IAudioFileInputNode] {
     fn put_PlaybackSpeedFactor(&self, value: f64) -> HRESULT,
@@ -1973,8 +1973,8 @@ impl IAudioFileInputNode {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioFileInputNode: IAudioFileInputNode}
-RT_ENUM! { enum AudioFileNodeCreationStatus: i32 {
+RT_CLASS!{class AudioFileInputNode: IAudioFileInputNode ["Windows.Media.Audio.AudioFileInputNode"]}
+RT_ENUM! { enum AudioFileNodeCreationStatus: i32 ["Windows.Media.Audio.AudioFileNodeCreationStatus"] {
     Success (AudioFileNodeCreationStatus_Success) = 0, FileNotFound (AudioFileNodeCreationStatus_FileNotFound) = 1, InvalidFileType (AudioFileNodeCreationStatus_InvalidFileType) = 2, FormatNotSupported (AudioFileNodeCreationStatus_FormatNotSupported) = 3, UnknownFailure (AudioFileNodeCreationStatus_UnknownFailure) = 4,
 }}
 DEFINE_IID!(IID_IAudioFileOutputNode, 1356863872, 20838, 16531, 128, 248, 173, 160, 0, 137, 233, 207);
@@ -2001,7 +2001,7 @@ impl IAudioFileOutputNode {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioFileOutputNode: IAudioFileOutputNode}
+RT_CLASS!{class AudioFileOutputNode: IAudioFileOutputNode ["Windows.Media.Audio.AudioFileOutputNode"]}
 DEFINE_IID!(IID_IAudioFrameCompletedEventArgs, 3699147422, 520, 17668, 165, 168, 240, 242, 104, 146, 10, 101);
 RT_INTERFACE!{interface IAudioFrameCompletedEventArgs(IAudioFrameCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAudioFrameCompletedEventArgs] {
     fn get_Frame(&self, out: *mut *mut super::AudioFrame) -> HRESULT
@@ -2013,7 +2013,7 @@ impl IAudioFrameCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioFrameCompletedEventArgs: IAudioFrameCompletedEventArgs}
+RT_CLASS!{class AudioFrameCompletedEventArgs: IAudioFrameCompletedEventArgs ["Windows.Media.Audio.AudioFrameCompletedEventArgs"]}
 DEFINE_IID!(IID_IAudioFrameInputNode, 28468935, 64918, 20469, 163, 197, 210, 122, 155, 244, 66, 55);
 RT_INTERFACE!{interface IAudioFrameInputNode(IAudioFrameInputNodeVtbl): IInspectable(IInspectableVtbl) [IID_IAudioFrameInputNode] {
     fn put_PlaybackSpeedFactor(&self, value: f64) -> HRESULT,
@@ -2068,7 +2068,7 @@ impl IAudioFrameInputNode {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioFrameInputNode: IAudioFrameInputNode}
+RT_CLASS!{class AudioFrameInputNode: IAudioFrameInputNode ["Windows.Media.Audio.AudioFrameInputNode"]}
 DEFINE_IID!(IID_IAudioFrameOutputNode, 3091674907, 12953, 17909, 136, 179, 201, 209, 42, 63, 28, 200);
 RT_INTERFACE!{interface IAudioFrameOutputNode(IAudioFrameOutputNodeVtbl): IInspectable(IInspectableVtbl) [IID_IAudioFrameOutputNode] {
     fn GetFrame(&self, out: *mut *mut super::AudioFrame) -> HRESULT
@@ -2080,7 +2080,7 @@ impl IAudioFrameOutputNode {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioFrameOutputNode: IAudioFrameOutputNode}
+RT_CLASS!{class AudioFrameOutputNode: IAudioFrameOutputNode ["Windows.Media.Audio.AudioFrameOutputNode"]}
 DEFINE_IID!(IID_IAudioGraph, 450129645, 58508, 19988, 150, 96, 44, 79, 131, 233, 205, 216);
 RT_INTERFACE!{interface IAudioGraph(IAudioGraphVtbl): IInspectable(IInspectableVtbl) [IID_IAudioGraph] {
     fn CreateFrameInputNode(&self, out: *mut *mut AudioFrameInputNode) -> HRESULT,
@@ -2253,7 +2253,7 @@ impl IAudioGraph {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioGraph: IAudioGraph}
+RT_CLASS!{class AudioGraph: IAudioGraph ["Windows.Media.Audio.AudioGraph"]}
 impl RtActivatable<IAudioGraphStatics> for AudioGraph {}
 impl AudioGraph {
     #[inline] pub fn create_async(settings: &AudioGraphSettings) -> Result<ComPtr<foundation::IAsyncOperation<CreateAudioGraphResult>>> {
@@ -2315,7 +2315,7 @@ impl IAudioGraph3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioGraphBatchUpdater: foundation::IClosable}
+RT_CLASS!{class AudioGraphBatchUpdater: foundation::IClosable ["Windows.Media.Audio.AudioGraphBatchUpdater"]}
 DEFINE_IID!(IID_IAudioGraphConnection, 1982886125, 53326, 20396, 178, 51, 96, 11, 66, 237, 212, 105);
 RT_INTERFACE!{interface IAudioGraphConnection(IAudioGraphConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IAudioGraphConnection] {
     fn get_Destination(&self, out: *mut *mut IAudioNode) -> HRESULT,
@@ -2338,8 +2338,8 @@ impl IAudioGraphConnection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioGraphConnection: IAudioGraphConnection}
-RT_ENUM! { enum AudioGraphCreationStatus: i32 {
+RT_CLASS!{class AudioGraphConnection: IAudioGraphConnection ["Windows.Media.Audio.AudioGraphConnection"]}
+RT_ENUM! { enum AudioGraphCreationStatus: i32 ["Windows.Media.Audio.AudioGraphCreationStatus"] {
     Success (AudioGraphCreationStatus_Success) = 0, DeviceNotAvailable (AudioGraphCreationStatus_DeviceNotAvailable) = 1, FormatNotSupported (AudioGraphCreationStatus_FormatNotSupported) = 2, UnknownFailure (AudioGraphCreationStatus_UnknownFailure) = 3,
 }}
 DEFINE_IID!(IID_IAudioGraphSettings, 492397695, 59134, 17960, 132, 248, 157, 139, 219, 162, 87, 133);
@@ -2415,7 +2415,7 @@ impl IAudioGraphSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioGraphSettings: IAudioGraphSettings}
+RT_CLASS!{class AudioGraphSettings: IAudioGraphSettings ["Windows.Media.Audio.AudioGraphSettings"]}
 impl RtActivatable<IAudioGraphSettingsFactory> for AudioGraphSettings {}
 impl AudioGraphSettings {
     #[inline] pub fn create(audioRenderCategory: super::render::AudioRenderCategory) -> Result<ComPtr<AudioGraphSettings>> {
@@ -2461,7 +2461,7 @@ impl IAudioGraphStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AudioGraphUnrecoverableError: i32 {
+RT_ENUM! { enum AudioGraphUnrecoverableError: i32 ["Windows.Media.Audio.AudioGraphUnrecoverableError"] {
     None (AudioGraphUnrecoverableError_None) = 0, AudioDeviceLost (AudioGraphUnrecoverableError_AudioDeviceLost) = 1, AudioSessionDisconnected (AudioGraphUnrecoverableError_AudioSessionDisconnected) = 2, UnknownFailure (AudioGraphUnrecoverableError_UnknownFailure) = 3,
 }}
 DEFINE_IID!(IID_IAudioGraphUnrecoverableErrorOccurredEventArgs, 3285830624, 16374, 20403, 178, 98, 80, 212, 53, 197, 84, 35);
@@ -2475,7 +2475,7 @@ impl IAudioGraphUnrecoverableErrorOccurredEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioGraphUnrecoverableErrorOccurredEventArgs: IAudioGraphUnrecoverableErrorOccurredEventArgs}
+RT_CLASS!{class AudioGraphUnrecoverableErrorOccurredEventArgs: IAudioGraphUnrecoverableErrorOccurredEventArgs ["Windows.Media.Audio.AudioGraphUnrecoverableErrorOccurredEventArgs"]}
 DEFINE_IID!(IID_IAudioInputNode, 3511156828, 33832, 18308, 183, 253, 169, 157, 70, 140, 93, 32);
 RT_INTERFACE!{interface IAudioInputNode(IAudioInputNodeVtbl): IInspectable(IInspectableVtbl) [IID_IAudioInputNode] {
     fn get_OutgoingConnections(&self, out: *mut *mut foundation::collections::IVectorView<AudioGraphConnection>) -> HRESULT,
@@ -2666,7 +2666,7 @@ impl IAudioNodeEmitter {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioNodeEmitter: IAudioNodeEmitter}
+RT_CLASS!{class AudioNodeEmitter: IAudioNodeEmitter ["Windows.Media.Audio.AudioNodeEmitter"]}
 impl RtActivatable<IAudioNodeEmitterFactory> for AudioNodeEmitter {}
 impl RtActivatable<IActivationFactory> for AudioNodeEmitter {}
 impl AudioNodeEmitter {
@@ -2714,8 +2714,8 @@ impl IAudioNodeEmitterConeProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioNodeEmitterConeProperties: IAudioNodeEmitterConeProperties}
-RT_ENUM! { enum AudioNodeEmitterDecayKind: i32 {
+RT_CLASS!{class AudioNodeEmitterConeProperties: IAudioNodeEmitterConeProperties ["Windows.Media.Audio.AudioNodeEmitterConeProperties"]}
+RT_ENUM! { enum AudioNodeEmitterDecayKind: i32 ["Windows.Media.Audio.AudioNodeEmitterDecayKind"] {
     Natural (AudioNodeEmitterDecayKind_Natural) = 0, Custom (AudioNodeEmitterDecayKind_Custom) = 1,
 }}
 DEFINE_IID!(IID_IAudioNodeEmitterDecayModel, 488463095, 3411, 20393, 189, 132, 213, 129, 106, 134, 243, 255);
@@ -2747,7 +2747,7 @@ impl IAudioNodeEmitterDecayModel {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioNodeEmitterDecayModel: IAudioNodeEmitterDecayModel}
+RT_CLASS!{class AudioNodeEmitterDecayModel: IAudioNodeEmitterDecayModel ["Windows.Media.Audio.AudioNodeEmitterDecayModel"]}
 impl RtActivatable<IAudioNodeEmitterDecayModelStatics> for AudioNodeEmitterDecayModel {}
 impl AudioNodeEmitterDecayModel {
     #[inline] pub fn create_natural(minGain: f64, maxGain: f64, unityGainDistance: f64, cutoffDistance: f64) -> Result<Option<ComPtr<AudioNodeEmitterDecayModel>>> {
@@ -2803,8 +2803,8 @@ impl IAudioNodeEmitterNaturalDecayModelProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioNodeEmitterNaturalDecayModelProperties: IAudioNodeEmitterNaturalDecayModelProperties}
-RT_ENUM! { enum AudioNodeEmitterSettings: u32 {
+RT_CLASS!{class AudioNodeEmitterNaturalDecayModelProperties: IAudioNodeEmitterNaturalDecayModelProperties ["Windows.Media.Audio.AudioNodeEmitterNaturalDecayModelProperties"]}
+RT_ENUM! { enum AudioNodeEmitterSettings: u32 ["Windows.Media.Audio.AudioNodeEmitterSettings"] {
     None (AudioNodeEmitterSettings_None) = 0, DisableDoppler (AudioNodeEmitterSettings_DisableDoppler) = 1,
 }}
 DEFINE_IID!(IID_IAudioNodeEmitterShape, 3926069701, 59197, 17596, 133, 156, 69, 85, 59, 188, 72, 40);
@@ -2824,7 +2824,7 @@ impl IAudioNodeEmitterShape {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioNodeEmitterShape: IAudioNodeEmitterShape}
+RT_CLASS!{class AudioNodeEmitterShape: IAudioNodeEmitterShape ["Windows.Media.Audio.AudioNodeEmitterShape"]}
 impl RtActivatable<IAudioNodeEmitterShapeStatics> for AudioNodeEmitterShape {}
 impl AudioNodeEmitterShape {
     #[inline] pub fn create_cone(innerAngle: f64, outerAngle: f64, outerAngleGain: f64) -> Result<Option<ComPtr<AudioNodeEmitterShape>>> {
@@ -2835,7 +2835,7 @@ impl AudioNodeEmitterShape {
     }
 }
 DEFINE_CLSID!(AudioNodeEmitterShape(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,78,111,100,101,69,109,105,116,116,101,114,83,104,97,112,101,0]) [CLSID_AudioNodeEmitterShape]);
-RT_ENUM! { enum AudioNodeEmitterShapeKind: i32 {
+RT_ENUM! { enum AudioNodeEmitterShapeKind: i32 ["Windows.Media.Audio.AudioNodeEmitterShapeKind"] {
     Omnidirectional (AudioNodeEmitterShapeKind_Omnidirectional) = 0, Cone (AudioNodeEmitterShapeKind_Cone) = 1,
 }}
 DEFINE_IID!(IID_IAudioNodeEmitterShapeStatics, 1471883121, 65445, 19334, 167, 121, 226, 100, 174, 185, 20, 95);
@@ -2904,7 +2904,7 @@ impl IAudioNodeListener {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioNodeListener: IAudioNodeListener}
+RT_CLASS!{class AudioNodeListener: IAudioNodeListener ["Windows.Media.Audio.AudioNodeListener"]}
 impl RtActivatable<IActivationFactory> for AudioNodeListener {}
 DEFINE_CLSID!(AudioNodeListener(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,65,117,100,105,111,46,65,117,100,105,111,78,111,100,101,76,105,115,116,101,110,101,114,0]) [CLSID_AudioNodeListener]);
 DEFINE_IID!(IID_IAudioNodeWithListener, 235901052, 31231, 17732, 158, 235, 1, 37, 123, 21, 16, 90);
@@ -2945,7 +2945,7 @@ impl IAudioStateMonitor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioStateMonitor: IAudioStateMonitor}
+RT_CLASS!{class AudioStateMonitor: IAudioStateMonitor ["Windows.Media.Audio.AudioStateMonitor"]}
 impl RtActivatable<IAudioStateMonitorStatics> for AudioStateMonitor {}
 impl AudioStateMonitor {
     #[inline] pub fn create_for_render_monitoring() -> Result<Option<ComPtr<AudioStateMonitor>>> {
@@ -3027,7 +3027,7 @@ impl IAudioStateMonitorStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioSubmixNode: IAudioInputNode}
+RT_CLASS!{class AudioSubmixNode: IAudioInputNode ["Windows.Media.Audio.AudioSubmixNode"]}
 DEFINE_IID!(IID_ICreateAudioDeviceInputNodeResult, 384747432, 7335, 16623, 145, 164, 211, 70, 224, 170, 27, 186);
 RT_INTERFACE!{interface ICreateAudioDeviceInputNodeResult(ICreateAudioDeviceInputNodeResultVtbl): IInspectable(IInspectableVtbl) [IID_ICreateAudioDeviceInputNodeResult] {
     fn get_Status(&self, out: *mut AudioDeviceNodeCreationStatus) -> HRESULT,
@@ -3045,7 +3045,7 @@ impl ICreateAudioDeviceInputNodeResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CreateAudioDeviceInputNodeResult: ICreateAudioDeviceInputNodeResult}
+RT_CLASS!{class CreateAudioDeviceInputNodeResult: ICreateAudioDeviceInputNodeResult ["Windows.Media.Audio.CreateAudioDeviceInputNodeResult"]}
 DEFINE_IID!(IID_ICreateAudioDeviceInputNodeResult2, 2451335630, 16181, 16839, 150, 34, 121, 246, 8, 186, 237, 194);
 RT_INTERFACE!{interface ICreateAudioDeviceInputNodeResult2(ICreateAudioDeviceInputNodeResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ICreateAudioDeviceInputNodeResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -3074,7 +3074,7 @@ impl ICreateAudioDeviceOutputNodeResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CreateAudioDeviceOutputNodeResult: ICreateAudioDeviceOutputNodeResult}
+RT_CLASS!{class CreateAudioDeviceOutputNodeResult: ICreateAudioDeviceOutputNodeResult ["Windows.Media.Audio.CreateAudioDeviceOutputNodeResult"]}
 DEFINE_IID!(IID_ICreateAudioDeviceOutputNodeResult2, 1214523039, 48590, 19121, 189, 56, 251, 174, 147, 174, 218, 202);
 RT_INTERFACE!{interface ICreateAudioDeviceOutputNodeResult2(ICreateAudioDeviceOutputNodeResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ICreateAudioDeviceOutputNodeResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -3103,7 +3103,7 @@ impl ICreateAudioFileInputNodeResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CreateAudioFileInputNodeResult: ICreateAudioFileInputNodeResult}
+RT_CLASS!{class CreateAudioFileInputNodeResult: ICreateAudioFileInputNodeResult ["Windows.Media.Audio.CreateAudioFileInputNodeResult"]}
 DEFINE_IID!(IID_ICreateAudioFileInputNodeResult2, 4178059296, 15744, 20448, 129, 193, 118, 143, 234, 124, 167, 224);
 RT_INTERFACE!{interface ICreateAudioFileInputNodeResult2(ICreateAudioFileInputNodeResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ICreateAudioFileInputNodeResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -3132,7 +3132,7 @@ impl ICreateAudioFileOutputNodeResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CreateAudioFileOutputNodeResult: ICreateAudioFileOutputNodeResult}
+RT_CLASS!{class CreateAudioFileOutputNodeResult: ICreateAudioFileOutputNodeResult ["Windows.Media.Audio.CreateAudioFileOutputNodeResult"]}
 DEFINE_IID!(IID_ICreateAudioFileOutputNodeResult2, 2667689229, 13080, 18355, 166, 10, 27, 73, 43, 231, 252, 13);
 RT_INTERFACE!{interface ICreateAudioFileOutputNodeResult2(ICreateAudioFileOutputNodeResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ICreateAudioFileOutputNodeResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -3161,7 +3161,7 @@ impl ICreateAudioGraphResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CreateAudioGraphResult: ICreateAudioGraphResult}
+RT_CLASS!{class CreateAudioGraphResult: ICreateAudioGraphResult ["Windows.Media.Audio.CreateAudioGraphResult"]}
 DEFINE_IID!(IID_ICreateAudioGraphResult2, 1836289532, 35014, 20427, 165, 52, 133, 206, 221, 64, 80, 161);
 RT_INTERFACE!{interface ICreateAudioGraphResult2(ICreateAudioGraphResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ICreateAudioGraphResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -3190,7 +3190,7 @@ impl ICreateMediaSourceAudioInputNodeResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CreateMediaSourceAudioInputNodeResult: ICreateMediaSourceAudioInputNodeResult}
+RT_CLASS!{class CreateMediaSourceAudioInputNodeResult: ICreateMediaSourceAudioInputNodeResult ["Windows.Media.Audio.CreateMediaSourceAudioInputNodeResult"]}
 DEFINE_IID!(IID_ICreateMediaSourceAudioInputNodeResult2, 1666272488, 27162, 18915, 151, 236, 40, 253, 91, 225, 20, 229);
 RT_INTERFACE!{interface ICreateMediaSourceAudioInputNodeResult2(ICreateMediaSourceAudioInputNodeResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ICreateMediaSourceAudioInputNodeResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -3240,7 +3240,7 @@ impl IEchoEffectDefinition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EchoEffectDefinition: IEchoEffectDefinition}
+RT_CLASS!{class EchoEffectDefinition: IEchoEffectDefinition ["Windows.Media.Audio.EchoEffectDefinition"]}
 impl RtActivatable<IEchoEffectDefinitionFactory> for EchoEffectDefinition {}
 impl EchoEffectDefinition {
     #[inline] pub fn create(audioGraph: &AudioGraph) -> Result<ComPtr<EchoEffectDefinition>> {
@@ -3297,7 +3297,7 @@ impl IEqualizerBand {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EqualizerBand: IEqualizerBand}
+RT_CLASS!{class EqualizerBand: IEqualizerBand ["Windows.Media.Audio.EqualizerBand"]}
 DEFINE_IID!(IID_IEqualizerEffectDefinition, 37711647, 33790, 17562, 168, 34, 198, 150, 68, 45, 22, 176);
 RT_INTERFACE!{interface IEqualizerEffectDefinition(IEqualizerEffectDefinitionVtbl): IInspectable(IInspectableVtbl) [IID_IEqualizerEffectDefinition] {
     fn get_Bands(&self, out: *mut *mut foundation::collections::IVectorView<EqualizerBand>) -> HRESULT
@@ -3309,7 +3309,7 @@ impl IEqualizerEffectDefinition {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EqualizerEffectDefinition: IEqualizerEffectDefinition}
+RT_CLASS!{class EqualizerEffectDefinition: IEqualizerEffectDefinition ["Windows.Media.Audio.EqualizerEffectDefinition"]}
 impl RtActivatable<IEqualizerEffectDefinitionFactory> for EqualizerEffectDefinition {}
 impl EqualizerEffectDefinition {
     #[inline] pub fn create(audioGraph: &AudioGraph) -> Result<ComPtr<EqualizerEffectDefinition>> {
@@ -3339,7 +3339,7 @@ impl IFrameInputNodeQuantumStartedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameInputNodeQuantumStartedEventArgs: IFrameInputNodeQuantumStartedEventArgs}
+RT_CLASS!{class FrameInputNodeQuantumStartedEventArgs: IFrameInputNodeQuantumStartedEventArgs ["Windows.Media.Audio.FrameInputNodeQuantumStartedEventArgs"]}
 DEFINE_IID!(IID_ILimiterEffectDefinition, 1802853657, 9731, 18362, 189, 235, 57, 5, 94, 52, 134, 220);
 RT_INTERFACE!{interface ILimiterEffectDefinition(ILimiterEffectDefinitionVtbl): IInspectable(IInspectableVtbl) [IID_ILimiterEffectDefinition] {
     fn put_Release(&self, value: u32) -> HRESULT,
@@ -3367,7 +3367,7 @@ impl ILimiterEffectDefinition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LimiterEffectDefinition: ILimiterEffectDefinition}
+RT_CLASS!{class LimiterEffectDefinition: ILimiterEffectDefinition ["Windows.Media.Audio.LimiterEffectDefinition"]}
 impl RtActivatable<ILimiterEffectDefinitionFactory> for LimiterEffectDefinition {}
 impl LimiterEffectDefinition {
     #[inline] pub fn create(audioGraph: &AudioGraph) -> Result<ComPtr<LimiterEffectDefinition>> {
@@ -3469,14 +3469,14 @@ impl IMediaSourceAudioInputNode {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaSourceAudioInputNode: IMediaSourceAudioInputNode}
-RT_ENUM! { enum MediaSourceAudioInputNodeCreationStatus: i32 {
+RT_CLASS!{class MediaSourceAudioInputNode: IMediaSourceAudioInputNode ["Windows.Media.Audio.MediaSourceAudioInputNode"]}
+RT_ENUM! { enum MediaSourceAudioInputNodeCreationStatus: i32 ["Windows.Media.Audio.MediaSourceAudioInputNodeCreationStatus"] {
     Success (MediaSourceAudioInputNodeCreationStatus_Success) = 0, FormatNotSupported (MediaSourceAudioInputNodeCreationStatus_FormatNotSupported) = 1, NetworkError (MediaSourceAudioInputNodeCreationStatus_NetworkError) = 2, UnknownFailure (MediaSourceAudioInputNodeCreationStatus_UnknownFailure) = 3,
 }}
-RT_ENUM! { enum MixedRealitySpatialAudioFormatPolicy: i32 {
+RT_ENUM! { enum MixedRealitySpatialAudioFormatPolicy: i32 ["Windows.Media.Audio.MixedRealitySpatialAudioFormatPolicy"] {
     UseMixedRealityDefaultSpatialAudioFormat (MixedRealitySpatialAudioFormatPolicy_UseMixedRealityDefaultSpatialAudioFormat) = 0, UseDeviceConfigurationDefaultSpatialAudioFormat (MixedRealitySpatialAudioFormatPolicy_UseDeviceConfigurationDefaultSpatialAudioFormat) = 1,
 }}
-RT_ENUM! { enum QuantumSizeSelectionMode: i32 {
+RT_ENUM! { enum QuantumSizeSelectionMode: i32 ["Windows.Media.Audio.QuantumSizeSelectionMode"] {
     SystemDefault (QuantumSizeSelectionMode_SystemDefault) = 0, LowestLatency (QuantumSizeSelectionMode_LowestLatency) = 1, ClosestToDesired (QuantumSizeSelectionMode_ClosestToDesired) = 2,
 }}
 DEFINE_IID!(IID_IReverbEffectDefinition, 1174841993, 62819, 19722, 143, 110, 240, 205, 223, 243, 93, 132);
@@ -3737,7 +3737,7 @@ impl IReverbEffectDefinition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ReverbEffectDefinition: IReverbEffectDefinition}
+RT_CLASS!{class ReverbEffectDefinition: IReverbEffectDefinition ["Windows.Media.Audio.ReverbEffectDefinition"]}
 impl RtActivatable<IReverbEffectDefinitionFactory> for ReverbEffectDefinition {}
 impl ReverbEffectDefinition {
     #[inline] pub fn create(audioGraph: &AudioGraph) -> Result<ComPtr<ReverbEffectDefinition>> {
@@ -3767,8 +3767,8 @@ impl ISetDefaultSpatialAudioFormatResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SetDefaultSpatialAudioFormatResult: ISetDefaultSpatialAudioFormatResult}
-RT_ENUM! { enum SetDefaultSpatialAudioFormatStatus: i32 {
+RT_CLASS!{class SetDefaultSpatialAudioFormatResult: ISetDefaultSpatialAudioFormatResult ["Windows.Media.Audio.SetDefaultSpatialAudioFormatResult"]}
+RT_ENUM! { enum SetDefaultSpatialAudioFormatStatus: i32 ["Windows.Media.Audio.SetDefaultSpatialAudioFormatStatus"] {
     Succeeded (SetDefaultSpatialAudioFormatStatus_Succeeded) = 0, AccessDenied (SetDefaultSpatialAudioFormatStatus_AccessDenied) = 1, LicenseExpired (SetDefaultSpatialAudioFormatStatus_LicenseExpired) = 2, LicenseNotValidForAudioEndpoint (SetDefaultSpatialAudioFormatStatus_LicenseNotValidForAudioEndpoint) = 3, NotSupportedOnAudioEndpoint (SetDefaultSpatialAudioFormatStatus_NotSupportedOnAudioEndpoint) = 4, UnknownError (SetDefaultSpatialAudioFormatStatus_UnknownError) = 5,
 }}
 DEFINE_IID!(IID_ISpatialAudioDeviceConfiguration, 4001562676, 25039, 22345, 157, 164, 16, 240, 254, 2, 129, 153);
@@ -3823,7 +3823,7 @@ impl ISpatialAudioDeviceConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAudioDeviceConfiguration: ISpatialAudioDeviceConfiguration}
+RT_CLASS!{class SpatialAudioDeviceConfiguration: ISpatialAudioDeviceConfiguration ["Windows.Media.Audio.SpatialAudioDeviceConfiguration"]}
 impl RtActivatable<ISpatialAudioDeviceConfigurationStatics> for SpatialAudioDeviceConfiguration {}
 impl SpatialAudioDeviceConfiguration {
     #[inline] pub fn get_for_device_id(deviceId: &HStringArg) -> Result<Option<ComPtr<SpatialAudioDeviceConfiguration>>> {
@@ -3870,7 +3870,7 @@ impl ISpatialAudioFormatConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAudioFormatConfiguration: ISpatialAudioFormatConfiguration}
+RT_CLASS!{class SpatialAudioFormatConfiguration: ISpatialAudioFormatConfiguration ["Windows.Media.Audio.SpatialAudioFormatConfiguration"]}
 impl RtActivatable<ISpatialAudioFormatConfigurationStatics> for SpatialAudioFormatConfiguration {}
 impl SpatialAudioFormatConfiguration {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<SpatialAudioFormatConfiguration>>> {
@@ -3953,7 +3953,7 @@ impl ISpatialAudioFormatSubtypeStatics {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialAudioModel: i32 {
+RT_ENUM! { enum SpatialAudioModel: i32 ["Windows.Media.Audio.SpatialAudioModel"] {
     ObjectBased (SpatialAudioModel_ObjectBased) = 0, FoldDown (SpatialAudioModel_FoldDown) = 1,
 }}
 } // Windows.Media.Audio
@@ -3982,7 +3982,7 @@ impl IAdvancedCapturedPhoto {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdvancedCapturedPhoto: IAdvancedCapturedPhoto}
+RT_CLASS!{class AdvancedCapturedPhoto: IAdvancedCapturedPhoto ["Windows.Media.Capture.AdvancedCapturedPhoto"]}
 DEFINE_IID!(IID_IAdvancedCapturedPhoto2, 416247000, 53246, 17112, 129, 4, 1, 123, 179, 24, 244, 161);
 RT_INTERFACE!{interface IAdvancedCapturedPhoto2(IAdvancedCapturedPhoto2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdvancedCapturedPhoto2] {
     fn get_FrameBoundsRelativeToReferencePhoto(&self, out: *mut *mut foundation::IReference<foundation::Rect>) -> HRESULT
@@ -4039,7 +4039,7 @@ impl IAdvancedPhotoCapture {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdvancedPhotoCapture: IAdvancedPhotoCapture}
+RT_CLASS!{class AdvancedPhotoCapture: IAdvancedPhotoCapture ["Windows.Media.Capture.AdvancedPhotoCapture"]}
 DEFINE_IID!(IID_IAppBroadcastBackgroundService, 3134318378, 64148, 18169, 149, 252, 215, 21, 17, 205, 167, 11);
 RT_INTERFACE!{interface IAppBroadcastBackgroundService(IAppBroadcastBackgroundServiceVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastBackgroundService] {
     fn put_PlugInState(&self, value: AppBroadcastPlugInState) -> HRESULT,
@@ -4123,7 +4123,7 @@ impl IAppBroadcastBackgroundService {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastBackgroundService: IAppBroadcastBackgroundService}
+RT_CLASS!{class AppBroadcastBackgroundService: IAppBroadcastBackgroundService ["Windows.Media.Capture.AppBroadcastBackgroundService"]}
 DEFINE_IID!(IID_IAppBroadcastBackgroundService2, 4237085631, 21833, 19335, 149, 159, 35, 202, 64, 31, 212, 115);
 RT_INTERFACE!{interface IAppBroadcastBackgroundService2(IAppBroadcastBackgroundService2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastBackgroundService2] {
     fn put_BroadcastTitle(&self, value: HSTRING) -> HRESULT,
@@ -4251,7 +4251,7 @@ impl IAppBroadcastBackgroundServiceSignInInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastBackgroundServiceSignInInfo: IAppBroadcastBackgroundServiceSignInInfo}
+RT_CLASS!{class AppBroadcastBackgroundServiceSignInInfo: IAppBroadcastBackgroundServiceSignInInfo ["Windows.Media.Capture.AppBroadcastBackgroundServiceSignInInfo"]}
 DEFINE_IID!(IID_IAppBroadcastBackgroundServiceSignInInfo2, 2432968796, 25295, 19004, 167, 238, 174, 181, 7, 64, 70, 69);
 RT_INTERFACE!{interface IAppBroadcastBackgroundServiceSignInInfo2(IAppBroadcastBackgroundServiceSignInInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastBackgroundServiceSignInInfo2] {
     fn add_UserNameChanged(&self, handler: *mut foundation::TypedEventHandler<AppBroadcastBackgroundServiceSignInInfo, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -4351,7 +4351,7 @@ impl IAppBroadcastBackgroundServiceStreamInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastBackgroundServiceStreamInfo: IAppBroadcastBackgroundServiceStreamInfo}
+RT_CLASS!{class AppBroadcastBackgroundServiceStreamInfo: IAppBroadcastBackgroundServiceStreamInfo ["Windows.Media.Capture.AppBroadcastBackgroundServiceStreamInfo"]}
 DEFINE_IID!(IID_IAppBroadcastBackgroundServiceStreamInfo2, 3172900717, 38108, 20430, 149, 65, 169, 241, 41, 89, 99, 52);
 RT_INTERFACE!{interface IAppBroadcastBackgroundServiceStreamInfo2(IAppBroadcastBackgroundServiceStreamInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastBackgroundServiceStreamInfo2] {
     fn ReportProblemWithStream(&self) -> HRESULT
@@ -4362,7 +4362,7 @@ impl IAppBroadcastBackgroundServiceStreamInfo2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppBroadcastCameraCaptureState: i32 {
+RT_ENUM! { enum AppBroadcastCameraCaptureState: i32 ["Windows.Media.Capture.AppBroadcastCameraCaptureState"] {
     Stopped (AppBroadcastCameraCaptureState_Stopped) = 0, Started (AppBroadcastCameraCaptureState_Started) = 1, Failed (AppBroadcastCameraCaptureState_Failed) = 2,
 }}
 DEFINE_IID!(IID_IAppBroadcastCameraCaptureStateChangedEventArgs, 506678480, 47234, 19336, 134, 146, 5, 153, 154, 206, 183, 15);
@@ -4382,17 +4382,17 @@ impl IAppBroadcastCameraCaptureStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastCameraCaptureStateChangedEventArgs: IAppBroadcastCameraCaptureStateChangedEventArgs}
-RT_ENUM! { enum AppBroadcastCameraOverlayLocation: i32 {
+RT_CLASS!{class AppBroadcastCameraCaptureStateChangedEventArgs: IAppBroadcastCameraCaptureStateChangedEventArgs ["Windows.Media.Capture.AppBroadcastCameraCaptureStateChangedEventArgs"]}
+RT_ENUM! { enum AppBroadcastCameraOverlayLocation: i32 ["Windows.Media.Capture.AppBroadcastCameraOverlayLocation"] {
     TopLeft (AppBroadcastCameraOverlayLocation_TopLeft) = 0, TopCenter (AppBroadcastCameraOverlayLocation_TopCenter) = 1, TopRight (AppBroadcastCameraOverlayLocation_TopRight) = 2, MiddleLeft (AppBroadcastCameraOverlayLocation_MiddleLeft) = 3, MiddleCenter (AppBroadcastCameraOverlayLocation_MiddleCenter) = 4, MiddleRight (AppBroadcastCameraOverlayLocation_MiddleRight) = 5, BottomLeft (AppBroadcastCameraOverlayLocation_BottomLeft) = 6, BottomCenter (AppBroadcastCameraOverlayLocation_BottomCenter) = 7, BottomRight (AppBroadcastCameraOverlayLocation_BottomRight) = 8,
 }}
-RT_ENUM! { enum AppBroadcastCameraOverlaySize: i32 {
+RT_ENUM! { enum AppBroadcastCameraOverlaySize: i32 ["Windows.Media.Capture.AppBroadcastCameraOverlaySize"] {
     Small (AppBroadcastCameraOverlaySize_Small) = 0, Medium (AppBroadcastCameraOverlaySize_Medium) = 1, Large (AppBroadcastCameraOverlaySize_Large) = 2,
 }}
-RT_ENUM! { enum AppBroadcastCaptureTargetType: i32 {
+RT_ENUM! { enum AppBroadcastCaptureTargetType: i32 ["Windows.Media.Capture.AppBroadcastCaptureTargetType"] {
     AppView (AppBroadcastCaptureTargetType_AppView) = 0, EntireDisplay (AppBroadcastCaptureTargetType_EntireDisplay) = 1,
 }}
-RT_ENUM! { enum AppBroadcastExitBroadcastModeReason: i32 {
+RT_ENUM! { enum AppBroadcastExitBroadcastModeReason: i32 ["Windows.Media.Capture.AppBroadcastExitBroadcastModeReason"] {
     NormalExit (AppBroadcastExitBroadcastModeReason_NormalExit) = 0, UserCanceled (AppBroadcastExitBroadcastModeReason_UserCanceled) = 1, AuthorizationFail (AppBroadcastExitBroadcastModeReason_AuthorizationFail) = 2, ForegroundAppActivated (AppBroadcastExitBroadcastModeReason_ForegroundAppActivated) = 3,
 }}
 DEFINE_IID!(IID_IAppBroadcastGlobalSettings, 2999658405, 28924, 19991, 128, 189, 107, 160, 253, 63, 243, 160);
@@ -4534,7 +4534,7 @@ impl IAppBroadcastGlobalSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastGlobalSettings: IAppBroadcastGlobalSettings}
+RT_CLASS!{class AppBroadcastGlobalSettings: IAppBroadcastGlobalSettings ["Windows.Media.Capture.AppBroadcastGlobalSettings"]}
 DEFINE_IID!(IID_IAppBroadcastHeartbeatRequestedEventArgs, 3466936963, 61009, 19903, 148, 114, 121, 169, 237, 78, 33, 101);
 RT_INTERFACE!{interface IAppBroadcastHeartbeatRequestedEventArgs(IAppBroadcastHeartbeatRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastHeartbeatRequestedEventArgs] {
     fn put_Handled(&self, value: bool) -> HRESULT,
@@ -4551,7 +4551,7 @@ impl IAppBroadcastHeartbeatRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastHeartbeatRequestedEventArgs: IAppBroadcastHeartbeatRequestedEventArgs}
+RT_CLASS!{class AppBroadcastHeartbeatRequestedEventArgs: IAppBroadcastHeartbeatRequestedEventArgs ["Windows.Media.Capture.AppBroadcastHeartbeatRequestedEventArgs"]}
 RT_CLASS!{static class AppBroadcastManager}
 impl RtActivatable<IAppBroadcastManagerStatics> for AppBroadcastManager {}
 impl AppBroadcastManager {
@@ -4596,7 +4596,7 @@ impl IAppBroadcastManagerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppBroadcastMicrophoneCaptureState: i32 {
+RT_ENUM! { enum AppBroadcastMicrophoneCaptureState: i32 ["Windows.Media.Capture.AppBroadcastMicrophoneCaptureState"] {
     Stopped (AppBroadcastMicrophoneCaptureState_Stopped) = 0, Started (AppBroadcastMicrophoneCaptureState_Started) = 1, Failed (AppBroadcastMicrophoneCaptureState_Failed) = 2,
 }}
 DEFINE_IID!(IID_IAppBroadcastMicrophoneCaptureStateChangedEventArgs, 2825573865, 37952, 18696, 157, 9, 101, 183, 227, 21, 215, 149);
@@ -4616,7 +4616,7 @@ impl IAppBroadcastMicrophoneCaptureStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastMicrophoneCaptureStateChangedEventArgs: IAppBroadcastMicrophoneCaptureStateChangedEventArgs}
+RT_CLASS!{class AppBroadcastMicrophoneCaptureStateChangedEventArgs: IAppBroadcastMicrophoneCaptureStateChangedEventArgs ["Windows.Media.Capture.AppBroadcastMicrophoneCaptureStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAppBroadcastPlugIn, 1376525926, 25875, 17780, 172, 84, 35, 183, 151, 41, 97, 91);
 RT_INTERFACE!{interface IAppBroadcastPlugIn(IAppBroadcastPlugInVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPlugIn] {
     fn get_AppId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4647,7 +4647,7 @@ impl IAppBroadcastPlugIn {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPlugIn: IAppBroadcastPlugIn}
+RT_CLASS!{class AppBroadcastPlugIn: IAppBroadcastPlugIn ["Windows.Media.Capture.AppBroadcastPlugIn"]}
 DEFINE_IID!(IID_IAppBroadcastPlugInManager, 3847281017, 10145, 18855, 187, 244, 215, 169, 233, 208, 118, 104);
 RT_INTERFACE!{interface IAppBroadcastPlugInManager(IAppBroadcastPlugInManagerVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPlugInManager] {
     fn get_IsBroadcastProviderAvailable(&self, out: *mut bool) -> HRESULT,
@@ -4676,7 +4676,7 @@ impl IAppBroadcastPlugInManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPlugInManager: IAppBroadcastPlugInManager}
+RT_CLASS!{class AppBroadcastPlugInManager: IAppBroadcastPlugInManager ["Windows.Media.Capture.AppBroadcastPlugInManager"]}
 impl RtActivatable<IAppBroadcastPlugInManagerStatics> for AppBroadcastPlugInManager {}
 impl AppBroadcastPlugInManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<AppBroadcastPlugInManager>>> {
@@ -4704,7 +4704,7 @@ impl IAppBroadcastPlugInManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppBroadcastPlugInState: i32 {
+RT_ENUM! { enum AppBroadcastPlugInState: i32 ["Windows.Media.Capture.AppBroadcastPlugInState"] {
     Unknown (AppBroadcastPlugInState_Unknown) = 0, Initialized (AppBroadcastPlugInState_Initialized) = 1, MicrosoftSignInRequired (AppBroadcastPlugInState_MicrosoftSignInRequired) = 2, OAuthSignInRequired (AppBroadcastPlugInState_OAuthSignInRequired) = 3, ProviderSignInRequired (AppBroadcastPlugInState_ProviderSignInRequired) = 4, InBandwidthTest (AppBroadcastPlugInState_InBandwidthTest) = 5, ReadyToBroadcast (AppBroadcastPlugInState_ReadyToBroadcast) = 6,
 }}
 DEFINE_IID!(IID_IAppBroadcastPlugInStateChangedEventArgs, 1216467186, 43973, 20422, 132, 176, 137, 55, 11, 180, 114, 18);
@@ -4718,7 +4718,7 @@ impl IAppBroadcastPlugInStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPlugInStateChangedEventArgs: IAppBroadcastPlugInStateChangedEventArgs}
+RT_CLASS!{class AppBroadcastPlugInStateChangedEventArgs: IAppBroadcastPlugInStateChangedEventArgs ["Windows.Media.Capture.AppBroadcastPlugInStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAppBroadcastPreview, 347475802, 28234, 19328, 161, 79, 103, 238, 119, 209, 83, 231);
 RT_INTERFACE!{interface IAppBroadcastPreview(IAppBroadcastPreviewVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPreview] {
     fn StopPreview(&self) -> HRESULT,
@@ -4758,8 +4758,8 @@ impl IAppBroadcastPreview {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPreview: IAppBroadcastPreview}
-RT_ENUM! { enum AppBroadcastPreviewState: i32 {
+RT_CLASS!{class AppBroadcastPreview: IAppBroadcastPreview ["Windows.Media.Capture.AppBroadcastPreview"]}
+RT_ENUM! { enum AppBroadcastPreviewState: i32 ["Windows.Media.Capture.AppBroadcastPreviewState"] {
     Started (AppBroadcastPreviewState_Started) = 0, Stopped (AppBroadcastPreviewState_Stopped) = 1, Failed (AppBroadcastPreviewState_Failed) = 2,
 }}
 DEFINE_IID!(IID_IAppBroadcastPreviewStateChangedEventArgs, 1515713246, 36330, 20102, 144, 173, 3, 252, 38, 185, 101, 60);
@@ -4779,7 +4779,7 @@ impl IAppBroadcastPreviewStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPreviewStateChangedEventArgs: IAppBroadcastPreviewStateChangedEventArgs}
+RT_CLASS!{class AppBroadcastPreviewStateChangedEventArgs: IAppBroadcastPreviewStateChangedEventArgs ["Windows.Media.Capture.AppBroadcastPreviewStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAppBroadcastPreviewStreamReader, 2451737936, 56127, 16552, 140, 212, 244, 227, 113, 221, 171, 55);
 RT_INTERFACE!{interface IAppBroadcastPreviewStreamReader(IAppBroadcastPreviewStreamReaderVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPreviewStreamReader] {
     fn get_VideoWidth(&self, out: *mut u32) -> HRESULT,
@@ -4834,7 +4834,7 @@ impl IAppBroadcastPreviewStreamReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPreviewStreamReader: IAppBroadcastPreviewStreamReader}
+RT_CLASS!{class AppBroadcastPreviewStreamReader: IAppBroadcastPreviewStreamReader ["Windows.Media.Capture.AppBroadcastPreviewStreamReader"]}
 DEFINE_IID!(IID_IAppBroadcastPreviewStreamVideoFrame, 17809057, 38142, 17561, 184, 192, 141, 36, 66, 121, 251, 18);
 RT_INTERFACE!{interface IAppBroadcastPreviewStreamVideoFrame(IAppBroadcastPreviewStreamVideoFrameVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPreviewStreamVideoFrame] {
     fn get_VideoHeader(&self, out: *mut *mut AppBroadcastPreviewStreamVideoHeader) -> HRESULT,
@@ -4852,7 +4852,7 @@ impl IAppBroadcastPreviewStreamVideoFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPreviewStreamVideoFrame: IAppBroadcastPreviewStreamVideoFrame}
+RT_CLASS!{class AppBroadcastPreviewStreamVideoFrame: IAppBroadcastPreviewStreamVideoFrame ["Windows.Media.Capture.AppBroadcastPreviewStreamVideoFrame"]}
 DEFINE_IID!(IID_IAppBroadcastPreviewStreamVideoHeader, 2347720979, 55940, 17561, 167, 171, 135, 17, 140, 180, 161, 87);
 RT_INTERFACE!{interface IAppBroadcastPreviewStreamVideoHeader(IAppBroadcastPreviewStreamVideoHeaderVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastPreviewStreamVideoHeader] {
     fn get_AbsoluteTimestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -4882,7 +4882,7 @@ impl IAppBroadcastPreviewStreamVideoHeader {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastPreviewStreamVideoHeader: IAppBroadcastPreviewStreamVideoHeader}
+RT_CLASS!{class AppBroadcastPreviewStreamVideoHeader: IAppBroadcastPreviewStreamVideoHeader ["Windows.Media.Capture.AppBroadcastPreviewStreamVideoHeader"]}
 DEFINE_IID!(IID_IAppBroadcastProviderSettings, 3272335202, 39240, 17807, 173, 80, 170, 6, 236, 3, 218, 8);
 RT_INTERFACE!{interface IAppBroadcastProviderSettings(IAppBroadcastProviderSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastProviderSettings] {
     fn put_DefaultBroadcastTitle(&self, value: HSTRING) -> HRESULT,
@@ -4965,7 +4965,7 @@ impl IAppBroadcastProviderSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastProviderSettings: IAppBroadcastProviderSettings}
+RT_CLASS!{class AppBroadcastProviderSettings: IAppBroadcastProviderSettings ["Windows.Media.Capture.AppBroadcastProviderSettings"]}
 DEFINE_IID!(IID_IAppBroadcastServices, 2254484694, 38555, 20028, 172, 58, 139, 4, 46, 228, 238, 99);
 RT_INTERFACE!{interface IAppBroadcastServices(IAppBroadcastServicesVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastServices] {
     fn get_CaptureTargetType(&self, out: *mut AppBroadcastCaptureTargetType) -> HRESULT,
@@ -5054,11 +5054,11 @@ impl IAppBroadcastServices {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastServices: IAppBroadcastServices}
-RT_ENUM! { enum AppBroadcastSignInResult: i32 {
+RT_CLASS!{class AppBroadcastServices: IAppBroadcastServices ["Windows.Media.Capture.AppBroadcastServices"]}
+RT_ENUM! { enum AppBroadcastSignInResult: i32 ["Windows.Media.Capture.AppBroadcastSignInResult"] {
     Success (AppBroadcastSignInResult_Success) = 0, AuthenticationFailed (AppBroadcastSignInResult_AuthenticationFailed) = 1, Unauthorized (AppBroadcastSignInResult_Unauthorized) = 2, ServiceUnavailable (AppBroadcastSignInResult_ServiceUnavailable) = 3, Unknown (AppBroadcastSignInResult_Unknown) = 4,
 }}
-RT_ENUM! { enum AppBroadcastSignInState: i32 {
+RT_ENUM! { enum AppBroadcastSignInState: i32 ["Windows.Media.Capture.AppBroadcastSignInState"] {
     NotSignedIn (AppBroadcastSignInState_NotSignedIn) = 0, MicrosoftSignInInProgress (AppBroadcastSignInState_MicrosoftSignInInProgress) = 1, MicrosoftSignInComplete (AppBroadcastSignInState_MicrosoftSignInComplete) = 2, OAuthSignInInProgress (AppBroadcastSignInState_OAuthSignInInProgress) = 3, OAuthSignInComplete (AppBroadcastSignInState_OAuthSignInComplete) = 4,
 }}
 DEFINE_IID!(IID_IAppBroadcastSignInStateChangedEventArgs, 45519524, 22809, 19102, 141, 94, 201, 187, 13, 211, 55, 122);
@@ -5078,7 +5078,7 @@ impl IAppBroadcastSignInStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastSignInStateChangedEventArgs: IAppBroadcastSignInStateChangedEventArgs}
+RT_CLASS!{class AppBroadcastSignInStateChangedEventArgs: IAppBroadcastSignInStateChangedEventArgs ["Windows.Media.Capture.AppBroadcastSignInStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAppBroadcastState, 3993503085, 32921, 19933, 146, 46, 197, 109, 172, 88, 171, 251);
 RT_INTERFACE!{interface IAppBroadcastState(IAppBroadcastStateVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastState] {
     fn get_IsCaptureTargetRunning(&self, out: *mut bool) -> HRESULT,
@@ -5284,7 +5284,7 @@ impl IAppBroadcastState {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastState: IAppBroadcastState}
+RT_CLASS!{class AppBroadcastState: IAppBroadcastState ["Windows.Media.Capture.AppBroadcastState"]}
 DEFINE_IID!(IID_IAppBroadcastStreamAudioFrame, 4020980424, 8634, 17727, 139, 183, 94, 147, 138, 46, 154, 116);
 RT_INTERFACE!{interface IAppBroadcastStreamAudioFrame(IAppBroadcastStreamAudioFrameVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastStreamAudioFrame] {
     fn get_AudioHeader(&self, out: *mut *mut AppBroadcastStreamAudioHeader) -> HRESULT,
@@ -5302,7 +5302,7 @@ impl IAppBroadcastStreamAudioFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastStreamAudioFrame: IAppBroadcastStreamAudioFrame}
+RT_CLASS!{class AppBroadcastStreamAudioFrame: IAppBroadcastStreamAudioFrame ["Windows.Media.Capture.AppBroadcastStreamAudioFrame"]}
 DEFINE_IID!(IID_IAppBroadcastStreamAudioHeader, 3206653296, 27512, 16918, 159, 7, 90, 255, 82, 86, 241, 183);
 RT_INTERFACE!{interface IAppBroadcastStreamAudioHeader(IAppBroadcastStreamAudioHeaderVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastStreamAudioHeader] {
     fn get_AbsoluteTimestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -5338,7 +5338,7 @@ impl IAppBroadcastStreamAudioHeader {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastStreamAudioHeader: IAppBroadcastStreamAudioHeader}
+RT_CLASS!{class AppBroadcastStreamAudioHeader: IAppBroadcastStreamAudioHeader ["Windows.Media.Capture.AppBroadcastStreamAudioHeader"]}
 DEFINE_IID!(IID_IAppBroadcastStreamReader, 3006840057, 13156, 17504, 181, 241, 60, 194, 121, 106, 138, 162);
 RT_INTERFACE!{interface IAppBroadcastStreamReader(IAppBroadcastStreamReaderVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastStreamReader] {
     fn get_AudioChannels(&self, out: *mut u32) -> HRESULT,
@@ -5421,8 +5421,8 @@ impl IAppBroadcastStreamReader {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastStreamReader: IAppBroadcastStreamReader}
-RT_ENUM! { enum AppBroadcastStreamState: i32 {
+RT_CLASS!{class AppBroadcastStreamReader: IAppBroadcastStreamReader ["Windows.Media.Capture.AppBroadcastStreamReader"]}
+RT_ENUM! { enum AppBroadcastStreamState: i32 ["Windows.Media.Capture.AppBroadcastStreamState"] {
     Initializing (AppBroadcastStreamState_Initializing) = 0, StreamReady (AppBroadcastStreamState_StreamReady) = 1, Started (AppBroadcastStreamState_Started) = 2, Paused (AppBroadcastStreamState_Paused) = 3, Terminated (AppBroadcastStreamState_Terminated) = 4,
 }}
 DEFINE_IID!(IID_IAppBroadcastStreamStateChangedEventArgs, 1359521587, 53256, 19081, 147, 190, 88, 174, 217, 97, 55, 78);
@@ -5436,7 +5436,7 @@ impl IAppBroadcastStreamStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastStreamStateChangedEventArgs: IAppBroadcastStreamStateChangedEventArgs}
+RT_CLASS!{class AppBroadcastStreamStateChangedEventArgs: IAppBroadcastStreamStateChangedEventArgs ["Windows.Media.Capture.AppBroadcastStreamStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAppBroadcastStreamVideoFrame, 261607211, 51684, 20104, 129, 148, 216, 20, 203, 213, 133, 216);
 RT_INTERFACE!{interface IAppBroadcastStreamVideoFrame(IAppBroadcastStreamVideoFrameVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastStreamVideoFrame] {
     fn get_VideoHeader(&self, out: *mut *mut AppBroadcastStreamVideoHeader) -> HRESULT,
@@ -5454,7 +5454,7 @@ impl IAppBroadcastStreamVideoFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastStreamVideoFrame: IAppBroadcastStreamVideoFrame}
+RT_CLASS!{class AppBroadcastStreamVideoFrame: IAppBroadcastStreamVideoFrame ["Windows.Media.Capture.AppBroadcastStreamVideoFrame"]}
 DEFINE_IID!(IID_IAppBroadcastStreamVideoHeader, 194952910, 32306, 17197, 140, 162, 54, 191, 16, 185, 244, 98);
 RT_INTERFACE!{interface IAppBroadcastStreamVideoHeader(IAppBroadcastStreamVideoHeaderVtbl): IInspectable(IInspectableVtbl) [IID_IAppBroadcastStreamVideoHeader] {
     fn get_AbsoluteTimestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -5496,8 +5496,8 @@ impl IAppBroadcastStreamVideoHeader {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastStreamVideoHeader: IAppBroadcastStreamVideoHeader}
-RT_ENUM! { enum AppBroadcastTerminationReason: i32 {
+RT_CLASS!{class AppBroadcastStreamVideoHeader: IAppBroadcastStreamVideoHeader ["Windows.Media.Capture.AppBroadcastStreamVideoHeader"]}
+RT_ENUM! { enum AppBroadcastTerminationReason: i32 ["Windows.Media.Capture.AppBroadcastTerminationReason"] {
     NormalTermination (AppBroadcastTerminationReason_NormalTermination) = 0, LostConnectionToService (AppBroadcastTerminationReason_LostConnectionToService) = 1, NoNetworkConnectivity (AppBroadcastTerminationReason_NoNetworkConnectivity) = 2, ServiceAbort (AppBroadcastTerminationReason_ServiceAbort) = 3, ServiceError (AppBroadcastTerminationReason_ServiceError) = 4, ServiceUnavailable (AppBroadcastTerminationReason_ServiceUnavailable) = 5, InternalError (AppBroadcastTerminationReason_InternalError) = 6, UnsupportedFormat (AppBroadcastTerminationReason_UnsupportedFormat) = 7, BackgroundTaskTerminated (AppBroadcastTerminationReason_BackgroundTaskTerminated) = 8, BackgroundTaskUnresponsive (AppBroadcastTerminationReason_BackgroundTaskUnresponsive) = 9,
 }}
 DEFINE_IID!(IID_IAppBroadcastTriggerDetails, 3739986741, 60510, 19855, 177, 192, 93, 166, 232, 199, 86, 56);
@@ -5511,11 +5511,11 @@ impl IAppBroadcastTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastTriggerDetails: IAppBroadcastTriggerDetails}
-RT_ENUM! { enum AppBroadcastVideoEncodingBitrateMode: i32 {
+RT_CLASS!{class AppBroadcastTriggerDetails: IAppBroadcastTriggerDetails ["Windows.Media.Capture.AppBroadcastTriggerDetails"]}
+RT_ENUM! { enum AppBroadcastVideoEncodingBitrateMode: i32 ["Windows.Media.Capture.AppBroadcastVideoEncodingBitrateMode"] {
     Custom (AppBroadcastVideoEncodingBitrateMode_Custom) = 0, Auto (AppBroadcastVideoEncodingBitrateMode_Auto) = 1,
 }}
-RT_ENUM! { enum AppBroadcastVideoEncodingResolutionMode: i32 {
+RT_ENUM! { enum AppBroadcastVideoEncodingResolutionMode: i32 ["Windows.Media.Capture.AppBroadcastVideoEncodingResolutionMode"] {
     Custom (AppBroadcastVideoEncodingResolutionMode_Custom) = 0, Auto (AppBroadcastVideoEncodingResolutionMode_Auto) = 1,
 }}
 DEFINE_IID!(IID_IAppBroadcastViewerCountChangedEventArgs, 3873511461, 21505, 19166, 139, 210, 193, 78, 206, 230, 128, 125);
@@ -5529,7 +5529,7 @@ impl IAppBroadcastViewerCountChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppBroadcastViewerCountChangedEventArgs: IAppBroadcastViewerCountChangedEventArgs}
+RT_CLASS!{class AppBroadcastViewerCountChangedEventArgs: IAppBroadcastViewerCountChangedEventArgs ["Windows.Media.Capture.AppBroadcastViewerCountChangedEventArgs"]}
 DEFINE_IID!(IID_IAppCapture, 2538198099, 41626, 17901, 143, 41, 34, 208, 153, 66, 207, 247);
 RT_INTERFACE!{interface IAppCapture(IAppCaptureVtbl): IInspectable(IInspectableVtbl) [IID_IAppCapture] {
     fn get_IsCapturingAudio(&self, out: *mut bool) -> HRESULT,
@@ -5558,7 +5558,7 @@ impl IAppCapture {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCapture: IAppCapture}
+RT_CLASS!{class AppCapture: IAppCapture ["Windows.Media.Capture.AppCapture"]}
 impl RtActivatable<IAppCaptureStatics> for AppCapture {}
 impl RtActivatable<IAppCaptureStatics2> for AppCapture {}
 impl AppCapture {
@@ -5685,7 +5685,7 @@ impl IAppCaptureAlternateShortcutKeys {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureAlternateShortcutKeys: IAppCaptureAlternateShortcutKeys}
+RT_CLASS!{class AppCaptureAlternateShortcutKeys: IAppCaptureAlternateShortcutKeys ["Windows.Media.Capture.AppCaptureAlternateShortcutKeys"]}
 DEFINE_IID!(IID_IAppCaptureAlternateShortcutKeys2, 3278278800, 56599, 18416, 149, 229, 206, 66, 40, 108, 243, 56);
 RT_INTERFACE!{interface IAppCaptureAlternateShortcutKeys2(IAppCaptureAlternateShortcutKeys2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureAlternateShortcutKeys2] {
     #[cfg(feature="windows-system")] fn put_ToggleMicrophoneCaptureKey(&self, value: super::super::system::VirtualKey) -> HRESULT,
@@ -5773,7 +5773,7 @@ impl IAppCaptureDurationGeneratedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureDurationGeneratedEventArgs: IAppCaptureDurationGeneratedEventArgs}
+RT_CLASS!{class AppCaptureDurationGeneratedEventArgs: IAppCaptureDurationGeneratedEventArgs ["Windows.Media.Capture.AppCaptureDurationGeneratedEventArgs"]}
 DEFINE_IID!(IID_IAppCaptureFileGeneratedEventArgs, 1099561972, 18014, 17855, 144, 127, 22, 91, 63, 178, 55, 88);
 RT_INTERFACE!{interface IAppCaptureFileGeneratedEventArgs(IAppCaptureFileGeneratedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureFileGeneratedEventArgs] {
     #[cfg(feature="windows-storage")] fn get_File(&self, out: *mut *mut super::super::storage::StorageFile) -> HRESULT
@@ -5785,8 +5785,8 @@ impl IAppCaptureFileGeneratedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureFileGeneratedEventArgs: IAppCaptureFileGeneratedEventArgs}
-RT_ENUM! { enum AppCaptureHistoricalBufferLengthUnit: i32 {
+RT_CLASS!{class AppCaptureFileGeneratedEventArgs: IAppCaptureFileGeneratedEventArgs ["Windows.Media.Capture.AppCaptureFileGeneratedEventArgs"]}
+RT_ENUM! { enum AppCaptureHistoricalBufferLengthUnit: i32 ["Windows.Media.Capture.AppCaptureHistoricalBufferLengthUnit"] {
     Megabytes (AppCaptureHistoricalBufferLengthUnit_Megabytes) = 0, Seconds (AppCaptureHistoricalBufferLengthUnit_Seconds) = 1,
 }}
 RT_CLASS!{static class AppCaptureManager}
@@ -5816,7 +5816,7 @@ impl IAppCaptureManagerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppCaptureMetadataPriority: i32 {
+RT_ENUM! { enum AppCaptureMetadataPriority: i32 ["Windows.Media.Capture.AppCaptureMetadataPriority"] {
     Informational (AppCaptureMetadataPriority_Informational) = 0, Important (AppCaptureMetadataPriority_Important) = 1,
 }}
 DEFINE_IID!(IID_IAppCaptureMetadataWriter, 3771615351, 39599, 18100, 173, 49, 106, 96, 180, 65, 199, 128);
@@ -5881,10 +5881,10 @@ impl IAppCaptureMetadataWriter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureMetadataWriter: IAppCaptureMetadataWriter}
+RT_CLASS!{class AppCaptureMetadataWriter: IAppCaptureMetadataWriter ["Windows.Media.Capture.AppCaptureMetadataWriter"]}
 impl RtActivatable<IActivationFactory> for AppCaptureMetadataWriter {}
 DEFINE_CLSID!(AppCaptureMetadataWriter(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,65,112,112,67,97,112,116,117,114,101,77,101,116,97,100,97,116,97,87,114,105,116,101,114,0]) [CLSID_AppCaptureMetadataWriter]);
-RT_ENUM! { enum AppCaptureMicrophoneCaptureState: i32 {
+RT_ENUM! { enum AppCaptureMicrophoneCaptureState: i32 ["Windows.Media.Capture.AppCaptureMicrophoneCaptureState"] {
     Stopped (AppCaptureMicrophoneCaptureState_Stopped) = 0, Started (AppCaptureMicrophoneCaptureState_Started) = 1, Failed (AppCaptureMicrophoneCaptureState_Failed) = 2,
 }}
 DEFINE_IID!(IID_IAppCaptureMicrophoneCaptureStateChangedEventArgs, 843916446, 17852, 19509, 188, 53, 228, 105, 252, 122, 105, 224);
@@ -5904,8 +5904,8 @@ impl IAppCaptureMicrophoneCaptureStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureMicrophoneCaptureStateChangedEventArgs: IAppCaptureMicrophoneCaptureStateChangedEventArgs}
-RT_ENUM! { enum AppCaptureRecordingState: i32 {
+RT_CLASS!{class AppCaptureMicrophoneCaptureStateChangedEventArgs: IAppCaptureMicrophoneCaptureStateChangedEventArgs ["Windows.Media.Capture.AppCaptureMicrophoneCaptureStateChangedEventArgs"]}
+RT_ENUM! { enum AppCaptureRecordingState: i32 ["Windows.Media.Capture.AppCaptureRecordingState"] {
     InProgress (AppCaptureRecordingState_InProgress) = 0, Completed (AppCaptureRecordingState_Completed) = 1, Failed (AppCaptureRecordingState_Failed) = 2,
 }}
 DEFINE_IID!(IID_IAppCaptureRecordingStateChangedEventArgs, 620529426, 58117, 18701, 180, 21, 107, 28, 144, 73, 115, 107);
@@ -5925,7 +5925,7 @@ impl IAppCaptureRecordingStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureRecordingStateChangedEventArgs: IAppCaptureRecordingStateChangedEventArgs}
+RT_CLASS!{class AppCaptureRecordingStateChangedEventArgs: IAppCaptureRecordingStateChangedEventArgs ["Windows.Media.Capture.AppCaptureRecordingStateChangedEventArgs"]}
 DEFINE_IID!(IID_IAppCaptureRecordOperation, 3328188585, 5432, 18780, 155, 187, 43, 168, 112, 236, 88, 97);
 RT_INTERFACE!{interface IAppCaptureRecordOperation(IAppCaptureRecordOperationVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureRecordOperation] {
     fn StopRecording(&self) -> HRESULT,
@@ -6000,7 +6000,7 @@ impl IAppCaptureRecordOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureRecordOperation: IAppCaptureRecordOperation}
+RT_CLASS!{class AppCaptureRecordOperation: IAppCaptureRecordOperation ["Windows.Media.Capture.AppCaptureRecordOperation"]}
 DEFINE_IID!(IID_IAppCaptureServices, 1157546165, 13557, 20248, 174, 140, 185, 18, 58, 187, 252, 13);
 RT_INTERFACE!{interface IAppCaptureServices(IAppCaptureServicesVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureServices] {
     fn Record(&self, out: *mut *mut AppCaptureRecordOperation) -> HRESULT,
@@ -6030,7 +6030,7 @@ impl IAppCaptureServices {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureServices: IAppCaptureServices}
+RT_CLASS!{class AppCaptureServices: IAppCaptureServices ["Windows.Media.Capture.AppCaptureServices"]}
 DEFINE_IID!(IID_IAppCaptureSettings, 342375046, 34823, 18643, 136, 58, 151, 14, 228, 83, 42, 57);
 RT_INTERFACE!{interface IAppCaptureSettings(IAppCaptureSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureSettings] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -6240,7 +6240,7 @@ impl IAppCaptureSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureSettings: IAppCaptureSettings}
+RT_CLASS!{class AppCaptureSettings: IAppCaptureSettings ["Windows.Media.Capture.AppCaptureSettings"]}
 DEFINE_IID!(IID_IAppCaptureSettings2, 4239970023, 57963, 18287, 155, 26, 236, 52, 45, 42, 143, 222);
 RT_INTERFACE!{interface IAppCaptureSettings2(IAppCaptureSettings2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureSettings2] {
     fn get_IsGpuConstrained(&self, out: *mut bool) -> HRESULT,
@@ -6417,7 +6417,7 @@ impl IAppCaptureState {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppCaptureState: IAppCaptureState}
+RT_CLASS!{class AppCaptureState: IAppCaptureState ["Windows.Media.Capture.AppCaptureState"]}
 DEFINE_IID!(IID_IAppCaptureStatics, 4179811692, 2686, 20084, 139, 32, 156, 31, 144, 45, 8, 161);
 RT_INTERFACE!{static interface IAppCaptureStatics(IAppCaptureStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAppCaptureStatics] {
     fn GetForCurrentView(&self, out: *mut *mut AppCapture) -> HRESULT
@@ -6440,13 +6440,13 @@ impl IAppCaptureStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppCaptureVideoEncodingBitrateMode: i32 {
+RT_ENUM! { enum AppCaptureVideoEncodingBitrateMode: i32 ["Windows.Media.Capture.AppCaptureVideoEncodingBitrateMode"] {
     Custom (AppCaptureVideoEncodingBitrateMode_Custom) = 0, High (AppCaptureVideoEncodingBitrateMode_High) = 1, Standard (AppCaptureVideoEncodingBitrateMode_Standard) = 2,
 }}
-RT_ENUM! { enum AppCaptureVideoEncodingFrameRateMode: i32 {
+RT_ENUM! { enum AppCaptureVideoEncodingFrameRateMode: i32 ["Windows.Media.Capture.AppCaptureVideoEncodingFrameRateMode"] {
     Standard (AppCaptureVideoEncodingFrameRateMode_Standard) = 0, High (AppCaptureVideoEncodingFrameRateMode_High) = 1,
 }}
-RT_ENUM! { enum AppCaptureVideoEncodingResolutionMode: i32 {
+RT_ENUM! { enum AppCaptureVideoEncodingResolutionMode: i32 ["Windows.Media.Capture.AppCaptureVideoEncodingResolutionMode"] {
     Custom (AppCaptureVideoEncodingResolutionMode_Custom) = 0, High (AppCaptureVideoEncodingResolutionMode_High) = 1, Standard (AppCaptureVideoEncodingResolutionMode_Standard) = 2,
 }}
 DEFINE_IID!(IID_ICameraCaptureUI, 1213756736, 28563, 19380, 184, 243, 232, 158, 72, 148, 140, 145);
@@ -6472,16 +6472,16 @@ impl ICameraCaptureUI {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CameraCaptureUI: ICameraCaptureUI}
+RT_CLASS!{class CameraCaptureUI: ICameraCaptureUI ["Windows.Media.Capture.CameraCaptureUI"]}
 impl RtActivatable<IActivationFactory> for CameraCaptureUI {}
 DEFINE_CLSID!(CameraCaptureUI(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,67,97,109,101,114,97,67,97,112,116,117,114,101,85,73,0]) [CLSID_CameraCaptureUI]);
-RT_ENUM! { enum CameraCaptureUIMaxPhotoResolution: i32 {
+RT_ENUM! { enum CameraCaptureUIMaxPhotoResolution: i32 ["Windows.Media.Capture.CameraCaptureUIMaxPhotoResolution"] {
     HighestAvailable (CameraCaptureUIMaxPhotoResolution_HighestAvailable) = 0, VerySmallQvga (CameraCaptureUIMaxPhotoResolution_VerySmallQvga) = 1, SmallVga (CameraCaptureUIMaxPhotoResolution_SmallVga) = 2, MediumXga (CameraCaptureUIMaxPhotoResolution_MediumXga) = 3, Large3M (CameraCaptureUIMaxPhotoResolution_Large3M) = 4, VeryLarge5M (CameraCaptureUIMaxPhotoResolution_VeryLarge5M) = 5,
 }}
-RT_ENUM! { enum CameraCaptureUIMaxVideoResolution: i32 {
+RT_ENUM! { enum CameraCaptureUIMaxVideoResolution: i32 ["Windows.Media.Capture.CameraCaptureUIMaxVideoResolution"] {
     HighestAvailable (CameraCaptureUIMaxVideoResolution_HighestAvailable) = 0, LowDefinition (CameraCaptureUIMaxVideoResolution_LowDefinition) = 1, StandardDefinition (CameraCaptureUIMaxVideoResolution_StandardDefinition) = 2, HighDefinition (CameraCaptureUIMaxVideoResolution_HighDefinition) = 3,
 }}
-RT_ENUM! { enum CameraCaptureUIMode: i32 {
+RT_ENUM! { enum CameraCaptureUIMode: i32 ["Windows.Media.Capture.CameraCaptureUIMode"] {
     PhotoOrVideo (CameraCaptureUIMode_PhotoOrVideo) = 0, Photo (CameraCaptureUIMode_Photo) = 1, Video (CameraCaptureUIMode_Video) = 2,
 }}
 DEFINE_IID!(IID_ICameraCaptureUIPhotoCaptureSettings, 3119890071, 13426, 18088, 138, 158, 4, 206, 66, 204, 201, 125);
@@ -6544,8 +6544,8 @@ impl ICameraCaptureUIPhotoCaptureSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CameraCaptureUIPhotoCaptureSettings: ICameraCaptureUIPhotoCaptureSettings}
-RT_ENUM! { enum CameraCaptureUIPhotoFormat: i32 {
+RT_CLASS!{class CameraCaptureUIPhotoCaptureSettings: ICameraCaptureUIPhotoCaptureSettings ["Windows.Media.Capture.CameraCaptureUIPhotoCaptureSettings"]}
+RT_ENUM! { enum CameraCaptureUIPhotoFormat: i32 ["Windows.Media.Capture.CameraCaptureUIPhotoFormat"] {
     Jpeg (CameraCaptureUIPhotoFormat_Jpeg) = 0, Png (CameraCaptureUIPhotoFormat_Png) = 1, JpegXR (CameraCaptureUIPhotoFormat_JpegXR) = 2,
 }}
 DEFINE_IID!(IID_ICameraCaptureUIVideoCaptureSettings, 1693003039, 41613, 16986, 184, 79, 229, 104, 51, 95, 242, 78);
@@ -6597,8 +6597,8 @@ impl ICameraCaptureUIVideoCaptureSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CameraCaptureUIVideoCaptureSettings: ICameraCaptureUIVideoCaptureSettings}
-RT_ENUM! { enum CameraCaptureUIVideoFormat: i32 {
+RT_CLASS!{class CameraCaptureUIVideoCaptureSettings: ICameraCaptureUIVideoCaptureSettings ["Windows.Media.Capture.CameraCaptureUIVideoCaptureSettings"]}
+RT_ENUM! { enum CameraCaptureUIVideoFormat: i32 ["Windows.Media.Capture.CameraCaptureUIVideoFormat"] {
     Mp4 (CameraCaptureUIVideoFormat_Mp4) = 0, Wmv (CameraCaptureUIVideoFormat_Wmv) = 1,
 }}
 RT_CLASS!{static class CameraOptionsUI}
@@ -6636,7 +6636,7 @@ impl ICapturedFrame {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CapturedFrame: ICapturedFrame}
+RT_CLASS!{class CapturedFrame: ICapturedFrame ["Windows.Media.Capture.CapturedFrame"]}
 DEFINE_IID!(IID_ICapturedFrame2, 1413457617, 48504, 18534, 173, 218, 36, 49, 75, 198, 93, 234);
 RT_INTERFACE!{interface ICapturedFrame2(ICapturedFrame2Vtbl): IInspectable(IInspectableVtbl) [IID_ICapturedFrame2] {
     fn get_ControlValues(&self, out: *mut *mut CapturedFrameControlValues) -> HRESULT,
@@ -6713,7 +6713,7 @@ impl ICapturedFrameControlValues {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CapturedFrameControlValues: ICapturedFrameControlValues}
+RT_CLASS!{class CapturedFrameControlValues: ICapturedFrameControlValues ["Windows.Media.Capture.CapturedFrameControlValues"]}
 DEFINE_IID!(IID_ICapturedFrameControlValues2, 1342909320, 1746, 19111, 167, 219, 211, 122, 247, 51, 33, 216);
 RT_INTERFACE!{interface ICapturedFrameControlValues2(ICapturedFrameControlValues2Vtbl): IInspectable(IInspectableVtbl) [IID_ICapturedFrameControlValues2] {
     fn get_FocusState(&self, out: *mut *mut foundation::IReference<super::devices::MediaCaptureFocusState>) -> HRESULT,
@@ -6777,14 +6777,14 @@ impl ICapturedPhoto {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CapturedPhoto: ICapturedPhoto}
-RT_ENUM! { enum ForegroundActivationArgument: i32 {
+RT_CLASS!{class CapturedPhoto: ICapturedPhoto ["Windows.Media.Capture.CapturedPhoto"]}
+RT_ENUM! { enum ForegroundActivationArgument: i32 ["Windows.Media.Capture.ForegroundActivationArgument"] {
     SignInRequired (ForegroundActivationArgument_SignInRequired) = 0, MoreSettings (ForegroundActivationArgument_MoreSettings) = 1,
 }}
-RT_ENUM! { enum GameBarCommand: i32 {
+RT_ENUM! { enum GameBarCommand: i32 ["Windows.Media.Capture.GameBarCommand"] {
     OpenGameBar (GameBarCommand_OpenGameBar) = 0, RecordHistoricalBuffer (GameBarCommand_RecordHistoricalBuffer) = 1, ToggleStartStopRecord (GameBarCommand_ToggleStartStopRecord) = 2, StartRecord (GameBarCommand_StartRecord) = 3, StopRecord (GameBarCommand_StopRecord) = 4, TakeScreenshot (GameBarCommand_TakeScreenshot) = 5, StartBroadcast (GameBarCommand_StartBroadcast) = 6, StopBroadcast (GameBarCommand_StopBroadcast) = 7, PauseBroadcast (GameBarCommand_PauseBroadcast) = 8, ResumeBroadcast (GameBarCommand_ResumeBroadcast) = 9, ToggleStartStopBroadcast (GameBarCommand_ToggleStartStopBroadcast) = 10, ToggleMicrophoneCapture (GameBarCommand_ToggleMicrophoneCapture) = 11, ToggleCameraCapture (GameBarCommand_ToggleCameraCapture) = 12, ToggleRecordingIndicator (GameBarCommand_ToggleRecordingIndicator) = 13,
 }}
-RT_ENUM! { enum GameBarCommandOrigin: i32 {
+RT_ENUM! { enum GameBarCommandOrigin: i32 ["Windows.Media.Capture.GameBarCommandOrigin"] {
     ShortcutKey (GameBarCommandOrigin_ShortcutKey) = 0, Cortana (GameBarCommandOrigin_Cortana) = 1, AppCommand (GameBarCommandOrigin_AppCommand) = 2,
 }}
 DEFINE_IID!(IID_IGameBarServices, 767470935, 20646, 18846, 140, 108, 211, 48, 167, 49, 23, 150);
@@ -6843,7 +6843,7 @@ impl IGameBarServices {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameBarServices: IGameBarServices}
+RT_CLASS!{class GameBarServices: IGameBarServices ["Windows.Media.Capture.GameBarServices"]}
 DEFINE_IID!(IID_IGameBarServicesCommandEventArgs, 2806130354, 61814, 20431, 143, 187, 207, 105, 139, 46, 184, 224);
 RT_INTERFACE!{interface IGameBarServicesCommandEventArgs(IGameBarServicesCommandEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IGameBarServicesCommandEventArgs] {
     fn get_Command(&self, out: *mut GameBarCommand) -> HRESULT,
@@ -6861,8 +6861,8 @@ impl IGameBarServicesCommandEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameBarServicesCommandEventArgs: IGameBarServicesCommandEventArgs}
-RT_ENUM! { enum GameBarServicesDisplayMode: i32 {
+RT_CLASS!{class GameBarServicesCommandEventArgs: IGameBarServicesCommandEventArgs ["Windows.Media.Capture.GameBarServicesCommandEventArgs"]}
+RT_ENUM! { enum GameBarServicesDisplayMode: i32 ["Windows.Media.Capture.GameBarServicesDisplayMode"] {
     Windowed (GameBarServicesDisplayMode_Windowed) = 0, FullScreenExclusive (GameBarServicesDisplayMode_FullScreenExclusive) = 1,
 }}
 DEFINE_IID!(IID_IGameBarServicesManager, 978033914, 32651, 19552, 157, 187, 11, 205, 38, 45, 255, 198);
@@ -6881,7 +6881,7 @@ impl IGameBarServicesManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameBarServicesManager: IGameBarServicesManager}
+RT_CLASS!{class GameBarServicesManager: IGameBarServicesManager ["Windows.Media.Capture.GameBarServicesManager"]}
 impl RtActivatable<IGameBarServicesManagerStatics> for GameBarServicesManager {}
 impl GameBarServicesManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<GameBarServicesManager>>> {
@@ -6900,7 +6900,7 @@ impl IGameBarServicesManagerGameBarServicesCreatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameBarServicesManagerGameBarServicesCreatedEventArgs: IGameBarServicesManagerGameBarServicesCreatedEventArgs}
+RT_CLASS!{class GameBarServicesManagerGameBarServicesCreatedEventArgs: IGameBarServicesManagerGameBarServicesCreatedEventArgs ["Windows.Media.Capture.GameBarServicesManagerGameBarServicesCreatedEventArgs"]}
 DEFINE_IID!(IID_IGameBarServicesManagerStatics, 885110294, 65317, 18322, 152, 242, 211, 117, 63, 21, 172, 19);
 RT_INTERFACE!{static interface IGameBarServicesManagerStatics(IGameBarServicesManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGameBarServicesManagerStatics] {
     fn GetDefault(&self, out: *mut *mut GameBarServicesManager) -> HRESULT
@@ -6941,11 +6941,11 @@ impl IGameBarServicesTargetInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GameBarServicesTargetInfo: IGameBarServicesTargetInfo}
-RT_ENUM! { enum GameBarTargetCapturePolicy: i32 {
+RT_CLASS!{class GameBarServicesTargetInfo: IGameBarServicesTargetInfo ["Windows.Media.Capture.GameBarServicesTargetInfo"]}
+RT_ENUM! { enum GameBarTargetCapturePolicy: i32 ["Windows.Media.Capture.GameBarTargetCapturePolicy"] {
     EnabledBySystem (GameBarTargetCapturePolicy_EnabledBySystem) = 0, EnabledByUser (GameBarTargetCapturePolicy_EnabledByUser) = 1, NotEnabled (GameBarTargetCapturePolicy_NotEnabled) = 2, ProhibitedBySystem (GameBarTargetCapturePolicy_ProhibitedBySystem) = 3, ProhibitedByPublisher (GameBarTargetCapturePolicy_ProhibitedByPublisher) = 4,
 }}
-RT_ENUM! { enum KnownVideoProfile: i32 {
+RT_ENUM! { enum KnownVideoProfile: i32 ["Windows.Media.Capture.KnownVideoProfile"] {
     VideoRecording (KnownVideoProfile_VideoRecording) = 0, HighQualityPhoto (KnownVideoProfile_HighQualityPhoto) = 1, BalancedVideoAndPhoto (KnownVideoProfile_BalancedVideoAndPhoto) = 2, VideoConferencing (KnownVideoProfile_VideoConferencing) = 3, PhotoSequence (KnownVideoProfile_PhotoSequence) = 4, HighFrameRate (KnownVideoProfile_HighFrameRate) = 5, VariablePhotoSequence (KnownVideoProfile_VariablePhotoSequence) = 6, HdrWithWcgVideo (KnownVideoProfile_HdrWithWcgVideo) = 7, HdrWithWcgPhoto (KnownVideoProfile_HdrWithWcgPhoto) = 8, VideoHdr8 (KnownVideoProfile_VideoHdr8) = 9,
 }}
 DEFINE_IID!(IID_ILowLagMediaRecording, 1103674103, 65343, 18928, 164, 119, 241, 149, 227, 206, 81, 8);
@@ -6971,7 +6971,7 @@ impl ILowLagMediaRecording {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLagMediaRecording: ILowLagMediaRecording}
+RT_CLASS!{class LowLagMediaRecording: ILowLagMediaRecording ["Windows.Media.Capture.LowLagMediaRecording"]}
 DEFINE_IID!(IID_ILowLagMediaRecording2, 1667876696, 22084, 16866, 151, 175, 142, 245, 106, 37, 226, 37);
 RT_INTERFACE!{interface ILowLagMediaRecording2(ILowLagMediaRecording2Vtbl): IInspectable(IInspectableVtbl) [IID_ILowLagMediaRecording2] {
     fn PauseAsync(&self, behavior: super::devices::MediaCapturePauseBehavior, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -7023,7 +7023,7 @@ impl ILowLagPhotoCapture {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLagPhotoCapture: ILowLagPhotoCapture}
+RT_CLASS!{class LowLagPhotoCapture: ILowLagPhotoCapture ["Windows.Media.Capture.LowLagPhotoCapture"]}
 DEFINE_IID!(IID_ILowLagPhotoSequenceCapture, 2093172411, 47529, 19601, 143, 250, 40, 126, 156, 102, 134, 105);
 RT_INTERFACE!{interface ILowLagPhotoSequenceCapture(ILowLagPhotoSequenceCaptureVtbl): IInspectable(IInspectableVtbl) [IID_ILowLagPhotoSequenceCapture] {
     fn StartAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -7058,7 +7058,7 @@ impl ILowLagPhotoSequenceCapture {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLagPhotoSequenceCapture: ILowLagPhotoSequenceCapture}
+RT_CLASS!{class LowLagPhotoSequenceCapture: ILowLagPhotoSequenceCapture ["Windows.Media.Capture.LowLagPhotoSequenceCapture"]}
 DEFINE_IID!(IID_IMediaCapture, 3323657140, 64272, 18996, 172, 24, 202, 128, 217, 200, 231, 238);
 RT_INTERFACE!{interface IMediaCapture(IMediaCaptureVtbl): IInspectable(IInspectableVtbl) [IID_IMediaCapture] {
     fn InitializeAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -7218,7 +7218,7 @@ impl IMediaCapture {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCapture: IMediaCapture}
+RT_CLASS!{class MediaCapture: IMediaCapture ["Windows.Media.Capture.MediaCapture"]}
 impl RtActivatable<IMediaCaptureStatics> for MediaCapture {}
 impl RtActivatable<IActivationFactory> for MediaCapture {}
 impl MediaCapture {
@@ -7468,7 +7468,7 @@ impl IMediaCapture6 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaCaptureDeviceExclusiveControlStatus: i32 {
+RT_ENUM! { enum MediaCaptureDeviceExclusiveControlStatus: i32 ["Windows.Media.Capture.MediaCaptureDeviceExclusiveControlStatus"] {
     ExclusiveControlAvailable (MediaCaptureDeviceExclusiveControlStatus_ExclusiveControlAvailable) = 0, SharedReadOnlyAvailable (MediaCaptureDeviceExclusiveControlStatus_SharedReadOnlyAvailable) = 1,
 }}
 DEFINE_IID!(IID_IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs, 2637140493, 42376, 17350, 137, 214, 90, 211, 34, 175, 0, 106);
@@ -7488,7 +7488,7 @@ impl IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureDeviceExclusiveControlStatusChangedEventArgs: IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs}
+RT_CLASS!{class MediaCaptureDeviceExclusiveControlStatusChangedEventArgs: IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs ["Windows.Media.Capture.MediaCaptureDeviceExclusiveControlStatusChangedEventArgs"]}
 DEFINE_IID!(IID_IMediaCaptureFailedEventArgs, 2164122612, 21700, 17088, 141, 25, 206, 161, 168, 124, 161, 139);
 RT_INTERFACE!{interface IMediaCaptureFailedEventArgs(IMediaCaptureFailedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureFailedEventArgs] {
     fn get_Message(&self, out: *mut HSTRING) -> HRESULT,
@@ -7506,7 +7506,7 @@ impl IMediaCaptureFailedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureFailedEventArgs: IMediaCaptureFailedEventArgs}
+RT_CLASS!{class MediaCaptureFailedEventArgs: IMediaCaptureFailedEventArgs ["Windows.Media.Capture.MediaCaptureFailedEventArgs"]}
 DEFINE_IID!(IID_MediaCaptureFailedEventHandler, 538243067, 23768, 20232, 163, 20, 13, 54, 13, 165, 159, 20);
 RT_DELEGATE!{delegate MediaCaptureFailedEventHandler(MediaCaptureFailedEventHandlerVtbl, MediaCaptureFailedEventHandlerImpl) [IID_MediaCaptureFailedEventHandler] {
     fn Invoke(&self, sender: *mut MediaCapture, errorEventArgs: *mut MediaCaptureFailedEventArgs) -> HRESULT
@@ -7528,7 +7528,7 @@ impl IMediaCaptureFocusChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureFocusChangedEventArgs: IMediaCaptureFocusChangedEventArgs}
+RT_CLASS!{class MediaCaptureFocusChangedEventArgs: IMediaCaptureFocusChangedEventArgs ["Windows.Media.Capture.MediaCaptureFocusChangedEventArgs"]}
 DEFINE_IID!(IID_IMediaCaptureInitializationSettings, 2541927024, 60005, 18688, 147, 86, 140, 168, 135, 114, 104, 132);
 RT_INTERFACE!{interface IMediaCaptureInitializationSettings(IMediaCaptureInitializationSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureInitializationSettings] {
     fn put_AudioDeviceId(&self, value: HSTRING) -> HRESULT,
@@ -7578,7 +7578,7 @@ impl IMediaCaptureInitializationSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureInitializationSettings: IMediaCaptureInitializationSettings}
+RT_CLASS!{class MediaCaptureInitializationSettings: IMediaCaptureInitializationSettings ["Windows.Media.Capture.MediaCaptureInitializationSettings"]}
 impl RtActivatable<IActivationFactory> for MediaCaptureInitializationSettings {}
 DEFINE_CLSID!(MediaCaptureInitializationSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,112,116,117,114,101,46,77,101,100,105,97,67,97,112,116,117,114,101,73,110,105,116,105,97,108,105,122,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_MediaCaptureInitializationSettings]);
 DEFINE_IID!(IID_IMediaCaptureInitializationSettings2, 1078855206, 51676, 17385, 174, 228, 230, 191, 27, 87, 180, 76);
@@ -7738,7 +7738,7 @@ impl IMediaCaptureInitializationSettings6 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaCaptureMemoryPreference: i32 {
+RT_ENUM! { enum MediaCaptureMemoryPreference: i32 ["Windows.Media.Capture.MediaCaptureMemoryPreference"] {
     Auto (MediaCaptureMemoryPreference_Auto) = 0, Cpu (MediaCaptureMemoryPreference_Cpu) = 1,
 }}
 DEFINE_IID!(IID_IMediaCapturePauseResult, 2932112547, 17527, 19204, 160, 111, 44, 28, 81, 130, 254, 157);
@@ -7758,7 +7758,7 @@ impl IMediaCapturePauseResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCapturePauseResult: IMediaCapturePauseResult}
+RT_CLASS!{class MediaCapturePauseResult: IMediaCapturePauseResult ["Windows.Media.Capture.MediaCapturePauseResult"]}
 DEFINE_IID!(IID_IMediaCaptureSettings, 495168254, 27973, 17527, 141, 196, 172, 91, 192, 28, 64, 145);
 RT_INTERFACE!{interface IMediaCaptureSettings(IMediaCaptureSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureSettings] {
     fn get_AudioDeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -7794,7 +7794,7 @@ impl IMediaCaptureSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureSettings: IMediaCaptureSettings}
+RT_CLASS!{class MediaCaptureSettings: IMediaCaptureSettings ["Windows.Media.Capture.MediaCaptureSettings"]}
 DEFINE_IID!(IID_IMediaCaptureSettings2, 1872657659, 64159, 19219, 156, 190, 90, 185, 79, 31, 52, 147);
 RT_INTERFACE!{interface IMediaCaptureSettings2(IMediaCaptureSettings2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureSettings2] {
     fn get_ConcurrentRecordAndPhotoSupported(&self, out: *mut bool) -> HRESULT,
@@ -7859,7 +7859,7 @@ impl IMediaCaptureSettings3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaCaptureSharingMode: i32 {
+RT_ENUM! { enum MediaCaptureSharingMode: i32 ["Windows.Media.Capture.MediaCaptureSharingMode"] {
     ExclusiveControl (MediaCaptureSharingMode_ExclusiveControl) = 0, SharedReadOnly (MediaCaptureSharingMode_SharedReadOnly) = 1,
 }}
 DEFINE_IID!(IID_IMediaCaptureStatics, 2901377535, 39405, 17989, 150, 94, 25, 37, 207, 198, 56, 52);
@@ -7908,8 +7908,8 @@ impl IMediaCaptureStopResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureStopResult: IMediaCaptureStopResult}
-RT_ENUM! { enum MediaCaptureThermalStatus: i32 {
+RT_CLASS!{class MediaCaptureStopResult: IMediaCaptureStopResult ["Windows.Media.Capture.MediaCaptureStopResult"]}
+RT_ENUM! { enum MediaCaptureThermalStatus: i32 ["Windows.Media.Capture.MediaCaptureThermalStatus"] {
     Normal (MediaCaptureThermalStatus_Normal) = 0, Overheated (MediaCaptureThermalStatus_Overheated) = 1,
 }}
 DEFINE_IID!(IID_IMediaCaptureVideoPreview, 661811315, 21662, 17535, 162, 10, 79, 3, 196, 121, 216, 192);
@@ -7982,7 +7982,7 @@ impl IMediaCaptureVideoProfile {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureVideoProfile: IMediaCaptureVideoProfile}
+RT_CLASS!{class MediaCaptureVideoProfile: IMediaCaptureVideoProfile ["Windows.Media.Capture.MediaCaptureVideoProfile"]}
 DEFINE_IID!(IID_IMediaCaptureVideoProfile2, 2547894623, 38094, 18063, 147, 22, 252, 91, 194, 99, 143, 107);
 RT_INTERFACE!{interface IMediaCaptureVideoProfile2(IMediaCaptureVideoProfile2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureVideoProfile2] {
     fn get_FrameSourceInfos(&self, out: *mut *mut foundation::collections::IVectorView<frames::MediaFrameSourceInfo>) -> HRESULT,
@@ -8035,7 +8035,7 @@ impl IMediaCaptureVideoProfileMediaDescription {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCaptureVideoProfileMediaDescription: IMediaCaptureVideoProfileMediaDescription}
+RT_CLASS!{class MediaCaptureVideoProfileMediaDescription: IMediaCaptureVideoProfileMediaDescription ["Windows.Media.Capture.MediaCaptureVideoProfileMediaDescription"]}
 DEFINE_IID!(IID_IMediaCaptureVideoProfileMediaDescription2, 3332828947, 12845, 16698, 184, 90, 104, 168, 142, 2, 244, 233);
 RT_INTERFACE!{interface IMediaCaptureVideoProfileMediaDescription2(IMediaCaptureVideoProfileMediaDescription2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaCaptureVideoProfileMediaDescription2] {
     fn get_Subtype(&self, out: *mut HSTRING) -> HRESULT,
@@ -8053,10 +8053,10 @@ impl IMediaCaptureVideoProfileMediaDescription2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaCategory: i32 {
+RT_ENUM! { enum MediaCategory: i32 ["Windows.Media.Capture.MediaCategory"] {
     Other (MediaCategory_Other) = 0, Communications (MediaCategory_Communications) = 1, Media (MediaCategory_Media) = 2, GameChat (MediaCategory_GameChat) = 3, Speech (MediaCategory_Speech) = 4,
 }}
-RT_ENUM! { enum MediaStreamType: i32 {
+RT_ENUM! { enum MediaStreamType: i32 ["Windows.Media.Capture.MediaStreamType"] {
     VideoPreview (MediaStreamType_VideoPreview) = 0, VideoRecord (MediaStreamType_VideoRecord) = 1, Audio (MediaStreamType_Audio) = 2, Photo (MediaStreamType_Photo) = 3,
 }}
 DEFINE_IID!(IID_IOptionalReferencePhotoCapturedEventArgs, 1192200371, 7789, 16465, 156, 139, 241, 216, 90, 240, 71, 183);
@@ -8076,7 +8076,7 @@ impl IOptionalReferencePhotoCapturedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OptionalReferencePhotoCapturedEventArgs: IOptionalReferencePhotoCapturedEventArgs}
+RT_CLASS!{class OptionalReferencePhotoCapturedEventArgs: IOptionalReferencePhotoCapturedEventArgs ["Windows.Media.Capture.OptionalReferencePhotoCapturedEventArgs"]}
 DEFINE_IID!(IID_IPhotoCapturedEventArgs, 926677953, 38990, 20464, 191, 133, 28, 0, 170, 188, 90, 69);
 RT_INTERFACE!{interface IPhotoCapturedEventArgs(IPhotoCapturedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPhotoCapturedEventArgs] {
     fn get_Frame(&self, out: *mut *mut CapturedFrame) -> HRESULT,
@@ -8100,8 +8100,8 @@ impl IPhotoCapturedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoCapturedEventArgs: IPhotoCapturedEventArgs}
-RT_ENUM! { enum PhotoCaptureSource: i32 {
+RT_CLASS!{class PhotoCapturedEventArgs: IPhotoCapturedEventArgs ["Windows.Media.Capture.PhotoCapturedEventArgs"]}
+RT_ENUM! { enum PhotoCaptureSource: i32 ["Windows.Media.Capture.PhotoCaptureSource"] {
     Auto (PhotoCaptureSource_Auto) = 0, VideoPreview (PhotoCaptureSource_VideoPreview) = 1, Photo (PhotoCaptureSource_Photo) = 2,
 }}
 DEFINE_IID!(IID_IPhotoConfirmationCapturedEventArgs, 2873570930, 49802, 18471, 143, 141, 54, 54, 211, 190, 181, 30);
@@ -8121,8 +8121,8 @@ impl IPhotoConfirmationCapturedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoConfirmationCapturedEventArgs: IPhotoConfirmationCapturedEventArgs}
-RT_ENUM! { enum PowerlineFrequency: i32 {
+RT_CLASS!{class PhotoConfirmationCapturedEventArgs: IPhotoConfirmationCapturedEventArgs ["Windows.Media.Capture.PhotoConfirmationCapturedEventArgs"]}
+RT_ENUM! { enum PowerlineFrequency: i32 ["Windows.Media.Capture.PowerlineFrequency"] {
     Disabled (PowerlineFrequency_Disabled) = 0, FiftyHertz (PowerlineFrequency_FiftyHertz) = 1, SixtyHertz (PowerlineFrequency_SixtyHertz) = 2, Auto (PowerlineFrequency_Auto) = 3,
 }}
 DEFINE_IID!(IID_RecordLimitationExceededEventHandler, 1068404526, 20449, 20477, 170, 186, 225, 241, 51, 125, 78, 83);
@@ -8135,13 +8135,13 @@ impl RecordLimitationExceededEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StreamingCaptureMode: i32 {
+RT_ENUM! { enum StreamingCaptureMode: i32 ["Windows.Media.Capture.StreamingCaptureMode"] {
     AudioAndVideo (StreamingCaptureMode_AudioAndVideo) = 0, Audio (StreamingCaptureMode_Audio) = 1, Video (StreamingCaptureMode_Video) = 2,
 }}
-RT_ENUM! { enum VideoDeviceCharacteristic: i32 {
+RT_ENUM! { enum VideoDeviceCharacteristic: i32 ["Windows.Media.Capture.VideoDeviceCharacteristic"] {
     AllStreamsIndependent (VideoDeviceCharacteristic_AllStreamsIndependent) = 0, PreviewRecordStreamsIdentical (VideoDeviceCharacteristic_PreviewRecordStreamsIdentical) = 1, PreviewPhotoStreamsIdentical (VideoDeviceCharacteristic_PreviewPhotoStreamsIdentical) = 2, RecordPhotoStreamsIdentical (VideoDeviceCharacteristic_RecordPhotoStreamsIdentical) = 3, AllStreamsIdentical (VideoDeviceCharacteristic_AllStreamsIdentical) = 4,
 }}
-RT_ENUM! { enum VideoRotation: i32 {
+RT_ENUM! { enum VideoRotation: i32 ["Windows.Media.Capture.VideoRotation"] {
     None (VideoRotation_None) = 0, Clockwise90Degrees (VideoRotation_Clockwise90Degrees) = 1, Clockwise180Degrees (VideoRotation_Clockwise180Degrees) = 2, Clockwise270Degrees (VideoRotation_Clockwise270Degrees) = 3,
 }}
 DEFINE_IID!(IID_IVideoStreamConfiguration, 3631680111, 17296, 19294, 173, 62, 15, 138, 240, 150, 52, 144);
@@ -8161,8 +8161,8 @@ impl IVideoStreamConfiguration {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoStreamConfiguration: IVideoStreamConfiguration}
-RT_STRUCT! { struct WhiteBalanceGain {
+RT_CLASS!{class VideoStreamConfiguration: IVideoStreamConfiguration ["Windows.Media.Capture.VideoStreamConfiguration"]}
+RT_STRUCT! { struct WhiteBalanceGain ["Windows.Media.Capture.WhiteBalanceGain"] {
     R: f64, G: f64, B: f64,
 }}
 pub mod core { // Windows.Media.Capture.Core
@@ -8196,7 +8196,7 @@ impl IVariablePhotoCapturedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VariablePhotoCapturedEventArgs: IVariablePhotoCapturedEventArgs}
+RT_CLASS!{class VariablePhotoCapturedEventArgs: IVariablePhotoCapturedEventArgs ["Windows.Media.Capture.Core.VariablePhotoCapturedEventArgs"]}
 DEFINE_IID!(IID_IVariablePhotoSequenceCapture, 3490786589, 798, 16449, 166, 214, 189, 116, 36, 118, 168, 238);
 RT_INTERFACE!{interface IVariablePhotoSequenceCapture(IVariablePhotoSequenceCaptureVtbl): IInspectable(IInspectableVtbl) [IID_IVariablePhotoSequenceCapture] {
     fn StartAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -8242,7 +8242,7 @@ impl IVariablePhotoSequenceCapture {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VariablePhotoSequenceCapture: IVariablePhotoSequenceCapture}
+RT_CLASS!{class VariablePhotoSequenceCapture: IVariablePhotoSequenceCapture ["Windows.Media.Capture.Core.VariablePhotoSequenceCapture"]}
 DEFINE_IID!(IID_IVariablePhotoSequenceCapture2, 4264321724, 20656, 17379, 145, 124, 227, 185, 39, 152, 148, 47);
 RT_INTERFACE!{interface IVariablePhotoSequenceCapture2(IVariablePhotoSequenceCapture2Vtbl): IInspectable(IInspectableVtbl) [IID_IVariablePhotoSequenceCapture2] {
     fn UpdateSettingsAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT
@@ -8280,7 +8280,7 @@ impl IAudioMediaFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioMediaFrame: IAudioMediaFrame}
+RT_CLASS!{class AudioMediaFrame: IAudioMediaFrame ["Windows.Media.Capture.Frames.AudioMediaFrame"]}
 DEFINE_IID!(IID_IBufferMediaFrame, 3048297415, 39812, 16482, 183, 156, 163, 101, 178, 89, 104, 84);
 RT_INTERFACE!{interface IBufferMediaFrame(IBufferMediaFrameVtbl): IInspectable(IInspectableVtbl) [IID_IBufferMediaFrame] {
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
@@ -8298,7 +8298,7 @@ impl IBufferMediaFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BufferMediaFrame: IBufferMediaFrame}
+RT_CLASS!{class BufferMediaFrame: IBufferMediaFrame ["Windows.Media.Capture.Frames.BufferMediaFrame"]}
 DEFINE_IID!(IID_IDepthMediaFrame, 1192451663, 34121, 17856, 146, 91, 128, 211, 94, 253, 177, 10);
 RT_INTERFACE!{interface IDepthMediaFrame(IDepthMediaFrameVtbl): IInspectable(IInspectableVtbl) [IID_IDepthMediaFrame] {
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
@@ -8328,7 +8328,7 @@ impl IDepthMediaFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DepthMediaFrame: IDepthMediaFrame}
+RT_CLASS!{class DepthMediaFrame: IDepthMediaFrame ["Windows.Media.Capture.Frames.DepthMediaFrame"]}
 DEFINE_IID!(IID_IDepthMediaFrame2, 1825195837, 50340, 16758, 176, 205, 51, 234, 227, 179, 90, 163);
 RT_INTERFACE!{interface IDepthMediaFrame2(IDepthMediaFrame2Vtbl): IInspectable(IInspectableVtbl) [IID_IDepthMediaFrame2] {
     fn get_MaxReliableDepth(&self, out: *mut u32) -> HRESULT,
@@ -8363,7 +8363,7 @@ impl IDepthMediaFrameFormat {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DepthMediaFrameFormat: IDepthMediaFrameFormat}
+RT_CLASS!{class DepthMediaFrameFormat: IDepthMediaFrameFormat ["Windows.Media.Capture.Frames.DepthMediaFrameFormat"]}
 DEFINE_IID!(IID_IInfraredMediaFrame, 1070675203, 75, 20238, 145, 172, 70, 82, 153, 180, 22, 88);
 RT_INTERFACE!{interface IInfraredMediaFrame(IInfraredMediaFrameVtbl): IInspectable(IInspectableVtbl) [IID_IInfraredMediaFrame] {
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
@@ -8387,12 +8387,12 @@ impl IInfraredMediaFrame {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InfraredMediaFrame: IInfraredMediaFrame}
+RT_CLASS!{class InfraredMediaFrame: IInfraredMediaFrame ["Windows.Media.Capture.Frames.InfraredMediaFrame"]}
 DEFINE_IID!(IID_IMediaFrameArrivedEventArgs, 188943069, 42128, 17461, 173, 161, 154, 255, 213, 82, 57, 247);
 RT_INTERFACE!{interface IMediaFrameArrivedEventArgs(IMediaFrameArrivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameArrivedEventArgs] {
     
 }}
-RT_CLASS!{class MediaFrameArrivedEventArgs: IMediaFrameArrivedEventArgs}
+RT_CLASS!{class MediaFrameArrivedEventArgs: IMediaFrameArrivedEventArgs ["Windows.Media.Capture.Frames.MediaFrameArrivedEventArgs"]}
 DEFINE_IID!(IID_IMediaFrameFormat, 1905273678, 45689, 19095, 169, 219, 189, 90, 47, 183, 143, 57);
 RT_INTERFACE!{interface IMediaFrameFormat(IMediaFrameFormatVtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameFormat] {
     fn get_MajorType(&self, out: *mut HSTRING) -> HRESULT,
@@ -8428,7 +8428,7 @@ impl IMediaFrameFormat {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameFormat: IMediaFrameFormat}
+RT_CLASS!{class MediaFrameFormat: IMediaFrameFormat ["Windows.Media.Capture.Frames.MediaFrameFormat"]}
 DEFINE_IID!(IID_IMediaFrameFormat2, 1669686080, 24199, 19472, 134, 209, 109, 240, 151, 166, 198, 168);
 RT_INTERFACE!{interface IMediaFrameFormat2(IMediaFrameFormat2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameFormat2] {
     fn get_AudioEncodingProperties(&self, out: *mut *mut super::super::mediaproperties::AudioEncodingProperties) -> HRESULT
@@ -8474,7 +8474,7 @@ impl IMediaFrameReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameReader: IMediaFrameReader}
+RT_CLASS!{class MediaFrameReader: IMediaFrameReader ["Windows.Media.Capture.Frames.MediaFrameReader"]}
 DEFINE_IID!(IID_IMediaFrameReader2, 2266048435, 34097, 16464, 135, 204, 161, 55, 51, 207, 62, 155);
 RT_INTERFACE!{interface IMediaFrameReader2(IMediaFrameReader2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameReader2] {
     fn put_AcquisitionMode(&self, value: MediaFrameReaderAcquisitionMode) -> HRESULT,
@@ -8491,10 +8491,10 @@ impl IMediaFrameReader2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaFrameReaderAcquisitionMode: i32 {
+RT_ENUM! { enum MediaFrameReaderAcquisitionMode: i32 ["Windows.Media.Capture.Frames.MediaFrameReaderAcquisitionMode"] {
     Realtime (MediaFrameReaderAcquisitionMode_Realtime) = 0, Buffered (MediaFrameReaderAcquisitionMode_Buffered) = 1,
 }}
-RT_ENUM! { enum MediaFrameReaderStartStatus: i32 {
+RT_ENUM! { enum MediaFrameReaderStartStatus: i32 ["Windows.Media.Capture.Frames.MediaFrameReaderStartStatus"] {
     Success (MediaFrameReaderStartStatus_Success) = 0, UnknownFailure (MediaFrameReaderStartStatus_UnknownFailure) = 1, DeviceNotAvailable (MediaFrameReaderStartStatus_DeviceNotAvailable) = 2, OutputFormatNotSupported (MediaFrameReaderStartStatus_OutputFormatNotSupported) = 3, ExclusiveControlNotAvailable (MediaFrameReaderStartStatus_ExclusiveControlNotAvailable) = 4,
 }}
 DEFINE_IID!(IID_IMediaFrameReference, 4139288129, 61660, 16452, 141, 201, 150, 28, 237, 208, 91, 173);
@@ -8550,7 +8550,7 @@ impl IMediaFrameReference {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameReference: IMediaFrameReference}
+RT_CLASS!{class MediaFrameReference: IMediaFrameReference ["Windows.Media.Capture.Frames.MediaFrameReference"]}
 DEFINE_IID!(IID_IMediaFrameReference2, 3720101580, 54706, 18927, 131, 106, 148, 125, 152, 155, 128, 193);
 RT_INTERFACE!{interface IMediaFrameReference2(IMediaFrameReference2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameReference2] {
     fn get_AudioMediaFrame(&self, out: *mut *mut AudioMediaFrame) -> HRESULT
@@ -8614,7 +8614,7 @@ impl IMediaFrameSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameSource: IMediaFrameSource}
+RT_CLASS!{class MediaFrameSource: IMediaFrameSource ["Windows.Media.Capture.Frames.MediaFrameSource"]}
 DEFINE_IID!(IID_IMediaFrameSourceController, 1829201461, 12653, 19343, 183, 182, 238, 176, 74, 140, 101, 37);
 RT_INTERFACE!{interface IMediaFrameSourceController(IMediaFrameSourceControllerVtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameSourceController] {
     fn GetPropertyAsync(&self, propertyId: HSTRING, out: *mut *mut foundation::IAsyncOperation<MediaFrameSourceGetPropertyResult>) -> HRESULT,
@@ -8638,7 +8638,7 @@ impl IMediaFrameSourceController {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameSourceController: IMediaFrameSourceController}
+RT_CLASS!{class MediaFrameSourceController: IMediaFrameSourceController ["Windows.Media.Capture.Frames.MediaFrameSourceController"]}
 DEFINE_IID!(IID_IMediaFrameSourceController2, 4022640596, 64754, 18947, 180, 228, 172, 150, 40, 115, 155, 238);
 RT_INTERFACE!{interface IMediaFrameSourceController2(IMediaFrameSourceController2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameSourceController2] {
     fn GetPropertyByExtendedIdAsync(&self, extendedPropertyIdSize: u32, extendedPropertyId: *mut u8, maxPropertyValueSize: *mut foundation::IReference<u32>, out: *mut *mut foundation::IAsyncOperation<MediaFrameSourceGetPropertyResult>) -> HRESULT,
@@ -8684,8 +8684,8 @@ impl IMediaFrameSourceGetPropertyResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameSourceGetPropertyResult: IMediaFrameSourceGetPropertyResult}
-RT_ENUM! { enum MediaFrameSourceGetPropertyStatus: i32 {
+RT_CLASS!{class MediaFrameSourceGetPropertyResult: IMediaFrameSourceGetPropertyResult ["Windows.Media.Capture.Frames.MediaFrameSourceGetPropertyResult"]}
+RT_ENUM! { enum MediaFrameSourceGetPropertyStatus: i32 ["Windows.Media.Capture.Frames.MediaFrameSourceGetPropertyStatus"] {
     Success (MediaFrameSourceGetPropertyStatus_Success) = 0, UnknownFailure (MediaFrameSourceGetPropertyStatus_UnknownFailure) = 1, NotSupported (MediaFrameSourceGetPropertyStatus_NotSupported) = 2, DeviceNotAvailable (MediaFrameSourceGetPropertyStatus_DeviceNotAvailable) = 3, MaxPropertyValueSizeTooSmall (MediaFrameSourceGetPropertyStatus_MaxPropertyValueSizeTooSmall) = 4, MaxPropertyValueSizeRequired (MediaFrameSourceGetPropertyStatus_MaxPropertyValueSizeRequired) = 5,
 }}
 DEFINE_IID!(IID_IMediaFrameSourceGroup, 2137021319, 18482, 19295, 174, 61, 65, 47, 170, 179, 125, 52);
@@ -8711,7 +8711,7 @@ impl IMediaFrameSourceGroup {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameSourceGroup: IMediaFrameSourceGroup}
+RT_CLASS!{class MediaFrameSourceGroup: IMediaFrameSourceGroup ["Windows.Media.Capture.Frames.MediaFrameSourceGroup"]}
 impl RtActivatable<IMediaFrameSourceGroupStatics> for MediaFrameSourceGroup {}
 impl MediaFrameSourceGroup {
     #[inline] pub fn find_all_async() -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<MediaFrameSourceGroup>>>> {
@@ -8796,7 +8796,7 @@ impl IMediaFrameSourceInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaFrameSourceInfo: IMediaFrameSourceInfo}
+RT_CLASS!{class MediaFrameSourceInfo: IMediaFrameSourceInfo ["Windows.Media.Capture.Frames.MediaFrameSourceInfo"]}
 DEFINE_IID!(IID_IMediaFrameSourceInfo2, 425359445, 25687, 17094, 167, 105, 25, 182, 91, 211, 46, 110);
 RT_INTERFACE!{interface IMediaFrameSourceInfo2(IMediaFrameSourceInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaFrameSourceInfo2] {
     fn get_ProfileId(&self, out: *mut HSTRING) -> HRESULT,
@@ -8814,17 +8814,17 @@ impl IMediaFrameSourceInfo2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaFrameSourceKind: i32 {
+RT_ENUM! { enum MediaFrameSourceKind: i32 ["Windows.Media.Capture.Frames.MediaFrameSourceKind"] {
     Custom (MediaFrameSourceKind_Custom) = 0, Color (MediaFrameSourceKind_Color) = 1, Infrared (MediaFrameSourceKind_Infrared) = 2, Depth (MediaFrameSourceKind_Depth) = 3, Audio (MediaFrameSourceKind_Audio) = 4, Image (MediaFrameSourceKind_Image) = 5,
 }}
-RT_ENUM! { enum MediaFrameSourceSetPropertyStatus: i32 {
+RT_ENUM! { enum MediaFrameSourceSetPropertyStatus: i32 ["Windows.Media.Capture.Frames.MediaFrameSourceSetPropertyStatus"] {
     Success (MediaFrameSourceSetPropertyStatus_Success) = 0, UnknownFailure (MediaFrameSourceSetPropertyStatus_UnknownFailure) = 1, NotSupported (MediaFrameSourceSetPropertyStatus_NotSupported) = 2, InvalidValue (MediaFrameSourceSetPropertyStatus_InvalidValue) = 3, DeviceNotAvailable (MediaFrameSourceSetPropertyStatus_DeviceNotAvailable) = 4, NotInControl (MediaFrameSourceSetPropertyStatus_NotInControl) = 5,
 }}
 DEFINE_IID!(IID_IMultiSourceMediaFrameArrivedEventArgs, 1662082561, 53073, 18685, 170, 176, 109, 105, 62, 180, 129, 39);
 RT_INTERFACE!{interface IMultiSourceMediaFrameArrivedEventArgs(IMultiSourceMediaFrameArrivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMultiSourceMediaFrameArrivedEventArgs] {
     
 }}
-RT_CLASS!{class MultiSourceMediaFrameArrivedEventArgs: IMultiSourceMediaFrameArrivedEventArgs}
+RT_CLASS!{class MultiSourceMediaFrameArrivedEventArgs: IMultiSourceMediaFrameArrivedEventArgs ["Windows.Media.Capture.Frames.MultiSourceMediaFrameArrivedEventArgs"]}
 DEFINE_IID!(IID_IMultiSourceMediaFrameReader, 2366915586, 63331, 18573, 152, 242, 180, 55, 188, 240, 117, 231);
 RT_INTERFACE!{interface IMultiSourceMediaFrameReader(IMultiSourceMediaFrameReaderVtbl): IInspectable(IInspectableVtbl) [IID_IMultiSourceMediaFrameReader] {
     fn add_FrameArrived(&self, handler: *mut foundation::TypedEventHandler<MultiSourceMediaFrameReader, MultiSourceMediaFrameArrivedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -8859,7 +8859,7 @@ impl IMultiSourceMediaFrameReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MultiSourceMediaFrameReader: IMultiSourceMediaFrameReader}
+RT_CLASS!{class MultiSourceMediaFrameReader: IMultiSourceMediaFrameReader ["Windows.Media.Capture.Frames.MultiSourceMediaFrameReader"]}
 DEFINE_IID!(IID_IMultiSourceMediaFrameReader2, 4015819453, 64604, 19563, 157, 129, 60, 185, 204, 99, 124, 38);
 RT_INTERFACE!{interface IMultiSourceMediaFrameReader2(IMultiSourceMediaFrameReader2Vtbl): IInspectable(IInspectableVtbl) [IID_IMultiSourceMediaFrameReader2] {
     fn put_AcquisitionMode(&self, value: MediaFrameReaderAcquisitionMode) -> HRESULT,
@@ -8876,7 +8876,7 @@ impl IMultiSourceMediaFrameReader2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MultiSourceMediaFrameReaderStartStatus: i32 {
+RT_ENUM! { enum MultiSourceMediaFrameReaderStartStatus: i32 ["Windows.Media.Capture.Frames.MultiSourceMediaFrameReaderStartStatus"] {
     Success (MultiSourceMediaFrameReaderStartStatus_Success) = 0, NotSupported (MultiSourceMediaFrameReaderStartStatus_NotSupported) = 1, InsufficientResources (MultiSourceMediaFrameReaderStartStatus_InsufficientResources) = 2, DeviceNotAvailable (MultiSourceMediaFrameReaderStartStatus_DeviceNotAvailable) = 3, UnknownFailure (MultiSourceMediaFrameReaderStartStatus_UnknownFailure) = 4,
 }}
 DEFINE_IID!(IID_IMultiSourceMediaFrameReference, 563497754, 32738, 17622, 146, 229, 41, 142, 109, 40, 16, 233);
@@ -8890,7 +8890,7 @@ impl IMultiSourceMediaFrameReference {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MultiSourceMediaFrameReference: IMultiSourceMediaFrameReference}
+RT_CLASS!{class MultiSourceMediaFrameReference: IMultiSourceMediaFrameReference ["Windows.Media.Capture.Frames.MultiSourceMediaFrameReference"]}
 DEFINE_IID!(IID_IVideoMediaFrame, 14503115, 12989, 20449, 160, 19, 124, 193, 60, 245, 219, 207);
 RT_INTERFACE!{interface IVideoMediaFrame(IVideoMediaFrameVtbl): IInspectable(IInspectableVtbl) [IID_IVideoMediaFrame] {
     fn get_FrameReference(&self, out: *mut *mut MediaFrameReference) -> HRESULT,
@@ -8946,7 +8946,7 @@ impl IVideoMediaFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoMediaFrame: IVideoMediaFrame}
+RT_CLASS!{class VideoMediaFrame: IVideoMediaFrame ["Windows.Media.Capture.Frames.VideoMediaFrame"]}
 DEFINE_IID!(IID_IVideoMediaFrameFormat, 1174568896, 55067, 17863, 143, 20, 109, 154, 10, 230, 4, 228);
 RT_INTERFACE!{interface IVideoMediaFrameFormat(IVideoMediaFrameFormatVtbl): IInspectable(IInspectableVtbl) [IID_IVideoMediaFrameFormat] {
     fn get_MediaFrameFormat(&self, out: *mut *mut MediaFrameFormat) -> HRESULT,
@@ -8976,7 +8976,7 @@ impl IVideoMediaFrameFormat {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoMediaFrameFormat: IVideoMediaFrameFormat}
+RT_CLASS!{class VideoMediaFrameFormat: IVideoMediaFrameFormat ["Windows.Media.Capture.Frames.VideoMediaFrameFormat"]}
 } // Windows.Media.Capture.Frames
 } // Windows.Media.Capture
 pub mod casting { // Windows.Media.Casting
@@ -9043,7 +9043,7 @@ impl ICastingConnection {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingConnection: ICastingConnection}
+RT_CLASS!{class CastingConnection: ICastingConnection ["Windows.Media.Casting.CastingConnection"]}
 DEFINE_IID!(IID_ICastingConnectionErrorOccurredEventArgs, 2818260073, 34585, 20224, 129, 251, 150, 24, 99, 199, 154, 50);
 RT_INTERFACE!{interface ICastingConnectionErrorOccurredEventArgs(ICastingConnectionErrorOccurredEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICastingConnectionErrorOccurredEventArgs] {
     fn get_ErrorStatus(&self, out: *mut CastingConnectionErrorStatus) -> HRESULT,
@@ -9061,11 +9061,11 @@ impl ICastingConnectionErrorOccurredEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingConnectionErrorOccurredEventArgs: ICastingConnectionErrorOccurredEventArgs}
-RT_ENUM! { enum CastingConnectionErrorStatus: i32 {
+RT_CLASS!{class CastingConnectionErrorOccurredEventArgs: ICastingConnectionErrorOccurredEventArgs ["Windows.Media.Casting.CastingConnectionErrorOccurredEventArgs"]}
+RT_ENUM! { enum CastingConnectionErrorStatus: i32 ["Windows.Media.Casting.CastingConnectionErrorStatus"] {
     Succeeded (CastingConnectionErrorStatus_Succeeded) = 0, DeviceDidNotRespond (CastingConnectionErrorStatus_DeviceDidNotRespond) = 1, DeviceError (CastingConnectionErrorStatus_DeviceError) = 2, DeviceLocked (CastingConnectionErrorStatus_DeviceLocked) = 3, ProtectedPlaybackFailed (CastingConnectionErrorStatus_ProtectedPlaybackFailed) = 4, InvalidCastingSource (CastingConnectionErrorStatus_InvalidCastingSource) = 5, Unknown (CastingConnectionErrorStatus_Unknown) = 6,
 }}
-RT_ENUM! { enum CastingConnectionState: i32 {
+RT_ENUM! { enum CastingConnectionState: i32 ["Windows.Media.Casting.CastingConnectionState"] {
     Disconnected (CastingConnectionState_Disconnected) = 0, Connected (CastingConnectionState_Connected) = 1, Rendering (CastingConnectionState_Rendering) = 2, Disconnecting (CastingConnectionState_Disconnecting) = 3, Connecting (CastingConnectionState_Connecting) = 4,
 }}
 DEFINE_IID!(IID_ICastingDevice, 3732020355, 19011, 19153, 166, 210, 36, 146, 167, 150, 195, 242);
@@ -9104,7 +9104,7 @@ impl ICastingDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingDevice: ICastingDevice}
+RT_CLASS!{class CastingDevice: ICastingDevice ["Windows.Media.Casting.CastingDevice"]}
 impl RtActivatable<ICastingDeviceStatics> for CastingDevice {}
 impl CastingDevice {
     #[inline] pub fn get_device_selector(type_: CastingPlaybackTypes) -> Result<HString> {
@@ -9177,7 +9177,7 @@ impl ICastingDevicePicker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingDevicePicker: ICastingDevicePicker}
+RT_CLASS!{class CastingDevicePicker: ICastingDevicePicker ["Windows.Media.Casting.CastingDevicePicker"]}
 impl RtActivatable<IActivationFactory> for CastingDevicePicker {}
 DEFINE_CLSID!(CastingDevicePicker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,97,115,116,105,110,103,46,67,97,115,116,105,110,103,68,101,118,105,99,101,80,105,99,107,101,114,0]) [CLSID_CastingDevicePicker]);
 DEFINE_IID!(IID_ICastingDevicePickerFilter, 3196871068, 46435, 17236, 174, 51, 159, 218, 173, 140, 98, 145);
@@ -9224,7 +9224,7 @@ impl ICastingDevicePickerFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingDevicePickerFilter: ICastingDevicePickerFilter}
+RT_CLASS!{class CastingDevicePickerFilter: ICastingDevicePickerFilter ["Windows.Media.Casting.CastingDevicePickerFilter"]}
 DEFINE_IID!(IID_ICastingDeviceSelectedEventArgs, 3695419014, 56663, 19725, 148, 0, 175, 69, 228, 251, 54, 99);
 RT_INTERFACE!{interface ICastingDeviceSelectedEventArgs(ICastingDeviceSelectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICastingDeviceSelectedEventArgs] {
     fn get_SelectedCastingDevice(&self, out: *mut *mut CastingDevice) -> HRESULT
@@ -9236,7 +9236,7 @@ impl ICastingDeviceSelectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingDeviceSelectedEventArgs: ICastingDeviceSelectedEventArgs}
+RT_CLASS!{class CastingDeviceSelectedEventArgs: ICastingDeviceSelectedEventArgs ["Windows.Media.Casting.CastingDeviceSelectedEventArgs"]}
 DEFINE_IID!(IID_ICastingDeviceStatics, 3889780951, 19731, 16951, 163, 101, 76, 79, 106, 76, 253, 47);
 RT_INTERFACE!{static interface ICastingDeviceStatics(ICastingDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICastingDeviceStatics] {
     fn GetDeviceSelector(&self, type_: CastingPlaybackTypes, out: *mut HSTRING) -> HRESULT,
@@ -9266,7 +9266,7 @@ impl ICastingDeviceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CastingPlaybackTypes: u32 {
+RT_ENUM! { enum CastingPlaybackTypes: u32 ["Windows.Media.Casting.CastingPlaybackTypes"] {
     None (CastingPlaybackTypes_None) = 0, Audio (CastingPlaybackTypes_Audio) = 1, Video (CastingPlaybackTypes_Video) = 2, Picture (CastingPlaybackTypes_Picture) = 4,
 }}
 DEFINE_IID!(IID_ICastingSource, 4096387698, 13415, 18406, 160, 39, 82, 41, 35, 233, 215, 39);
@@ -9285,17 +9285,17 @@ impl ICastingSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CastingSource: ICastingSource}
+RT_CLASS!{class CastingSource: ICastingSource ["Windows.Media.Casting.CastingSource"]}
 } // Windows.Media.Casting
 pub mod closedcaptioning { // Windows.Media.ClosedCaptioning
 use ::prelude::*;
-RT_ENUM! { enum ClosedCaptionColor: i32 {
+RT_ENUM! { enum ClosedCaptionColor: i32 ["Windows.Media.ClosedCaptioning.ClosedCaptionColor"] {
     Default (ClosedCaptionColor_Default) = 0, White (ClosedCaptionColor_White) = 1, Black (ClosedCaptionColor_Black) = 2, Red (ClosedCaptionColor_Red) = 3, Green (ClosedCaptionColor_Green) = 4, Blue (ClosedCaptionColor_Blue) = 5, Yellow (ClosedCaptionColor_Yellow) = 6, Magenta (ClosedCaptionColor_Magenta) = 7, Cyan (ClosedCaptionColor_Cyan) = 8,
 }}
-RT_ENUM! { enum ClosedCaptionEdgeEffect: i32 {
+RT_ENUM! { enum ClosedCaptionEdgeEffect: i32 ["Windows.Media.ClosedCaptioning.ClosedCaptionEdgeEffect"] {
     Default (ClosedCaptionEdgeEffect_Default) = 0, None (ClosedCaptionEdgeEffect_None) = 1, Raised (ClosedCaptionEdgeEffect_Raised) = 2, Depressed (ClosedCaptionEdgeEffect_Depressed) = 3, Uniform (ClosedCaptionEdgeEffect_Uniform) = 4, DropShadow (ClosedCaptionEdgeEffect_DropShadow) = 5,
 }}
-RT_ENUM! { enum ClosedCaptionOpacity: i32 {
+RT_ENUM! { enum ClosedCaptionOpacity: i32 ["Windows.Media.ClosedCaptioning.ClosedCaptionOpacity"] {
     Default (ClosedCaptionOpacity_Default) = 0, OneHundredPercent (ClosedCaptionOpacity_OneHundredPercent) = 1, SeventyFivePercent (ClosedCaptionOpacity_SeventyFivePercent) = 2, TwentyFivePercent (ClosedCaptionOpacity_TwentyFivePercent) = 3, ZeroPercent (ClosedCaptionOpacity_ZeroPercent) = 4,
 }}
 RT_CLASS!{static class ClosedCaptionProperties}
@@ -9419,16 +9419,16 @@ impl IClosedCaptionPropertiesStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ClosedCaptionSize: i32 {
+RT_ENUM! { enum ClosedCaptionSize: i32 ["Windows.Media.ClosedCaptioning.ClosedCaptionSize"] {
     Default (ClosedCaptionSize_Default) = 0, FiftyPercent (ClosedCaptionSize_FiftyPercent) = 1, OneHundredPercent (ClosedCaptionSize_OneHundredPercent) = 2, OneHundredFiftyPercent (ClosedCaptionSize_OneHundredFiftyPercent) = 3, TwoHundredPercent (ClosedCaptionSize_TwoHundredPercent) = 4,
 }}
-RT_ENUM! { enum ClosedCaptionStyle: i32 {
+RT_ENUM! { enum ClosedCaptionStyle: i32 ["Windows.Media.ClosedCaptioning.ClosedCaptionStyle"] {
     Default (ClosedCaptionStyle_Default) = 0, MonospacedWithSerifs (ClosedCaptionStyle_MonospacedWithSerifs) = 1, ProportionalWithSerifs (ClosedCaptionStyle_ProportionalWithSerifs) = 2, MonospacedWithoutSerifs (ClosedCaptionStyle_MonospacedWithoutSerifs) = 3, ProportionalWithoutSerifs (ClosedCaptionStyle_ProportionalWithoutSerifs) = 4, Casual (ClosedCaptionStyle_Casual) = 5, Cursive (ClosedCaptionStyle_Cursive) = 6, SmallCapitals (ClosedCaptionStyle_SmallCapitals) = 7,
 }}
 } // Windows.Media.ClosedCaptioning
 pub mod contentrestrictions { // Windows.Media.ContentRestrictions
 use ::prelude::*;
-RT_ENUM! { enum ContentAccessRestrictionLevel: i32 {
+RT_ENUM! { enum ContentAccessRestrictionLevel: i32 ["Windows.Media.ContentRestrictions.ContentAccessRestrictionLevel"] {
     Allow (ContentAccessRestrictionLevel_Allow) = 0, Warn (ContentAccessRestrictionLevel_Warn) = 1, Block (ContentAccessRestrictionLevel_Block) = 2, Hide (ContentAccessRestrictionLevel_Hide) = 3,
 }}
 DEFINE_IID!(IID_IContentRestrictionsBrowsePolicy, 2348888996, 17454, 17946, 135, 87, 250, 210, 245, 189, 55, 228);
@@ -9454,8 +9454,8 @@ impl IContentRestrictionsBrowsePolicy {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContentRestrictionsBrowsePolicy: IContentRestrictionsBrowsePolicy}
-RT_ENUM! { enum RatedContentCategory: i32 {
+RT_CLASS!{class ContentRestrictionsBrowsePolicy: IContentRestrictionsBrowsePolicy ["Windows.Media.ContentRestrictions.ContentRestrictionsBrowsePolicy"]}
+RT_ENUM! { enum RatedContentCategory: i32 ["Windows.Media.ContentRestrictions.RatedContentCategory"] {
     General (RatedContentCategory_General) = 0, Application (RatedContentCategory_Application) = 1, Game (RatedContentCategory_Game) = 2, Movie (RatedContentCategory_Movie) = 3, Television (RatedContentCategory_Television) = 4, Music (RatedContentCategory_Music) = 5,
 }}
 DEFINE_IID!(IID_IRatedContentDescription, 1766352607, 26290, 19907, 150, 177, 240, 144, 238, 222, 226, 85);
@@ -9520,7 +9520,7 @@ impl IRatedContentDescription {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RatedContentDescription: IRatedContentDescription}
+RT_CLASS!{class RatedContentDescription: IRatedContentDescription ["Windows.Media.ContentRestrictions.RatedContentDescription"]}
 impl RtActivatable<IRatedContentDescriptionFactory> for RatedContentDescription {}
 impl RatedContentDescription {
     #[inline] pub fn create(id: &HStringArg, title: &HStringArg, category: RatedContentCategory) -> Result<ComPtr<RatedContentDescription>> {
@@ -9573,7 +9573,7 @@ impl IRatedContentRestrictions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RatedContentRestrictions: IRatedContentRestrictions}
+RT_CLASS!{class RatedContentRestrictions: IRatedContentRestrictions ["Windows.Media.ContentRestrictions.RatedContentRestrictions"]}
 impl RtActivatable<IRatedContentRestrictionsFactory> for RatedContentRestrictions {}
 impl RtActivatable<IActivationFactory> for RatedContentRestrictions {}
 impl RatedContentRestrictions {
@@ -9600,7 +9600,7 @@ DEFINE_IID!(IID_ICurrentSessionChangedEventArgs, 1768540985, 3066, 24544, 141, 1
 RT_INTERFACE!{interface ICurrentSessionChangedEventArgs(ICurrentSessionChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICurrentSessionChangedEventArgs] {
     
 }}
-RT_CLASS!{class CurrentSessionChangedEventArgs: ICurrentSessionChangedEventArgs}
+RT_CLASS!{class CurrentSessionChangedEventArgs: ICurrentSessionChangedEventArgs ["Windows.Media.Control.CurrentSessionChangedEventArgs"]}
 DEFINE_IID!(IID_IGlobalSystemMediaTransportControlsSession, 1900595253, 39700, 23266, 171, 133, 220, 155, 28, 20, 225, 168);
 RT_INTERFACE!{interface IGlobalSystemMediaTransportControlsSession(IGlobalSystemMediaTransportControlsSessionVtbl): IInspectable(IInspectableVtbl) [IID_IGlobalSystemMediaTransportControlsSession] {
     fn get_SourceAppUserModelId(&self, out: *mut HSTRING) -> HRESULT,
@@ -9753,7 +9753,7 @@ impl IGlobalSystemMediaTransportControlsSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalSystemMediaTransportControlsSession: IGlobalSystemMediaTransportControlsSession}
+RT_CLASS!{class GlobalSystemMediaTransportControlsSession: IGlobalSystemMediaTransportControlsSession ["Windows.Media.Control.GlobalSystemMediaTransportControlsSession"]}
 DEFINE_IID!(IID_IGlobalSystemMediaTransportControlsSessionManager, 3402534572, 59502, 20554, 171, 49, 95, 248, 255, 27, 206, 73);
 RT_INTERFACE!{interface IGlobalSystemMediaTransportControlsSessionManager(IGlobalSystemMediaTransportControlsSessionManagerVtbl): IInspectable(IInspectableVtbl) [IID_IGlobalSystemMediaTransportControlsSessionManager] {
     fn GetCurrentSession(&self, out: *mut *mut GlobalSystemMediaTransportControlsSession) -> HRESULT,
@@ -9793,7 +9793,7 @@ impl IGlobalSystemMediaTransportControlsSessionManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalSystemMediaTransportControlsSessionManager: IGlobalSystemMediaTransportControlsSessionManager}
+RT_CLASS!{class GlobalSystemMediaTransportControlsSessionManager: IGlobalSystemMediaTransportControlsSessionManager ["Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager"]}
 impl RtActivatable<IGlobalSystemMediaTransportControlsSessionManagerStatics> for GlobalSystemMediaTransportControlsSessionManager {}
 impl GlobalSystemMediaTransportControlsSessionManager {
     #[inline] pub fn request_async() -> Result<ComPtr<foundation::IAsyncOperation<GlobalSystemMediaTransportControlsSessionManager>>> {
@@ -9877,7 +9877,7 @@ impl IGlobalSystemMediaTransportControlsSessionMediaProperties {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalSystemMediaTransportControlsSessionMediaProperties: IGlobalSystemMediaTransportControlsSessionMediaProperties}
+RT_CLASS!{class GlobalSystemMediaTransportControlsSessionMediaProperties: IGlobalSystemMediaTransportControlsSessionMediaProperties ["Windows.Media.Control.GlobalSystemMediaTransportControlsSessionMediaProperties"]}
 DEFINE_IID!(IID_IGlobalSystemMediaTransportControlsSessionPlaybackControls, 1694606310, 48250, 20538, 187, 27, 104, 241, 88, 243, 251, 3);
 RT_INTERFACE!{interface IGlobalSystemMediaTransportControlsSessionPlaybackControls(IGlobalSystemMediaTransportControlsSessionPlaybackControlsVtbl): IInspectable(IInspectableVtbl) [IID_IGlobalSystemMediaTransportControlsSessionPlaybackControls] {
     fn get_IsPlayEnabled(&self, out: *mut bool) -> HRESULT,
@@ -9973,7 +9973,7 @@ impl IGlobalSystemMediaTransportControlsSessionPlaybackControls {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalSystemMediaTransportControlsSessionPlaybackControls: IGlobalSystemMediaTransportControlsSessionPlaybackControls}
+RT_CLASS!{class GlobalSystemMediaTransportControlsSessionPlaybackControls: IGlobalSystemMediaTransportControlsSessionPlaybackControls ["Windows.Media.Control.GlobalSystemMediaTransportControlsSessionPlaybackControls"]}
 DEFINE_IID!(IID_IGlobalSystemMediaTransportControlsSessionPlaybackInfo, 2494871247, 59578, 20909, 135, 167, 193, 10, 222, 16, 97, 39);
 RT_INTERFACE!{interface IGlobalSystemMediaTransportControlsSessionPlaybackInfo(IGlobalSystemMediaTransportControlsSessionPlaybackInfoVtbl): IInspectable(IInspectableVtbl) [IID_IGlobalSystemMediaTransportControlsSessionPlaybackInfo] {
     fn get_Controls(&self, out: *mut *mut GlobalSystemMediaTransportControlsSessionPlaybackControls) -> HRESULT,
@@ -10015,8 +10015,8 @@ impl IGlobalSystemMediaTransportControlsSessionPlaybackInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalSystemMediaTransportControlsSessionPlaybackInfo: IGlobalSystemMediaTransportControlsSessionPlaybackInfo}
-RT_ENUM! { enum GlobalSystemMediaTransportControlsSessionPlaybackStatus: i32 {
+RT_CLASS!{class GlobalSystemMediaTransportControlsSessionPlaybackInfo: IGlobalSystemMediaTransportControlsSessionPlaybackInfo ["Windows.Media.Control.GlobalSystemMediaTransportControlsSessionPlaybackInfo"]}
+RT_ENUM! { enum GlobalSystemMediaTransportControlsSessionPlaybackStatus: i32 ["Windows.Media.Control.GlobalSystemMediaTransportControlsSessionPlaybackStatus"] {
     Closed (GlobalSystemMediaTransportControlsSessionPlaybackStatus_Closed) = 0, Opened (GlobalSystemMediaTransportControlsSessionPlaybackStatus_Opened) = 1, Changing (GlobalSystemMediaTransportControlsSessionPlaybackStatus_Changing) = 2, Stopped (GlobalSystemMediaTransportControlsSessionPlaybackStatus_Stopped) = 3, Playing (GlobalSystemMediaTransportControlsSessionPlaybackStatus_Playing) = 4, Paused (GlobalSystemMediaTransportControlsSessionPlaybackStatus_Paused) = 5,
 }}
 DEFINE_IID!(IID_IGlobalSystemMediaTransportControlsSessionTimelineProperties, 3991093558, 28453, 22669, 142, 207, 234, 91, 103, 53, 170, 165);
@@ -10060,34 +10060,34 @@ impl IGlobalSystemMediaTransportControlsSessionTimelineProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalSystemMediaTransportControlsSessionTimelineProperties: IGlobalSystemMediaTransportControlsSessionTimelineProperties}
+RT_CLASS!{class GlobalSystemMediaTransportControlsSessionTimelineProperties: IGlobalSystemMediaTransportControlsSessionTimelineProperties ["Windows.Media.Control.GlobalSystemMediaTransportControlsSessionTimelineProperties"]}
 DEFINE_IID!(IID_IMediaPropertiesChangedEventArgs, 2100773323, 44528, 23791, 145, 186, 207, 171, 205, 215, 118, 120);
 RT_INTERFACE!{interface IMediaPropertiesChangedEventArgs(IMediaPropertiesChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPropertiesChangedEventArgs] {
     
 }}
-RT_CLASS!{class MediaPropertiesChangedEventArgs: IMediaPropertiesChangedEventArgs}
+RT_CLASS!{class MediaPropertiesChangedEventArgs: IMediaPropertiesChangedEventArgs ["Windows.Media.Control.MediaPropertiesChangedEventArgs"]}
 DEFINE_IID!(IID_IPlaybackInfoChangedEventArgs, 2020038338, 48141, 20645, 136, 7, 5, 66, 145, 254, 241, 57);
 RT_INTERFACE!{interface IPlaybackInfoChangedEventArgs(IPlaybackInfoChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPlaybackInfoChangedEventArgs] {
     
 }}
-RT_CLASS!{class PlaybackInfoChangedEventArgs: IPlaybackInfoChangedEventArgs}
+RT_CLASS!{class PlaybackInfoChangedEventArgs: IPlaybackInfoChangedEventArgs ["Windows.Media.Control.PlaybackInfoChangedEventArgs"]}
 DEFINE_IID!(IID_ISessionsChangedEventArgs, 3153120562, 17092, 23128, 179, 23, 243, 75, 191, 189, 38, 224);
 RT_INTERFACE!{interface ISessionsChangedEventArgs(ISessionsChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISessionsChangedEventArgs] {
     
 }}
-RT_CLASS!{class SessionsChangedEventArgs: ISessionsChangedEventArgs}
+RT_CLASS!{class SessionsChangedEventArgs: ISessionsChangedEventArgs ["Windows.Media.Control.SessionsChangedEventArgs"]}
 DEFINE_IID!(IID_ITimelinePropertiesChangedEventArgs, 688077359, 51491, 23159, 188, 175, 5, 95, 244, 21, 173, 50);
 RT_INTERFACE!{interface ITimelinePropertiesChangedEventArgs(ITimelinePropertiesChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITimelinePropertiesChangedEventArgs] {
     
 }}
-RT_CLASS!{class TimelinePropertiesChangedEventArgs: ITimelinePropertiesChangedEventArgs}
+RT_CLASS!{class TimelinePropertiesChangedEventArgs: ITimelinePropertiesChangedEventArgs ["Windows.Media.Control.TimelinePropertiesChangedEventArgs"]}
 } // Windows.Media.Control
 pub mod core { // Windows.Media.Core
 use ::prelude::*;
-RT_ENUM! { enum AudioDecoderDegradation: i32 {
+RT_ENUM! { enum AudioDecoderDegradation: i32 ["Windows.Media.Core.AudioDecoderDegradation"] {
     None (AudioDecoderDegradation_None) = 0, DownmixTo2Channels (AudioDecoderDegradation_DownmixTo2Channels) = 1, DownmixTo6Channels (AudioDecoderDegradation_DownmixTo6Channels) = 2, DownmixTo8Channels (AudioDecoderDegradation_DownmixTo8Channels) = 3,
 }}
-RT_ENUM! { enum AudioDecoderDegradationReason: i32 {
+RT_ENUM! { enum AudioDecoderDegradationReason: i32 ["Windows.Media.Core.AudioDecoderDegradationReason"] {
     None (AudioDecoderDegradationReason_None) = 0, LicensingRequirement (AudioDecoderDegradationReason_LicensingRequirement) = 1, SpatialAudioNotSupported (AudioDecoderDegradationReason_SpatialAudioNotSupported) = 2,
 }}
 DEFINE_IID!(IID_IAudioStreamDescriptor, 506893028, 16423, 18503, 167, 11, 223, 29, 154, 42, 123, 4);
@@ -10101,7 +10101,7 @@ impl IAudioStreamDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioStreamDescriptor: IAudioStreamDescriptor}
+RT_CLASS!{class AudioStreamDescriptor: IAudioStreamDescriptor ["Windows.Media.Core.AudioStreamDescriptor"]}
 impl RtActivatable<IAudioStreamDescriptorFactory> for AudioStreamDescriptor {}
 impl AudioStreamDescriptor {
     #[inline] pub fn create(encodingProperties: &super::mediaproperties::AudioEncodingProperties) -> Result<ComPtr<AudioStreamDescriptor>> {
@@ -10198,7 +10198,7 @@ impl IAudioTrack {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioTrack: IMediaTrack}
+RT_CLASS!{class AudioTrack: IMediaTrack ["Windows.Media.Core.AudioTrack"]}
 DEFINE_IID!(IID_IAudioTrackOpenFailedEventArgs, 4007508409, 47996, 16658, 191, 118, 147, 132, 103, 111, 130, 75);
 RT_INTERFACE!{interface IAudioTrackOpenFailedEventArgs(IAudioTrackOpenFailedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAudioTrackOpenFailedEventArgs] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -10210,7 +10210,7 @@ impl IAudioTrackOpenFailedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioTrackOpenFailedEventArgs: IAudioTrackOpenFailedEventArgs}
+RT_CLASS!{class AudioTrackOpenFailedEventArgs: IAudioTrackOpenFailedEventArgs ["Windows.Media.Core.AudioTrackOpenFailedEventArgs"]}
 DEFINE_IID!(IID_IAudioTrackSupportInfo, 395046903, 52281, 17574, 185, 81, 74, 86, 83, 240, 115, 250);
 RT_INTERFACE!{interface IAudioTrackSupportInfo(IAudioTrackSupportInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAudioTrackSupportInfo] {
     fn get_DecoderStatus(&self, out: *mut MediaDecoderStatus) -> HRESULT,
@@ -10240,7 +10240,7 @@ impl IAudioTrackSupportInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioTrackSupportInfo: IAudioTrackSupportInfo}
+RT_CLASS!{class AudioTrackSupportInfo: IAudioTrackSupportInfo ["Windows.Media.Core.AudioTrackSupportInfo"]}
 DEFINE_IID!(IID_IChapterCue, 1923710977, 54154, 19466, 143, 166, 117, 205, 218, 244, 102, 76);
 RT_INTERFACE!{interface IChapterCue(IChapterCueVtbl): IInspectable(IInspectableVtbl) [IID_IChapterCue] {
     fn put_Title(&self, value: HSTRING) -> HRESULT,
@@ -10257,10 +10257,10 @@ impl IChapterCue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChapterCue: IChapterCue}
+RT_CLASS!{class ChapterCue: IChapterCue ["Windows.Media.Core.ChapterCue"]}
 impl RtActivatable<IActivationFactory> for ChapterCue {}
 DEFINE_CLSID!(ChapterCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,67,104,97,112,116,101,114,67,117,101,0]) [CLSID_ChapterCue]);
-RT_ENUM! { enum CodecCategory: i32 {
+RT_ENUM! { enum CodecCategory: i32 ["Windows.Media.Core.CodecCategory"] {
     Encoder (CodecCategory_Encoder) = 0, Decoder (CodecCategory_Decoder) = 1,
 }}
 DEFINE_IID!(IID_ICodecInfo, 1374199685, 60055, 18844, 134, 172, 76, 229, 231, 63, 58, 66);
@@ -10298,8 +10298,8 @@ impl ICodecInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CodecInfo: ICodecInfo}
-RT_ENUM! { enum CodecKind: i32 {
+RT_CLASS!{class CodecInfo: ICodecInfo ["Windows.Media.Core.CodecInfo"]}
+RT_ENUM! { enum CodecKind: i32 ["Windows.Media.Core.CodecKind"] {
     Audio (CodecKind_Audio) = 0, Video (CodecKind_Video) = 1,
 }}
 DEFINE_IID!(IID_ICodecQuery, 573216058, 44897, 19972, 128, 138, 164, 99, 78, 47, 58, 196);
@@ -10313,7 +10313,7 @@ impl ICodecQuery {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CodecQuery: ICodecQuery}
+RT_CLASS!{class CodecQuery: ICodecQuery ["Windows.Media.Core.CodecQuery"]}
 impl RtActivatable<IActivationFactory> for CodecQuery {}
 DEFINE_CLSID!(CodecQuery(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,67,111,100,101,99,81,117,101,114,121,0]) [CLSID_CodecQuery]);
 RT_CLASS!{static class CodecSubtypes}
@@ -10801,7 +10801,7 @@ impl IDataCue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataCue: IDataCue}
+RT_CLASS!{class DataCue: IDataCue ["Windows.Media.Core.DataCue"]}
 impl RtActivatable<IActivationFactory> for DataCue {}
 DEFINE_CLSID!(DataCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,68,97,116,97,67,117,101,0]) [CLSID_DataCue]);
 DEFINE_IID!(IID_IDataCue2, 3159759637, 38386, 18920, 150, 241, 141, 213, 218, 198, 141, 147);
@@ -10826,7 +10826,7 @@ impl IFaceDetectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FaceDetectedEventArgs: IFaceDetectedEventArgs}
+RT_CLASS!{class FaceDetectedEventArgs: IFaceDetectedEventArgs ["Windows.Media.Core.FaceDetectedEventArgs"]}
 DEFINE_IID!(IID_IFaceDetectionEffect, 2920672210, 1346, 17065, 188, 144, 242, 131, 162, 159, 70, 193);
 RT_INTERFACE!{interface IFaceDetectionEffect(IFaceDetectionEffectVtbl): IInspectable(IInspectableVtbl) [IID_IFaceDetectionEffect] {
     fn put_Enabled(&self, value: bool) -> HRESULT,
@@ -10865,7 +10865,7 @@ impl IFaceDetectionEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FaceDetectionEffect: IFaceDetectionEffect}
+RT_CLASS!{class FaceDetectionEffect: IFaceDetectionEffect ["Windows.Media.Core.FaceDetectionEffect"]}
 DEFINE_IID!(IID_IFaceDetectionEffectDefinition, 1138532481, 47176, 20275, 183, 2, 31, 210, 98, 79, 176, 22);
 RT_INTERFACE!{interface IFaceDetectionEffectDefinition(IFaceDetectionEffectDefinitionVtbl): IInspectable(IInspectableVtbl) [IID_IFaceDetectionEffectDefinition] {
     fn put_DetectionMode(&self, value: FaceDetectionMode) -> HRESULT,
@@ -10893,7 +10893,7 @@ impl IFaceDetectionEffectDefinition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FaceDetectionEffectDefinition: super::effects::IVideoEffectDefinition}
+RT_CLASS!{class FaceDetectionEffectDefinition: super::effects::IVideoEffectDefinition ["Windows.Media.Core.FaceDetectionEffectDefinition"]}
 impl RtActivatable<IActivationFactory> for FaceDetectionEffectDefinition {}
 DEFINE_CLSID!(FaceDetectionEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,70,97,99,101,68,101,116,101,99,116,105,111,110,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_FaceDetectionEffectDefinition]);
 DEFINE_IID!(IID_IFaceDetectionEffectFrame, 2326825363, 24008, 17531, 162, 71, 82, 112, 189, 128, 46, 206);
@@ -10907,8 +10907,8 @@ impl IFaceDetectionEffectFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FaceDetectionEffectFrame: IFaceDetectionEffectFrame}
-RT_ENUM! { enum FaceDetectionMode: i32 {
+RT_CLASS!{class FaceDetectionEffectFrame: IFaceDetectionEffectFrame ["Windows.Media.Core.FaceDetectionEffectFrame"]}
+RT_ENUM! { enum FaceDetectionMode: i32 ["Windows.Media.Core.FaceDetectionMode"] {
     HighPerformance (FaceDetectionMode_HighPerformance) = 0, Balanced (FaceDetectionMode_Balanced) = 1, HighQuality (FaceDetectionMode_HighQuality) = 2,
 }}
 DEFINE_IID!(IID_IHighDynamicRangeControl, 1441900462, 55639, 19913, 157, 28, 133, 83, 168, 42, 125, 153);
@@ -10927,7 +10927,7 @@ impl IHighDynamicRangeControl {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HighDynamicRangeControl: IHighDynamicRangeControl}
+RT_CLASS!{class HighDynamicRangeControl: IHighDynamicRangeControl ["Windows.Media.Core.HighDynamicRangeControl"]}
 DEFINE_IID!(IID_IHighDynamicRangeOutput, 257392747, 9531, 16665, 187, 64, 58, 144, 229, 19, 132, 247);
 RT_INTERFACE!{interface IHighDynamicRangeOutput(IHighDynamicRangeOutputVtbl): IInspectable(IInspectableVtbl) [IID_IHighDynamicRangeOutput] {
     fn get_Certainty(&self, out: *mut f64) -> HRESULT,
@@ -10945,7 +10945,7 @@ impl IHighDynamicRangeOutput {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HighDynamicRangeOutput: IHighDynamicRangeOutput}
+RT_CLASS!{class HighDynamicRangeOutput: IHighDynamicRangeOutput ["Windows.Media.Core.HighDynamicRangeOutput"]}
 DEFINE_IID!(IID_IImageCue, 1384284802, 13947, 17419, 145, 22, 60, 132, 87, 13, 210, 112);
 RT_INTERFACE!{interface IImageCue(IImageCueVtbl): IInspectable(IInspectableVtbl) [IID_IImageCue] {
     fn get_Position(&self, out: *mut TimedTextPoint) -> HRESULT,
@@ -10984,7 +10984,7 @@ impl IImageCue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageCue: IImageCue}
+RT_CLASS!{class ImageCue: IImageCue ["Windows.Media.Core.ImageCue"]}
 impl RtActivatable<IActivationFactory> for ImageCue {}
 DEFINE_CLSID!(ImageCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,73,109,97,103,101,67,117,101,0]) [CLSID_ImageCue]);
 DEFINE_IID!(IID_IInitializeMediaStreamSourceRequestedEventArgs, 633095649, 39688, 19502, 168, 85, 69, 66, 241, 167, 93, 235);
@@ -11011,7 +11011,7 @@ impl IInitializeMediaStreamSourceRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InitializeMediaStreamSourceRequestedEventArgs: IInitializeMediaStreamSourceRequestedEventArgs}
+RT_CLASS!{class InitializeMediaStreamSourceRequestedEventArgs: IInitializeMediaStreamSourceRequestedEventArgs ["Windows.Media.Core.InitializeMediaStreamSourceRequestedEventArgs"]}
 RT_CLASS!{static class LowLightFusion}
 impl RtActivatable<ILowLightFusionStatics> for LowLightFusion {}
 impl LowLightFusion {
@@ -11037,7 +11037,7 @@ impl ILowLightFusionResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLightFusionResult: ILowLightFusionResult}
+RT_CLASS!{class LowLightFusionResult: ILowLightFusionResult ["Windows.Media.Core.LowLightFusionResult"]}
 DEFINE_IID!(IID_ILowLightFusionStatics, 1392836973, 49822, 16610, 135, 169, 158, 31, 210, 241, 146, 245);
 RT_INTERFACE!{static interface ILowLightFusionStatics(ILowLightFusionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILowLightFusionStatics] {
     #[cfg(feature="windows-graphics")] fn get_SupportedBitmapPixelFormats(&self, out: *mut *mut foundation::collections::IVectorView<super::super::graphics::imaging::BitmapPixelFormat>) -> HRESULT,
@@ -11094,7 +11094,7 @@ impl IMediaBinder {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBinder: IMediaBinder}
+RT_CLASS!{class MediaBinder: IMediaBinder ["Windows.Media.Core.MediaBinder"]}
 impl RtActivatable<IActivationFactory> for MediaBinder {}
 DEFINE_CLSID!(MediaBinder(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,77,101,100,105,97,66,105,110,100,101,114,0]) [CLSID_MediaBinder]);
 DEFINE_IID!(IID_IMediaBindingEventArgs, 3055333978, 7021, 17968, 168, 109, 47, 8, 55, 247, 18, 229);
@@ -11140,7 +11140,7 @@ impl IMediaBindingEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBindingEventArgs: IMediaBindingEventArgs}
+RT_CLASS!{class MediaBindingEventArgs: IMediaBindingEventArgs ["Windows.Media.Core.MediaBindingEventArgs"]}
 DEFINE_IID!(IID_IMediaBindingEventArgs2, 73714923, 47962, 18479, 184, 186, 240, 40, 76, 105, 101, 103);
 RT_INTERFACE!{interface IMediaBindingEventArgs2(IMediaBindingEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaBindingEventArgs2] {
     fn SetAdaptiveMediaSource(&self, mediaSource: *mut super::streaming::adaptive::AdaptiveMediaSource) -> HRESULT,
@@ -11215,15 +11215,15 @@ impl IMediaCueEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaCueEventArgs: IMediaCueEventArgs}
-RT_ENUM! { enum MediaDecoderStatus: i32 {
+RT_CLASS!{class MediaCueEventArgs: IMediaCueEventArgs ["Windows.Media.Core.MediaCueEventArgs"]}
+RT_ENUM! { enum MediaDecoderStatus: i32 ["Windows.Media.Core.MediaDecoderStatus"] {
     FullySupported (MediaDecoderStatus_FullySupported) = 0, UnsupportedSubtype (MediaDecoderStatus_UnsupportedSubtype) = 1, UnsupportedEncoderProperties (MediaDecoderStatus_UnsupportedEncoderProperties) = 2, Degraded (MediaDecoderStatus_Degraded) = 3,
 }}
 DEFINE_IID!(IID_IMediaSource, 3888100761, 41117, 19489, 188, 223, 32, 175, 79, 134, 179, 217);
 RT_INTERFACE!{interface IMediaSource(IMediaSourceVtbl): IInspectable(IInspectableVtbl) [IID_IMediaSource] {
     
 }}
-RT_CLASS!{class MediaSource: IMediaSource2}
+RT_CLASS!{class MediaSource: IMediaSource2 ["Windows.Media.Core.MediaSource"]}
 impl RtActivatable<IMediaSourceStatics> for MediaSource {}
 impl RtActivatable<IMediaSourceStatics2> for MediaSource {}
 impl RtActivatable<IMediaSourceStatics3> for MediaSource {}
@@ -11404,7 +11404,7 @@ impl IMediaSourceAppServiceConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaSourceAppServiceConnection: IMediaSourceAppServiceConnection}
+RT_CLASS!{class MediaSourceAppServiceConnection: IMediaSourceAppServiceConnection ["Windows.Media.Core.MediaSourceAppServiceConnection"]}
 impl RtActivatable<IMediaSourceAppServiceConnectionFactory> for MediaSourceAppServiceConnection {}
 impl MediaSourceAppServiceConnection {
     #[cfg(feature="windows-applicationmodel")] #[inline] pub fn create(appServiceConnection: &super::super::applicationmodel::appservice::AppServiceConnection) -> Result<ComPtr<MediaSourceAppServiceConnection>> {
@@ -11434,7 +11434,7 @@ impl IMediaSourceError {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaSourceError: IMediaSourceError}
+RT_CLASS!{class MediaSourceError: IMediaSourceError ["Windows.Media.Core.MediaSourceError"]}
 DEFINE_IID!(IID_IMediaSourceOpenOperationCompletedEventArgs, 4234685675, 57985, 18300, 168, 224, 26, 205, 101, 65, 20, 200);
 RT_INTERFACE!{interface IMediaSourceOpenOperationCompletedEventArgs(IMediaSourceOpenOperationCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaSourceOpenOperationCompletedEventArgs] {
     fn get_Error(&self, out: *mut *mut MediaSourceError) -> HRESULT
@@ -11446,8 +11446,8 @@ impl IMediaSourceOpenOperationCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaSourceOpenOperationCompletedEventArgs: IMediaSourceOpenOperationCompletedEventArgs}
-RT_ENUM! { enum MediaSourceState: i32 {
+RT_CLASS!{class MediaSourceOpenOperationCompletedEventArgs: IMediaSourceOpenOperationCompletedEventArgs ["Windows.Media.Core.MediaSourceOpenOperationCompletedEventArgs"]}
+RT_ENUM! { enum MediaSourceState: i32 ["Windows.Media.Core.MediaSourceState"] {
     Initial (MediaSourceState_Initial) = 0, Opening (MediaSourceState_Opening) = 1, Opened (MediaSourceState_Opened) = 2, Failed (MediaSourceState_Failed) = 3, Closed (MediaSourceState_Closed) = 4,
 }}
 DEFINE_IID!(IID_IMediaSourceStateChangedEventArgs, 170962818, 36977, 19372, 188, 57, 202, 42, 147, 183, 23, 169);
@@ -11467,7 +11467,7 @@ impl IMediaSourceStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaSourceStateChangedEventArgs: IMediaSourceStateChangedEventArgs}
+RT_CLASS!{class MediaSourceStateChangedEventArgs: IMediaSourceStateChangedEventArgs ["Windows.Media.Core.MediaSourceStateChangedEventArgs"]}
 DEFINE_IID!(IID_IMediaSourceStatics, 4152192932, 18002, 16654, 177, 216, 233, 165, 226, 69, 164, 92);
 RT_INTERFACE!{static interface IMediaSourceStatics(IMediaSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaSourceStatics] {
     fn CreateFromAdaptiveMediaSource(&self, mediaSource: *mut super::streaming::adaptive::AdaptiveMediaSource, out: *mut *mut MediaSource) -> HRESULT,
@@ -11557,7 +11557,7 @@ impl IMediaSourceStatics4 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaSourceStatus: i32 {
+RT_ENUM! { enum MediaSourceStatus: i32 ["Windows.Media.Core.MediaSourceStatus"] {
     FullySupported (MediaSourceStatus_FullySupported) = 0, Unknown (MediaSourceStatus_Unknown) = 1,
 }}
 DEFINE_IID!(IID_IMediaStreamDescriptor, 2163306094, 37623, 17694, 151, 210, 175, 216, 7, 66, 218, 112);
@@ -11694,7 +11694,7 @@ impl IMediaStreamSample {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSample: IMediaStreamSample}
+RT_CLASS!{class MediaStreamSample: IMediaStreamSample ["Windows.Media.Core.MediaStreamSample"]}
 impl RtActivatable<IMediaStreamSampleStatics> for MediaStreamSample {}
 impl RtActivatable<IMediaStreamSampleStatics2> for MediaStreamSample {}
 impl MediaStreamSample {
@@ -11720,7 +11720,7 @@ impl IMediaStreamSample2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSamplePropertySet: foundation::collections::IMap<Guid, IInspectable>}
+RT_CLASS!{class MediaStreamSamplePropertySet: foundation::collections::IMap<Guid, IInspectable> ["Windows.Media.Core.MediaStreamSamplePropertySet"]}
 DEFINE_IID!(IID_IMediaStreamSampleProtectionProperties, 1320714898, 60639, 18750, 132, 29, 221, 74, 221, 124, 172, 162);
 RT_INTERFACE!{interface IMediaStreamSampleProtectionProperties(IMediaStreamSampleProtectionPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSampleProtectionProperties] {
     fn SetKeyIdentifier(&self, valueSize: u32, value: *mut u8) -> HRESULT,
@@ -11759,7 +11759,7 @@ impl IMediaStreamSampleProtectionProperties {
         if hr == S_OK { Ok(ComArray::from_raw(valueSize, value)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSampleProtectionProperties: IMediaStreamSampleProtectionProperties}
+RT_CLASS!{class MediaStreamSampleProtectionProperties: IMediaStreamSampleProtectionProperties ["Windows.Media.Core.MediaStreamSampleProtectionProperties"]}
 DEFINE_IID!(IID_IMediaStreamSampleStatics, 3755942287, 42703, 17785, 190, 65, 115, 221, 148, 26, 217, 114);
 RT_INTERFACE!{static interface IMediaStreamSampleStatics(IMediaStreamSampleStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSampleStatics] {
     #[cfg(feature="windows-storage")] fn CreateFromBuffer(&self, buffer: *mut super::super::storage::streams::IBuffer, timestamp: foundation::TimeSpan, out: *mut *mut MediaStreamSample) -> HRESULT,
@@ -11939,7 +11939,7 @@ impl IMediaStreamSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSource: IMediaStreamSource}
+RT_CLASS!{class MediaStreamSource: IMediaStreamSource ["Windows.Media.Core.MediaStreamSource"]}
 impl RtActivatable<IMediaStreamSourceFactory> for MediaStreamSource {}
 impl MediaStreamSource {
     #[inline] pub fn create_from_descriptor(descriptor: &IMediaStreamDescriptor) -> Result<ComPtr<MediaStreamSource>> {
@@ -12009,8 +12009,8 @@ impl IMediaStreamSourceClosedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceClosedEventArgs: IMediaStreamSourceClosedEventArgs}
-RT_ENUM! { enum MediaStreamSourceClosedReason: i32 {
+RT_CLASS!{class MediaStreamSourceClosedEventArgs: IMediaStreamSourceClosedEventArgs ["Windows.Media.Core.MediaStreamSourceClosedEventArgs"]}
+RT_ENUM! { enum MediaStreamSourceClosedReason: i32 ["Windows.Media.Core.MediaStreamSourceClosedReason"] {
     Done (MediaStreamSourceClosedReason_Done) = 0, UnknownError (MediaStreamSourceClosedReason_UnknownError) = 1, AppReportedError (MediaStreamSourceClosedReason_AppReportedError) = 2, UnsupportedProtectionSystem (MediaStreamSourceClosedReason_UnsupportedProtectionSystem) = 3, ProtectionSystemFailure (MediaStreamSourceClosedReason_ProtectionSystemFailure) = 4, UnsupportedEncodingFormat (MediaStreamSourceClosedReason_UnsupportedEncodingFormat) = 5, MissingSampleRequestedEventHandler (MediaStreamSourceClosedReason_MissingSampleRequestedEventHandler) = 6,
 }}
 DEFINE_IID!(IID_IMediaStreamSourceClosedRequest, 2424045801, 6307, 18769, 136, 122, 44, 30, 235, 213, 198, 158);
@@ -12024,8 +12024,8 @@ impl IMediaStreamSourceClosedRequest {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceClosedRequest: IMediaStreamSourceClosedRequest}
-RT_ENUM! { enum MediaStreamSourceErrorStatus: i32 {
+RT_CLASS!{class MediaStreamSourceClosedRequest: IMediaStreamSourceClosedRequest ["Windows.Media.Core.MediaStreamSourceClosedRequest"]}
+RT_ENUM! { enum MediaStreamSourceErrorStatus: i32 ["Windows.Media.Core.MediaStreamSourceErrorStatus"] {
     Other (MediaStreamSourceErrorStatus_Other) = 0, OutOfMemory (MediaStreamSourceErrorStatus_OutOfMemory) = 1, FailedToOpenFile (MediaStreamSourceErrorStatus_FailedToOpenFile) = 2, FailedToConnectToServer (MediaStreamSourceErrorStatus_FailedToConnectToServer) = 3, ConnectionToServerLost (MediaStreamSourceErrorStatus_ConnectionToServerLost) = 4, UnspecifiedNetworkError (MediaStreamSourceErrorStatus_UnspecifiedNetworkError) = 5, DecodeError (MediaStreamSourceErrorStatus_DecodeError) = 6, UnsupportedMediaFormat (MediaStreamSourceErrorStatus_UnsupportedMediaFormat) = 7,
 }}
 DEFINE_IID!(IID_IMediaStreamSourceFactory, 4017610969, 53592, 19322, 134, 63, 32, 51, 66, 251, 253, 65);
@@ -12056,7 +12056,7 @@ impl IMediaStreamSourceSampleRenderedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSampleRenderedEventArgs: IMediaStreamSourceSampleRenderedEventArgs}
+RT_CLASS!{class MediaStreamSourceSampleRenderedEventArgs: IMediaStreamSourceSampleRenderedEventArgs ["Windows.Media.Core.MediaStreamSourceSampleRenderedEventArgs"]}
 DEFINE_IID!(IID_IMediaStreamSourceSampleRequest, 1303593385, 13569, 19867, 131, 249, 143, 35, 92, 130, 37, 50);
 RT_INTERFACE!{interface IMediaStreamSourceSampleRequest(IMediaStreamSourceSampleRequestVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceSampleRequest] {
     fn get_StreamDescriptor(&self, out: *mut *mut IMediaStreamDescriptor) -> HRESULT,
@@ -12090,7 +12090,7 @@ impl IMediaStreamSourceSampleRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSampleRequest: IMediaStreamSourceSampleRequest}
+RT_CLASS!{class MediaStreamSourceSampleRequest: IMediaStreamSourceSampleRequest ["Windows.Media.Core.MediaStreamSourceSampleRequest"]}
 DEFINE_IID!(IID_IMediaStreamSourceSampleRequestDeferral, 2023083010, 63874, 17352, 157, 22, 198, 45, 153, 147, 25, 190);
 RT_INTERFACE!{interface IMediaStreamSourceSampleRequestDeferral(IMediaStreamSourceSampleRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceSampleRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -12101,7 +12101,7 @@ impl IMediaStreamSourceSampleRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSampleRequestDeferral: IMediaStreamSourceSampleRequestDeferral}
+RT_CLASS!{class MediaStreamSourceSampleRequestDeferral: IMediaStreamSourceSampleRequestDeferral ["Windows.Media.Core.MediaStreamSourceSampleRequestDeferral"]}
 DEFINE_IID!(IID_IMediaStreamSourceSampleRequestedEventArgs, 284801950, 29125, 18735, 132, 127, 13, 161, 243, 94, 129, 248);
 RT_INTERFACE!{interface IMediaStreamSourceSampleRequestedEventArgs(IMediaStreamSourceSampleRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceSampleRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut MediaStreamSourceSampleRequest) -> HRESULT
@@ -12113,7 +12113,7 @@ impl IMediaStreamSourceSampleRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSampleRequestedEventArgs: IMediaStreamSourceSampleRequestedEventArgs}
+RT_CLASS!{class MediaStreamSourceSampleRequestedEventArgs: IMediaStreamSourceSampleRequestedEventArgs ["Windows.Media.Core.MediaStreamSourceSampleRequestedEventArgs"]}
 DEFINE_IID!(IID_IMediaStreamSourceStartingEventArgs, 4094978290, 49780, 18752, 165, 187, 40, 165, 114, 69, 47, 167);
 RT_INTERFACE!{interface IMediaStreamSourceStartingEventArgs(IMediaStreamSourceStartingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceStartingEventArgs] {
     fn get_Request(&self, out: *mut *mut MediaStreamSourceStartingRequest) -> HRESULT
@@ -12125,7 +12125,7 @@ impl IMediaStreamSourceStartingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceStartingEventArgs: IMediaStreamSourceStartingEventArgs}
+RT_CLASS!{class MediaStreamSourceStartingEventArgs: IMediaStreamSourceStartingEventArgs ["Windows.Media.Core.MediaStreamSourceStartingEventArgs"]}
 DEFINE_IID!(IID_IMediaStreamSourceStartingRequest, 714118116, 13764, 19227, 167, 145, 13, 153, 219, 86, 221, 29);
 RT_INTERFACE!{interface IMediaStreamSourceStartingRequest(IMediaStreamSourceStartingRequestVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceStartingRequest] {
     fn get_StartPosition(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -12148,7 +12148,7 @@ impl IMediaStreamSourceStartingRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceStartingRequest: IMediaStreamSourceStartingRequest}
+RT_CLASS!{class MediaStreamSourceStartingRequest: IMediaStreamSourceStartingRequest ["Windows.Media.Core.MediaStreamSourceStartingRequest"]}
 DEFINE_IID!(IID_IMediaStreamSourceStartingRequestDeferral, 1058231973, 25408, 19908, 153, 16, 6, 142, 217, 245, 152, 248);
 RT_INTERFACE!{interface IMediaStreamSourceStartingRequestDeferral(IMediaStreamSourceStartingRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceStartingRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -12159,7 +12159,7 @@ impl IMediaStreamSourceStartingRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceStartingRequestDeferral: IMediaStreamSourceStartingRequestDeferral}
+RT_CLASS!{class MediaStreamSourceStartingRequestDeferral: IMediaStreamSourceStartingRequestDeferral ["Windows.Media.Core.MediaStreamSourceStartingRequestDeferral"]}
 DEFINE_IID!(IID_IMediaStreamSourceSwitchStreamsRequest, 1102610574, 14505, 20163, 155, 160, 182, 155, 133, 80, 30, 144);
 RT_INTERFACE!{interface IMediaStreamSourceSwitchStreamsRequest(IMediaStreamSourceSwitchStreamsRequestVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceSwitchStreamsRequest] {
     fn get_OldStreamDescriptor(&self, out: *mut *mut IMediaStreamDescriptor) -> HRESULT,
@@ -12183,7 +12183,7 @@ impl IMediaStreamSourceSwitchStreamsRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSwitchStreamsRequest: IMediaStreamSourceSwitchStreamsRequest}
+RT_CLASS!{class MediaStreamSourceSwitchStreamsRequest: IMediaStreamSourceSwitchStreamsRequest ["Windows.Media.Core.MediaStreamSourceSwitchStreamsRequest"]}
 DEFINE_IID!(IID_IMediaStreamSourceSwitchStreamsRequestDeferral, 3202603061, 42245, 20378, 185, 67, 43, 140, 177, 180, 187, 217);
 RT_INTERFACE!{interface IMediaStreamSourceSwitchStreamsRequestDeferral(IMediaStreamSourceSwitchStreamsRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceSwitchStreamsRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -12194,7 +12194,7 @@ impl IMediaStreamSourceSwitchStreamsRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSwitchStreamsRequestDeferral: IMediaStreamSourceSwitchStreamsRequestDeferral}
+RT_CLASS!{class MediaStreamSourceSwitchStreamsRequestDeferral: IMediaStreamSourceSwitchStreamsRequestDeferral ["Windows.Media.Core.MediaStreamSourceSwitchStreamsRequestDeferral"]}
 DEFINE_IID!(IID_IMediaStreamSourceSwitchStreamsRequestedEventArgs, 1109404530, 28321, 18039, 152, 30, 53, 10, 13, 164, 18, 170);
 RT_INTERFACE!{interface IMediaStreamSourceSwitchStreamsRequestedEventArgs(IMediaStreamSourceSwitchStreamsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaStreamSourceSwitchStreamsRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut MediaStreamSourceSwitchStreamsRequest) -> HRESULT
@@ -12206,7 +12206,7 @@ impl IMediaStreamSourceSwitchStreamsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaStreamSourceSwitchStreamsRequestedEventArgs: IMediaStreamSourceSwitchStreamsRequestedEventArgs}
+RT_CLASS!{class MediaStreamSourceSwitchStreamsRequestedEventArgs: IMediaStreamSourceSwitchStreamsRequestedEventArgs ["Windows.Media.Core.MediaStreamSourceSwitchStreamsRequestedEventArgs"]}
 DEFINE_IID!(IID_IMediaTrack, 65141500, 51505, 18714, 180, 107, 193, 14, 232, 194, 86, 183);
 RT_INTERFACE!{interface IMediaTrack(IMediaTrackVtbl): IInspectable(IInspectableVtbl) [IID_IMediaTrack] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -12241,16 +12241,16 @@ impl IMediaTrack {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaTrackKind: i32 {
+RT_ENUM! { enum MediaTrackKind: i32 ["Windows.Media.Core.MediaTrackKind"] {
     Audio (MediaTrackKind_Audio) = 0, Video (MediaTrackKind_Video) = 1, TimedMetadata (MediaTrackKind_TimedMetadata) = 2,
 }}
-RT_ENUM! { enum MseAppendMode: i32 {
+RT_ENUM! { enum MseAppendMode: i32 ["Windows.Media.Core.MseAppendMode"] {
     Segments (MseAppendMode_Segments) = 0, Sequence (MseAppendMode_Sequence) = 1,
 }}
-RT_ENUM! { enum MseEndOfStreamStatus: i32 {
+RT_ENUM! { enum MseEndOfStreamStatus: i32 ["Windows.Media.Core.MseEndOfStreamStatus"] {
     Success (MseEndOfStreamStatus_Success) = 0, NetworkError (MseEndOfStreamStatus_NetworkError) = 1, DecodeError (MseEndOfStreamStatus_DecodeError) = 2, UnknownError (MseEndOfStreamStatus_UnknownError) = 3,
 }}
-RT_ENUM! { enum MseReadyState: i32 {
+RT_ENUM! { enum MseReadyState: i32 ["Windows.Media.Core.MseReadyState"] {
     Closed (MseReadyState_Closed) = 0, Open (MseReadyState_Open) = 1, Ended (MseReadyState_Ended) = 2,
 }}
 DEFINE_IID!(IID_IMseSourceBuffer, 203072483, 57229, 16505, 163, 254, 104, 73, 24, 75, 78, 47);
@@ -12397,7 +12397,7 @@ impl IMseSourceBuffer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MseSourceBuffer: IMseSourceBuffer}
+RT_CLASS!{class MseSourceBuffer: IMseSourceBuffer ["Windows.Media.Core.MseSourceBuffer"]}
 DEFINE_IID!(IID_IMseSourceBufferList, 2516248807, 43239, 20159, 137, 39, 20, 94, 148, 11, 165, 17);
 RT_INTERFACE!{interface IMseSourceBufferList(IMseSourceBufferListVtbl): IInspectable(IInspectableVtbl) [IID_IMseSourceBufferList] {
     fn add_SourceBufferAdded(&self, handler: *mut foundation::TypedEventHandler<MseSourceBufferList, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -12431,7 +12431,7 @@ impl IMseSourceBufferList {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MseSourceBufferList: IMseSourceBufferList}
+RT_CLASS!{class MseSourceBufferList: IMseSourceBufferList ["Windows.Media.Core.MseSourceBufferList"]}
 DEFINE_IID!(IID_IMseStreamSource, 2964593037, 756, 18723, 136, 221, 129, 188, 63, 54, 15, 250);
 RT_INTERFACE!{interface IMseStreamSource(IMseStreamSourceVtbl): IInspectable(IInspectableVtbl) [IID_IMseStreamSource] {
     fn add_Opened(&self, handler: *mut foundation::TypedEventHandler<MseStreamSource, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -12515,7 +12515,7 @@ impl IMseStreamSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MseStreamSource: IMseStreamSource}
+RT_CLASS!{class MseStreamSource: IMseStreamSource ["Windows.Media.Core.MseStreamSource"]}
 impl RtActivatable<IMseStreamSourceStatics> for MseStreamSource {}
 impl RtActivatable<IActivationFactory> for MseStreamSource {}
 impl MseStreamSource {
@@ -12551,7 +12551,7 @@ impl IMseStreamSourceStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct MseTimeRange {
+RT_STRUCT! { struct MseTimeRange ["Windows.Media.Core.MseTimeRange"] {
     Start: foundation::TimeSpan, End: foundation::TimeSpan,
 }}
 DEFINE_IID!(IID_ISceneAnalysisEffect, 3226182425, 51777, 18451, 191, 253, 123, 8, 176, 237, 37, 87);
@@ -12587,8 +12587,8 @@ impl ISceneAnalysisEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SceneAnalysisEffect: ISceneAnalysisEffect}
-RT_CLASS!{class SceneAnalysisEffectDefinition: super::effects::IVideoEffectDefinition}
+RT_CLASS!{class SceneAnalysisEffect: ISceneAnalysisEffect ["Windows.Media.Core.SceneAnalysisEffect"]}
+RT_CLASS!{class SceneAnalysisEffectDefinition: super::effects::IVideoEffectDefinition ["Windows.Media.Core.SceneAnalysisEffectDefinition"]}
 impl RtActivatable<IActivationFactory> for SceneAnalysisEffectDefinition {}
 DEFINE_CLSID!(SceneAnalysisEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,83,99,101,110,101,65,110,97,108,121,115,105,115,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_SceneAnalysisEffectDefinition]);
 DEFINE_IID!(IID_ISceneAnalysisEffectFrame, 3635482188, 32729, 17121, 133, 235, 101, 114, 194, 151, 201, 135);
@@ -12608,7 +12608,7 @@ impl ISceneAnalysisEffectFrame {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SceneAnalysisEffectFrame: ISceneAnalysisEffectFrame}
+RT_CLASS!{class SceneAnalysisEffectFrame: ISceneAnalysisEffectFrame ["Windows.Media.Core.SceneAnalysisEffectFrame"]}
 DEFINE_IID!(IID_ISceneAnalysisEffectFrame2, 760097214, 1567, 18350, 153, 21, 2, 82, 75, 95, 154, 95);
 RT_INTERFACE!{interface ISceneAnalysisEffectFrame2(ISceneAnalysisEffectFrame2Vtbl): IInspectable(IInspectableVtbl) [IID_ISceneAnalysisEffectFrame2] {
     fn get_AnalysisRecommendation(&self, out: *mut SceneAnalysisRecommendation) -> HRESULT
@@ -12620,7 +12620,7 @@ impl ISceneAnalysisEffectFrame2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SceneAnalysisRecommendation: i32 {
+RT_ENUM! { enum SceneAnalysisRecommendation: i32 ["Windows.Media.Core.SceneAnalysisRecommendation"] {
     Standard (SceneAnalysisRecommendation_Standard) = 0, Hdr (SceneAnalysisRecommendation_Hdr) = 1, LowLight (SceneAnalysisRecommendation_LowLight) = 2,
 }}
 DEFINE_IID!(IID_ISceneAnalyzedEventArgs, 342594952, 10321, 17892, 173, 85, 68, 207, 141, 248, 219, 77);
@@ -12634,7 +12634,7 @@ impl ISceneAnalyzedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SceneAnalyzedEventArgs: ISceneAnalyzedEventArgs}
+RT_CLASS!{class SceneAnalyzedEventArgs: ISceneAnalyzedEventArgs ["Windows.Media.Core.SceneAnalyzedEventArgs"]}
 DEFINE_IID!(IID_ISingleSelectMediaTrackList, 1998614303, 49999, 18767, 128, 119, 43, 173, 159, 244, 236, 241);
 RT_INTERFACE!{interface ISingleSelectMediaTrackList(ISingleSelectMediaTrackListVtbl): IInspectable(IInspectableVtbl) [IID_ISingleSelectMediaTrackList] {
     fn add_SelectedIndexChanged(&self, handler: *mut foundation::TypedEventHandler<ISingleSelectMediaTrackList, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -12700,10 +12700,10 @@ impl ISpeechCue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechCue: ISpeechCue}
+RT_CLASS!{class SpeechCue: ISpeechCue ["Windows.Media.Core.SpeechCue"]}
 impl RtActivatable<IActivationFactory> for SpeechCue {}
 DEFINE_CLSID!(SpeechCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,83,112,101,101,99,104,67,117,101,0]) [CLSID_SpeechCue]);
-RT_ENUM! { enum TimedMetadataKind: i32 {
+RT_ENUM! { enum TimedMetadataKind: i32 ["Windows.Media.Core.TimedMetadataKind"] {
     Caption (TimedMetadataKind_Caption) = 0, Chapter (TimedMetadataKind_Chapter) = 1, Custom (TimedMetadataKind_Custom) = 2, Data (TimedMetadataKind_Data) = 3, Description (TimedMetadataKind_Description) = 4, Subtitle (TimedMetadataKind_Subtitle) = 5, ImageSubtitle (TimedMetadataKind_ImageSubtitle) = 6, Speech (TimedMetadataKind_Speech) = 7,
 }}
 DEFINE_IID!(IID_ITimedMetadataStreamDescriptor, 322123455, 10602, 17982, 159, 249, 1, 205, 37, 105, 20, 8);
@@ -12723,7 +12723,7 @@ impl ITimedMetadataStreamDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedMetadataStreamDescriptor: IMediaStreamDescriptor}
+RT_CLASS!{class TimedMetadataStreamDescriptor: IMediaStreamDescriptor ["Windows.Media.Core.TimedMetadataStreamDescriptor"]}
 impl RtActivatable<ITimedMetadataStreamDescriptorFactory> for TimedMetadataStreamDescriptor {}
 impl TimedMetadataStreamDescriptor {
     #[inline] pub fn create(encodingProperties: &super::mediaproperties::TimedMetadataEncodingProperties) -> Result<ComPtr<TimedMetadataStreamDescriptor>> {
@@ -12814,7 +12814,7 @@ impl ITimedMetadataTrack {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedMetadataTrack: ITimedMetadataTrack}
+RT_CLASS!{class TimedMetadataTrack: ITimedMetadataTrack ["Windows.Media.Core.TimedMetadataTrack"]}
 impl RtActivatable<ITimedMetadataTrackFactory> for TimedMetadataTrack {}
 impl TimedMetadataTrack {
     #[inline] pub fn create(id: &HStringArg, language: &HStringArg, kind: TimedMetadataKind) -> Result<ComPtr<TimedMetadataTrack>> {
@@ -12856,8 +12856,8 @@ impl ITimedMetadataTrackError {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedMetadataTrackError: ITimedMetadataTrackError}
-RT_ENUM! { enum TimedMetadataTrackErrorCode: i32 {
+RT_CLASS!{class TimedMetadataTrackError: ITimedMetadataTrackError ["Windows.Media.Core.TimedMetadataTrackError"]}
+RT_ENUM! { enum TimedMetadataTrackErrorCode: i32 ["Windows.Media.Core.TimedMetadataTrackErrorCode"] {
     None (TimedMetadataTrackErrorCode_None) = 0, DataFormatError (TimedMetadataTrackErrorCode_DataFormatError) = 1, NetworkError (TimedMetadataTrackErrorCode_NetworkError) = 2, InternalError (TimedMetadataTrackErrorCode_InternalError) = 3,
 }}
 DEFINE_IID!(IID_ITimedMetadataTrackFactory, 2379576849, 38835, 19999, 133, 44, 15, 72, 44, 129, 173, 38);
@@ -12882,7 +12882,7 @@ impl ITimedMetadataTrackFailedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedMetadataTrackFailedEventArgs: ITimedMetadataTrackFailedEventArgs}
+RT_CLASS!{class TimedMetadataTrackFailedEventArgs: ITimedMetadataTrackFailedEventArgs ["Windows.Media.Core.TimedMetadataTrackFailedEventArgs"]}
 DEFINE_IID!(IID_ITimedMetadataTrackProvider, 998187044, 63310, 19166, 147, 197, 33, 157, 160, 91, 104, 86);
 RT_INTERFACE!{interface ITimedMetadataTrackProvider(ITimedMetadataTrackProviderVtbl): IInspectable(IInspectableVtbl) [IID_ITimedMetadataTrackProvider] {
     fn get_TimedMetadataTracks(&self, out: *mut *mut foundation::collections::IVectorView<TimedMetadataTrack>) -> HRESULT
@@ -12927,19 +12927,19 @@ impl ITimedTextCue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextCue: ITimedTextCue}
+RT_CLASS!{class TimedTextCue: ITimedTextCue ["Windows.Media.Core.TimedTextCue"]}
 impl RtActivatable<IActivationFactory> for TimedTextCue {}
 DEFINE_CLSID!(TimedTextCue(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,67,117,101,0]) [CLSID_TimedTextCue]);
-RT_ENUM! { enum TimedTextDisplayAlignment: i32 {
+RT_ENUM! { enum TimedTextDisplayAlignment: i32 ["Windows.Media.Core.TimedTextDisplayAlignment"] {
     Before (TimedTextDisplayAlignment_Before) = 0, After (TimedTextDisplayAlignment_After) = 1, Center (TimedTextDisplayAlignment_Center) = 2,
 }}
-RT_STRUCT! { struct TimedTextDouble {
+RT_STRUCT! { struct TimedTextDouble ["Windows.Media.Core.TimedTextDouble"] {
     Value: f64, Unit: TimedTextUnit,
 }}
-RT_ENUM! { enum TimedTextFlowDirection: i32 {
+RT_ENUM! { enum TimedTextFlowDirection: i32 ["Windows.Media.Core.TimedTextFlowDirection"] {
     LeftToRight (TimedTextFlowDirection_LeftToRight) = 0, RightToLeft (TimedTextFlowDirection_RightToLeft) = 1,
 }}
-RT_ENUM! { enum TimedTextFontStyle: i32 {
+RT_ENUM! { enum TimedTextFontStyle: i32 ["Windows.Media.Core.TimedTextFontStyle"] {
     Normal (TimedTextFontStyle_Normal) = 0, Oblique (TimedTextFontStyle_Oblique) = 1, Italic (TimedTextFontStyle_Italic) = 2,
 }}
 DEFINE_IID!(IID_ITimedTextLine, 2542632162, 29448, 19558, 190, 80, 101, 119, 114, 137, 245, 223);
@@ -12964,16 +12964,16 @@ impl ITimedTextLine {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextLine: ITimedTextLine}
+RT_CLASS!{class TimedTextLine: ITimedTextLine ["Windows.Media.Core.TimedTextLine"]}
 impl RtActivatable<IActivationFactory> for TimedTextLine {}
 DEFINE_CLSID!(TimedTextLine(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,76,105,110,101,0]) [CLSID_TimedTextLine]);
-RT_ENUM! { enum TimedTextLineAlignment: i32 {
+RT_ENUM! { enum TimedTextLineAlignment: i32 ["Windows.Media.Core.TimedTextLineAlignment"] {
     Start (TimedTextLineAlignment_Start) = 0, End (TimedTextLineAlignment_End) = 1, Center (TimedTextLineAlignment_Center) = 2,
 }}
-RT_STRUCT! { struct TimedTextPadding {
+RT_STRUCT! { struct TimedTextPadding ["Windows.Media.Core.TimedTextPadding"] {
     Before: f64, After: f64, Start: f64, End: f64, Unit: TimedTextUnit,
 }}
-RT_STRUCT! { struct TimedTextPoint {
+RT_STRUCT! { struct TimedTextPoint ["Windows.Media.Core.TimedTextPoint"] {
     X: f64, Y: f64, Unit: TimedTextUnit,
 }}
 DEFINE_IID!(IID_ITimedTextRegion, 516982815, 35334, 16930, 159, 89, 178, 27, 244, 1, 36, 180);
@@ -13115,13 +13115,13 @@ impl ITimedTextRegion {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextRegion: ITimedTextRegion}
+RT_CLASS!{class TimedTextRegion: ITimedTextRegion ["Windows.Media.Core.TimedTextRegion"]}
 impl RtActivatable<IActivationFactory> for TimedTextRegion {}
 DEFINE_CLSID!(TimedTextRegion(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,82,101,103,105,111,110,0]) [CLSID_TimedTextRegion]);
-RT_ENUM! { enum TimedTextScrollMode: i32 {
+RT_ENUM! { enum TimedTextScrollMode: i32 ["Windows.Media.Core.TimedTextScrollMode"] {
     Popon (TimedTextScrollMode_Popon) = 0, Rollup (TimedTextScrollMode_Rollup) = 1,
 }}
-RT_STRUCT! { struct TimedTextSize {
+RT_STRUCT! { struct TimedTextSize ["Windows.Media.Core.TimedTextSize"] {
     Height: f64, Width: f64, Unit: TimedTextUnit,
 }}
 DEFINE_IID!(IID_ITimedTextSource, 3303906214, 4127, 16461, 169, 73, 130, 243, 63, 205, 147, 183);
@@ -13140,7 +13140,7 @@ impl ITimedTextSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextSource: ITimedTextSource}
+RT_CLASS!{class TimedTextSource: ITimedTextSource ["Windows.Media.Core.TimedTextSource"]}
 impl RtActivatable<ITimedTextSourceStatics> for TimedTextSource {}
 impl RtActivatable<ITimedTextSourceStatics2> for TimedTextSource {}
 impl TimedTextSource {
@@ -13187,7 +13187,7 @@ impl ITimedTextSourceResolveResultEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextSourceResolveResultEventArgs: ITimedTextSourceResolveResultEventArgs}
+RT_CLASS!{class TimedTextSourceResolveResultEventArgs: ITimedTextSourceResolveResultEventArgs ["Windows.Media.Core.TimedTextSourceResolveResultEventArgs"]}
 DEFINE_IID!(IID_ITimedTextSourceStatics, 2117146707, 39610, 19140, 187, 152, 47, 177, 118, 195, 191, 221);
 RT_INTERFACE!{static interface ITimedTextSourceStatics(ITimedTextSourceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITimedTextSourceStatics] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -13393,7 +13393,7 @@ impl ITimedTextStyle {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextStyle: ITimedTextStyle}
+RT_CLASS!{class TimedTextStyle: ITimedTextStyle ["Windows.Media.Core.TimedTextStyle"]}
 impl RtActivatable<IActivationFactory> for TimedTextStyle {}
 DEFINE_CLSID!(TimedTextStyle(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,83,116,121,108,101,0]) [CLSID_TimedTextStyle]);
 DEFINE_IID!(IID_ITimedTextStyle2, 1700743469, 24849, 18311, 137, 204, 104, 111, 236, 229, 126, 20);
@@ -13483,19 +13483,19 @@ impl ITimedTextSubformat {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedTextSubformat: ITimedTextSubformat}
+RT_CLASS!{class TimedTextSubformat: ITimedTextSubformat ["Windows.Media.Core.TimedTextSubformat"]}
 impl RtActivatable<IActivationFactory> for TimedTextSubformat {}
 DEFINE_CLSID!(TimedTextSubformat(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,84,105,109,101,100,84,101,120,116,83,117,98,102,111,114,109,97,116,0]) [CLSID_TimedTextSubformat]);
-RT_ENUM! { enum TimedTextUnit: i32 {
+RT_ENUM! { enum TimedTextUnit: i32 ["Windows.Media.Core.TimedTextUnit"] {
     Pixels (TimedTextUnit_Pixels) = 0, Percentage (TimedTextUnit_Percentage) = 1,
 }}
-RT_ENUM! { enum TimedTextWeight: i32 {
+RT_ENUM! { enum TimedTextWeight: i32 ["Windows.Media.Core.TimedTextWeight"] {
     Normal (TimedTextWeight_Normal) = 400, Bold (TimedTextWeight_Bold) = 700,
 }}
-RT_ENUM! { enum TimedTextWrapping: i32 {
+RT_ENUM! { enum TimedTextWrapping: i32 ["Windows.Media.Core.TimedTextWrapping"] {
     NoWrap (TimedTextWrapping_NoWrap) = 0, Wrap (TimedTextWrapping_Wrap) = 1,
 }}
-RT_ENUM! { enum TimedTextWritingMode: i32 {
+RT_ENUM! { enum TimedTextWritingMode: i32 ["Windows.Media.Core.TimedTextWritingMode"] {
     LeftRightTopBottom (TimedTextWritingMode_LeftRightTopBottom) = 0, RightLeftTopBottom (TimedTextWritingMode_RightLeftTopBottom) = 1, TopBottomRightLeft (TimedTextWritingMode_TopBottomRightLeft) = 2, TopBottomLeftRight (TimedTextWritingMode_TopBottomLeftRight) = 3, LeftRight (TimedTextWritingMode_LeftRight) = 4, RightLeft (TimedTextWritingMode_RightLeft) = 5, TopBottom (TimedTextWritingMode_TopBottom) = 6,
 }}
 DEFINE_IID!(IID_IVideoStabilizationEffect, 134784592, 38552, 20055, 135, 123, 189, 124, 178, 238, 15, 138);
@@ -13531,8 +13531,8 @@ impl IVideoStabilizationEffect {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoStabilizationEffect: IVideoStabilizationEffect}
-RT_CLASS!{class VideoStabilizationEffectDefinition: super::effects::IVideoEffectDefinition}
+RT_CLASS!{class VideoStabilizationEffect: IVideoStabilizationEffect ["Windows.Media.Core.VideoStabilizationEffect"]}
+RT_CLASS!{class VideoStabilizationEffectDefinition: super::effects::IVideoEffectDefinition ["Windows.Media.Core.VideoStabilizationEffectDefinition"]}
 impl RtActivatable<IActivationFactory> for VideoStabilizationEffectDefinition {}
 DEFINE_CLSID!(VideoStabilizationEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,67,111,114,101,46,86,105,100,101,111,83,116,97,98,105,108,105,122,97,116,105,111,110,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_VideoStabilizationEffectDefinition]);
 DEFINE_IID!(IID_IVideoStabilizationEffectEnabledChangedEventArgs, 410976040, 26555, 18195, 185, 0, 65, 104, 218, 22, 69, 41);
@@ -13546,8 +13546,8 @@ impl IVideoStabilizationEffectEnabledChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoStabilizationEffectEnabledChangedEventArgs: IVideoStabilizationEffectEnabledChangedEventArgs}
-RT_ENUM! { enum VideoStabilizationEffectEnabledChangedReason: i32 {
+RT_CLASS!{class VideoStabilizationEffectEnabledChangedEventArgs: IVideoStabilizationEffectEnabledChangedEventArgs ["Windows.Media.Core.VideoStabilizationEffectEnabledChangedEventArgs"]}
+RT_ENUM! { enum VideoStabilizationEffectEnabledChangedReason: i32 ["Windows.Media.Core.VideoStabilizationEffectEnabledChangedReason"] {
     Programmatic (VideoStabilizationEffectEnabledChangedReason_Programmatic) = 0, PixelRateTooHigh (VideoStabilizationEffectEnabledChangedReason_PixelRateTooHigh) = 1, RunningSlowly (VideoStabilizationEffectEnabledChangedReason_RunningSlowly) = 2,
 }}
 DEFINE_IID!(IID_IVideoStreamDescriptor, 317590869, 39979, 17472, 128, 87, 44, 122, 144, 240, 203, 236);
@@ -13561,7 +13561,7 @@ impl IVideoStreamDescriptor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoStreamDescriptor: IVideoStreamDescriptor}
+RT_CLASS!{class VideoStreamDescriptor: IVideoStreamDescriptor ["Windows.Media.Core.VideoStreamDescriptor"]}
 impl RtActivatable<IVideoStreamDescriptorFactory> for VideoStreamDescriptor {}
 impl VideoStreamDescriptor {
     #[inline] pub fn create(encodingProperties: &super::mediaproperties::VideoEncodingProperties) -> Result<ComPtr<VideoStreamDescriptor>> {
@@ -13631,7 +13631,7 @@ impl IVideoTrack {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoTrack: IMediaTrack}
+RT_CLASS!{class VideoTrack: IMediaTrack ["Windows.Media.Core.VideoTrack"]}
 DEFINE_IID!(IID_IVideoTrackOpenFailedEventArgs, 1987699249, 1273, 19586, 164, 238, 134, 2, 200, 187, 71, 84);
 RT_INTERFACE!{interface IVideoTrackOpenFailedEventArgs(IVideoTrackOpenFailedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVideoTrackOpenFailedEventArgs] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -13643,7 +13643,7 @@ impl IVideoTrackOpenFailedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoTrackOpenFailedEventArgs: IVideoTrackOpenFailedEventArgs}
+RT_CLASS!{class VideoTrackOpenFailedEventArgs: IVideoTrackOpenFailedEventArgs ["Windows.Media.Core.VideoTrackOpenFailedEventArgs"]}
 DEFINE_IID!(IID_IVideoTrackSupportInfo, 1270166688, 64607, 17677, 143, 240, 119, 141, 89, 4, 134, 222);
 RT_INTERFACE!{interface IVideoTrackSupportInfo(IVideoTrackSupportInfoVtbl): IInspectable(IInspectableVtbl) [IID_IVideoTrackSupportInfo] {
     fn get_DecoderStatus(&self, out: *mut MediaDecoderStatus) -> HRESULT,
@@ -13661,7 +13661,7 @@ impl IVideoTrackSupportInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoTrackSupportInfo: IVideoTrackSupportInfo}
+RT_CLASS!{class VideoTrackSupportInfo: IVideoTrackSupportInfo ["Windows.Media.Core.VideoTrackSupportInfo"]}
 pub mod preview { // Windows.Media.Core.Preview
 use ::prelude::*;
 RT_CLASS!{static class SoundLevelBroker}
@@ -13720,7 +13720,7 @@ impl IAdvancedPhotoCaptureSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdvancedPhotoCaptureSettings: IAdvancedPhotoCaptureSettings}
+RT_CLASS!{class AdvancedPhotoCaptureSettings: IAdvancedPhotoCaptureSettings ["Windows.Media.Devices.AdvancedPhotoCaptureSettings"]}
 impl RtActivatable<IActivationFactory> for AdvancedPhotoCaptureSettings {}
 DEFINE_CLSID!(AdvancedPhotoCaptureSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,65,100,118,97,110,99,101,100,80,104,111,116,111,67,97,112,116,117,114,101,83,101,116,116,105,110,103,115,0]) [CLSID_AdvancedPhotoCaptureSettings]);
 DEFINE_IID!(IID_IAdvancedPhotoControl, 3316733062, 36865, 18050, 147, 9, 104, 234, 224, 8, 14, 236);
@@ -13751,8 +13751,8 @@ impl IAdvancedPhotoControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdvancedPhotoControl: IAdvancedPhotoControl}
-RT_ENUM! { enum AdvancedPhotoMode: i32 {
+RT_CLASS!{class AdvancedPhotoControl: IAdvancedPhotoControl ["Windows.Media.Devices.AdvancedPhotoControl"]}
+RT_ENUM! { enum AdvancedPhotoMode: i32 ["Windows.Media.Devices.AdvancedPhotoMode"] {
     Auto (AdvancedPhotoMode_Auto) = 0, Standard (AdvancedPhotoMode_Standard) = 1, Hdr (AdvancedPhotoMode_Hdr) = 2, LowLight (AdvancedPhotoMode_LowLight) = 3,
 }}
 DEFINE_IID!(IID_IAdvancedVideoCaptureDeviceController, 3731879123, 11158, 17795, 128, 171, 181, 176, 29, 198, 168, 215);
@@ -13989,7 +13989,7 @@ impl IAudioDeviceController {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioDeviceController: IAudioDeviceController}
+RT_CLASS!{class AudioDeviceController: IAudioDeviceController ["Windows.Media.Devices.AudioDeviceController"]}
 DEFINE_IID!(IID_IAudioDeviceModule, 2261756982, 18369, 19251, 152, 82, 135, 115, 236, 75, 225, 35);
 RT_INTERFACE!{interface IAudioDeviceModule(IAudioDeviceModuleVtbl): IInspectable(IInspectableVtbl) [IID_IAudioDeviceModule] {
     fn get_ClassId(&self, out: *mut HSTRING) -> HRESULT,
@@ -14031,7 +14031,7 @@ impl IAudioDeviceModule {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioDeviceModule: IAudioDeviceModule}
+RT_CLASS!{class AudioDeviceModule: IAudioDeviceModule ["Windows.Media.Devices.AudioDeviceModule"]}
 DEFINE_IID!(IID_IAudioDeviceModuleNotificationEventArgs, 3823357103, 8780, 18622, 149, 107, 154, 19, 19, 78, 150, 232);
 RT_INTERFACE!{interface IAudioDeviceModuleNotificationEventArgs(IAudioDeviceModuleNotificationEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAudioDeviceModuleNotificationEventArgs] {
     fn get_Module(&self, out: *mut *mut AudioDeviceModule) -> HRESULT,
@@ -14049,7 +14049,7 @@ impl IAudioDeviceModuleNotificationEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioDeviceModuleNotificationEventArgs: IAudioDeviceModuleNotificationEventArgs}
+RT_CLASS!{class AudioDeviceModuleNotificationEventArgs: IAudioDeviceModuleNotificationEventArgs ["Windows.Media.Devices.AudioDeviceModuleNotificationEventArgs"]}
 DEFINE_IID!(IID_IAudioDeviceModulesManager, 1789135949, 38410, 19740, 179, 24, 0, 34, 96, 69, 71, 237);
 RT_INTERFACE!{interface IAudioDeviceModulesManager(IAudioDeviceModulesManagerVtbl): IInspectable(IInspectableVtbl) [IID_IAudioDeviceModulesManager] {
     fn add_ModuleNotificationReceived(&self, handler: *mut foundation::TypedEventHandler<AudioDeviceModulesManager, AudioDeviceModuleNotificationEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -14078,7 +14078,7 @@ impl IAudioDeviceModulesManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioDeviceModulesManager: IAudioDeviceModulesManager}
+RT_CLASS!{class AudioDeviceModulesManager: IAudioDeviceModulesManager ["Windows.Media.Devices.AudioDeviceModulesManager"]}
 impl RtActivatable<IAudioDeviceModulesManagerFactory> for AudioDeviceModulesManager {}
 impl AudioDeviceModulesManager {
     #[inline] pub fn create(deviceId: &HStringArg) -> Result<ComPtr<AudioDeviceModulesManager>> {
@@ -14097,10 +14097,10 @@ impl IAudioDeviceModulesManagerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AudioDeviceRole: i32 {
+RT_ENUM! { enum AudioDeviceRole: i32 ["Windows.Media.Devices.AudioDeviceRole"] {
     Default (AudioDeviceRole_Default) = 0, Communications (AudioDeviceRole_Communications) = 1,
 }}
-RT_ENUM! { enum AutoFocusRange: i32 {
+RT_ENUM! { enum AutoFocusRange: i32 ["Windows.Media.Devices.AutoFocusRange"] {
     FullRange (AutoFocusRange_FullRange) = 0, Macro (AutoFocusRange_Macro) = 1, Normal (AutoFocusRange_Normal) = 2,
 }}
 DEFINE_IID!(IID_ICallControl, 2770391254, 44685, 17883, 128, 17, 202, 73, 211, 179, 229, 120);
@@ -14202,7 +14202,7 @@ impl ICallControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CallControl: ICallControl}
+RT_CLASS!{class CallControl: ICallControl ["Windows.Media.Devices.CallControl"]}
 impl RtActivatable<ICallControlStatics> for CallControl {}
 impl CallControl {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<CallControl>>> {
@@ -14240,19 +14240,19 @@ impl ICallControlStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CameraStreamState: i32 {
+RT_ENUM! { enum CameraStreamState: i32 ["Windows.Media.Devices.CameraStreamState"] {
     NotStreaming (CameraStreamState_NotStreaming) = 0, Streaming (CameraStreamState_Streaming) = 1, BlockedForPrivacy (CameraStreamState_BlockedForPrivacy) = 2, Shutdown (CameraStreamState_Shutdown) = 3,
 }}
-RT_ENUM! { enum CaptureSceneMode: i32 {
+RT_ENUM! { enum CaptureSceneMode: i32 ["Windows.Media.Devices.CaptureSceneMode"] {
     Auto (CaptureSceneMode_Auto) = 0, Manual (CaptureSceneMode_Manual) = 1, Macro (CaptureSceneMode_Macro) = 2, Portrait (CaptureSceneMode_Portrait) = 3, Sport (CaptureSceneMode_Sport) = 4, Snow (CaptureSceneMode_Snow) = 5, Night (CaptureSceneMode_Night) = 6, Beach (CaptureSceneMode_Beach) = 7, Sunset (CaptureSceneMode_Sunset) = 8, Candlelight (CaptureSceneMode_Candlelight) = 9, Landscape (CaptureSceneMode_Landscape) = 10, NightPortrait (CaptureSceneMode_NightPortrait) = 11, Backlit (CaptureSceneMode_Backlit) = 12,
 }}
-RT_ENUM! { enum CaptureUse: i32 {
+RT_ENUM! { enum CaptureUse: i32 ["Windows.Media.Devices.CaptureUse"] {
     None (CaptureUse_None) = 0, Photo (CaptureUse_Photo) = 1, Video (CaptureUse_Video) = 2,
 }}
-RT_ENUM! { enum ColorTemperaturePreset: i32 {
+RT_ENUM! { enum ColorTemperaturePreset: i32 ["Windows.Media.Devices.ColorTemperaturePreset"] {
     Auto (ColorTemperaturePreset_Auto) = 0, Manual (ColorTemperaturePreset_Manual) = 1, Cloudy (ColorTemperaturePreset_Cloudy) = 2, Daylight (ColorTemperaturePreset_Daylight) = 3, Flash (ColorTemperaturePreset_Flash) = 4, Fluorescent (ColorTemperaturePreset_Fluorescent) = 5, Tungsten (ColorTemperaturePreset_Tungsten) = 6, Candlelight (ColorTemperaturePreset_Candlelight) = 7,
 }}
-RT_CLASS!{class DefaultAudioCaptureDeviceChangedEventArgs: IDefaultAudioDeviceChangedEventArgs}
+RT_CLASS!{class DefaultAudioCaptureDeviceChangedEventArgs: IDefaultAudioDeviceChangedEventArgs ["Windows.Media.Devices.DefaultAudioCaptureDeviceChangedEventArgs"]}
 DEFINE_IID!(IID_IDefaultAudioDeviceChangedEventArgs, 286230575, 7173, 18007, 161, 142, 71, 201, 182, 159, 7, 171);
 RT_INTERFACE!{interface IDefaultAudioDeviceChangedEventArgs(IDefaultAudioDeviceChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDefaultAudioDeviceChangedEventArgs] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -14270,7 +14270,7 @@ impl IDefaultAudioDeviceChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DefaultAudioRenderDeviceChangedEventArgs: IDefaultAudioDeviceChangedEventArgs}
+RT_CLASS!{class DefaultAudioRenderDeviceChangedEventArgs: IDefaultAudioDeviceChangedEventArgs ["Windows.Media.Devices.DefaultAudioRenderDeviceChangedEventArgs"]}
 DEFINE_IID!(IID_IDialRequestedEventArgs, 58430110, 38204, 17030, 136, 102, 79, 15, 55, 108, 133, 90);
 RT_INTERFACE!{interface IDialRequestedEventArgs(IDialRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDialRequestedEventArgs] {
     fn Handled(&self) -> HRESULT,
@@ -14287,7 +14287,7 @@ impl IDialRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialRequestedEventArgs: IDialRequestedEventArgs}
+RT_CLASS!{class DialRequestedEventArgs: IDialRequestedEventArgs ["Windows.Media.Devices.DialRequestedEventArgs"]}
 DEFINE_IID!(IID_DialRequestedEventHandler, 1522270171, 49695, 19396, 137, 27, 37, 126, 40, 193, 177, 164);
 RT_DELEGATE!{delegate DialRequestedEventHandler(DialRequestedEventHandlerVtbl, DialRequestedEventHandlerImpl) [IID_DialRequestedEventHandler] {
     fn Invoke(&self, sender: *mut CallControl, e: *mut DialRequestedEventArgs) -> HRESULT
@@ -14339,7 +14339,7 @@ impl IExposureCompensationControl {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExposureCompensationControl: IExposureCompensationControl}
+RT_CLASS!{class ExposureCompensationControl: IExposureCompensationControl ["Windows.Media.Devices.ExposureCompensationControl"]}
 DEFINE_IID!(IID_IExposureControl, 166251490, 44438, 20264, 160, 224, 150, 237, 126, 27, 95, 210);
 RT_INTERFACE!{interface IExposureControl(IExposureControlVtbl): IInspectable(IInspectableVtbl) [IID_IExposureControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -14393,7 +14393,7 @@ impl IExposureControl {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExposureControl: IExposureControl}
+RT_CLASS!{class ExposureControl: IExposureControl ["Windows.Media.Devices.ExposureControl"]}
 DEFINE_IID!(IID_IExposurePriorityVideoControl, 749879459, 20840, 17009, 158, 165, 71, 98, 26, 152, 163, 82);
 RT_INTERFACE!{interface IExposurePriorityVideoControl(IExposurePriorityVideoControlVtbl): IInspectable(IInspectableVtbl) [IID_IExposurePriorityVideoControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -14416,7 +14416,7 @@ impl IExposurePriorityVideoControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExposurePriorityVideoControl: IExposurePriorityVideoControl}
+RT_CLASS!{class ExposurePriorityVideoControl: IExposurePriorityVideoControl ["Windows.Media.Devices.ExposurePriorityVideoControl"]}
 DEFINE_IID!(IID_IFlashControl, 3740540350, 32104, 17891, 140, 15, 190, 123, 179, 40, 55, 208);
 RT_INTERFACE!{interface IFlashControl(IFlashControlVtbl): IInspectable(IInspectableVtbl) [IID_IFlashControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -14484,7 +14484,7 @@ impl IFlashControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FlashControl: IFlashControl}
+RT_CLASS!{class FlashControl: IFlashControl ["Windows.Media.Devices.FlashControl"]}
 DEFINE_IID!(IID_IFlashControl2, 2099891358, 30177, 19191, 189, 125, 78, 56, 225, 192, 108, 214);
 RT_INTERFACE!{interface IFlashControl2(IFlashControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IFlashControl2] {
     fn get_AssistantLightSupported(&self, out: *mut bool) -> HRESULT,
@@ -14578,7 +14578,7 @@ impl IFocusControl {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FocusControl: IFocusControl}
+RT_CLASS!{class FocusControl: IFocusControl ["Windows.Media.Devices.FocusControl"]}
 DEFINE_IID!(IID_IFocusControl2, 1065156424, 50484, 20126, 148, 195, 82, 239, 42, 253, 93, 7);
 RT_INTERFACE!{interface IFocusControl2(IFocusControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IFocusControl2] {
     fn get_FocusChangedSupported(&self, out: *mut bool) -> HRESULT,
@@ -14643,10 +14643,10 @@ impl IFocusControl2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum FocusMode: i32 {
+RT_ENUM! { enum FocusMode: i32 ["Windows.Media.Devices.FocusMode"] {
     Auto (FocusMode_Auto) = 0, Single (FocusMode_Single) = 1, Continuous (FocusMode_Continuous) = 2, Manual (FocusMode_Manual) = 3,
 }}
-RT_ENUM! { enum FocusPreset: i32 {
+RT_ENUM! { enum FocusPreset: i32 ["Windows.Media.Devices.FocusPreset"] {
     Auto (FocusPreset_Auto) = 0, Manual (FocusPreset_Manual) = 1, AutoMacro (FocusPreset_AutoMacro) = 2, AutoNormal (FocusPreset_AutoNormal) = 3, AutoInfinity (FocusPreset_AutoInfinity) = 4, AutoHyperfocal (FocusPreset_AutoHyperfocal) = 5,
 }}
 DEFINE_IID!(IID_IFocusSettings, 2039844715, 12899, 17013, 133, 214, 174, 174, 137, 28, 150, 238);
@@ -14720,7 +14720,7 @@ impl IFocusSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FocusSettings: IFocusSettings}
+RT_CLASS!{class FocusSettings: IFocusSettings ["Windows.Media.Devices.FocusSettings"]}
 impl RtActivatable<IActivationFactory> for FocusSettings {}
 DEFINE_CLSID!(FocusSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,70,111,99,117,115,83,101,116,116,105,110,103,115,0]) [CLSID_FocusSettings]);
 DEFINE_IID!(IID_IHdrVideoControl, 1440277200, 12480, 17343, 155, 154, 151, 153, 215, 12, 237, 148);
@@ -14751,8 +14751,8 @@ impl IHdrVideoControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HdrVideoControl: IHdrVideoControl}
-RT_ENUM! { enum HdrVideoMode: i32 {
+RT_CLASS!{class HdrVideoControl: IHdrVideoControl ["Windows.Media.Devices.HdrVideoControl"]}
+RT_ENUM! { enum HdrVideoMode: i32 ["Windows.Media.Devices.HdrVideoMode"] {
     Off (HdrVideoMode_Off) = 0, On (HdrVideoMode_On) = 1, Auto (HdrVideoMode_Auto) = 2,
 }}
 DEFINE_IID!(IID_IIsoSpeedControl, 666288930, 9645, 20251, 170, 171, 82, 74, 179, 118, 202, 51);
@@ -14784,7 +14784,7 @@ impl IIsoSpeedControl {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class IsoSpeedControl: IIsoSpeedControl}
+RT_CLASS!{class IsoSpeedControl: IIsoSpeedControl ["Windows.Media.Devices.IsoSpeedControl"]}
 DEFINE_IID!(IID_IIsoSpeedControl2, 1863678194, 28023, 20362, 140, 47, 97, 48, 182, 57, 80, 83);
 RT_INTERFACE!{interface IIsoSpeedControl2(IIsoSpeedControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IIsoSpeedControl2] {
     fn get_Min(&self, out: *mut u32) -> HRESULT,
@@ -14832,7 +14832,7 @@ impl IIsoSpeedControl2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum IsoSpeedPreset: i32 {
+RT_ENUM! { enum IsoSpeedPreset: i32 ["Windows.Media.Devices.IsoSpeedPreset"] {
     Auto (IsoSpeedPreset_Auto) = 0, Iso50 (IsoSpeedPreset_Iso50) = 1, Iso80 (IsoSpeedPreset_Iso80) = 2, Iso100 (IsoSpeedPreset_Iso100) = 3, Iso200 (IsoSpeedPreset_Iso200) = 4, Iso400 (IsoSpeedPreset_Iso400) = 5, Iso800 (IsoSpeedPreset_Iso800) = 6, Iso1600 (IsoSpeedPreset_Iso1600) = 7, Iso3200 (IsoSpeedPreset_Iso3200) = 8, Iso6400 (IsoSpeedPreset_Iso6400) = 9, Iso12800 (IsoSpeedPreset_Iso12800) = 10, Iso25600 (IsoSpeedPreset_Iso25600) = 11,
 }}
 DEFINE_IID!(IID_IKeypadPressedEventArgs, 3550755072, 46330, 18893, 148, 66, 137, 175, 101, 104, 246, 1);
@@ -14846,7 +14846,7 @@ impl IKeypadPressedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeypadPressedEventArgs: IKeypadPressedEventArgs}
+RT_CLASS!{class KeypadPressedEventArgs: IKeypadPressedEventArgs ["Windows.Media.Devices.KeypadPressedEventArgs"]}
 DEFINE_IID!(IID_KeypadPressedEventHandler, 3862406228, 50471, 16940, 137, 38, 201, 175, 131, 181, 89, 160);
 RT_DELEGATE!{delegate KeypadPressedEventHandler(KeypadPressedEventHandlerVtbl, KeypadPressedEventHandlerImpl) [IID_KeypadPressedEventHandler] {
     fn Invoke(&self, sender: *mut CallControl, e: *mut KeypadPressedEventArgs) -> HRESULT
@@ -14913,7 +14913,7 @@ impl ILowLagPhotoControl {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLagPhotoControl: ILowLagPhotoControl}
+RT_CLASS!{class LowLagPhotoControl: ILowLagPhotoControl ["Windows.Media.Devices.LowLagPhotoControl"]}
 DEFINE_IID!(IID_ILowLagPhotoSequenceControl, 1037013149, 27926, 16540, 186, 254, 185, 165, 148, 198, 253, 230);
 RT_INTERFACE!{interface ILowLagPhotoSequenceControl(ILowLagPhotoSequenceControlVtbl): IInspectable(IInspectableVtbl) [IID_ILowLagPhotoSequenceControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -15010,17 +15010,17 @@ impl ILowLagPhotoSequenceControl {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LowLagPhotoSequenceControl: ILowLagPhotoSequenceControl}
-RT_ENUM! { enum ManualFocusDistance: i32 {
+RT_CLASS!{class LowLagPhotoSequenceControl: ILowLagPhotoSequenceControl ["Windows.Media.Devices.LowLagPhotoSequenceControl"]}
+RT_ENUM! { enum ManualFocusDistance: i32 ["Windows.Media.Devices.ManualFocusDistance"] {
     Infinity (ManualFocusDistance_Infinity) = 0, Hyperfocal (ManualFocusDistance_Hyperfocal) = 1, Nearest (ManualFocusDistance_Nearest) = 2,
 }}
-RT_ENUM! { enum MediaCaptureFocusState: i32 {
+RT_ENUM! { enum MediaCaptureFocusState: i32 ["Windows.Media.Devices.MediaCaptureFocusState"] {
     Uninitialized (MediaCaptureFocusState_Uninitialized) = 0, Lost (MediaCaptureFocusState_Lost) = 1, Searching (MediaCaptureFocusState_Searching) = 2, Focused (MediaCaptureFocusState_Focused) = 3, Failed (MediaCaptureFocusState_Failed) = 4,
 }}
-RT_ENUM! { enum MediaCaptureOptimization: i32 {
+RT_ENUM! { enum MediaCaptureOptimization: i32 ["Windows.Media.Devices.MediaCaptureOptimization"] {
     Default (MediaCaptureOptimization_Default) = 0, Quality (MediaCaptureOptimization_Quality) = 1, Latency (MediaCaptureOptimization_Latency) = 2, Power (MediaCaptureOptimization_Power) = 3, LatencyThenQuality (MediaCaptureOptimization_LatencyThenQuality) = 4, LatencyThenPower (MediaCaptureOptimization_LatencyThenPower) = 5, PowerAndQuality (MediaCaptureOptimization_PowerAndQuality) = 6,
 }}
-RT_ENUM! { enum MediaCapturePauseBehavior: i32 {
+RT_ENUM! { enum MediaCapturePauseBehavior: i32 ["Windows.Media.Devices.MediaCapturePauseBehavior"] {
     RetainHardwareResources (MediaCapturePauseBehavior_RetainHardwareResources) = 0, ReleaseHardwareResources (MediaCapturePauseBehavior_ReleaseHardwareResources) = 1,
 }}
 RT_CLASS!{static class MediaDevice}
@@ -15090,7 +15090,7 @@ impl IMediaDeviceControl {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaDeviceControl: IMediaDeviceControl}
+RT_CLASS!{class MediaDeviceControl: IMediaDeviceControl ["Windows.Media.Devices.MediaDeviceControl"]}
 DEFINE_IID!(IID_IMediaDeviceControlCapabilities, 587225110, 60293, 17378, 185, 43, 130, 64, 213, 238, 112, 236);
 RT_INTERFACE!{interface IMediaDeviceControlCapabilities(IMediaDeviceControlCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IMediaDeviceControlCapabilities] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -15132,7 +15132,7 @@ impl IMediaDeviceControlCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaDeviceControlCapabilities: IMediaDeviceControlCapabilities}
+RT_CLASS!{class MediaDeviceControlCapabilities: IMediaDeviceControlCapabilities ["Windows.Media.Devices.MediaDeviceControlCapabilities"]}
 DEFINE_IID!(IID_IMediaDeviceController, 4143510990, 8346, 18683, 134, 252, 212, 69, 120, 243, 23, 230);
 RT_INTERFACE!{interface IMediaDeviceController(IMediaDeviceControllerVtbl): IInspectable(IInspectableVtbl) [IID_IMediaDeviceController] {
     fn GetAvailableMediaStreamProperties(&self, mediaStreamType: super::capture::MediaStreamType, out: *mut *mut foundation::collections::IVectorView<super::mediaproperties::IMediaEncodingProperties>) -> HRESULT,
@@ -15230,7 +15230,7 @@ impl IModuleCommandResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ModuleCommandResult: IModuleCommandResult}
+RT_CLASS!{class ModuleCommandResult: IModuleCommandResult ["Windows.Media.Devices.ModuleCommandResult"]}
 DEFINE_IID!(IID_IOpticalImageStabilizationControl, 3215825949, 188, 16955, 142, 178, 160, 23, 140, 169, 66, 71);
 RT_INTERFACE!{interface IOpticalImageStabilizationControl(IOpticalImageStabilizationControlVtbl): IInspectable(IInspectableVtbl) [IID_IOpticalImageStabilizationControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -15259,8 +15259,8 @@ impl IOpticalImageStabilizationControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OpticalImageStabilizationControl: IOpticalImageStabilizationControl}
-RT_ENUM! { enum OpticalImageStabilizationMode: i32 {
+RT_CLASS!{class OpticalImageStabilizationControl: IOpticalImageStabilizationControl ["Windows.Media.Devices.OpticalImageStabilizationControl"]}
+RT_ENUM! { enum OpticalImageStabilizationMode: i32 ["Windows.Media.Devices.OpticalImageStabilizationMode"] {
     Off (OpticalImageStabilizationMode_Off) = 0, On (OpticalImageStabilizationMode_On) = 1, Auto (OpticalImageStabilizationMode_Auto) = 2,
 }}
 DEFINE_IID!(IID_IPhotoConfirmationControl, 3371430755, 65374, 17794, 169, 168, 5, 80, 248, 90, 74, 118);
@@ -15296,7 +15296,7 @@ impl IPhotoConfirmationControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoConfirmationControl: IPhotoConfirmationControl}
+RT_CLASS!{class PhotoConfirmationControl: IPhotoConfirmationControl ["Windows.Media.Devices.PhotoConfirmationControl"]}
 DEFINE_IID!(IID_IRedialRequestedEventArgs, 2125812233, 30379, 19505, 180, 14, 75, 88, 55, 157, 88, 12);
 RT_INTERFACE!{interface IRedialRequestedEventArgs(IRedialRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRedialRequestedEventArgs] {
     fn Handled(&self) -> HRESULT
@@ -15307,7 +15307,7 @@ impl IRedialRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RedialRequestedEventArgs: IRedialRequestedEventArgs}
+RT_CLASS!{class RedialRequestedEventArgs: IRedialRequestedEventArgs ["Windows.Media.Devices.RedialRequestedEventArgs"]}
 DEFINE_IID!(IID_RedialRequestedEventHandler, 3136444369, 20157, 19332, 159, 71, 110, 196, 61, 117, 216, 177);
 RT_DELEGATE!{delegate RedialRequestedEventHandler(RedialRequestedEventHandlerVtbl, RedialRequestedEventHandlerImpl) [IID_RedialRequestedEventHandler] {
     fn Invoke(&self, sender: *mut CallControl, e: *mut RedialRequestedEventArgs) -> HRESULT
@@ -15367,7 +15367,7 @@ impl IRegionOfInterest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RegionOfInterest: IRegionOfInterest}
+RT_CLASS!{class RegionOfInterest: IRegionOfInterest ["Windows.Media.Devices.RegionOfInterest"]}
 impl RtActivatable<IActivationFactory> for RegionOfInterest {}
 DEFINE_CLSID!(RegionOfInterest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,82,101,103,105,111,110,79,102,73,110,116,101,114,101,115,116,0]) [CLSID_RegionOfInterest]);
 DEFINE_IID!(IID_IRegionOfInterest2, 436087441, 29610, 19793, 138, 157, 86, 204, 247, 219, 127, 84);
@@ -15408,7 +15408,7 @@ impl IRegionOfInterest2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RegionOfInterestType: i32 {
+RT_ENUM! { enum RegionOfInterestType: i32 ["Windows.Media.Devices.RegionOfInterestType"] {
     Unknown (RegionOfInterestType_Unknown) = 0, Face (RegionOfInterestType_Face) = 1,
 }}
 DEFINE_IID!(IID_IRegionsOfInterestControl, 3273913639, 43787, 17752, 139, 91, 223, 86, 147, 219, 3, 120);
@@ -15458,7 +15458,7 @@ impl IRegionsOfInterestControl {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RegionsOfInterestControl: IRegionsOfInterestControl}
+RT_CLASS!{class RegionsOfInterestControl: IRegionsOfInterestControl ["Windows.Media.Devices.RegionsOfInterestControl"]}
 DEFINE_IID!(IID_ISceneModeControl, 3566099191, 36185, 18516, 140, 98, 18, 199, 11, 168, 155, 124);
 RT_INTERFACE!{interface ISceneModeControl(ISceneModeControlVtbl): IInspectable(IInspectableVtbl) [IID_ISceneModeControl] {
     fn get_SupportedModes(&self, out: *mut *mut foundation::collections::IVectorView<CaptureSceneMode>) -> HRESULT,
@@ -15482,11 +15482,11 @@ impl ISceneModeControl {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SceneModeControl: ISceneModeControl}
-RT_ENUM! { enum SendCommandStatus: i32 {
+RT_CLASS!{class SceneModeControl: ISceneModeControl ["Windows.Media.Devices.SceneModeControl"]}
+RT_ENUM! { enum SendCommandStatus: i32 ["Windows.Media.Devices.SendCommandStatus"] {
     Success (SendCommandStatus_Success) = 0, DeviceNotAvailable (SendCommandStatus_DeviceNotAvailable) = 1,
 }}
-RT_ENUM! { enum TelephonyKey: i32 {
+RT_ENUM! { enum TelephonyKey: i32 ["Windows.Media.Devices.TelephonyKey"] {
     D0 (TelephonyKey_D0) = 0, D1 (TelephonyKey_D1) = 1, D2 (TelephonyKey_D2) = 2, D3 (TelephonyKey_D3) = 3, D4 (TelephonyKey_D4) = 4, D5 (TelephonyKey_D5) = 5, D6 (TelephonyKey_D6) = 6, D7 (TelephonyKey_D7) = 7, D8 (TelephonyKey_D8) = 8, D9 (TelephonyKey_D9) = 9, Star (TelephonyKey_Star) = 10, Pound (TelephonyKey_Pound) = 11, A (TelephonyKey_A) = 12, B (TelephonyKey_B) = 13, C (TelephonyKey_C) = 14, D (TelephonyKey_D) = 15,
 }}
 DEFINE_IID!(IID_ITorchControl, 2785359461, 33360, 16748, 145, 154, 114, 66, 150, 175, 163, 6);
@@ -15528,7 +15528,7 @@ impl ITorchControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TorchControl: ITorchControl}
+RT_CLASS!{class TorchControl: ITorchControl ["Windows.Media.Devices.TorchControl"]}
 DEFINE_IID!(IID_IVideoDeviceController, 2572506485, 11822, 16568, 182, 199, 248, 45, 16, 1, 50, 16);
 RT_INTERFACE!{interface IVideoDeviceController(IVideoDeviceControllerVtbl): IInspectable(IInspectableVtbl) [IID_IVideoDeviceController] {
     fn get_Brightness(&self, out: *mut *mut MediaDeviceControl) -> HRESULT,
@@ -15612,7 +15612,7 @@ impl IVideoDeviceController {
         if hr == S_OK { Ok((value, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoDeviceController: IVideoDeviceController}
+RT_CLASS!{class VideoDeviceController: IVideoDeviceController ["Windows.Media.Devices.VideoDeviceController"]}
 DEFINE_IID!(IID_IVideoDeviceControllerGetDevicePropertyResult, 3319301013, 28373, 18320, 139, 93, 14, 241, 57, 53, 208, 248);
 RT_INTERFACE!{interface IVideoDeviceControllerGetDevicePropertyResult(IVideoDeviceControllerGetDevicePropertyResultVtbl): IInspectable(IInspectableVtbl) [IID_IVideoDeviceControllerGetDevicePropertyResult] {
     fn get_Status(&self, out: *mut VideoDeviceControllerGetDevicePropertyStatus) -> HRESULT,
@@ -15630,11 +15630,11 @@ impl IVideoDeviceControllerGetDevicePropertyResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoDeviceControllerGetDevicePropertyResult: IVideoDeviceControllerGetDevicePropertyResult}
-RT_ENUM! { enum VideoDeviceControllerGetDevicePropertyStatus: i32 {
+RT_CLASS!{class VideoDeviceControllerGetDevicePropertyResult: IVideoDeviceControllerGetDevicePropertyResult ["Windows.Media.Devices.VideoDeviceControllerGetDevicePropertyResult"]}
+RT_ENUM! { enum VideoDeviceControllerGetDevicePropertyStatus: i32 ["Windows.Media.Devices.VideoDeviceControllerGetDevicePropertyStatus"] {
     Success (VideoDeviceControllerGetDevicePropertyStatus_Success) = 0, UnknownFailure (VideoDeviceControllerGetDevicePropertyStatus_UnknownFailure) = 1, BufferTooSmall (VideoDeviceControllerGetDevicePropertyStatus_BufferTooSmall) = 2, NotSupported (VideoDeviceControllerGetDevicePropertyStatus_NotSupported) = 3, DeviceNotAvailable (VideoDeviceControllerGetDevicePropertyStatus_DeviceNotAvailable) = 4, MaxPropertyValueSizeTooSmall (VideoDeviceControllerGetDevicePropertyStatus_MaxPropertyValueSizeTooSmall) = 5, MaxPropertyValueSizeRequired (VideoDeviceControllerGetDevicePropertyStatus_MaxPropertyValueSizeRequired) = 6,
 }}
-RT_ENUM! { enum VideoDeviceControllerSetDevicePropertyStatus: i32 {
+RT_ENUM! { enum VideoDeviceControllerSetDevicePropertyStatus: i32 ["Windows.Media.Devices.VideoDeviceControllerSetDevicePropertyStatus"] {
     Success (VideoDeviceControllerSetDevicePropertyStatus_Success) = 0, UnknownFailure (VideoDeviceControllerSetDevicePropertyStatus_UnknownFailure) = 1, NotSupported (VideoDeviceControllerSetDevicePropertyStatus_NotSupported) = 2, InvalidValue (VideoDeviceControllerSetDevicePropertyStatus_InvalidValue) = 3, DeviceNotAvailable (VideoDeviceControllerSetDevicePropertyStatus_DeviceNotAvailable) = 4, NotInControl (VideoDeviceControllerSetDevicePropertyStatus_NotInControl) = 5,
 }}
 DEFINE_IID!(IID_IVideoTemporalDenoisingControl, 2058569525, 15914, 18994, 186, 255, 67, 88, 196, 251, 221, 87);
@@ -15665,8 +15665,8 @@ impl IVideoTemporalDenoisingControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoTemporalDenoisingControl: IVideoTemporalDenoisingControl}
-RT_ENUM! { enum VideoTemporalDenoisingMode: i32 {
+RT_CLASS!{class VideoTemporalDenoisingControl: IVideoTemporalDenoisingControl ["Windows.Media.Devices.VideoTemporalDenoisingControl"]}
+RT_ENUM! { enum VideoTemporalDenoisingMode: i32 ["Windows.Media.Devices.VideoTemporalDenoisingMode"] {
     Off (VideoTemporalDenoisingMode_Off) = 0, On (VideoTemporalDenoisingMode_On) = 1, Auto (VideoTemporalDenoisingMode_Auto) = 2,
 }}
 DEFINE_IID!(IID_IWhiteBalanceControl, 2015298686, 29026, 18888, 168, 249, 148, 129, 197, 101, 54, 62);
@@ -15722,7 +15722,7 @@ impl IWhiteBalanceControl {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WhiteBalanceControl: IWhiteBalanceControl}
+RT_CLASS!{class WhiteBalanceControl: IWhiteBalanceControl ["Windows.Media.Devices.WhiteBalanceControl"]}
 DEFINE_IID!(IID_IZoomControl, 975047442, 13018, 19479, 191, 215, 141, 12, 115, 200, 245, 165);
 RT_INTERFACE!{interface IZoomControl(IZoomControlVtbl): IInspectable(IInspectableVtbl) [IID_IZoomControl] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -15763,7 +15763,7 @@ impl IZoomControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ZoomControl: IZoomControl}
+RT_CLASS!{class ZoomControl: IZoomControl ["Windows.Media.Devices.ZoomControl"]}
 DEFINE_IID!(IID_IZoomControl2, 1770274224, 11929, 17985, 133, 41, 24, 79, 49, 157, 22, 113);
 RT_INTERFACE!{interface IZoomControl2(IZoomControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IZoomControl2] {
     fn get_SupportedModes(&self, out: *mut *mut foundation::collections::IVectorView<ZoomTransitionMode>) -> HRESULT,
@@ -15813,10 +15813,10 @@ impl IZoomSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ZoomSettings: IZoomSettings}
+RT_CLASS!{class ZoomSettings: IZoomSettings ["Windows.Media.Devices.ZoomSettings"]}
 impl RtActivatable<IActivationFactory> for ZoomSettings {}
 DEFINE_CLSID!(ZoomSettings(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,90,111,111,109,83,101,116,116,105,110,103,115,0]) [CLSID_ZoomSettings]);
-RT_ENUM! { enum ZoomTransitionMode: i32 {
+RT_ENUM! { enum ZoomTransitionMode: i32 ["Windows.Media.Devices.ZoomTransitionMode"] {
     Auto (ZoomTransitionMode_Auto) = 0, Direct (ZoomTransitionMode_Direct) = 1, Smooth (ZoomTransitionMode_Smooth) = 2,
 }}
 pub mod core { // Windows.Media.Devices.Core
@@ -15884,7 +15884,7 @@ impl ICameraIntrinsics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CameraIntrinsics: ICameraIntrinsics}
+RT_CLASS!{class CameraIntrinsics: ICameraIntrinsics ["Windows.Media.Devices.Core.CameraIntrinsics"]}
 impl RtActivatable<ICameraIntrinsicsFactory> for CameraIntrinsics {}
 impl CameraIntrinsics {
     #[inline] pub fn create(focalLength: foundation::numerics::Vector2, principalPoint: foundation::numerics::Vector2, radialDistortion: foundation::numerics::Vector3, tangentialDistortion: foundation::numerics::Vector2, imageWidth: u32, imageHeight: u32) -> Result<ComPtr<CameraIntrinsics>> {
@@ -15963,7 +15963,7 @@ impl IDepthCorrelatedCoordinateMapper {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DepthCorrelatedCoordinateMapper: IDepthCorrelatedCoordinateMapper}
+RT_CLASS!{class DepthCorrelatedCoordinateMapper: IDepthCorrelatedCoordinateMapper ["Windows.Media.Devices.Core.DepthCorrelatedCoordinateMapper"]}
 DEFINE_IID!(IID_IFrameControlCapabilities, 2835328608, 20126, 17271, 167, 137, 226, 76, 74, 231, 229, 68);
 RT_INTERFACE!{interface IFrameControlCapabilities(IFrameControlCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IFrameControlCapabilities] {
     fn get_Exposure(&self, out: *mut *mut FrameExposureCapabilities) -> HRESULT,
@@ -15999,7 +15999,7 @@ impl IFrameControlCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameControlCapabilities: IFrameControlCapabilities}
+RT_CLASS!{class FrameControlCapabilities: IFrameControlCapabilities ["Windows.Media.Devices.Core.FrameControlCapabilities"]}
 DEFINE_IID!(IID_IFrameControlCapabilities2, 3466265700, 18224, 17423, 189, 62, 239, 232, 168, 242, 48, 168);
 RT_INTERFACE!{interface IFrameControlCapabilities2(IFrameControlCapabilities2Vtbl): IInspectable(IInspectableVtbl) [IID_IFrameControlCapabilities2] {
     fn get_Flash(&self, out: *mut *mut FrameFlashCapabilities) -> HRESULT
@@ -16051,7 +16051,7 @@ impl IFrameController {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameController: IFrameController}
+RT_CLASS!{class FrameController: IFrameController ["Windows.Media.Devices.Core.FrameController"]}
 impl RtActivatable<IActivationFactory> for FrameController {}
 DEFINE_CLSID!(FrameController(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,101,118,105,99,101,115,46,67,111,114,101,46,70,114,97,109,101,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_FrameController]);
 DEFINE_IID!(IID_IFrameController2, 13876341, 55420, 18523, 138, 9, 92, 53, 133, 104, 180, 39);
@@ -16094,7 +16094,7 @@ impl IFrameExposureCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameExposureCapabilities: IFrameExposureCapabilities}
+RT_CLASS!{class FrameExposureCapabilities: IFrameExposureCapabilities ["Windows.Media.Devices.Core.FrameExposureCapabilities"]}
 DEFINE_IID!(IID_IFrameExposureCompensationCapabilities, 3112740899, 32869, 16878, 176, 79, 114, 34, 101, 149, 69, 0);
 RT_INTERFACE!{interface IFrameExposureCompensationCapabilities(IFrameExposureCompensationCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IFrameExposureCompensationCapabilities] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -16124,7 +16124,7 @@ impl IFrameExposureCompensationCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameExposureCompensationCapabilities: IFrameExposureCompensationCapabilities}
+RT_CLASS!{class FrameExposureCompensationCapabilities: IFrameExposureCompensationCapabilities ["Windows.Media.Devices.Core.FrameExposureCompensationCapabilities"]}
 DEFINE_IID!(IID_IFrameExposureCompensationControl, 3914897097, 63481, 18634, 133, 145, 162, 101, 49, 203, 21, 120);
 RT_INTERFACE!{interface IFrameExposureCompensationControl(IFrameExposureCompensationControlVtbl): IInspectable(IInspectableVtbl) [IID_IFrameExposureCompensationControl] {
     fn get_Value(&self, out: *mut *mut foundation::IReference<f32>) -> HRESULT,
@@ -16141,7 +16141,7 @@ impl IFrameExposureCompensationControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameExposureCompensationControl: IFrameExposureCompensationControl}
+RT_CLASS!{class FrameExposureCompensationControl: IFrameExposureCompensationControl ["Windows.Media.Devices.Core.FrameExposureCompensationControl"]}
 DEFINE_IID!(IID_IFrameExposureControl, 2975881825, 65455, 18258, 182, 33, 245, 182, 241, 23, 244, 50);
 RT_INTERFACE!{interface IFrameExposureControl(IFrameExposureControlVtbl): IInspectable(IInspectableVtbl) [IID_IFrameExposureControl] {
     fn get_Auto(&self, out: *mut bool) -> HRESULT,
@@ -16169,7 +16169,7 @@ impl IFrameExposureControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameExposureControl: IFrameExposureControl}
+RT_CLASS!{class FrameExposureControl: IFrameExposureControl ["Windows.Media.Devices.Core.FrameExposureControl"]}
 DEFINE_IID!(IID_IFrameFlashCapabilities, 3146989986, 24254, 20322, 130, 35, 14, 43, 5, 191, 187, 208);
 RT_INTERFACE!{interface IFrameFlashCapabilities(IFrameFlashCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IFrameFlashCapabilities] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -16193,7 +16193,7 @@ impl IFrameFlashCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameFlashCapabilities: IFrameFlashCapabilities}
+RT_CLASS!{class FrameFlashCapabilities: IFrameFlashCapabilities ["Windows.Media.Devices.Core.FrameFlashCapabilities"]}
 DEFINE_IID!(IID_IFrameFlashControl, 1976956615, 48453, 20395, 147, 117, 69, 172, 4, 179, 50, 194);
 RT_INTERFACE!{interface IFrameFlashControl(IFrameFlashControlVtbl): IInspectable(IInspectableVtbl) [IID_IFrameFlashControl] {
     fn get_Mode(&self, out: *mut FrameFlashMode) -> HRESULT,
@@ -16243,8 +16243,8 @@ impl IFrameFlashControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameFlashControl: IFrameFlashControl}
-RT_ENUM! { enum FrameFlashMode: i32 {
+RT_CLASS!{class FrameFlashControl: IFrameFlashControl ["Windows.Media.Devices.Core.FrameFlashControl"]}
+RT_ENUM! { enum FrameFlashMode: i32 ["Windows.Media.Devices.Core.FrameFlashMode"] {
     Disable (FrameFlashMode_Disable) = 0, Enable (FrameFlashMode_Enable) = 1, Global (FrameFlashMode_Global) = 2,
 }}
 DEFINE_IID!(IID_IFrameFocusCapabilities, 2066074968, 448, 16485, 156, 64, 193, 167, 33, 66, 92, 26);
@@ -16276,7 +16276,7 @@ impl IFrameFocusCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameFocusCapabilities: IFrameFocusCapabilities}
+RT_CLASS!{class FrameFocusCapabilities: IFrameFocusCapabilities ["Windows.Media.Devices.Core.FrameFocusCapabilities"]}
 DEFINE_IID!(IID_IFrameFocusControl, 657322448, 55570, 16916, 166, 123, 227, 138, 141, 72, 216, 198);
 RT_INTERFACE!{interface IFrameFocusControl(IFrameFocusControlVtbl): IInspectable(IInspectableVtbl) [IID_IFrameFocusControl] {
     fn get_Value(&self, out: *mut *mut foundation::IReference<u32>) -> HRESULT,
@@ -16293,7 +16293,7 @@ impl IFrameFocusControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameFocusControl: IFrameFocusControl}
+RT_CLASS!{class FrameFocusControl: IFrameFocusControl ["Windows.Media.Devices.Core.FrameFocusControl"]}
 DEFINE_IID!(IID_IFrameIsoSpeedCapabilities, 381550433, 28150, 19145, 185, 42, 159, 110, 205, 26, 210, 250);
 RT_INTERFACE!{interface IFrameIsoSpeedCapabilities(IFrameIsoSpeedCapabilitiesVtbl): IInspectable(IInspectableVtbl) [IID_IFrameIsoSpeedCapabilities] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -16323,7 +16323,7 @@ impl IFrameIsoSpeedCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameIsoSpeedCapabilities: IFrameIsoSpeedCapabilities}
+RT_CLASS!{class FrameIsoSpeedCapabilities: IFrameIsoSpeedCapabilities ["Windows.Media.Devices.Core.FrameIsoSpeedCapabilities"]}
 DEFINE_IID!(IID_IFrameIsoSpeedControl, 436465645, 30826, 19573, 165, 87, 122, 185, 168, 95, 88, 140);
 RT_INTERFACE!{interface IFrameIsoSpeedControl(IFrameIsoSpeedControlVtbl): IInspectable(IInspectableVtbl) [IID_IFrameIsoSpeedControl] {
     fn get_Auto(&self, out: *mut bool) -> HRESULT,
@@ -16351,7 +16351,7 @@ impl IFrameIsoSpeedControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FrameIsoSpeedControl: IFrameIsoSpeedControl}
+RT_CLASS!{class FrameIsoSpeedControl: IFrameIsoSpeedControl ["Windows.Media.Devices.Core.FrameIsoSpeedControl"]}
 DEFINE_IID!(IID_IVariablePhotoSequenceController, 2143287424, 60812, 17405, 167, 195, 179, 88, 9, 228, 34, 154);
 RT_INTERFACE!{interface IVariablePhotoSequenceController(IVariablePhotoSequenceControllerVtbl): IInspectable(IInspectableVtbl) [IID_IVariablePhotoSequenceController] {
     fn get_Supported(&self, out: *mut bool) -> HRESULT,
@@ -16404,7 +16404,7 @@ impl IVariablePhotoSequenceController {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VariablePhotoSequenceController: IVariablePhotoSequenceController}
+RT_CLASS!{class VariablePhotoSequenceController: IVariablePhotoSequenceController ["Windows.Media.Devices.Core.VariablePhotoSequenceController"]}
 } // Windows.Media.Devices.Core
 } // Windows.Media.Devices
 pub mod dialprotocol { // Windows.Media.DialProtocol
@@ -16438,11 +16438,11 @@ impl IDialApp {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialApp: IDialApp}
-RT_ENUM! { enum DialAppLaunchResult: i32 {
+RT_CLASS!{class DialApp: IDialApp ["Windows.Media.DialProtocol.DialApp"]}
+RT_ENUM! { enum DialAppLaunchResult: i32 ["Windows.Media.DialProtocol.DialAppLaunchResult"] {
     Launched (DialAppLaunchResult_Launched) = 0, FailedToLaunch (DialAppLaunchResult_FailedToLaunch) = 1, NotFound (DialAppLaunchResult_NotFound) = 2, NetworkFailure (DialAppLaunchResult_NetworkFailure) = 3,
 }}
-RT_ENUM! { enum DialAppState: i32 {
+RT_ENUM! { enum DialAppState: i32 ["Windows.Media.DialProtocol.DialAppState"] {
     Unknown (DialAppState_Unknown) = 0, Stopped (DialAppState_Stopped) = 1, Running (DialAppState_Running) = 2, NetworkFailure (DialAppState_NetworkFailure) = 3,
 }}
 DEFINE_IID!(IID_IDialAppStateDetails, 3720651937, 62942, 16397, 190, 164, 140, 132, 102, 187, 41, 97);
@@ -16462,8 +16462,8 @@ impl IDialAppStateDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialAppStateDetails: IDialAppStateDetails}
-RT_ENUM! { enum DialAppStopResult: i32 {
+RT_CLASS!{class DialAppStateDetails: IDialAppStateDetails ["Windows.Media.DialProtocol.DialAppStateDetails"]}
+RT_ENUM! { enum DialAppStopResult: i32 ["Windows.Media.DialProtocol.DialAppStopResult"] {
     Stopped (DialAppStopResult_Stopped) = 0, StopFailed (DialAppStopResult_StopFailed) = 1, OperationNotSupported (DialAppStopResult_OperationNotSupported) = 2, NetworkFailure (DialAppStopResult_NetworkFailure) = 3,
 }}
 DEFINE_IID!(IID_IDialDevice, 4293979567, 30111, 16850, 162, 10, 127, 41, 206, 11, 55, 132);
@@ -16483,7 +16483,7 @@ impl IDialDevice {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialDevice: IDialDevice}
+RT_CLASS!{class DialDevice: IDialDevice ["Windows.Media.DialProtocol.DialDevice"]}
 impl RtActivatable<IDialDeviceStatics> for DialDevice {}
 impl DialDevice {
     #[inline] pub fn get_device_selector(appName: &HStringArg) -> Result<HString> {
@@ -16514,7 +16514,7 @@ impl IDialDevice2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DialDeviceDisplayStatus: i32 {
+RT_ENUM! { enum DialDeviceDisplayStatus: i32 ["Windows.Media.DialProtocol.DialDeviceDisplayStatus"] {
     None (DialDeviceDisplayStatus_None) = 0, Connecting (DialDeviceDisplayStatus_Connecting) = 1, Connected (DialDeviceDisplayStatus_Connected) = 2, Disconnecting (DialDeviceDisplayStatus_Disconnecting) = 3, Disconnected (DialDeviceDisplayStatus_Disconnected) = 4, Error (DialDeviceDisplayStatus_Error) = 5,
 }}
 DEFINE_IID!(IID_IDialDevicePicker, 3128840714, 65369, 20299, 189, 172, 216, 159, 73, 90, 214, 225);
@@ -16602,7 +16602,7 @@ impl IDialDevicePicker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialDevicePicker: IDialDevicePicker}
+RT_CLASS!{class DialDevicePicker: IDialDevicePicker ["Windows.Media.DialProtocol.DialDevicePicker"]}
 impl RtActivatable<IActivationFactory> for DialDevicePicker {}
 DEFINE_CLSID!(DialDevicePicker(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,68,105,97,108,80,114,111,116,111,99,111,108,46,68,105,97,108,68,101,118,105,99,101,80,105,99,107,101,114,0]) [CLSID_DialDevicePicker]);
 DEFINE_IID!(IID_IDialDevicePickerFilter, 3246166970, 34496, 18525, 184, 214, 15, 154, 143, 100, 21, 144);
@@ -16616,7 +16616,7 @@ impl IDialDevicePickerFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialDevicePickerFilter: IDialDevicePickerFilter}
+RT_CLASS!{class DialDevicePickerFilter: IDialDevicePickerFilter ["Windows.Media.DialProtocol.DialDevicePickerFilter"]}
 DEFINE_IID!(IID_IDialDeviceSelectedEventArgs, 1208717997, 44150, 18411, 156, 6, 161, 147, 4, 218, 2, 71);
 RT_INTERFACE!{interface IDialDeviceSelectedEventArgs(IDialDeviceSelectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDialDeviceSelectedEventArgs] {
     fn get_SelectedDialDevice(&self, out: *mut *mut DialDevice) -> HRESULT
@@ -16628,7 +16628,7 @@ impl IDialDeviceSelectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialDeviceSelectedEventArgs: IDialDeviceSelectedEventArgs}
+RT_CLASS!{class DialDeviceSelectedEventArgs: IDialDeviceSelectedEventArgs ["Windows.Media.DialProtocol.DialDeviceSelectedEventArgs"]}
 DEFINE_IID!(IID_IDialDeviceStatics, 2859060373, 504, 18264, 132, 97, 43, 189, 28, 220, 60, 243);
 RT_INTERFACE!{static interface IDialDeviceStatics(IDialDeviceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDialDeviceStatics] {
     fn GetDeviceSelector(&self, appName: HSTRING, out: *mut HSTRING) -> HRESULT,
@@ -16663,7 +16663,7 @@ impl IDialDisconnectButtonClickedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialDisconnectButtonClickedEventArgs: IDialDisconnectButtonClickedEventArgs}
+RT_CLASS!{class DialDisconnectButtonClickedEventArgs: IDialDisconnectButtonClickedEventArgs ["Windows.Media.DialProtocol.DialDisconnectButtonClickedEventArgs"]}
 DEFINE_IID!(IID_IDialReceiverApp, 4248730711, 20549, 18190, 179, 4, 77, 217, 177, 62, 125, 17);
 RT_INTERFACE!{interface IDialReceiverApp(IDialReceiverAppVtbl): IInspectable(IInspectableVtbl) [IID_IDialReceiverApp] {
     fn GetAdditionalDataAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IMap<HString, HString>>) -> HRESULT,
@@ -16681,7 +16681,7 @@ impl IDialReceiverApp {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DialReceiverApp: IDialReceiverApp}
+RT_CLASS!{class DialReceiverApp: IDialReceiverApp ["Windows.Media.DialProtocol.DialReceiverApp"]}
 impl RtActivatable<IDialReceiverAppStatics> for DialReceiverApp {}
 impl DialReceiverApp {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<DialReceiverApp>>> {
@@ -16799,7 +16799,7 @@ impl IBackgroundAudioTrack {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundAudioTrack: IBackgroundAudioTrack}
+RT_CLASS!{class BackgroundAudioTrack: IBackgroundAudioTrack ["Windows.Media.Editing.BackgroundAudioTrack"]}
 impl RtActivatable<IBackgroundAudioTrackStatics> for BackgroundAudioTrack {}
 impl BackgroundAudioTrack {
     #[inline] pub fn create_from_embedded_audio_track(embeddedAudioTrack: &EmbeddedAudioTrack) -> Result<Option<ComPtr<BackgroundAudioTrack>>> {
@@ -16838,7 +16838,7 @@ impl IEmbeddedAudioTrack {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EmbeddedAudioTrack: IEmbeddedAudioTrack}
+RT_CLASS!{class EmbeddedAudioTrack: IEmbeddedAudioTrack ["Windows.Media.Editing.EmbeddedAudioTrack"]}
 DEFINE_IID!(IID_IMediaClip, 1408389990, 24506, 16036, 134, 147, 36, 118, 24, 17, 20, 10);
 RT_INTERFACE!{interface IMediaClip(IMediaClipVtbl): IInspectable(IInspectableVtbl) [IID_IMediaClip] {
     fn get_TrimTimeFromStart(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -16948,7 +16948,7 @@ impl IMediaClip {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaClip: IMediaClip}
+RT_CLASS!{class MediaClip: IMediaClip ["Windows.Media.Editing.MediaClip"]}
 impl RtActivatable<IMediaClipStatics> for MediaClip {}
 impl RtActivatable<IMediaClipStatics2> for MediaClip {}
 impl MediaClip {
@@ -17102,7 +17102,7 @@ impl IMediaComposition {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaComposition: IMediaComposition}
+RT_CLASS!{class MediaComposition: IMediaComposition ["Windows.Media.Editing.MediaComposition"]}
 impl RtActivatable<IMediaCompositionStatics> for MediaComposition {}
 impl RtActivatable<IActivationFactory> for MediaComposition {}
 impl MediaComposition {
@@ -17194,7 +17194,7 @@ impl IMediaOverlay {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaOverlay: IMediaOverlay}
+RT_CLASS!{class MediaOverlay: IMediaOverlay ["Windows.Media.Editing.MediaOverlay"]}
 impl RtActivatable<IMediaOverlayFactory> for MediaOverlay {}
 impl MediaOverlay {
     #[inline] pub fn create(clip: &MediaClip) -> Result<ComPtr<MediaOverlay>> {
@@ -17245,7 +17245,7 @@ impl IMediaOverlayLayer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaOverlayLayer: IMediaOverlayLayer}
+RT_CLASS!{class MediaOverlayLayer: IMediaOverlayLayer ["Windows.Media.Editing.MediaOverlayLayer"]}
 impl RtActivatable<IMediaOverlayLayerFactory> for MediaOverlayLayer {}
 impl RtActivatable<IActivationFactory> for MediaOverlayLayer {}
 impl MediaOverlayLayer {
@@ -17265,10 +17265,10 @@ impl IMediaOverlayLayerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaTrimmingPreference: i32 {
+RT_ENUM! { enum MediaTrimmingPreference: i32 ["Windows.Media.Editing.MediaTrimmingPreference"] {
     Fast (MediaTrimmingPreference_Fast) = 0, Precise (MediaTrimmingPreference_Precise) = 1,
 }}
-RT_ENUM! { enum VideoFramePrecision: i32 {
+RT_ENUM! { enum VideoFramePrecision: i32 ["Windows.Media.Editing.VideoFramePrecision"] {
     NearestFrame (VideoFramePrecision_NearestFrame) = 0, NearestKeyFrame (VideoFramePrecision_NearestKeyFrame) = 1,
 }}
 } // Windows.Media.Editing
@@ -17296,7 +17296,7 @@ impl IAudioCaptureEffectsManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioCaptureEffectsManager: IAudioCaptureEffectsManager}
+RT_CLASS!{class AudioCaptureEffectsManager: IAudioCaptureEffectsManager ["Windows.Media.Effects.AudioCaptureEffectsManager"]}
 DEFINE_IID!(IID_IAudioEffect, 883620433, 37383, 16469, 190, 147, 110, 87, 52, 168, 106, 228);
 RT_INTERFACE!{interface IAudioEffect(IAudioEffectVtbl): IInspectable(IInspectableVtbl) [IID_IAudioEffect] {
     fn get_AudioEffectType(&self, out: *mut AudioEffectType) -> HRESULT
@@ -17308,7 +17308,7 @@ impl IAudioEffect {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioEffect: IAudioEffect}
+RT_CLASS!{class AudioEffect: IAudioEffect ["Windows.Media.Effects.AudioEffect"]}
 DEFINE_IID!(IID_IAudioEffectDefinition, 3839359348, 32128, 20339, 144, 137, 227, 28, 157, 185, 194, 148);
 RT_INTERFACE!{interface IAudioEffectDefinition(IAudioEffectDefinitionVtbl): IInspectable(IInspectableVtbl) [IID_IAudioEffectDefinition] {
     fn get_ActivatableClassId(&self, out: *mut HSTRING) -> HRESULT,
@@ -17326,7 +17326,7 @@ impl IAudioEffectDefinition {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioEffectDefinition: IAudioEffectDefinition}
+RT_CLASS!{class AudioEffectDefinition: IAudioEffectDefinition ["Windows.Media.Effects.AudioEffectDefinition"]}
 impl RtActivatable<IAudioEffectDefinitionFactory> for AudioEffectDefinition {}
 impl AudioEffectDefinition {
     #[inline] pub fn create(activatableClassId: &HStringArg) -> Result<ComPtr<AudioEffectDefinition>> {
@@ -17400,7 +17400,7 @@ impl IAudioEffectsManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AudioEffectType: i32 {
+RT_ENUM! { enum AudioEffectType: i32 ["Windows.Media.Effects.AudioEffectType"] {
     Other (AudioEffectType_Other) = 0, AcousticEchoCancellation (AudioEffectType_AcousticEchoCancellation) = 1, NoiseSuppression (AudioEffectType_NoiseSuppression) = 2, AutomaticGainControl (AudioEffectType_AutomaticGainControl) = 3, BeamForming (AudioEffectType_BeamForming) = 4, ConstantToneRemoval (AudioEffectType_ConstantToneRemoval) = 5, Equalizer (AudioEffectType_Equalizer) = 6, LoudnessEqualizer (AudioEffectType_LoudnessEqualizer) = 7, BassBoost (AudioEffectType_BassBoost) = 8, VirtualSurround (AudioEffectType_VirtualSurround) = 9, VirtualHeadphones (AudioEffectType_VirtualHeadphones) = 10, SpeakerFill (AudioEffectType_SpeakerFill) = 11, RoomCorrection (AudioEffectType_RoomCorrection) = 12, BassManagement (AudioEffectType_BassManagement) = 13, EnvironmentalEffects (AudioEffectType_EnvironmentalEffects) = 14, SpeakerProtection (AudioEffectType_SpeakerProtection) = 15, SpeakerCompensation (AudioEffectType_SpeakerCompensation) = 16, DynamicRangeCompression (AudioEffectType_DynamicRangeCompression) = 17,
 }}
 DEFINE_IID!(IID_IAudioRenderEffectsManager, 1305053542, 34641, 17074, 191, 203, 57, 202, 120, 100, 189, 71);
@@ -17425,7 +17425,7 @@ impl IAudioRenderEffectsManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioRenderEffectsManager: IAudioRenderEffectsManager}
+RT_CLASS!{class AudioRenderEffectsManager: IAudioRenderEffectsManager ["Windows.Media.Effects.AudioRenderEffectsManager"]}
 DEFINE_IID!(IID_IAudioRenderEffectsManager2, 2823081225, 24268, 17587, 187, 78, 29, 176, 114, 135, 19, 156);
 RT_INTERFACE!{interface IAudioRenderEffectsManager2(IAudioRenderEffectsManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IAudioRenderEffectsManager2] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -17565,11 +17565,11 @@ impl ICompositeVideoFrameContext {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositeVideoFrameContext: ICompositeVideoFrameContext}
-RT_ENUM! { enum MediaEffectClosedReason: i32 {
+RT_CLASS!{class CompositeVideoFrameContext: ICompositeVideoFrameContext ["Windows.Media.Effects.CompositeVideoFrameContext"]}
+RT_ENUM! { enum MediaEffectClosedReason: i32 ["Windows.Media.Effects.MediaEffectClosedReason"] {
     Done (MediaEffectClosedReason_Done) = 0, UnknownError (MediaEffectClosedReason_UnknownError) = 1, UnsupportedEncodingFormat (MediaEffectClosedReason_UnsupportedEncodingFormat) = 2, EffectCurrentlyUnloaded (MediaEffectClosedReason_EffectCurrentlyUnloaded) = 3,
 }}
-RT_ENUM! { enum MediaMemoryTypes: i32 {
+RT_ENUM! { enum MediaMemoryTypes: i32 ["Windows.Media.Effects.MediaMemoryTypes"] {
     Gpu (MediaMemoryTypes_Gpu) = 0, Cpu (MediaMemoryTypes_Cpu) = 1, GpuAndCpu (MediaMemoryTypes_GpuAndCpu) = 2,
 }}
 DEFINE_IID!(IID_IProcessAudioFrameContext, 1289300294, 4642, 18983, 165, 134, 251, 62, 32, 39, 50, 85);
@@ -17589,7 +17589,7 @@ impl IProcessAudioFrameContext {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessAudioFrameContext: IProcessAudioFrameContext}
+RT_CLASS!{class ProcessAudioFrameContext: IProcessAudioFrameContext ["Windows.Media.Effects.ProcessAudioFrameContext"]}
 DEFINE_IID!(IID_IProcessVideoFrameContext, 661589547, 25697, 16414, 186, 120, 15, 218, 214, 17, 78, 236);
 RT_INTERFACE!{interface IProcessVideoFrameContext(IProcessVideoFrameContextVtbl): IInspectable(IInspectableVtbl) [IID_IProcessVideoFrameContext] {
     fn get_InputFrame(&self, out: *mut *mut super::VideoFrame) -> HRESULT,
@@ -17607,7 +17607,7 @@ impl IProcessVideoFrameContext {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessVideoFrameContext: IProcessVideoFrameContext}
+RT_CLASS!{class ProcessVideoFrameContext: IProcessVideoFrameContext ["Windows.Media.Effects.ProcessVideoFrameContext"]}
 DEFINE_IID!(IID_IVideoCompositor, 2232464446, 16908, 16911, 150, 199, 124, 152, 187, 161, 252, 85);
 RT_INTERFACE!{interface IVideoCompositor(IVideoCompositorVtbl): IInspectable(IInspectableVtbl) [IID_IVideoCompositor] {
     fn get_TimeIndependent(&self, out: *mut bool) -> HRESULT,
@@ -17657,7 +17657,7 @@ impl IVideoCompositorDefinition {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoCompositorDefinition: IVideoCompositorDefinition}
+RT_CLASS!{class VideoCompositorDefinition: IVideoCompositorDefinition ["Windows.Media.Effects.VideoCompositorDefinition"]}
 impl RtActivatable<IVideoCompositorDefinitionFactory> for VideoCompositorDefinition {}
 impl VideoCompositorDefinition {
     #[inline] pub fn create(activatableClassId: &HStringArg) -> Result<ComPtr<VideoCompositorDefinition>> {
@@ -17702,7 +17702,7 @@ impl IVideoEffectDefinition {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoEffectDefinition: IVideoEffectDefinition}
+RT_CLASS!{class VideoEffectDefinition: IVideoEffectDefinition ["Windows.Media.Effects.VideoEffectDefinition"]}
 impl RtActivatable<IVideoEffectDefinitionFactory> for VideoEffectDefinition {}
 impl VideoEffectDefinition {
     #[inline] pub fn create(activatableClassId: &HStringArg) -> Result<ComPtr<VideoEffectDefinition>> {
@@ -17803,7 +17803,7 @@ impl IVideoTransformEffectDefinition {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoTransformEffectDefinition: IVideoEffectDefinition}
+RT_CLASS!{class VideoTransformEffectDefinition: IVideoEffectDefinition ["Windows.Media.Effects.VideoTransformEffectDefinition"]}
 impl RtActivatable<IActivationFactory> for VideoTransformEffectDefinition {}
 DEFINE_CLSID!(VideoTransformEffectDefinition(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,69,102,102,101,99,116,115,46,86,105,100,101,111,84,114,97,110,115,102,111,114,109,69,102,102,101,99,116,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_VideoTransformEffectDefinition]);
 DEFINE_IID!(IID_IVideoTransformEffectDefinition2, 4037544095, 26312, 18068, 159, 217, 17, 54, 171, 247, 68, 74);
@@ -17877,7 +17877,7 @@ impl IVideoTransformSphericalProjection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoTransformSphericalProjection: IVideoTransformSphericalProjection}
+RT_CLASS!{class VideoTransformSphericalProjection: IVideoTransformSphericalProjection ["Windows.Media.Effects.VideoTransformSphericalProjection"]}
 } // Windows.Media.Effects
 pub mod faceanalysis { // Windows.Media.FaceAnalysis
 use ::prelude::*;
@@ -17892,7 +17892,7 @@ impl IDetectedFace {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DetectedFace: IDetectedFace}
+RT_CLASS!{class DetectedFace: IDetectedFace ["Windows.Media.FaceAnalysis.DetectedFace"]}
 DEFINE_IID!(IID_IFaceDetector, 381055708, 65135, 12567, 141, 149, 195, 240, 77, 81, 99, 12);
 RT_INTERFACE!{interface IFaceDetector(IFaceDetectorVtbl): IInspectable(IInspectableVtbl) [IID_IFaceDetector] {
     #[cfg(feature="windows-graphics")] fn DetectFacesAsync(&self, image: *mut super::super::graphics::imaging::SoftwareBitmap, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVector<DetectedFace>>) -> HRESULT,
@@ -17932,7 +17932,7 @@ impl IFaceDetector {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FaceDetector: IFaceDetector}
+RT_CLASS!{class FaceDetector: IFaceDetector ["Windows.Media.FaceAnalysis.FaceDetector"]}
 impl RtActivatable<IFaceDetectorStatics> for FaceDetector {}
 impl FaceDetector {
     #[inline] pub fn create_async() -> Result<ComPtr<foundation::IAsyncOperation<FaceDetector>>> {
@@ -18013,7 +18013,7 @@ impl IFaceTracker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FaceTracker: IFaceTracker}
+RT_CLASS!{class FaceTracker: IFaceTracker ["Windows.Media.FaceAnalysis.FaceTracker"]}
 impl RtActivatable<IFaceTrackerStatics> for FaceTracker {}
 impl FaceTracker {
     #[inline] pub fn create_async() -> Result<ComPtr<foundation::IAsyncOperation<FaceTracker>>> {
@@ -18064,16 +18064,16 @@ impl IFaceTrackerStatics {
 } // Windows.Media.FaceAnalysis
 pub mod import { // Windows.Media.Import
 use ::prelude::*;
-RT_ENUM! { enum PhotoImportAccessMode: i32 {
+RT_ENUM! { enum PhotoImportAccessMode: i32 ["Windows.Media.Import.PhotoImportAccessMode"] {
     ReadWrite (PhotoImportAccessMode_ReadWrite) = 0, ReadOnly (PhotoImportAccessMode_ReadOnly) = 1, ReadAndDelete (PhotoImportAccessMode_ReadAndDelete) = 2,
 }}
-RT_ENUM! { enum PhotoImportConnectionTransport: i32 {
+RT_ENUM! { enum PhotoImportConnectionTransport: i32 ["Windows.Media.Import.PhotoImportConnectionTransport"] {
     Unknown (PhotoImportConnectionTransport_Unknown) = 0, Usb (PhotoImportConnectionTransport_Usb) = 1, IP (PhotoImportConnectionTransport_IP) = 2, Bluetooth (PhotoImportConnectionTransport_Bluetooth) = 3,
 }}
-RT_ENUM! { enum PhotoImportContentType: i32 {
+RT_ENUM! { enum PhotoImportContentType: i32 ["Windows.Media.Import.PhotoImportContentType"] {
     Unknown (PhotoImportContentType_Unknown) = 0, Image (PhotoImportContentType_Image) = 1, Video (PhotoImportContentType_Video) = 2,
 }}
-RT_ENUM! { enum PhotoImportContentTypeFilter: i32 {
+RT_ENUM! { enum PhotoImportContentTypeFilter: i32 ["Windows.Media.Import.PhotoImportContentTypeFilter"] {
     OnlyImages (PhotoImportContentTypeFilter_OnlyImages) = 0, OnlyVideos (PhotoImportContentTypeFilter_OnlyVideos) = 1, ImagesAndVideos (PhotoImportContentTypeFilter_ImagesAndVideos) = 2, ImagesAndVideosFromCameraRoll (PhotoImportContentTypeFilter_ImagesAndVideosFromCameraRoll) = 3,
 }}
 DEFINE_IID!(IID_IPhotoImportDeleteImportedItemsFromSourceResult, 4108391160, 33853, 17034, 161, 166, 129, 81, 2, 146, 176, 174);
@@ -18159,7 +18159,7 @@ impl IPhotoImportDeleteImportedItemsFromSourceResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportDeleteImportedItemsFromSourceResult: IPhotoImportDeleteImportedItemsFromSourceResult}
+RT_CLASS!{class PhotoImportDeleteImportedItemsFromSourceResult: IPhotoImportDeleteImportedItemsFromSourceResult ["Windows.Media.Import.PhotoImportDeleteImportedItemsFromSourceResult"]}
 DEFINE_IID!(IID_IPhotoImportFindItemsResult, 957736519, 27768, 18731, 132, 78, 143, 229, 232, 246, 191, 185);
 RT_INTERFACE!{interface IPhotoImportFindItemsResult(IPhotoImportFindItemsResultVtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportFindItemsResult] {
     fn get_Session(&self, out: *mut *mut PhotoImportSession) -> HRESULT,
@@ -18358,7 +18358,7 @@ impl IPhotoImportFindItemsResult {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportFindItemsResult: IPhotoImportFindItemsResult}
+RT_CLASS!{class PhotoImportFindItemsResult: IPhotoImportFindItemsResult ["Windows.Media.Import.PhotoImportFindItemsResult"]}
 DEFINE_IID!(IID_IPhotoImportFindItemsResult2, 4225591867, 60665, 16490, 129, 94, 80, 21, 98, 91, 10, 136);
 RT_INTERFACE!{interface IPhotoImportFindItemsResult2(IPhotoImportFindItemsResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportFindItemsResult2] {
     fn AddItemsInDateRangeToSelection(&self, rangeStart: foundation::DateTime, rangeLength: foundation::TimeSpan) -> HRESULT
@@ -18458,8 +18458,8 @@ impl IPhotoImportImportItemsResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportImportItemsResult: IPhotoImportImportItemsResult}
-RT_ENUM! { enum PhotoImportImportMode: i32 {
+RT_CLASS!{class PhotoImportImportItemsResult: IPhotoImportImportItemsResult ["Windows.Media.Import.PhotoImportImportItemsResult"]}
+RT_ENUM! { enum PhotoImportImportMode: i32 ["Windows.Media.Import.PhotoImportImportMode"] {
     ImportEverything (PhotoImportImportMode_ImportEverything) = 0, IgnoreSidecars (PhotoImportImportMode_IgnoreSidecars) = 1, IgnoreSiblings (PhotoImportImportMode_IgnoreSiblings) = 2, IgnoreSidecarsAndSiblings (PhotoImportImportMode_IgnoreSidecarsAndSiblings) = 3,
 }}
 DEFINE_IID!(IID_IPhotoImportItem, 2849013366, 39932, 17336, 179, 86, 99, 59, 106, 152, 140, 158);
@@ -18545,7 +18545,7 @@ impl IPhotoImportItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportItem: IPhotoImportItem}
+RT_CLASS!{class PhotoImportItem: IPhotoImportItem ["Windows.Media.Import.PhotoImportItem"]}
 DEFINE_IID!(IID_IPhotoImportItem2, 4043650309, 62779, 18083, 158, 48, 54, 16, 121, 26, 145, 16);
 RT_INTERFACE!{interface IPhotoImportItem2(IPhotoImportItem2Vtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportItem2] {
     fn get_Path(&self, out: *mut HSTRING) -> HRESULT
@@ -18568,8 +18568,8 @@ impl IPhotoImportItemImportedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportItemImportedEventArgs: IPhotoImportItemImportedEventArgs}
-RT_ENUM! { enum PhotoImportItemSelectionMode: i32 {
+RT_CLASS!{class PhotoImportItemImportedEventArgs: IPhotoImportItemImportedEventArgs ["Windows.Media.Import.PhotoImportItemImportedEventArgs"]}
+RT_ENUM! { enum PhotoImportItemSelectionMode: i32 ["Windows.Media.Import.PhotoImportItemSelectionMode"] {
     SelectAll (PhotoImportItemSelectionMode_SelectAll) = 0, SelectNone (PhotoImportItemSelectionMode_SelectNone) = 1, SelectNew (PhotoImportItemSelectionMode_SelectNew) = 2,
 }}
 RT_CLASS!{static class PhotoImportManager}
@@ -18644,11 +18644,11 @@ impl IPhotoImportOperation {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportOperation: IPhotoImportOperation}
-RT_ENUM! { enum PhotoImportPowerSource: i32 {
+RT_CLASS!{class PhotoImportOperation: IPhotoImportOperation ["Windows.Media.Import.PhotoImportOperation"]}
+RT_ENUM! { enum PhotoImportPowerSource: i32 ["Windows.Media.Import.PhotoImportPowerSource"] {
     Unknown (PhotoImportPowerSource_Unknown) = 0, Battery (PhotoImportPowerSource_Battery) = 1, External (PhotoImportPowerSource_External) = 2,
 }}
-RT_STRUCT! { struct PhotoImportProgress {
+RT_STRUCT! { struct PhotoImportProgress ["Windows.Media.Import.PhotoImportProgress"] {
     ItemsImported: u32, TotalItemsToImport: u32, BytesImported: u64, TotalBytesToImport: u64, ImportProgress: f64,
 }}
 DEFINE_IID!(IID_IPhotoImportSelectionChangedEventArgs, 273028994, 64157, 19504, 139, 201, 77, 100, 145, 21, 114, 213);
@@ -18662,7 +18662,7 @@ impl IPhotoImportSelectionChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportSelectionChangedEventArgs: IPhotoImportSelectionChangedEventArgs}
+RT_CLASS!{class PhotoImportSelectionChangedEventArgs: IPhotoImportSelectionChangedEventArgs ["Windows.Media.Import.PhotoImportSelectionChangedEventArgs"]}
 DEFINE_IID!(IID_IPhotoImportSession, 2858652014, 60635, 20222, 148, 198, 95, 92, 175, 227, 76, 251);
 RT_INTERFACE!{interface IPhotoImportSession(IPhotoImportSessionVtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportSession] {
     fn get_Source(&self, out: *mut *mut PhotoImportSource) -> HRESULT,
@@ -18732,7 +18732,7 @@ impl IPhotoImportSession {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportSession: IPhotoImportSession}
+RT_CLASS!{class PhotoImportSession: IPhotoImportSession ["Windows.Media.Import.PhotoImportSession"]}
 DEFINE_IID!(IID_IPhotoImportSession2, 710043408, 16070, 18077, 163, 117, 43, 159, 71, 133, 57, 30);
 RT_INTERFACE!{interface IPhotoImportSession2(IPhotoImportSession2Vtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportSession2] {
     fn put_SubfolderDateFormat(&self, value: PhotoImportSubfolderDateFormat) -> HRESULT,
@@ -18783,7 +18783,7 @@ impl IPhotoImportSidecar {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportSidecar: IPhotoImportSidecar}
+RT_CLASS!{class PhotoImportSidecar: IPhotoImportSidecar ["Windows.Media.Import.PhotoImportSidecar"]}
 DEFINE_IID!(IID_IPhotoImportSource, 529441630, 5211, 19670, 135, 241, 84, 150, 90, 152, 47, 239);
 RT_INTERFACE!{interface IPhotoImportSource(IPhotoImportSourceVtbl): IInspectable(IInspectableVtbl) [IID_IPhotoImportSource] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -18892,7 +18892,7 @@ impl IPhotoImportSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportSource: IPhotoImportSource}
+RT_CLASS!{class PhotoImportSource: IPhotoImportSource ["Windows.Media.Import.PhotoImportSource"]}
 impl RtActivatable<IPhotoImportSourceStatics> for PhotoImportSource {}
 impl PhotoImportSource {
     #[inline] pub fn from_id_async(sourceId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<PhotoImportSource>>> {
@@ -18920,10 +18920,10 @@ impl IPhotoImportSourceStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PhotoImportSourceType: i32 {
+RT_ENUM! { enum PhotoImportSourceType: i32 ["Windows.Media.Import.PhotoImportSourceType"] {
     Generic (PhotoImportSourceType_Generic) = 0, Camera (PhotoImportSourceType_Camera) = 1, MediaPlayer (PhotoImportSourceType_MediaPlayer) = 2, Phone (PhotoImportSourceType_Phone) = 3, Video (PhotoImportSourceType_Video) = 4, PersonalInfoManager (PhotoImportSourceType_PersonalInfoManager) = 5, AudioRecorder (PhotoImportSourceType_AudioRecorder) = 6,
 }}
-RT_ENUM! { enum PhotoImportStage: i32 {
+RT_ENUM! { enum PhotoImportStage: i32 ["Windows.Media.Import.PhotoImportStage"] {
     NotStarted (PhotoImportStage_NotStarted) = 0, FindingItems (PhotoImportStage_FindingItems) = 1, ImportingItems (PhotoImportStage_ImportingItems) = 2, DeletingImportedItemsFromSource (PhotoImportStage_DeletingImportedItemsFromSource) = 3,
 }}
 DEFINE_IID!(IID_IPhotoImportStorageMedium, 4072255635, 64645, 18559, 135, 194, 88, 214, 117, 208, 91, 7);
@@ -18978,14 +18978,14 @@ impl IPhotoImportStorageMedium {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportStorageMedium: IPhotoImportStorageMedium}
-RT_ENUM! { enum PhotoImportStorageMediumType: i32 {
+RT_CLASS!{class PhotoImportStorageMedium: IPhotoImportStorageMedium ["Windows.Media.Import.PhotoImportStorageMedium"]}
+RT_ENUM! { enum PhotoImportStorageMediumType: i32 ["Windows.Media.Import.PhotoImportStorageMediumType"] {
     Undefined (PhotoImportStorageMediumType_Undefined) = 0, Fixed (PhotoImportStorageMediumType_Fixed) = 1, Removable (PhotoImportStorageMediumType_Removable) = 2,
 }}
-RT_ENUM! { enum PhotoImportSubfolderCreationMode: i32 {
+RT_ENUM! { enum PhotoImportSubfolderCreationMode: i32 ["Windows.Media.Import.PhotoImportSubfolderCreationMode"] {
     DoNotCreateSubfolders (PhotoImportSubfolderCreationMode_DoNotCreateSubfolders) = 0, CreateSubfoldersFromFileDate (PhotoImportSubfolderCreationMode_CreateSubfoldersFromFileDate) = 1, CreateSubfoldersFromExifDate (PhotoImportSubfolderCreationMode_CreateSubfoldersFromExifDate) = 2, KeepOriginalFolderStructure (PhotoImportSubfolderCreationMode_KeepOriginalFolderStructure) = 3,
 }}
-RT_ENUM! { enum PhotoImportSubfolderDateFormat: i32 {
+RT_ENUM! { enum PhotoImportSubfolderDateFormat: i32 ["Windows.Media.Import.PhotoImportSubfolderDateFormat"] {
     Year (PhotoImportSubfolderDateFormat_Year) = 0, YearMonth (PhotoImportSubfolderDateFormat_YearMonth) = 1, YearMonthDay (PhotoImportSubfolderDateFormat_YearMonthDay) = 2,
 }}
 DEFINE_IID!(IID_IPhotoImportVideoSegment, 1648099977, 12826, 16856, 145, 102, 140, 98, 163, 51, 39, 108);
@@ -19023,7 +19023,7 @@ impl IPhotoImportVideoSegment {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PhotoImportVideoSegment: IPhotoImportVideoSegment}
+RT_CLASS!{class PhotoImportVideoSegment: IPhotoImportVideoSegment ["Windows.Media.Import.PhotoImportVideoSegment"]}
 } // Windows.Media.Import
 pub mod mediaproperties { // Windows.Media.MediaProperties
 use ::prelude::*;
@@ -19076,7 +19076,7 @@ impl IAudioEncodingProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AudioEncodingProperties: IAudioEncodingProperties}
+RT_CLASS!{class AudioEncodingProperties: IAudioEncodingProperties ["Windows.Media.MediaProperties.AudioEncodingProperties"]}
 impl RtActivatable<IAudioEncodingPropertiesStatics> for AudioEncodingProperties {}
 impl RtActivatable<IAudioEncodingPropertiesStatics2> for AudioEncodingProperties {}
 impl RtActivatable<IActivationFactory> for AudioEncodingProperties {}
@@ -19194,14 +19194,14 @@ impl IAudioEncodingPropertiesWithFormatUserData {
         if hr == S_OK { Ok(ComArray::from_raw(valueSize, value)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AudioEncodingQuality: i32 {
+RT_ENUM! { enum AudioEncodingQuality: i32 ["Windows.Media.MediaProperties.AudioEncodingQuality"] {
     Auto (AudioEncodingQuality_Auto) = 0, High (AudioEncodingQuality_High) = 1, Medium (AudioEncodingQuality_Medium) = 2, Low (AudioEncodingQuality_Low) = 3,
 }}
 DEFINE_IID!(IID_IContainerEncodingProperties, 1504455255, 45866, 18334, 138, 97, 75, 127, 46, 158, 126, 160);
 RT_INTERFACE!{interface IContainerEncodingProperties(IContainerEncodingPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IContainerEncodingProperties] {
     
 }}
-RT_CLASS!{class ContainerEncodingProperties: IContainerEncodingProperties}
+RT_CLASS!{class ContainerEncodingProperties: IContainerEncodingProperties ["Windows.Media.MediaProperties.ContainerEncodingProperties"]}
 impl RtActivatable<IActivationFactory> for ContainerEncodingProperties {}
 DEFINE_CLSID!(ContainerEncodingProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,67,111,110,116,97,105,110,101,114,69,110,99,111,100,105,110,103,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_ContainerEncodingProperties]);
 DEFINE_IID!(IID_IContainerEncodingProperties2, 2993864745, 44582, 18457, 186, 173, 173, 122, 73, 176, 168, 118);
@@ -19342,7 +19342,7 @@ impl IImageEncodingProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageEncodingProperties: IImageEncodingProperties}
+RT_CLASS!{class ImageEncodingProperties: IImageEncodingProperties ["Windows.Media.MediaProperties.ImageEncodingProperties"]}
 impl RtActivatable<IImageEncodingPropertiesStatics> for ImageEncodingProperties {}
 impl RtActivatable<IImageEncodingPropertiesStatics2> for ImageEncodingProperties {}
 impl RtActivatable<IImageEncodingPropertiesStatics3> for ImageEncodingProperties {}
@@ -19468,7 +19468,7 @@ impl IMediaEncodingProfile {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaEncodingProfile: IMediaEncodingProfile}
+RT_CLASS!{class MediaEncodingProfile: IMediaEncodingProfile ["Windows.Media.MediaProperties.MediaEncodingProfile"]}
 impl RtActivatable<IMediaEncodingProfileStatics> for MediaEncodingProfile {}
 impl RtActivatable<IMediaEncodingProfileStatics2> for MediaEncodingProfile {}
 impl RtActivatable<IMediaEncodingProfileStatics3> for MediaEncodingProfile {}
@@ -20136,13 +20136,13 @@ impl IMediaEncodingSubtypesStatics5 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaMirroringOptions: u32 {
+RT_ENUM! { enum MediaMirroringOptions: u32 ["Windows.Media.MediaProperties.MediaMirroringOptions"] {
     None (MediaMirroringOptions_None) = 0, Horizontal (MediaMirroringOptions_Horizontal) = 1, Vertical (MediaMirroringOptions_Vertical) = 2,
 }}
-RT_ENUM! { enum MediaPixelFormat: i32 {
+RT_ENUM! { enum MediaPixelFormat: i32 ["Windows.Media.MediaProperties.MediaPixelFormat"] {
     Nv12 (MediaPixelFormat_Nv12) = 0, Bgra8 (MediaPixelFormat_Bgra8) = 1, P010 (MediaPixelFormat_P010) = 2,
 }}
-RT_CLASS!{class MediaPropertySet: foundation::collections::IMap<Guid, IInspectable>}
+RT_CLASS!{class MediaPropertySet: foundation::collections::IMap<Guid, IInspectable> ["Windows.Media.MediaProperties.MediaPropertySet"]}
 impl RtActivatable<IActivationFactory> for MediaPropertySet {}
 DEFINE_CLSID!(MediaPropertySet(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,77,101,100,105,97,80,114,111,112,101,114,116,121,83,101,116,0]) [CLSID_MediaPropertySet]);
 DEFINE_IID!(IID_IMediaRatio, 3536912101, 35113, 16413, 172, 120, 125, 53, 126, 55, 129, 99);
@@ -20172,11 +20172,11 @@ impl IMediaRatio {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaRatio: IMediaRatio}
-RT_ENUM! { enum MediaRotation: i32 {
+RT_CLASS!{class MediaRatio: IMediaRatio ["Windows.Media.MediaProperties.MediaRatio"]}
+RT_ENUM! { enum MediaRotation: i32 ["Windows.Media.MediaProperties.MediaRotation"] {
     None (MediaRotation_None) = 0, Clockwise90Degrees (MediaRotation_Clockwise90Degrees) = 1, Clockwise180Degrees (MediaRotation_Clockwise180Degrees) = 2, Clockwise270Degrees (MediaRotation_Clockwise270Degrees) = 3,
 }}
-RT_ENUM! { enum MediaThumbnailFormat: i32 {
+RT_ENUM! { enum MediaThumbnailFormat: i32 ["Windows.Media.MediaProperties.MediaThumbnailFormat"] {
     Bmp (MediaThumbnailFormat_Bmp) = 0, Bgra8 (MediaThumbnailFormat_Bgra8) = 1,
 }}
 RT_CLASS!{static class Mpeg2ProfileIds}
@@ -20234,10 +20234,10 @@ impl IMpeg2ProfileIdsStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SphericalVideoFrameFormat: i32 {
+RT_ENUM! { enum SphericalVideoFrameFormat: i32 ["Windows.Media.MediaProperties.SphericalVideoFrameFormat"] {
     None (SphericalVideoFrameFormat_None) = 0, Unsupported (SphericalVideoFrameFormat_Unsupported) = 1, Equirectangular (SphericalVideoFrameFormat_Equirectangular) = 2,
 }}
-RT_ENUM! { enum StereoscopicVideoPackingMode: i32 {
+RT_ENUM! { enum StereoscopicVideoPackingMode: i32 ["Windows.Media.MediaProperties.StereoscopicVideoPackingMode"] {
     None (StereoscopicVideoPackingMode_None) = 0, SideBySide (StereoscopicVideoPackingMode_SideBySide) = 1, TopBottom (StereoscopicVideoPackingMode_TopBottom) = 2,
 }}
 DEFINE_IID!(IID_ITimedMetadataEncodingProperties, 1372401875, 54928, 19706, 151, 244, 74, 57, 142, 157, 180, 32);
@@ -20262,7 +20262,7 @@ impl ITimedMetadataEncodingProperties {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedMetadataEncodingProperties: IMediaEncodingProperties}
+RT_CLASS!{class TimedMetadataEncodingProperties: IMediaEncodingProperties ["Windows.Media.MediaProperties.TimedMetadataEncodingProperties"]}
 impl RtActivatable<IActivationFactory> for TimedMetadataEncodingProperties {}
 DEFINE_CLSID!(TimedMetadataEncodingProperties(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,77,101,100,105,97,80,114,111,112,101,114,116,105,101,115,46,84,105,109,101,100,77,101,116,97,100,97,116,97,69,110,99,111,100,105,110,103,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_TimedMetadataEncodingProperties]);
 DEFINE_IID!(IID_IVideoEncodingProperties, 1995336858, 14274, 20266, 136, 10, 18, 130, 187, 180, 55, 61);
@@ -20315,7 +20315,7 @@ impl IVideoEncodingProperties {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoEncodingProperties: IVideoEncodingProperties}
+RT_CLASS!{class VideoEncodingProperties: IVideoEncodingProperties ["Windows.Media.MediaProperties.VideoEncodingProperties"]}
 impl RtActivatable<IVideoEncodingPropertiesStatics> for VideoEncodingProperties {}
 impl RtActivatable<IVideoEncodingPropertiesStatics2> for VideoEncodingProperties {}
 impl RtActivatable<IActivationFactory> for VideoEncodingProperties {}
@@ -20428,7 +20428,7 @@ impl IVideoEncodingPropertiesStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VideoEncodingQuality: i32 {
+RT_ENUM! { enum VideoEncodingQuality: i32 ["Windows.Media.MediaProperties.VideoEncodingQuality"] {
     Auto (VideoEncodingQuality_Auto) = 0, HD1080p (VideoEncodingQuality_HD1080p) = 1, HD720p (VideoEncodingQuality_HD720p) = 2, Wvga (VideoEncodingQuality_Wvga) = 3, Ntsc (VideoEncodingQuality_Ntsc) = 4, Pal (VideoEncodingQuality_Pal) = 5, Vga (VideoEncodingQuality_Vga) = 6, Qvga (VideoEncodingQuality_Qvga) = 7, Uhd2160p (VideoEncodingQuality_Uhd2160p) = 8, Uhd4320p (VideoEncodingQuality_Uhd4320p) = 9,
 }}
 } // Windows.Media.MediaProperties
@@ -20452,7 +20452,7 @@ impl IOcrEngine {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OcrEngine: IOcrEngine}
+RT_CLASS!{class OcrEngine: IOcrEngine ["Windows.Media.Ocr.OcrEngine"]}
 impl RtActivatable<IOcrEngineStatics> for OcrEngine {}
 impl OcrEngine {
     #[inline] pub fn get_max_image_dimension() -> Result<u32> {
@@ -20527,7 +20527,7 @@ impl IOcrLine {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OcrLine: IOcrLine}
+RT_CLASS!{class OcrLine: IOcrLine ["Windows.Media.Ocr.OcrLine"]}
 DEFINE_IID!(IID_IOcrResult, 2614244786, 5979, 15722, 146, 226, 56, 140, 32, 110, 47, 99);
 RT_INTERFACE!{interface IOcrResult(IOcrResultVtbl): IInspectable(IInspectableVtbl) [IID_IOcrResult] {
     fn get_Lines(&self, out: *mut *mut foundation::collections::IVectorView<OcrLine>) -> HRESULT,
@@ -20551,7 +20551,7 @@ impl IOcrResult {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OcrResult: IOcrResult}
+RT_CLASS!{class OcrResult: IOcrResult ["Windows.Media.Ocr.OcrResult"]}
 DEFINE_IID!(IID_IOcrWord, 1009403770, 23769, 13605, 186, 42, 35, 209, 224, 166, 138, 29);
 RT_INTERFACE!{interface IOcrWord(IOcrWordVtbl): IInspectable(IInspectableVtbl) [IID_IOcrWord] {
     fn get_BoundingRect(&self, out: *mut foundation::Rect) -> HRESULT,
@@ -20569,7 +20569,7 @@ impl IOcrWord {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OcrWord: IOcrWord}
+RT_CLASS!{class OcrWord: IOcrWord ["Windows.Media.Ocr.OcrWord"]}
 } // Windows.Media.Ocr
 pub mod playto { // Windows.Media.PlayTo
 use ::prelude::*;
@@ -20584,7 +20584,7 @@ impl ICurrentTimeChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CurrentTimeChangeRequestedEventArgs: ICurrentTimeChangeRequestedEventArgs}
+RT_CLASS!{class CurrentTimeChangeRequestedEventArgs: ICurrentTimeChangeRequestedEventArgs ["Windows.Media.PlayTo.CurrentTimeChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IMuteChangeRequestedEventArgs, 3837064694, 44831, 20254, 180, 55, 125, 163, 36, 0, 225, 212);
 RT_INTERFACE!{interface IMuteChangeRequestedEventArgs(IMuteChangeRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMuteChangeRequestedEventArgs] {
     fn get_Mute(&self, out: *mut bool) -> HRESULT
@@ -20596,7 +20596,7 @@ impl IMuteChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MuteChangeRequestedEventArgs: IMuteChangeRequestedEventArgs}
+RT_CLASS!{class MuteChangeRequestedEventArgs: IMuteChangeRequestedEventArgs ["Windows.Media.PlayTo.MuteChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IPlaybackRateChangeRequestedEventArgs, 257319342, 11400, 19658, 133, 64, 213, 134, 9, 93, 19, 165);
 RT_INTERFACE!{interface IPlaybackRateChangeRequestedEventArgs(IPlaybackRateChangeRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPlaybackRateChangeRequestedEventArgs] {
     fn get_Rate(&self, out: *mut f64) -> HRESULT
@@ -20608,7 +20608,7 @@ impl IPlaybackRateChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaybackRateChangeRequestedEventArgs: IPlaybackRateChangeRequestedEventArgs}
+RT_CLASS!{class PlaybackRateChangeRequestedEventArgs: IPlaybackRateChangeRequestedEventArgs ["Windows.Media.PlayTo.PlaybackRateChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IPlayToConnection, 288341960, 62005, 20446, 141, 65, 155, 242, 124, 158, 154, 64);
 RT_INTERFACE!{interface IPlayToConnection(IPlayToConnectionVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToConnection] {
     fn get_State(&self, out: *mut PlayToConnectionState) -> HRESULT,
@@ -20653,8 +20653,8 @@ impl IPlayToConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToConnection: IPlayToConnection}
-RT_ENUM! { enum PlayToConnectionError: i32 {
+RT_CLASS!{class PlayToConnection: IPlayToConnection ["Windows.Media.PlayTo.PlayToConnection"]}
+RT_ENUM! { enum PlayToConnectionError: i32 ["Windows.Media.PlayTo.PlayToConnectionError"] {
     None (PlayToConnectionError_None) = 0, DeviceNotResponding (PlayToConnectionError_DeviceNotResponding) = 1, DeviceError (PlayToConnectionError_DeviceError) = 2, DeviceLocked (PlayToConnectionError_DeviceLocked) = 3, ProtectedPlaybackFailed (PlayToConnectionError_ProtectedPlaybackFailed) = 4,
 }}
 DEFINE_IID!(IID_IPlayToConnectionErrorEventArgs, 3210653094, 35046, 17503, 157, 64, 217, 185, 248, 147, 152, 150);
@@ -20674,8 +20674,8 @@ impl IPlayToConnectionErrorEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToConnectionErrorEventArgs: IPlayToConnectionErrorEventArgs}
-RT_ENUM! { enum PlayToConnectionState: i32 {
+RT_CLASS!{class PlayToConnectionErrorEventArgs: IPlayToConnectionErrorEventArgs ["Windows.Media.PlayTo.PlayToConnectionErrorEventArgs"]}
+RT_ENUM! { enum PlayToConnectionState: i32 ["Windows.Media.PlayTo.PlayToConnectionState"] {
     Disconnected (PlayToConnectionState_Disconnected) = 0, Connected (PlayToConnectionState_Connected) = 1, Rendering (PlayToConnectionState_Rendering) = 2,
 }}
 DEFINE_IID!(IID_IPlayToConnectionStateChangedEventArgs, 1757721871, 3104, 18816, 134, 2, 88, 198, 34, 56, 212, 35);
@@ -20695,7 +20695,7 @@ impl IPlayToConnectionStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToConnectionStateChangedEventArgs: IPlayToConnectionStateChangedEventArgs}
+RT_CLASS!{class PlayToConnectionStateChangedEventArgs: IPlayToConnectionStateChangedEventArgs ["Windows.Media.PlayTo.PlayToConnectionStateChangedEventArgs"]}
 DEFINE_IID!(IID_IPlayToConnectionTransferredEventArgs, 4209187130, 1667, 18393, 141, 240, 24, 203, 180, 137, 132, 216);
 RT_INTERFACE!{interface IPlayToConnectionTransferredEventArgs(IPlayToConnectionTransferredEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToConnectionTransferredEventArgs] {
     fn get_PreviousSource(&self, out: *mut *mut PlayToSource) -> HRESULT,
@@ -20713,7 +20713,7 @@ impl IPlayToConnectionTransferredEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToConnectionTransferredEventArgs: IPlayToConnectionTransferredEventArgs}
+RT_CLASS!{class PlayToConnectionTransferredEventArgs: IPlayToConnectionTransferredEventArgs ["Windows.Media.PlayTo.PlayToConnectionTransferredEventArgs"]}
 DEFINE_IID!(IID_IPlayToManager, 4117373038, 7031, 17135, 143, 13, 185, 73, 248, 217, 178, 96);
 RT_INTERFACE!{interface IPlayToManager(IPlayToManagerVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToManager] {
     fn add_SourceRequested(&self, handler: *mut foundation::TypedEventHandler<PlayToManager, PlayToSourceRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -20752,7 +20752,7 @@ impl IPlayToManager {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToManager: IPlayToManager}
+RT_CLASS!{class PlayToManager: IPlayToManager ["Windows.Media.PlayTo.PlayToManager"]}
 impl RtActivatable<IPlayToManagerStatics> for PlayToManager {}
 impl PlayToManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<PlayToManager>>> {
@@ -21005,7 +21005,7 @@ impl IPlayToReceiver {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToReceiver: IPlayToReceiver}
+RT_CLASS!{class PlayToReceiver: IPlayToReceiver ["Windows.Media.PlayTo.PlayToReceiver"]}
 impl RtActivatable<IActivationFactory> for PlayToReceiver {}
 DEFINE_CLSID!(PlayToReceiver(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,84,111,46,80,108,97,121,84,111,82,101,99,101,105,118,101,114,0]) [CLSID_PlayToReceiver]);
 DEFINE_IID!(IID_IPlayToSource, 2131986952, 64439, 19209, 131, 86, 170, 95, 78, 51, 92, 49);
@@ -21035,7 +21035,7 @@ impl IPlayToSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToSource: IPlayToSource}
+RT_CLASS!{class PlayToSource: IPlayToSource ["Windows.Media.PlayTo.PlayToSource"]}
 DEFINE_IID!(IID_IPlayToSourceDeferral, 1090554141, 10126, 20265, 133, 155, 169, 229, 1, 5, 62, 125);
 RT_INTERFACE!{interface IPlayToSourceDeferral(IPlayToSourceDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToSourceDeferral] {
     fn Complete(&self) -> HRESULT
@@ -21046,7 +21046,7 @@ impl IPlayToSourceDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToSourceDeferral: IPlayToSourceDeferral}
+RT_CLASS!{class PlayToSourceDeferral: IPlayToSourceDeferral ["Windows.Media.PlayTo.PlayToSourceDeferral"]}
 DEFINE_IID!(IID_IPlayToSourceRequest, 4166534757, 25844, 17568, 172, 13, 70, 141, 43, 143, 218, 131);
 RT_INTERFACE!{interface IPlayToSourceRequest(IPlayToSourceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToSourceRequest] {
     fn get_Deadline(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -21074,7 +21074,7 @@ impl IPlayToSourceRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToSourceRequest: IPlayToSourceRequest}
+RT_CLASS!{class PlayToSourceRequest: IPlayToSourceRequest ["Windows.Media.PlayTo.PlayToSourceRequest"]}
 DEFINE_IID!(IID_IPlayToSourceRequestedEventArgs, 3318596400, 10719, 20166, 157, 169, 159, 189, 252, 252, 27, 62);
 RT_INTERFACE!{interface IPlayToSourceRequestedEventArgs(IPlayToSourceRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToSourceRequestedEventArgs] {
     fn get_SourceRequest(&self, out: *mut *mut PlayToSourceRequest) -> HRESULT
@@ -21086,7 +21086,7 @@ impl IPlayToSourceRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToSourceRequestedEventArgs: IPlayToSourceRequestedEventArgs}
+RT_CLASS!{class PlayToSourceRequestedEventArgs: IPlayToSourceRequestedEventArgs ["Windows.Media.PlayTo.PlayToSourceRequestedEventArgs"]}
 DEFINE_IID!(IID_IPlayToSourceSelectedEventArgs, 211649809, 20994, 19915, 140, 103, 171, 218, 18, 187, 60, 18);
 RT_INTERFACE!{interface IPlayToSourceSelectedEventArgs(IPlayToSourceSelectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToSourceSelectedEventArgs] {
     fn get_FriendlyName(&self, out: *mut HSTRING) -> HRESULT,
@@ -21123,7 +21123,7 @@ impl IPlayToSourceSelectedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayToSourceSelectedEventArgs: IPlayToSourceSelectedEventArgs}
+RT_CLASS!{class PlayToSourceSelectedEventArgs: IPlayToSourceSelectedEventArgs ["Windows.Media.PlayTo.PlayToSourceSelectedEventArgs"]}
 DEFINE_IID!(IID_IPlayToSourceWithPreferredSourceUri, 2863813611, 13057, 19908, 175, 186, 178, 242, 237, 150, 53, 160);
 RT_INTERFACE!{interface IPlayToSourceWithPreferredSourceUri(IPlayToSourceWithPreferredSourceUriVtbl): IInspectable(IInspectableVtbl) [IID_IPlayToSourceWithPreferredSourceUri] {
     fn get_PreferredSourceUri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -21207,7 +21207,7 @@ impl ISourceChangeRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SourceChangeRequestedEventArgs: ISourceChangeRequestedEventArgs}
+RT_CLASS!{class SourceChangeRequestedEventArgs: ISourceChangeRequestedEventArgs ["Windows.Media.PlayTo.SourceChangeRequestedEventArgs"]}
 DEFINE_IID!(IID_IVolumeChangeRequestedEventArgs, 1862430044, 53109, 19499, 145, 62, 109, 124, 108, 50, 145, 121);
 RT_INTERFACE!{interface IVolumeChangeRequestedEventArgs(IVolumeChangeRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVolumeChangeRequestedEventArgs] {
     fn get_Volume(&self, out: *mut f64) -> HRESULT
@@ -21219,11 +21219,11 @@ impl IVolumeChangeRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VolumeChangeRequestedEventArgs: IVolumeChangeRequestedEventArgs}
+RT_CLASS!{class VolumeChangeRequestedEventArgs: IVolumeChangeRequestedEventArgs ["Windows.Media.PlayTo.VolumeChangeRequestedEventArgs"]}
 } // Windows.Media.PlayTo
 pub mod playback { // Windows.Media.Playback
 use ::prelude::*;
-RT_ENUM! { enum AutoLoadedDisplayPropertyKind: i32 {
+RT_ENUM! { enum AutoLoadedDisplayPropertyKind: i32 ["Windows.Media.Playback.AutoLoadedDisplayPropertyKind"] {
     None (AutoLoadedDisplayPropertyKind_None) = 0, MusicOrVideo (AutoLoadedDisplayPropertyKind_MusicOrVideo) = 1, Music (AutoLoadedDisplayPropertyKind_Music) = 2, Video (AutoLoadedDisplayPropertyKind_Video) = 3,
 }}
 RT_CLASS!{static class BackgroundMediaPlayer}
@@ -21329,7 +21329,7 @@ impl ICurrentMediaPlaybackItemChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CurrentMediaPlaybackItemChangedEventArgs: ICurrentMediaPlaybackItemChangedEventArgs}
+RT_CLASS!{class CurrentMediaPlaybackItemChangedEventArgs: ICurrentMediaPlaybackItemChangedEventArgs ["Windows.Media.Playback.CurrentMediaPlaybackItemChangedEventArgs"]}
 DEFINE_IID!(IID_ICurrentMediaPlaybackItemChangedEventArgs2, 494970142, 39278, 16553, 190, 72, 230, 110, 201, 11, 43, 125);
 RT_INTERFACE!{interface ICurrentMediaPlaybackItemChangedEventArgs2(ICurrentMediaPlaybackItemChangedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_ICurrentMediaPlaybackItemChangedEventArgs2] {
     fn get_Reason(&self, out: *mut MediaPlaybackItemChangedReason) -> HRESULT
@@ -21341,7 +21341,7 @@ impl ICurrentMediaPlaybackItemChangedEventArgs2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum FailedMediaStreamKind: i32 {
+RT_ENUM! { enum FailedMediaStreamKind: i32 ["Windows.Media.Playback.FailedMediaStreamKind"] {
     Unknown (FailedMediaStreamKind_Unknown) = 0, Audio (FailedMediaStreamKind_Audio) = 1, Video (FailedMediaStreamKind_Video) = 2,
 }}
 DEFINE_IID!(IID_IMediaBreak, 1900798576, 3567, 20156, 164, 137, 107, 52, 147, 14, 21, 88);
@@ -21384,7 +21384,7 @@ impl IMediaBreak {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreak: IMediaBreak}
+RT_CLASS!{class MediaBreak: IMediaBreak ["Windows.Media.Playback.MediaBreak"]}
 impl RtActivatable<IMediaBreakFactory> for MediaBreak {}
 impl MediaBreak {
     #[inline] pub fn create(insertionMethod: MediaBreakInsertionMethod) -> Result<ComPtr<MediaBreak>> {
@@ -21406,7 +21406,7 @@ impl IMediaBreakEndedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreakEndedEventArgs: IMediaBreakEndedEventArgs}
+RT_CLASS!{class MediaBreakEndedEventArgs: IMediaBreakEndedEventArgs ["Windows.Media.Playback.MediaBreakEndedEventArgs"]}
 DEFINE_IID!(IID_IMediaBreakFactory, 1159127042, 6368, 16505, 139, 95, 211, 52, 149, 193, 93, 46);
 RT_INTERFACE!{static interface IMediaBreakFactory(IMediaBreakFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBreakFactory] {
     fn Create(&self, insertionMethod: MediaBreakInsertionMethod, out: *mut *mut MediaBreak) -> HRESULT,
@@ -21424,7 +21424,7 @@ impl IMediaBreakFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaBreakInsertionMethod: i32 {
+RT_ENUM! { enum MediaBreakInsertionMethod: i32 ["Windows.Media.Playback.MediaBreakInsertionMethod"] {
     Interrupt (MediaBreakInsertionMethod_Interrupt) = 0, Replace (MediaBreakInsertionMethod_Replace) = 1,
 }}
 DEFINE_IID!(IID_IMediaBreakManager, 2824134065, 65204, 19867, 157, 151, 15, 219, 229, 142, 94, 57);
@@ -21498,7 +21498,7 @@ impl IMediaBreakManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreakManager: IMediaBreakManager}
+RT_CLASS!{class MediaBreakManager: IMediaBreakManager ["Windows.Media.Playback.MediaBreakManager"]}
 DEFINE_IID!(IID_IMediaBreakSchedule, 2711246867, 39094, 16856, 131, 218, 249, 113, 210, 43, 123, 186);
 RT_INTERFACE!{interface IMediaBreakSchedule(IMediaBreakScheduleVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBreakSchedule] {
     fn add_ScheduleChanged(&self, handler: *mut foundation::TypedEventHandler<MediaBreakSchedule, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -21559,7 +21559,7 @@ impl IMediaBreakSchedule {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreakSchedule: IMediaBreakSchedule}
+RT_CLASS!{class MediaBreakSchedule: IMediaBreakSchedule ["Windows.Media.Playback.MediaBreakSchedule"]}
 DEFINE_IID!(IID_IMediaBreakSeekedOverEventArgs, 3853150022, 1542, 17554, 185, 211, 195, 200, 253, 224, 164, 234);
 RT_INTERFACE!{interface IMediaBreakSeekedOverEventArgs(IMediaBreakSeekedOverEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBreakSeekedOverEventArgs] {
     fn get_SeekedOverBreaks(&self, out: *mut *mut foundation::collections::IVectorView<MediaBreak>) -> HRESULT,
@@ -21583,7 +21583,7 @@ impl IMediaBreakSeekedOverEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreakSeekedOverEventArgs: IMediaBreakSeekedOverEventArgs}
+RT_CLASS!{class MediaBreakSeekedOverEventArgs: IMediaBreakSeekedOverEventArgs ["Windows.Media.Playback.MediaBreakSeekedOverEventArgs"]}
 DEFINE_IID!(IID_IMediaBreakSkippedEventArgs, 1860783109, 12116, 19006, 163, 171, 36, 195, 178, 112, 180, 163);
 RT_INTERFACE!{interface IMediaBreakSkippedEventArgs(IMediaBreakSkippedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBreakSkippedEventArgs] {
     fn get_MediaBreak(&self, out: *mut *mut MediaBreak) -> HRESULT
@@ -21595,7 +21595,7 @@ impl IMediaBreakSkippedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreakSkippedEventArgs: IMediaBreakSkippedEventArgs}
+RT_CLASS!{class MediaBreakSkippedEventArgs: IMediaBreakSkippedEventArgs ["Windows.Media.Playback.MediaBreakSkippedEventArgs"]}
 DEFINE_IID!(IID_IMediaBreakStartedEventArgs, 2826894961, 57300, 17738, 149, 110, 10, 74, 100, 131, 149, 248);
 RT_INTERFACE!{interface IMediaBreakStartedEventArgs(IMediaBreakStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaBreakStartedEventArgs] {
     fn get_MediaBreak(&self, out: *mut *mut MediaBreak) -> HRESULT
@@ -21607,8 +21607,8 @@ impl IMediaBreakStartedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaBreakStartedEventArgs: IMediaBreakStartedEventArgs}
-RT_ENUM! { enum MediaCommandEnablingRule: i32 {
+RT_CLASS!{class MediaBreakStartedEventArgs: IMediaBreakStartedEventArgs ["Windows.Media.Playback.MediaBreakStartedEventArgs"]}
+RT_ENUM! { enum MediaCommandEnablingRule: i32 ["Windows.Media.Playback.MediaCommandEnablingRule"] {
     Auto (MediaCommandEnablingRule_Auto) = 0, Always (MediaCommandEnablingRule_Always) = 1, Never (MediaCommandEnablingRule_Never) = 2,
 }}
 DEFINE_IID!(IID_IMediaEnginePlaybackSource, 1545407399, 14422, 18617, 141, 198, 36, 75, 241, 7, 191, 140);
@@ -21673,8 +21673,8 @@ impl IMediaItemDisplayProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaItemDisplayProperties: IMediaItemDisplayProperties}
-RT_CLASS!{class MediaPlaybackAudioTrackList: foundation::collections::IVectorView<super::core::AudioTrack>}
+RT_CLASS!{class MediaItemDisplayProperties: IMediaItemDisplayProperties ["Windows.Media.Playback.MediaItemDisplayProperties"]}
+RT_CLASS!{class MediaPlaybackAudioTrackList: foundation::collections::IVectorView<super::core::AudioTrack> ["Windows.Media.Playback.MediaPlaybackAudioTrackList"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManager, 1523508646, 23734, 19034, 133, 33, 204, 134, 177, 193, 237, 55);
 RT_INTERFACE!{interface IMediaPlaybackCommandManager(IMediaPlaybackCommandManagerVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManager] {
     fn get_IsEnabled(&self, out: *mut bool) -> HRESULT,
@@ -21867,7 +21867,7 @@ impl IMediaPlaybackCommandManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManager: IMediaPlaybackCommandManager}
+RT_CLASS!{class MediaPlaybackCommandManager: IMediaPlaybackCommandManager ["Windows.Media.Playback.MediaPlaybackCommandManager"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs, 1030704931, 21040, 17425, 160, 233, 186, 217, 76, 42, 4, 92);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs(IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -21896,7 +21896,7 @@ impl IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs: IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs: IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerCommandBehavior, 2020351608, 52856, 18960, 175, 214, 132, 63, 203, 185, 12, 46);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerCommandBehavior(IMediaPlaybackCommandManagerCommandBehaviorVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerCommandBehavior] {
     fn get_CommandManager(&self, out: *mut *mut MediaPlaybackCommandManager) -> HRESULT,
@@ -21936,7 +21936,7 @@ impl IMediaPlaybackCommandManagerCommandBehavior {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerCommandBehavior: IMediaPlaybackCommandManagerCommandBehavior}
+RT_CLASS!{class MediaPlaybackCommandManagerCommandBehavior: IMediaPlaybackCommandManagerCommandBehavior ["Windows.Media.Playback.MediaPlaybackCommandManagerCommandBehavior"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerFastForwardReceivedEventArgs, 821060825, 46225, 19722, 188, 33, 48, 152, 189, 19, 50, 233);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerFastForwardReceivedEventArgs(IMediaPlaybackCommandManagerFastForwardReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerFastForwardReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -21959,7 +21959,7 @@ impl IMediaPlaybackCommandManagerFastForwardReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerFastForwardReceivedEventArgs: IMediaPlaybackCommandManagerFastForwardReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerFastForwardReceivedEventArgs: IMediaPlaybackCommandManagerFastForwardReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerFastForwardReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerNextReceivedEventArgs, 3780133939, 41648, 17876, 185, 222, 95, 66, 172, 20, 168, 57);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerNextReceivedEventArgs(IMediaPlaybackCommandManagerNextReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerNextReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -21982,7 +21982,7 @@ impl IMediaPlaybackCommandManagerNextReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerNextReceivedEventArgs: IMediaPlaybackCommandManagerNextReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerNextReceivedEventArgs: IMediaPlaybackCommandManagerNextReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerNextReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerPauseReceivedEventArgs, 1559022876, 49756, 16929, 177, 108, 195, 201, 140, 224, 18, 214);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerPauseReceivedEventArgs(IMediaPlaybackCommandManagerPauseReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerPauseReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22005,7 +22005,7 @@ impl IMediaPlaybackCommandManagerPauseReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerPauseReceivedEventArgs: IMediaPlaybackCommandManagerPauseReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerPauseReceivedEventArgs: IMediaPlaybackCommandManagerPauseReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerPauseReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerPlayReceivedEventArgs, 2599419982, 22411, 19542, 160, 6, 22, 21, 157, 136, 138, 72);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerPlayReceivedEventArgs(IMediaPlaybackCommandManagerPlayReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerPlayReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22028,7 +22028,7 @@ impl IMediaPlaybackCommandManagerPlayReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerPlayReceivedEventArgs: IMediaPlaybackCommandManagerPlayReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerPlayReceivedEventArgs: IMediaPlaybackCommandManagerPlayReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerPlayReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerPositionReceivedEventArgs, 1435608916, 54823, 19421, 169, 13, 134, 160, 21, 178, 73, 2);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerPositionReceivedEventArgs(IMediaPlaybackCommandManagerPositionReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerPositionReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22057,7 +22057,7 @@ impl IMediaPlaybackCommandManagerPositionReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerPositionReceivedEventArgs: IMediaPlaybackCommandManagerPositionReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerPositionReceivedEventArgs: IMediaPlaybackCommandManagerPositionReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerPositionReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerPreviousReceivedEventArgs, 1381904513, 17970, 20342, 153, 177, 215, 113, 98, 63, 98, 135);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerPreviousReceivedEventArgs(IMediaPlaybackCommandManagerPreviousReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerPreviousReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22080,7 +22080,7 @@ impl IMediaPlaybackCommandManagerPreviousReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerPreviousReceivedEventArgs: IMediaPlaybackCommandManagerPreviousReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerPreviousReceivedEventArgs: IMediaPlaybackCommandManagerPreviousReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerPreviousReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerRateReceivedEventArgs, 418003257, 18966, 16745, 139, 5, 62, 185, 245, 255, 120, 235);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerRateReceivedEventArgs(IMediaPlaybackCommandManagerRateReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerRateReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22109,7 +22109,7 @@ impl IMediaPlaybackCommandManagerRateReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerRateReceivedEventArgs: IMediaPlaybackCommandManagerRateReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerRateReceivedEventArgs: IMediaPlaybackCommandManagerRateReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerRateReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerRewindReceivedEventArgs, 2668124487, 41920, 16989, 170, 239, 151, 186, 120, 152, 177, 65);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerRewindReceivedEventArgs(IMediaPlaybackCommandManagerRewindReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerRewindReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22132,7 +22132,7 @@ impl IMediaPlaybackCommandManagerRewindReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerRewindReceivedEventArgs: IMediaPlaybackCommandManagerRewindReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerRewindReceivedEventArgs: IMediaPlaybackCommandManagerRewindReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerRewindReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackCommandManagerShuffleReceivedEventArgs, 1352686831, 25582, 19094, 183, 181, 254, 224, 139, 159, 249, 12);
 RT_INTERFACE!{interface IMediaPlaybackCommandManagerShuffleReceivedEventArgs(IMediaPlaybackCommandManagerShuffleReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackCommandManagerShuffleReceivedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -22161,7 +22161,7 @@ impl IMediaPlaybackCommandManagerShuffleReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackCommandManagerShuffleReceivedEventArgs: IMediaPlaybackCommandManagerShuffleReceivedEventArgs}
+RT_CLASS!{class MediaPlaybackCommandManagerShuffleReceivedEventArgs: IMediaPlaybackCommandManagerShuffleReceivedEventArgs ["Windows.Media.Playback.MediaPlaybackCommandManagerShuffleReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackItem, 74487762, 58543, 18603, 178, 131, 105, 41, 230, 116, 236, 226);
 RT_INTERFACE!{interface IMediaPlaybackItem(IMediaPlaybackItemVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackItem] {
     fn add_AudioTracksChanged(&self, handler: *mut foundation::TypedEventHandler<MediaPlaybackItem, foundation::collections::IVectorChangedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -22224,7 +22224,7 @@ impl IMediaPlaybackItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackItem: IMediaPlaybackItem}
+RT_CLASS!{class MediaPlaybackItem: IMediaPlaybackItem ["Windows.Media.Playback.MediaPlaybackItem"]}
 impl RtActivatable<IMediaPlaybackItemFactory> for MediaPlaybackItem {}
 impl RtActivatable<IMediaPlaybackItemFactory2> for MediaPlaybackItem {}
 impl RtActivatable<IMediaPlaybackItemStatics> for MediaPlaybackItem {}
@@ -22321,7 +22321,7 @@ impl IMediaPlaybackItem3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaPlaybackItemChangedReason: i32 {
+RT_ENUM! { enum MediaPlaybackItemChangedReason: i32 ["Windows.Media.Playback.MediaPlaybackItemChangedReason"] {
     InitialItem (MediaPlaybackItemChangedReason_InitialItem) = 0, EndOfStream (MediaPlaybackItemChangedReason_EndOfStream) = 1, Error (MediaPlaybackItemChangedReason_Error) = 2, AppRequested (MediaPlaybackItemChangedReason_AppRequested) = 3,
 }}
 DEFINE_IID!(IID_IMediaPlaybackItemError, 1778118443, 56534, 19961, 164, 80, 219, 244, 198, 241, 194, 194);
@@ -22341,8 +22341,8 @@ impl IMediaPlaybackItemError {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackItemError: IMediaPlaybackItemError}
-RT_ENUM! { enum MediaPlaybackItemErrorCode: i32 {
+RT_CLASS!{class MediaPlaybackItemError: IMediaPlaybackItemError ["Windows.Media.Playback.MediaPlaybackItemError"]}
+RT_ENUM! { enum MediaPlaybackItemErrorCode: i32 ["Windows.Media.Playback.MediaPlaybackItemErrorCode"] {
     None (MediaPlaybackItemErrorCode_None) = 0, Aborted (MediaPlaybackItemErrorCode_Aborted) = 1, NetworkError (MediaPlaybackItemErrorCode_NetworkError) = 2, DecodeError (MediaPlaybackItemErrorCode_DecodeError) = 3, SourceNotSupportedError (MediaPlaybackItemErrorCode_SourceNotSupportedError) = 4, EncryptionError (MediaPlaybackItemErrorCode_EncryptionError) = 5,
 }}
 DEFINE_IID!(IID_IMediaPlaybackItemFactory, 1899232481, 5993, 20473, 167, 193, 56, 210, 196, 212, 35, 96);
@@ -22390,7 +22390,7 @@ impl IMediaPlaybackItemFailedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackItemFailedEventArgs: IMediaPlaybackItemFailedEventArgs}
+RT_CLASS!{class MediaPlaybackItemFailedEventArgs: IMediaPlaybackItemFailedEventArgs ["Windows.Media.Playback.MediaPlaybackItemFailedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackItemOpenedEventArgs, 3420044674, 12343, 20414, 174, 143, 57, 252, 57, 237, 244, 239);
 RT_INTERFACE!{interface IMediaPlaybackItemOpenedEventArgs(IMediaPlaybackItemOpenedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackItemOpenedEventArgs] {
     fn get_Item(&self, out: *mut *mut MediaPlaybackItem) -> HRESULT
@@ -22402,7 +22402,7 @@ impl IMediaPlaybackItemOpenedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackItemOpenedEventArgs: IMediaPlaybackItemOpenedEventArgs}
+RT_CLASS!{class MediaPlaybackItemOpenedEventArgs: IMediaPlaybackItemOpenedEventArgs ["Windows.Media.Playback.MediaPlaybackItemOpenedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackItemStatics, 1260120052, 17221, 16444, 138, 103, 245, 222, 145, 223, 76, 134);
 RT_INTERFACE!{static interface IMediaPlaybackItemStatics(IMediaPlaybackItemStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackItemStatics] {
     fn FindFromMediaSource(&self, source: *mut super::core::MediaSource, out: *mut *mut MediaPlaybackItem) -> HRESULT
@@ -22510,7 +22510,7 @@ impl IMediaPlaybackList {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackList: IMediaPlaybackList}
+RT_CLASS!{class MediaPlaybackList: IMediaPlaybackList ["Windows.Media.Playback.MediaPlaybackList"]}
 impl RtActivatable<IActivationFactory> for MediaPlaybackList {}
 DEFINE_CLSID!(MediaPlaybackList(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,77,101,100,105,97,80,108,97,121,98,97,99,107,76,105,115,116,0]) [CLSID_MediaPlaybackList]);
 DEFINE_IID!(IID_IMediaPlaybackList2, 235517048, 24586, 17012, 161, 75, 11, 103, 35, 208, 244, 139);
@@ -22786,7 +22786,7 @@ impl IMediaPlaybackSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackSession: IMediaPlaybackSession}
+RT_CLASS!{class MediaPlaybackSession: IMediaPlaybackSession ["Windows.Media.Playback.MediaPlaybackSession"]}
 DEFINE_IID!(IID_IMediaPlaybackSession2, 4172971129, 8136, 16535, 173, 112, 192, 250, 24, 204, 0, 80);
 RT_INTERFACE!{interface IMediaPlaybackSession2(IMediaPlaybackSession2Vtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackSession2] {
     fn add_BufferedRangesChanged(&self, value: *mut foundation::TypedEventHandler<MediaPlaybackSession, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -22910,7 +22910,7 @@ impl IMediaPlaybackSessionBufferingStartedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackSessionBufferingStartedEventArgs: IMediaPlaybackSessionBufferingStartedEventArgs}
+RT_CLASS!{class MediaPlaybackSessionBufferingStartedEventArgs: IMediaPlaybackSessionBufferingStartedEventArgs ["Windows.Media.Playback.MediaPlaybackSessionBufferingStartedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlaybackSessionOutputDegradationPolicyState, 1435398781, 63027, 18937, 150, 90, 171, 170, 29, 183, 9, 190);
 RT_INTERFACE!{interface IMediaPlaybackSessionOutputDegradationPolicyState(IMediaPlaybackSessionOutputDegradationPolicyStateVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlaybackSessionOutputDegradationPolicyState] {
     fn get_VideoConstrictionReason(&self, out: *mut MediaPlaybackSessionVideoConstrictionReason) -> HRESULT
@@ -22922,8 +22922,8 @@ impl IMediaPlaybackSessionOutputDegradationPolicyState {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackSessionOutputDegradationPolicyState: IMediaPlaybackSessionOutputDegradationPolicyState}
-RT_ENUM! { enum MediaPlaybackSessionVideoConstrictionReason: i32 {
+RT_CLASS!{class MediaPlaybackSessionOutputDegradationPolicyState: IMediaPlaybackSessionOutputDegradationPolicyState ["Windows.Media.Playback.MediaPlaybackSessionOutputDegradationPolicyState"]}
+RT_ENUM! { enum MediaPlaybackSessionVideoConstrictionReason: i32 ["Windows.Media.Playback.MediaPlaybackSessionVideoConstrictionReason"] {
     None (MediaPlaybackSessionVideoConstrictionReason_None) = 0, VirtualMachine (MediaPlaybackSessionVideoConstrictionReason_VirtualMachine) = 1, UnsupportedDisplayAdapter (MediaPlaybackSessionVideoConstrictionReason_UnsupportedDisplayAdapter) = 2, UnsignedDriver (MediaPlaybackSessionVideoConstrictionReason_UnsignedDriver) = 3, FrameServerEnabled (MediaPlaybackSessionVideoConstrictionReason_FrameServerEnabled) = 4, OutputProtectionFailed (MediaPlaybackSessionVideoConstrictionReason_OutputProtectionFailed) = 5, Unknown (MediaPlaybackSessionVideoConstrictionReason_Unknown) = 6,
 }}
 DEFINE_IID!(IID_IMediaPlaybackSource, 4020093628, 37655, 18070, 176, 81, 43, 173, 100, 49, 119, 181);
@@ -22990,8 +22990,8 @@ impl IMediaPlaybackSphericalVideoProjection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackSphericalVideoProjection: IMediaPlaybackSphericalVideoProjection}
-RT_ENUM! { enum MediaPlaybackState: i32 {
+RT_CLASS!{class MediaPlaybackSphericalVideoProjection: IMediaPlaybackSphericalVideoProjection ["Windows.Media.Playback.MediaPlaybackSphericalVideoProjection"]}
+RT_ENUM! { enum MediaPlaybackState: i32 ["Windows.Media.Playback.MediaPlaybackState"] {
     None (MediaPlaybackState_None) = 0, Opening (MediaPlaybackState_Opening) = 1, Buffering (MediaPlaybackState_Buffering) = 2, Playing (MediaPlaybackState_Playing) = 3, Paused (MediaPlaybackState_Paused) = 4,
 }}
 DEFINE_IID!(IID_IMediaPlaybackTimedMetadataTrackList, 1924403993, 48123, 18083, 147, 114, 156, 156, 116, 75, 148, 56);
@@ -23021,8 +23021,8 @@ impl IMediaPlaybackTimedMetadataTrackList {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlaybackTimedMetadataTrackList: foundation::collections::IVectorView<super::core::TimedMetadataTrack>}
-RT_CLASS!{class MediaPlaybackVideoTrackList: foundation::collections::IVectorView<super::core::VideoTrack>}
+RT_CLASS!{class MediaPlaybackTimedMetadataTrackList: foundation::collections::IVectorView<super::core::TimedMetadataTrack> ["Windows.Media.Playback.MediaPlaybackTimedMetadataTrackList"]}
+RT_CLASS!{class MediaPlaybackVideoTrackList: foundation::collections::IVectorView<super::core::VideoTrack> ["Windows.Media.Playback.MediaPlaybackVideoTrackList"]}
 DEFINE_IID!(IID_IMediaPlayer, 941261771, 28671, 18843, 141, 100, 40, 133, 223, 193, 36, 158);
 RT_INTERFACE!{interface IMediaPlayer(IMediaPlayerVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlayer] {
     fn get_AutoPlay(&self, out: *mut bool) -> HRESULT,
@@ -23261,7 +23261,7 @@ impl IMediaPlayer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlayer: IMediaPlayer}
+RT_CLASS!{class MediaPlayer: IMediaPlayer ["Windows.Media.Playback.MediaPlayer"]}
 impl RtActivatable<IActivationFactory> for MediaPlayer {}
 DEFINE_CLSID!(MediaPlayer(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,98,97,99,107,46,77,101,100,105,97,80,108,97,121,101,114,0]) [CLSID_MediaPlayer]);
 DEFINE_IID!(IID_IMediaPlayer2, 1015288344, 8483, 20421, 144, 130, 47, 136, 63, 119, 189, 245);
@@ -23523,10 +23523,10 @@ impl IMediaPlayer7 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaPlayerAudioCategory: i32 {
+RT_ENUM! { enum MediaPlayerAudioCategory: i32 ["Windows.Media.Playback.MediaPlayerAudioCategory"] {
     Other (MediaPlayerAudioCategory_Other) = 0, Communications (MediaPlayerAudioCategory_Communications) = 3, Alerts (MediaPlayerAudioCategory_Alerts) = 4, SoundEffects (MediaPlayerAudioCategory_SoundEffects) = 5, GameEffects (MediaPlayerAudioCategory_GameEffects) = 6, GameMedia (MediaPlayerAudioCategory_GameMedia) = 7, GameChat (MediaPlayerAudioCategory_GameChat) = 8, Speech (MediaPlayerAudioCategory_Speech) = 9, Movie (MediaPlayerAudioCategory_Movie) = 10, Media (MediaPlayerAudioCategory_Media) = 11,
 }}
-RT_ENUM! { enum MediaPlayerAudioDeviceType: i32 {
+RT_ENUM! { enum MediaPlayerAudioDeviceType: i32 ["Windows.Media.Playback.MediaPlayerAudioDeviceType"] {
     Console (MediaPlayerAudioDeviceType_Console) = 0, Multimedia (MediaPlayerAudioDeviceType_Multimedia) = 1, Communications (MediaPlayerAudioDeviceType_Communications) = 2,
 }}
 DEFINE_IID!(IID_IMediaPlayerDataReceivedEventArgs, 3344602117, 51201, 16682, 131, 91, 131, 252, 14, 98, 42, 142);
@@ -23540,7 +23540,7 @@ impl IMediaPlayerDataReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlayerDataReceivedEventArgs: IMediaPlayerDataReceivedEventArgs}
+RT_CLASS!{class MediaPlayerDataReceivedEventArgs: IMediaPlayerDataReceivedEventArgs ["Windows.Media.Playback.MediaPlayerDataReceivedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlayerEffects, 2241978074, 51894, 19648, 139, 227, 96, 53, 244, 222, 37, 145);
 RT_INTERFACE!{interface IMediaPlayerEffects(IMediaPlayerEffectsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlayerEffects] {
     fn AddAudioEffect(&self, activatableClassId: HSTRING, effectOptional: bool, configuration: *mut foundation::collections::IPropertySet) -> HRESULT,
@@ -23566,7 +23566,7 @@ impl IMediaPlayerEffects2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaPlayerError: i32 {
+RT_ENUM! { enum MediaPlayerError: i32 ["Windows.Media.Playback.MediaPlayerError"] {
     Unknown (MediaPlayerError_Unknown) = 0, Aborted (MediaPlayerError_Aborted) = 1, NetworkError (MediaPlayerError_NetworkError) = 2, DecodingError (MediaPlayerError_DecodingError) = 3, SourceNotSupported (MediaPlayerError_SourceNotSupported) = 4,
 }}
 DEFINE_IID!(IID_IMediaPlayerFailedEventArgs, 658827705, 42979, 20246, 186, 196, 121, 20, 235, 192, 131, 1);
@@ -23592,7 +23592,7 @@ impl IMediaPlayerFailedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlayerFailedEventArgs: IMediaPlayerFailedEventArgs}
+RT_CLASS!{class MediaPlayerFailedEventArgs: IMediaPlayerFailedEventArgs ["Windows.Media.Playback.MediaPlayerFailedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlayerRateChangedEventArgs, 1080036696, 15201, 19378, 152, 159, 252, 101, 96, 139, 108, 171);
 RT_INTERFACE!{interface IMediaPlayerRateChangedEventArgs(IMediaPlayerRateChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlayerRateChangedEventArgs] {
     fn get_NewRate(&self, out: *mut f64) -> HRESULT
@@ -23604,7 +23604,7 @@ impl IMediaPlayerRateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlayerRateChangedEventArgs: IMediaPlayerRateChangedEventArgs}
+RT_CLASS!{class MediaPlayerRateChangedEventArgs: IMediaPlayerRateChangedEventArgs ["Windows.Media.Playback.MediaPlayerRateChangedEventArgs"]}
 DEFINE_IID!(IID_IMediaPlayerSource, 3176106135, 5155, 19518, 130, 197, 15, 177, 175, 148, 247, 21);
 RT_INTERFACE!{interface IMediaPlayerSource(IMediaPlayerSourceVtbl): IInspectable(IInspectableVtbl) [IID_IMediaPlayerSource] {
     fn get_ProtectionManager(&self, out: *mut *mut super::protection::MediaProtectionManager) -> HRESULT,
@@ -23654,7 +23654,7 @@ impl IMediaPlayerSource2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaPlayerState: i32 {
+RT_ENUM! { enum MediaPlayerState: i32 ["Windows.Media.Playback.MediaPlayerState"] {
     Closed (MediaPlayerState_Closed) = 0, Opening (MediaPlayerState_Opening) = 1, Buffering (MediaPlayerState_Buffering) = 2, Playing (MediaPlayerState_Playing) = 3, Paused (MediaPlayerState_Paused) = 4, Stopped (MediaPlayerState_Stopped) = 5,
 }}
 DEFINE_IID!(IID_IMediaPlayerSurface, 248927164, 46902, 18883, 131, 11, 118, 74, 56, 69, 49, 58);
@@ -23682,7 +23682,7 @@ impl IMediaPlayerSurface {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaPlayerSurface: IMediaPlayerSurface}
+RT_CLASS!{class MediaPlayerSurface: IMediaPlayerSurface ["Windows.Media.Playback.MediaPlayerSurface"]}
 DEFINE_IID!(IID_IPlaybackMediaMarker, 3302109020, 15388, 17476, 182, 185, 119, 139, 4, 34, 212, 26);
 RT_INTERFACE!{interface IPlaybackMediaMarker(IPlaybackMediaMarkerVtbl): IInspectable(IInspectableVtbl) [IID_IPlaybackMediaMarker] {
     fn get_Time(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -23706,7 +23706,7 @@ impl IPlaybackMediaMarker {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaybackMediaMarker: IPlaybackMediaMarker}
+RT_CLASS!{class PlaybackMediaMarker: IPlaybackMediaMarker ["Windows.Media.Playback.PlaybackMediaMarker"]}
 impl RtActivatable<IPlaybackMediaMarkerFactory> for PlaybackMediaMarker {}
 impl PlaybackMediaMarker {
     #[inline] pub fn create_from_time(value: foundation::TimeSpan) -> Result<ComPtr<PlaybackMediaMarker>> {
@@ -23745,7 +23745,7 @@ impl IPlaybackMediaMarkerReachedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaybackMediaMarkerReachedEventArgs: IPlaybackMediaMarkerReachedEventArgs}
+RT_CLASS!{class PlaybackMediaMarkerReachedEventArgs: IPlaybackMediaMarkerReachedEventArgs ["Windows.Media.Playback.PlaybackMediaMarkerReachedEventArgs"]}
 DEFINE_IID!(IID_IPlaybackMediaMarkerSequence, 4068543726, 25483, 18127, 136, 23, 29, 17, 31, 233, 216, 196);
 RT_INTERFACE!{interface IPlaybackMediaMarkerSequence(IPlaybackMediaMarkerSequenceVtbl): IInspectable(IInspectableVtbl) [IID_IPlaybackMediaMarkerSequence] {
     fn get_Size(&self, out: *mut u32) -> HRESULT,
@@ -23767,11 +23767,11 @@ impl IPlaybackMediaMarkerSequence {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaybackMediaMarkerSequence: IPlaybackMediaMarkerSequence}
-RT_ENUM! { enum SphericalVideoProjectionMode: i32 {
+RT_CLASS!{class PlaybackMediaMarkerSequence: IPlaybackMediaMarkerSequence ["Windows.Media.Playback.PlaybackMediaMarkerSequence"]}
+RT_ENUM! { enum SphericalVideoProjectionMode: i32 ["Windows.Media.Playback.SphericalVideoProjectionMode"] {
     Spherical (SphericalVideoProjectionMode_Spherical) = 0, Flat (SphericalVideoProjectionMode_Flat) = 1,
 }}
-RT_ENUM! { enum StereoscopicVideoRenderMode: i32 {
+RT_ENUM! { enum StereoscopicVideoRenderMode: i32 ["Windows.Media.Playback.StereoscopicVideoRenderMode"] {
     Mono (StereoscopicVideoRenderMode_Mono) = 0, Stereo (StereoscopicVideoRenderMode_Stereo) = 1,
 }}
 DEFINE_IID!(IID_ITimedMetadataPresentationModeChangedEventArgs, 3512950937, 26079, 17838, 140, 239, 220, 11, 83, 253, 194, 187);
@@ -23797,8 +23797,8 @@ impl ITimedMetadataPresentationModeChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TimedMetadataPresentationModeChangedEventArgs: ITimedMetadataPresentationModeChangedEventArgs}
-RT_ENUM! { enum TimedMetadataTrackPresentationMode: i32 {
+RT_CLASS!{class TimedMetadataPresentationModeChangedEventArgs: ITimedMetadataPresentationModeChangedEventArgs ["Windows.Media.Playback.TimedMetadataPresentationModeChangedEventArgs"]}
+RT_ENUM! { enum TimedMetadataTrackPresentationMode: i32 ["Windows.Media.Playback.TimedMetadataTrackPresentationMode"] {
     Disabled (TimedMetadataTrackPresentationMode_Disabled) = 0, Hidden (TimedMetadataTrackPresentationMode_Hidden) = 1, ApplicationPresented (TimedMetadataTrackPresentationMode_ApplicationPresented) = 2, PlatformPresented (TimedMetadataTrackPresentationMode_PlatformPresented) = 3,
 }}
 } // Windows.Media.Playback
@@ -23833,7 +23833,7 @@ impl IPlaylist {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Playlist: IPlaylist}
+RT_CLASS!{class Playlist: IPlaylist ["Windows.Media.Playlists.Playlist"]}
 impl RtActivatable<IPlaylistStatics> for Playlist {}
 impl RtActivatable<IActivationFactory> for Playlist {}
 impl Playlist {
@@ -23842,7 +23842,7 @@ impl Playlist {
     }
 }
 DEFINE_CLSID!(Playlist(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,108,97,121,108,105,115,116,115,46,80,108,97,121,108,105,115,116,0]) [CLSID_Playlist]);
-RT_ENUM! { enum PlaylistFormat: i32 {
+RT_ENUM! { enum PlaylistFormat: i32 ["Windows.Media.Playlists.PlaylistFormat"] {
     WindowsMedia (PlaylistFormat_WindowsMedia) = 0, Zune (PlaylistFormat_Zune) = 1, M3u (PlaylistFormat_M3u) = 2,
 }}
 DEFINE_IID!(IID_IPlaylistStatics, 3317903821, 33273, 20467, 149, 185, 112, 182, 255, 4, 107, 104);
@@ -23876,7 +23876,7 @@ impl IComponentLoadFailedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ComponentLoadFailedEventArgs: IComponentLoadFailedEventArgs}
+RT_CLASS!{class ComponentLoadFailedEventArgs: IComponentLoadFailedEventArgs ["Windows.Media.Protection.ComponentLoadFailedEventArgs"]}
 DEFINE_IID!(IID_ComponentLoadFailedEventHandler, 2514117692, 28089, 16971, 134, 202, 9, 26, 244, 50, 8, 28);
 RT_DELEGATE!{delegate ComponentLoadFailedEventHandler(ComponentLoadFailedEventHandlerVtbl, ComponentLoadFailedEventHandlerImpl) [IID_ComponentLoadFailedEventHandler] {
     fn Invoke(&self, sender: *mut MediaProtectionManager, e: *mut ComponentLoadFailedEventArgs) -> HRESULT
@@ -23906,10 +23906,10 @@ impl IComponentRenewalStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum GraphicsTrustStatus: i32 {
+RT_ENUM! { enum GraphicsTrustStatus: i32 ["Windows.Media.Protection.GraphicsTrustStatus"] {
     TrustNotRequired (GraphicsTrustStatus_TrustNotRequired) = 0, TrustEstablished (GraphicsTrustStatus_TrustEstablished) = 1, EnvironmentNotSupported (GraphicsTrustStatus_EnvironmentNotSupported) = 2, DriverNotSupported (GraphicsTrustStatus_DriverNotSupported) = 3, DriverSigningFailure (GraphicsTrustStatus_DriverSigningFailure) = 4, UnknownFailure (GraphicsTrustStatus_UnknownFailure) = 5,
 }}
-RT_ENUM! { enum HdcpProtection: i32 {
+RT_ENUM! { enum HdcpProtection: i32 ["Windows.Media.Protection.HdcpProtection"] {
     Off (HdcpProtection_Off) = 0, On (HdcpProtection_On) = 1, OnWithTypeEnforcement (HdcpProtection_OnWithTypeEnforcement) = 2,
 }}
 DEFINE_IID!(IID_IHdcpSession, 1904756201, 25815, 17005, 128, 155, 27, 228, 97, 148, 26, 42);
@@ -23946,10 +23946,10 @@ impl IHdcpSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HdcpSession: IHdcpSession}
+RT_CLASS!{class HdcpSession: IHdcpSession ["Windows.Media.Protection.HdcpSession"]}
 impl RtActivatable<IActivationFactory> for HdcpSession {}
 DEFINE_CLSID!(HdcpSession(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,72,100,99,112,83,101,115,115,105,111,110,0]) [CLSID_HdcpSession]);
-RT_ENUM! { enum HdcpSetProtectionResult: i32 {
+RT_ENUM! { enum HdcpSetProtectionResult: i32 ["Windows.Media.Protection.HdcpSetProtectionResult"] {
     Success (HdcpSetProtectionResult_Success) = 0, TimedOut (HdcpSetProtectionResult_TimedOut) = 1, NotSupported (HdcpSetProtectionResult_NotSupported) = 2, UnknownFailure (HdcpSetProtectionResult_UnknownFailure) = 3,
 }}
 DEFINE_IID!(IID_IMediaProtectionManager, 1164527943, 51009, 17227, 167, 158, 71, 76, 18, 217, 61, 47);
@@ -23996,7 +23996,7 @@ impl IMediaProtectionManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaProtectionManager: IMediaProtectionManager}
+RT_CLASS!{class MediaProtectionManager: IMediaProtectionManager ["Windows.Media.Protection.MediaProtectionManager"]}
 impl RtActivatable<IActivationFactory> for MediaProtectionManager {}
 DEFINE_CLSID!(MediaProtectionManager(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,77,101,100,105,97,80,114,111,116,101,99,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MediaProtectionManager]);
 DEFINE_IID!(IID_IMediaProtectionPMPServer, 202445350, 31526, 19761, 149, 187, 156, 27, 8, 239, 127, 192);
@@ -24010,7 +24010,7 @@ impl IMediaProtectionPMPServer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaProtectionPMPServer: IMediaProtectionPMPServer}
+RT_CLASS!{class MediaProtectionPMPServer: IMediaProtectionPMPServer ["Windows.Media.Protection.MediaProtectionPMPServer"]}
 impl RtActivatable<IMediaProtectionPMPServerFactory> for MediaProtectionPMPServer {}
 impl MediaProtectionPMPServer {
     #[inline] pub fn create_pmp_server(pProperties: &foundation::collections::IPropertySet) -> Result<ComPtr<MediaProtectionPMPServer>> {
@@ -24039,7 +24039,7 @@ impl IMediaProtectionServiceCompletion {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaProtectionServiceCompletion: IMediaProtectionServiceCompletion}
+RT_CLASS!{class MediaProtectionServiceCompletion: IMediaProtectionServiceCompletion ["Windows.Media.Protection.MediaProtectionServiceCompletion"]}
 DEFINE_IID!(IID_IMediaProtectionServiceRequest, 2984119974, 8340, 18317, 135, 164, 139, 149, 32, 15, 133, 198);
 RT_INTERFACE!{interface IMediaProtectionServiceRequest(IMediaProtectionServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IMediaProtectionServiceRequest] {
     fn get_ProtectionSystem(&self, out: *mut Guid) -> HRESULT,
@@ -24068,10 +24068,10 @@ impl IProtectionCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectionCapabilities: IProtectionCapabilities}
+RT_CLASS!{class ProtectionCapabilities: IProtectionCapabilities ["Windows.Media.Protection.ProtectionCapabilities"]}
 impl RtActivatable<IActivationFactory> for ProtectionCapabilities {}
 DEFINE_CLSID!(ProtectionCapabilities(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,114,111,116,101,99,116,105,111,110,67,97,112,97,98,105,108,105,116,105,101,115,0]) [CLSID_ProtectionCapabilities]);
-RT_ENUM! { enum ProtectionCapabilityResult: i32 {
+RT_ENUM! { enum ProtectionCapabilityResult: i32 ["Windows.Media.Protection.ProtectionCapabilityResult"] {
     NotSupported (ProtectionCapabilityResult_NotSupported) = 0, Maybe (ProtectionCapabilityResult_Maybe) = 1, Probably (ProtectionCapabilityResult_Probably) = 2,
 }}
 DEFINE_IID!(IID_RebootNeededEventHandler, 1692478021, 38715, 19002, 178, 96, 145, 137, 138, 73, 168, 44);
@@ -24084,7 +24084,7 @@ impl RebootNeededEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RenewalStatus: i32 {
+RT_ENUM! { enum RenewalStatus: i32 ["Windows.Media.Protection.RenewalStatus"] {
     NotStarted (RenewalStatus_NotStarted) = 0, UpdatesInProgress (RenewalStatus_UpdatesInProgress) = 1, UserCancelled (RenewalStatus_UserCancelled) = 2, AppComponentsMayNeedUpdating (RenewalStatus_AppComponentsMayNeedUpdating) = 3, NoComponentsFound (RenewalStatus_NoComponentsFound) = 4,
 }}
 DEFINE_IID!(IID_IRevocationAndRenewalInformation, 4087452539, 9473, 17310, 166, 231, 111, 201, 94, 23, 95, 207);
@@ -24098,7 +24098,7 @@ impl IRevocationAndRenewalInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RevocationAndRenewalInformation: IRevocationAndRenewalInformation}
+RT_CLASS!{class RevocationAndRenewalInformation: IRevocationAndRenewalInformation ["Windows.Media.Protection.RevocationAndRenewalInformation"]}
 DEFINE_IID!(IID_IRevocationAndRenewalItem, 815383052, 15600, 18922, 144, 45, 202, 243, 45, 45, 222, 44);
 RT_INTERFACE!{interface IRevocationAndRenewalItem(IRevocationAndRenewalItemVtbl): IInspectable(IInspectableVtbl) [IID_IRevocationAndRenewalItem] {
     fn get_Reasons(&self, out: *mut RevocationAndRenewalReasons) -> HRESULT,
@@ -24134,8 +24134,8 @@ impl IRevocationAndRenewalItem {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RevocationAndRenewalItem: IRevocationAndRenewalItem}
-RT_ENUM! { enum RevocationAndRenewalReasons: u32 {
+RT_CLASS!{class RevocationAndRenewalItem: IRevocationAndRenewalItem ["Windows.Media.Protection.RevocationAndRenewalItem"]}
+RT_ENUM! { enum RevocationAndRenewalReasons: u32 ["Windows.Media.Protection.RevocationAndRenewalReasons"] {
     UserModeComponentLoad (RevocationAndRenewalReasons_UserModeComponentLoad) = 1, KernelModeComponentLoad (RevocationAndRenewalReasons_KernelModeComponentLoad) = 2, AppComponent (RevocationAndRenewalReasons_AppComponent) = 4, GlobalRevocationListLoadFailed (RevocationAndRenewalReasons_GlobalRevocationListLoadFailed) = 16, InvalidGlobalRevocationListSignature (RevocationAndRenewalReasons_InvalidGlobalRevocationListSignature) = 32, GlobalRevocationListAbsent (RevocationAndRenewalReasons_GlobalRevocationListAbsent) = 4096, ComponentRevoked (RevocationAndRenewalReasons_ComponentRevoked) = 8192, InvalidComponentCertificateExtendedKeyUse (RevocationAndRenewalReasons_InvalidComponentCertificateExtendedKeyUse) = 16384, ComponentCertificateRevoked (RevocationAndRenewalReasons_ComponentCertificateRevoked) = 32768, InvalidComponentCertificateRoot (RevocationAndRenewalReasons_InvalidComponentCertificateRoot) = 65536, ComponentHighSecurityCertificateRevoked (RevocationAndRenewalReasons_ComponentHighSecurityCertificateRevoked) = 131072, ComponentLowSecurityCertificateRevoked (RevocationAndRenewalReasons_ComponentLowSecurityCertificateRevoked) = 262144, BootDriverVerificationFailed (RevocationAndRenewalReasons_BootDriverVerificationFailed) = 1048576, ComponentSignedWithTestCertificate (RevocationAndRenewalReasons_ComponentSignedWithTestCertificate) = 16777216, EncryptionFailure (RevocationAndRenewalReasons_EncryptionFailure) = 268435456,
 }}
 DEFINE_IID!(IID_IServiceRequestedEventArgs, 875051951, 43956, 20417, 189, 137, 147, 241, 6, 87, 58, 73);
@@ -24155,7 +24155,7 @@ impl IServiceRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServiceRequestedEventArgs: IServiceRequestedEventArgs}
+RT_CLASS!{class ServiceRequestedEventArgs: IServiceRequestedEventArgs ["Windows.Media.Protection.ServiceRequestedEventArgs"]}
 DEFINE_IID!(IID_IServiceRequestedEventArgs2, 1430022614, 64254, 16680, 141, 250, 19, 14, 57, 138, 19, 167);
 RT_INTERFACE!{interface IServiceRequestedEventArgs2(IServiceRequestedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IServiceRequestedEventArgs2] {
     fn get_MediaPlaybackItem(&self, out: *mut *mut super::playback::MediaPlaybackItem) -> HRESULT
@@ -24179,13 +24179,13 @@ impl ServiceRequestedEventHandler {
 }
 pub mod playready { // Windows.Media.Protection.PlayReady
 use ::prelude::*;
-RT_ENUM! { enum NDCertificateFeature: i32 {
+RT_ENUM! { enum NDCertificateFeature: i32 ["Windows.Media.Protection.PlayReady.NDCertificateFeature"] {
     Transmitter (NDCertificateFeature_Transmitter) = 1, Receiver (NDCertificateFeature_Receiver) = 2, SharedCertificate (NDCertificateFeature_SharedCertificate) = 3, SecureClock (NDCertificateFeature_SecureClock) = 4, AntiRollBackClock (NDCertificateFeature_AntiRollBackClock) = 5, CRLS (NDCertificateFeature_CRLS) = 9, PlayReady3Features (NDCertificateFeature_PlayReady3Features) = 13,
 }}
-RT_ENUM! { enum NDCertificatePlatformID: i32 {
+RT_ENUM! { enum NDCertificatePlatformID: i32 ["Windows.Media.Protection.PlayReady.NDCertificatePlatformID"] {
     Windows (NDCertificatePlatformID_Windows) = 0, OSX (NDCertificatePlatformID_OSX) = 1, WindowsOnARM (NDCertificatePlatformID_WindowsOnARM) = 2, WindowsMobile7 (NDCertificatePlatformID_WindowsMobile7) = 5, iOSOnARM (NDCertificatePlatformID_iOSOnARM) = 6, XBoxOnPPC (NDCertificatePlatformID_XBoxOnPPC) = 7, WindowsPhone8OnARM (NDCertificatePlatformID_WindowsPhone8OnARM) = 8, WindowsPhone8OnX86 (NDCertificatePlatformID_WindowsPhone8OnX86) = 9, XboxOne (NDCertificatePlatformID_XboxOne) = 10, AndroidOnARM (NDCertificatePlatformID_AndroidOnARM) = 11, WindowsPhone81OnARM (NDCertificatePlatformID_WindowsPhone81OnARM) = 12, WindowsPhone81OnX86 (NDCertificatePlatformID_WindowsPhone81OnX86) = 13,
 }}
-RT_ENUM! { enum NDCertificateType: i32 {
+RT_ENUM! { enum NDCertificateType: i32 ["Windows.Media.Protection.PlayReady.NDCertificateType"] {
     Unknown (NDCertificateType_Unknown) = 0, PC (NDCertificateType_PC) = 1, Device (NDCertificateType_Device) = 2, Domain (NDCertificateType_Domain) = 3, Issuer (NDCertificateType_Issuer) = 4, CrlSigner (NDCertificateType_CrlSigner) = 5, Service (NDCertificateType_Service) = 6, Silverlight (NDCertificateType_Silverlight) = 7, Application (NDCertificateType_Application) = 8, Metering (NDCertificateType_Metering) = 9, KeyFileSigner (NDCertificateType_KeyFileSigner) = 10, Server (NDCertificateType_Server) = 11, LicenseSigner (NDCertificateType_LicenseSigner) = 12,
 }}
 DEFINE_IID!(IID_INDClient, 1003911195, 25016, 18146, 153, 165, 138, 188, 182, 185, 247, 214);
@@ -24271,7 +24271,7 @@ impl INDClient {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NDClient: INDClient}
+RT_CLASS!{class NDClient: INDClient ["Windows.Media.Protection.PlayReady.NDClient"]}
 impl RtActivatable<INDClientFactory> for NDClient {}
 impl NDClient {
     #[inline] pub fn create_instance(downloadEngine: &INDDownloadEngine, streamParser: &INDStreamParser, pMessenger: &INDMessenger) -> Result<ComPtr<NDClient>> {
@@ -24313,10 +24313,10 @@ impl INDClosedCaptionDataReceivedEventArgs {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum NDClosedCaptionFormat: i32 {
+RT_ENUM! { enum NDClosedCaptionFormat: i32 ["Windows.Media.Protection.PlayReady.NDClosedCaptionFormat"] {
     ATSC (NDClosedCaptionFormat_ATSC) = 0, SCTE20 (NDClosedCaptionFormat_SCTE20) = 1, Unknown (NDClosedCaptionFormat_Unknown) = 2,
 }}
-RT_ENUM! { enum NDContentIDType: i32 {
+RT_ENUM! { enum NDContentIDType: i32 ["Windows.Media.Protection.PlayReady.NDContentIDType"] {
     KeyID (NDContentIDType_KeyID) = 1, PlayReadyObject (NDContentIDType_PlayReadyObject) = 2, Custom (NDContentIDType_Custom) = 3,
 }}
 DEFINE_IID!(IID_INDCustomData, 4123725788, 11529, 20249, 181, 225, 118, 160, 179, 238, 146, 103);
@@ -24336,7 +24336,7 @@ impl INDCustomData {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NDCustomData: INDCustomData}
+RT_CLASS!{class NDCustomData: INDCustomData ["Windows.Media.Protection.PlayReady.NDCustomData"]}
 impl RtActivatable<INDCustomDataFactory> for NDCustomData {}
 impl NDCustomData {
     #[inline] pub fn create_instance(customDataTypeIDBytes: &[u8], customDataBytes: &[u8]) -> Result<ComPtr<NDCustomData>> {
@@ -24444,7 +24444,7 @@ impl INDDownloadEngineNotifier {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NDDownloadEngineNotifier: INDDownloadEngineNotifier}
+RT_CLASS!{class NDDownloadEngineNotifier: INDDownloadEngineNotifier ["Windows.Media.Protection.PlayReady.NDDownloadEngineNotifier"]}
 impl RtActivatable<IActivationFactory> for NDDownloadEngineNotifier {}
 DEFINE_CLSID!(NDDownloadEngineNotifier(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,68,111,119,110,108,111,97,100,69,110,103,105,110,101,78,111,116,105,102,105,101,114,0]) [CLSID_NDDownloadEngineNotifier]);
 DEFINE_IID!(IID_INDLicenseFetchCompletedEventArgs, 518195738, 4530, 17752, 136, 101, 227, 165, 22, 146, 37, 23);
@@ -24486,7 +24486,7 @@ impl INDLicenseFetchDescriptor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NDLicenseFetchDescriptor: INDLicenseFetchDescriptor}
+RT_CLASS!{class NDLicenseFetchDescriptor: INDLicenseFetchDescriptor ["Windows.Media.Protection.PlayReady.NDLicenseFetchDescriptor"]}
 impl RtActivatable<INDLicenseFetchDescriptorFactory> for NDLicenseFetchDescriptor {}
 impl NDLicenseFetchDescriptor {
     #[inline] pub fn create_instance(contentIDType: NDContentIDType, contentIDBytes: &[u8], licenseFetchChallengeCustomData: &INDCustomData) -> Result<ComPtr<NDLicenseFetchDescriptor>> {
@@ -24516,7 +24516,7 @@ impl INDLicenseFetchResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum NDMediaStreamType: i32 {
+RT_ENUM! { enum NDMediaStreamType: i32 ["Windows.Media.Protection.PlayReady.NDMediaStreamType"] {
     Audio (NDMediaStreamType_Audio) = 1, Video (NDMediaStreamType_Video) = 2,
 }}
 DEFINE_IID!(IID_INDMessenger, 3559782749, 42843, 18367, 130, 73, 188, 131, 130, 13, 163, 138);
@@ -24559,7 +24559,7 @@ impl INDProximityDetectionCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum NDProximityDetectionType: i32 {
+RT_ENUM! { enum NDProximityDetectionType: i32 ["Windows.Media.Protection.PlayReady.NDProximityDetectionType"] {
     UDP (NDProximityDetectionType_UDP) = 1, TCP (NDProximityDetectionType_TCP) = 2, TransportAgnostic (NDProximityDetectionType_TransportAgnostic) = 4,
 }}
 DEFINE_IID!(IID_INDRegistrationCompletedEventArgs, 2654582349, 43867, 18693, 172, 220, 120, 122, 119, 198, 55, 77);
@@ -24601,7 +24601,7 @@ impl INDSendResult {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum NDStartAsyncOptions: i32 {
+RT_ENUM! { enum NDStartAsyncOptions: i32 ["Windows.Media.Protection.PlayReady.NDStartAsyncOptions"] {
     MutualAuthentication (NDStartAsyncOptions_MutualAuthentication) = 1, WaitForLicenseDescriptor (NDStartAsyncOptions_WaitForLicenseDescriptor) = 2,
 }}
 DEFINE_IID!(IID_INDStartResult, 2046224750, 62735, 16405, 139, 164, 194, 188, 52, 78, 189, 78);
@@ -24626,7 +24626,7 @@ impl INDStorageFileHelper {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NDStorageFileHelper: INDStorageFileHelper}
+RT_CLASS!{class NDStorageFileHelper: INDStorageFileHelper ["Windows.Media.Protection.PlayReady.NDStorageFileHelper"]}
 impl RtActivatable<IActivationFactory> for NDStorageFileHelper {}
 DEFINE_CLSID!(NDStorageFileHelper(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,83,116,111,114,97,103,101,70,105,108,101,72,101,108,112,101,114,0]) [CLSID_NDStorageFileHelper]);
 DEFINE_IID!(IID_INDStreamParser, 3770327448, 38806, 16841, 134, 149, 89, 67, 126, 103, 230, 106);
@@ -24686,10 +24686,10 @@ impl INDStreamParserNotifier {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NDStreamParserNotifier: INDStreamParserNotifier}
+RT_CLASS!{class NDStreamParserNotifier: INDStreamParserNotifier ["Windows.Media.Protection.PlayReady.NDStreamParserNotifier"]}
 impl RtActivatable<IActivationFactory> for NDStreamParserNotifier {}
 DEFINE_CLSID!(NDStreamParserNotifier(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,78,68,83,116,114,101,97,109,80,97,114,115,101,114,78,111,116,105,102,105,101,114,0]) [CLSID_NDStreamParserNotifier]);
-RT_CLASS!{class NDTCPMessenger: INDMessenger}
+RT_CLASS!{class NDTCPMessenger: INDMessenger ["Windows.Media.Protection.PlayReady.NDTCPMessenger"]}
 impl RtActivatable<INDTCPMessengerFactory> for NDTCPMessenger {}
 impl NDTCPMessenger {
     #[inline] pub fn create_instance(remoteHostName: &HStringArg, remoteHostPort: u32) -> Result<ComPtr<NDTCPMessenger>> {
@@ -24844,7 +24844,7 @@ impl IPlayReadyContentHeader {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyContentHeader: IPlayReadyContentHeader}
+RT_CLASS!{class PlayReadyContentHeader: IPlayReadyContentHeader ["Windows.Media.Protection.PlayReady.PlayReadyContentHeader"]}
 impl RtActivatable<IPlayReadyContentHeaderFactory> for PlayReadyContentHeader {}
 impl RtActivatable<IPlayReadyContentHeaderFactory2> for PlayReadyContentHeader {}
 impl PlayReadyContentHeader {
@@ -24932,7 +24932,7 @@ impl PlayReadyContentResolver {
     }
 }
 DEFINE_CLSID!(PlayReadyContentResolver(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,67,111,110,116,101,110,116,82,101,115,111,108,118,101,114,0]) [CLSID_PlayReadyContentResolver]);
-RT_ENUM! { enum PlayReadyDecryptorSetup: i32 {
+RT_ENUM! { enum PlayReadyDecryptorSetup: i32 ["Windows.Media.Protection.PlayReady.PlayReadyDecryptorSetup"] {
     Uninitialized (PlayReadyDecryptorSetup_Uninitialized) = 0, OnDemand (PlayReadyDecryptorSetup_OnDemand) = 1,
 }}
 DEFINE_IID!(IID_IPlayReadyDomain, 2915865516, 38886, 17391, 149, 228, 215, 134, 143, 59, 22, 169);
@@ -24970,8 +24970,8 @@ impl IPlayReadyDomain {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyDomain: IPlayReadyDomain}
-RT_CLASS!{class PlayReadyDomainIterable: foundation::collections::IIterable<IPlayReadyDomain>}
+RT_CLASS!{class PlayReadyDomain: IPlayReadyDomain ["Windows.Media.Protection.PlayReady.PlayReadyDomain"]}
+RT_CLASS!{class PlayReadyDomainIterable: foundation::collections::IIterable<IPlayReadyDomain> ["Windows.Media.Protection.PlayReady.PlayReadyDomainIterable"]}
 impl RtActivatable<IPlayReadyDomainIterableFactory> for PlayReadyDomainIterable {}
 impl PlayReadyDomainIterable {
     #[inline] pub fn create_instance(domainAccountId: Guid) -> Result<ComPtr<PlayReadyDomainIterable>> {
@@ -24990,7 +24990,7 @@ impl IPlayReadyDomainIterableFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyDomainIterator: foundation::collections::IIterator<IPlayReadyDomain>}
+RT_CLASS!{class PlayReadyDomainIterator: foundation::collections::IIterator<IPlayReadyDomain> ["Windows.Media.Protection.PlayReady.PlayReadyDomainIterator"]}
 DEFINE_IID!(IID_IPlayReadyDomainJoinServiceRequest, 387664474, 16479, 18233, 176, 64, 103, 185, 240, 195, 135, 88);
 RT_INTERFACE!{interface IPlayReadyDomainJoinServiceRequest(IPlayReadyDomainJoinServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyDomainJoinServiceRequest] {
     fn get_DomainAccountId(&self, out: *mut Guid) -> HRESULT,
@@ -25029,7 +25029,7 @@ impl IPlayReadyDomainJoinServiceRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyDomainJoinServiceRequest: IPlayReadyDomainJoinServiceRequest}
+RT_CLASS!{class PlayReadyDomainJoinServiceRequest: IPlayReadyDomainJoinServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadyDomainJoinServiceRequest"]}
 impl RtActivatable<IActivationFactory> for PlayReadyDomainJoinServiceRequest {}
 DEFINE_CLSID!(PlayReadyDomainJoinServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,68,111,109,97,105,110,74,111,105,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyDomainJoinServiceRequest]);
 DEFINE_IID!(IID_IPlayReadyDomainLeaveServiceRequest, 103635134, 38829, 18711, 170, 3, 70, 212, 194, 82, 212, 100);
@@ -25059,23 +25059,23 @@ impl IPlayReadyDomainLeaveServiceRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyDomainLeaveServiceRequest: IPlayReadyDomainLeaveServiceRequest}
+RT_CLASS!{class PlayReadyDomainLeaveServiceRequest: IPlayReadyDomainLeaveServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadyDomainLeaveServiceRequest"]}
 impl RtActivatable<IActivationFactory> for PlayReadyDomainLeaveServiceRequest {}
 DEFINE_CLSID!(PlayReadyDomainLeaveServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,68,111,109,97,105,110,76,101,97,118,101,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyDomainLeaveServiceRequest]);
-RT_ENUM! { enum PlayReadyEncryptionAlgorithm: i32 {
+RT_ENUM! { enum PlayReadyEncryptionAlgorithm: i32 ["Windows.Media.Protection.PlayReady.PlayReadyEncryptionAlgorithm"] {
     Unprotected (PlayReadyEncryptionAlgorithm_Unprotected) = 0, Aes128Ctr (PlayReadyEncryptionAlgorithm_Aes128Ctr) = 1, Cocktail (PlayReadyEncryptionAlgorithm_Cocktail) = 4, Aes128Cbc (PlayReadyEncryptionAlgorithm_Aes128Cbc) = 5, Unspecified (PlayReadyEncryptionAlgorithm_Unspecified) = 65535, Uninitialized (PlayReadyEncryptionAlgorithm_Uninitialized) = 2147483647,
 }}
-RT_ENUM! { enum PlayReadyHardwareDRMFeatures: i32 {
+RT_ENUM! { enum PlayReadyHardwareDRMFeatures: i32 ["Windows.Media.Protection.PlayReady.PlayReadyHardwareDRMFeatures"] {
     HardwareDRM (PlayReadyHardwareDRMFeatures_HardwareDRM) = 1, HEVC (PlayReadyHardwareDRMFeatures_HEVC) = 2, Aes128Cbc (PlayReadyHardwareDRMFeatures_Aes128Cbc) = 3,
 }}
 DEFINE_IID!(IID_IPlayReadyIndividualizationServiceRequest, 569747563, 140, 17937, 171, 47, 170, 166, 198, 159, 14, 36);
 RT_INTERFACE!{interface IPlayReadyIndividualizationServiceRequest(IPlayReadyIndividualizationServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyIndividualizationServiceRequest] {
     
 }}
-RT_CLASS!{class PlayReadyIndividualizationServiceRequest: IPlayReadyIndividualizationServiceRequest}
+RT_CLASS!{class PlayReadyIndividualizationServiceRequest: IPlayReadyIndividualizationServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadyIndividualizationServiceRequest"]}
 impl RtActivatable<IActivationFactory> for PlayReadyIndividualizationServiceRequest {}
 DEFINE_CLSID!(PlayReadyIndividualizationServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,73,110,100,105,118,105,100,117,97,108,105,122,97,116,105,111,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyIndividualizationServiceRequest]);
-RT_ENUM! { enum PlayReadyITADataFormat: i32 {
+RT_ENUM! { enum PlayReadyITADataFormat: i32 ["Windows.Media.Protection.PlayReady.PlayReadyITADataFormat"] {
     SerializedProperties (PlayReadyITADataFormat_SerializedProperties) = 0, SerializedProperties_WithContentProtectionWrapper (PlayReadyITADataFormat_SerializedProperties_WithContentProtectionWrapper) = 1,
 }}
 DEFINE_IID!(IID_IPlayReadyITADataGenerator, 608463758, 4281, 17712, 178, 91, 144, 26, 128, 41, 169, 178);
@@ -25089,7 +25089,7 @@ impl IPlayReadyITADataGenerator {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyITADataGenerator: IPlayReadyITADataGenerator}
+RT_CLASS!{class PlayReadyITADataGenerator: IPlayReadyITADataGenerator ["Windows.Media.Protection.PlayReady.PlayReadyITADataGenerator"]}
 impl RtActivatable<IActivationFactory> for PlayReadyITADataGenerator {}
 DEFINE_CLSID!(PlayReadyITADataGenerator(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,73,84,65,68,97,116,97,71,101,110,101,114,97,116,111,114,0]) [CLSID_PlayReadyITADataGenerator]);
 DEFINE_IID!(IID_IPlayReadyLicense, 3997649998, 64060, 16717, 169, 242, 63, 252, 30, 248, 50, 212);
@@ -25139,7 +25139,7 @@ impl IPlayReadyLicense {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyLicense: IPlayReadyLicense}
+RT_CLASS!{class PlayReadyLicense: IPlayReadyLicense ["Windows.Media.Protection.PlayReady.PlayReadyLicense"]}
 DEFINE_IID!(IID_IPlayReadyLicense2, 821356455, 55523, 18592, 188, 218, 255, 159, 64, 83, 4, 54);
 RT_INTERFACE!{interface IPlayReadyLicense2(IPlayReadyLicense2Vtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicense2] {
     fn get_SecureStopId(&self, out: *mut Guid) -> HRESULT,
@@ -25196,7 +25196,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyLicenseAcquisitionServiceRequest: IPlayReadyLicenseAcquisitionServiceRequest}
+RT_CLASS!{class PlayReadyLicenseAcquisitionServiceRequest: IPlayReadyLicenseAcquisitionServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadyLicenseAcquisitionServiceRequest"]}
 impl RtActivatable<IActivationFactory> for PlayReadyLicenseAcquisitionServiceRequest {}
 DEFINE_CLSID!(PlayReadyLicenseAcquisitionServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,76,105,99,101,110,115,101,65,99,113,117,105,115,105,116,105,111,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyLicenseAcquisitionServiceRequest]);
 DEFINE_IID!(IID_IPlayReadyLicenseAcquisitionServiceRequest2, 3086638773, 65036, 45605, 188, 96, 90, 158, 221, 50, 206, 181);
@@ -25221,7 +25221,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyLicenseIterable: foundation::collections::IIterable<IPlayReadyLicense>}
+RT_CLASS!{class PlayReadyLicenseIterable: foundation::collections::IIterable<IPlayReadyLicense> ["Windows.Media.Protection.PlayReady.PlayReadyLicenseIterable"]}
 impl RtActivatable<IPlayReadyLicenseIterableFactory> for PlayReadyLicenseIterable {}
 impl RtActivatable<IActivationFactory> for PlayReadyLicenseIterable {}
 impl PlayReadyLicenseIterable {
@@ -25241,7 +25241,7 @@ impl IPlayReadyLicenseIterableFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyLicenseIterator: foundation::collections::IIterator<IPlayReadyLicense>}
+RT_CLASS!{class PlayReadyLicenseIterator: foundation::collections::IIterator<IPlayReadyLicense> ["Windows.Media.Protection.PlayReady.PlayReadyLicenseIterator"]}
 DEFINE_IID!(IID_IPlayReadyLicenseManagement, 2867536193, 2391, 17413, 184, 146, 139, 243, 236, 93, 173, 217);
 RT_INTERFACE!{static interface IPlayReadyLicenseManagement(IPlayReadyLicenseManagementVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyLicenseManagement] {
     fn DeleteLicenses(&self, contentHeader: *mut PlayReadyContentHeader, out: *mut *mut foundation::IAsyncAction) -> HRESULT
@@ -25277,7 +25277,7 @@ impl IPlayReadyLicenseSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyLicenseSession: IPlayReadyLicenseSession}
+RT_CLASS!{class PlayReadyLicenseSession: IPlayReadyLicenseSession ["Windows.Media.Protection.PlayReady.PlayReadyLicenseSession"]}
 impl RtActivatable<IPlayReadyLicenseSessionFactory> for PlayReadyLicenseSession {}
 impl PlayReadyLicenseSession {
     #[inline] pub fn create_instance(configuration: &foundation::collections::IPropertySet) -> Result<ComPtr<PlayReadyLicenseSession>> {
@@ -25323,17 +25323,17 @@ impl IPlayReadyMeteringReportServiceRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadyMeteringReportServiceRequest: IPlayReadyMeteringReportServiceRequest}
+RT_CLASS!{class PlayReadyMeteringReportServiceRequest: IPlayReadyMeteringReportServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadyMeteringReportServiceRequest"]}
 impl RtActivatable<IActivationFactory> for PlayReadyMeteringReportServiceRequest {}
 DEFINE_CLSID!(PlayReadyMeteringReportServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,77,101,116,101,114,105,110,103,82,101,112,111,114,116,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyMeteringReportServiceRequest]);
 DEFINE_IID!(IID_IPlayReadyRevocationServiceRequest, 1413310124, 64240, 17760, 132, 165, 14, 74, 206, 201, 57, 228);
 RT_INTERFACE!{interface IPlayReadyRevocationServiceRequest(IPlayReadyRevocationServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyRevocationServiceRequest] {
     
 }}
-RT_CLASS!{class PlayReadyRevocationServiceRequest: IPlayReadyRevocationServiceRequest}
+RT_CLASS!{class PlayReadyRevocationServiceRequest: IPlayReadyRevocationServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadyRevocationServiceRequest"]}
 impl RtActivatable<IActivationFactory> for PlayReadyRevocationServiceRequest {}
 DEFINE_CLSID!(PlayReadyRevocationServiceRequest(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,80,114,111,116,101,99,116,105,111,110,46,80,108,97,121,82,101,97,100,121,46,80,108,97,121,82,101,97,100,121,82,101,118,111,99,97,116,105,111,110,83,101,114,118,105,99,101,82,101,113,117,101,115,116,0]) [CLSID_PlayReadyRevocationServiceRequest]);
-RT_CLASS!{class PlayReadySecureStopIterable: foundation::collections::IIterable<IPlayReadySecureStopServiceRequest>}
+RT_CLASS!{class PlayReadySecureStopIterable: foundation::collections::IIterable<IPlayReadySecureStopServiceRequest> ["Windows.Media.Protection.PlayReady.PlayReadySecureStopIterable"]}
 impl RtActivatable<IPlayReadySecureStopIterableFactory> for PlayReadySecureStopIterable {}
 impl PlayReadySecureStopIterable {
     #[inline] pub fn create_instance(publisherCertBytes: &[u8]) -> Result<ComPtr<PlayReadySecureStopIterable>> {
@@ -25352,7 +25352,7 @@ impl IPlayReadySecureStopIterableFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadySecureStopIterator: foundation::collections::IIterator<IPlayReadySecureStopServiceRequest>}
+RT_CLASS!{class PlayReadySecureStopIterator: foundation::collections::IIterator<IPlayReadySecureStopServiceRequest> ["Windows.Media.Protection.PlayReady.PlayReadySecureStopIterator"]}
 DEFINE_IID!(IID_IPlayReadySecureStopServiceRequest, 3041926885, 447, 17409, 150, 119, 5, 99, 10, 106, 76, 200);
 RT_INTERFACE!{interface IPlayReadySecureStopServiceRequest(IPlayReadySecureStopServiceRequestVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadySecureStopServiceRequest] {
     fn get_SessionID(&self, out: *mut Guid) -> HRESULT,
@@ -25388,7 +25388,7 @@ impl IPlayReadySecureStopServiceRequest {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadySecureStopServiceRequest: IPlayReadySecureStopServiceRequest}
+RT_CLASS!{class PlayReadySecureStopServiceRequest: IPlayReadySecureStopServiceRequest ["Windows.Media.Protection.PlayReady.PlayReadySecureStopServiceRequest"]}
 impl RtActivatable<IPlayReadySecureStopServiceRequestFactory> for PlayReadySecureStopServiceRequest {}
 impl PlayReadySecureStopServiceRequest {
     #[inline] pub fn create_instance(publisherCertBytes: &[u8]) -> Result<ComPtr<PlayReadySecureStopServiceRequest>> {
@@ -25496,7 +25496,7 @@ impl IPlayReadySoapMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlayReadySoapMessage: IPlayReadySoapMessage}
+RT_CLASS!{class PlayReadySoapMessage: IPlayReadySoapMessage ["Windows.Media.Protection.PlayReady.PlayReadySoapMessage"]}
 DEFINE_IID!(IID_IPlayReadyStatics, 1583988749, 9340, 18074, 143, 49, 92, 26, 21, 113, 217, 198);
 RT_INTERFACE!{static interface IPlayReadyStatics(IPlayReadyStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IPlayReadyStatics] {
     fn get_DomainJoinServiceRequestType(&self, out: *mut Guid) -> HRESULT,
@@ -25678,7 +25678,7 @@ impl IPlayReadyStatics5 {
 } // Windows.Media.Protection
 pub mod render { // Windows.Media.Render
 use ::prelude::*;
-RT_ENUM! { enum AudioRenderCategory: i32 {
+RT_ENUM! { enum AudioRenderCategory: i32 ["Windows.Media.Render.AudioRenderCategory"] {
     Other (AudioRenderCategory_Other) = 0, ForegroundOnlyMedia (AudioRenderCategory_ForegroundOnlyMedia) = 1, BackgroundCapableMedia (AudioRenderCategory_BackgroundCapableMedia) = 2, Communications (AudioRenderCategory_Communications) = 3, Alerts (AudioRenderCategory_Alerts) = 4, SoundEffects (AudioRenderCategory_SoundEffects) = 5, GameEffects (AudioRenderCategory_GameEffects) = 6, GameMedia (AudioRenderCategory_GameMedia) = 7, GameChat (AudioRenderCategory_GameChat) = 8, Speech (AudioRenderCategory_Speech) = 9, Movie (AudioRenderCategory_Movie) = 10, Media (AudioRenderCategory_Media) = 11,
 }}
 } // Windows.Media.Render
@@ -25695,8 +25695,8 @@ impl ISpeechContinuousRecognitionCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechContinuousRecognitionCompletedEventArgs: ISpeechContinuousRecognitionCompletedEventArgs}
-RT_ENUM! { enum SpeechContinuousRecognitionMode: i32 {
+RT_CLASS!{class SpeechContinuousRecognitionCompletedEventArgs: ISpeechContinuousRecognitionCompletedEventArgs ["Windows.Media.SpeechRecognition.SpeechContinuousRecognitionCompletedEventArgs"]}
+RT_ENUM! { enum SpeechContinuousRecognitionMode: i32 ["Windows.Media.SpeechRecognition.SpeechContinuousRecognitionMode"] {
     Default (SpeechContinuousRecognitionMode_Default) = 0, PauseOnRecognition (SpeechContinuousRecognitionMode_PauseOnRecognition) = 1,
 }}
 DEFINE_IID!(IID_ISpeechContinuousRecognitionResultGeneratedEventArgs, 420027934, 28286, 23110, 64, 251, 118, 89, 79, 120, 101, 4);
@@ -25710,7 +25710,7 @@ impl ISpeechContinuousRecognitionResultGeneratedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechContinuousRecognitionResultGeneratedEventArgs: ISpeechContinuousRecognitionResultGeneratedEventArgs}
+RT_CLASS!{class SpeechContinuousRecognitionResultGeneratedEventArgs: ISpeechContinuousRecognitionResultGeneratedEventArgs ["Windows.Media.SpeechRecognition.SpeechContinuousRecognitionResultGeneratedEventArgs"]}
 DEFINE_IID!(IID_ISpeechContinuousRecognitionSession, 1780562948, 26132, 18936, 153, 162, 181, 233, 179, 160, 133, 200);
 RT_INTERFACE!{interface ISpeechContinuousRecognitionSession(ISpeechContinuousRecognitionSessionVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechContinuousRecognitionSession] {
     fn get_AutoStopSilenceTimeout(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -25784,8 +25784,8 @@ impl ISpeechContinuousRecognitionSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechContinuousRecognitionSession: ISpeechContinuousRecognitionSession}
-RT_ENUM! { enum SpeechRecognitionAudioProblem: i32 {
+RT_CLASS!{class SpeechContinuousRecognitionSession: ISpeechContinuousRecognitionSession ["Windows.Media.SpeechRecognition.SpeechContinuousRecognitionSession"]}
+RT_ENUM! { enum SpeechRecognitionAudioProblem: i32 ["Windows.Media.SpeechRecognition.SpeechRecognitionAudioProblem"] {
     None (SpeechRecognitionAudioProblem_None) = 0, TooNoisy (SpeechRecognitionAudioProblem_TooNoisy) = 1, NoSignal (SpeechRecognitionAudioProblem_NoSignal) = 2, TooLoud (SpeechRecognitionAudioProblem_TooLoud) = 3, TooQuiet (SpeechRecognitionAudioProblem_TooQuiet) = 4, TooFast (SpeechRecognitionAudioProblem_TooFast) = 5, TooSlow (SpeechRecognitionAudioProblem_TooSlow) = 6,
 }}
 DEFINE_IID!(IID_ISpeechRecognitionCompilationResult, 1082027101, 27335, 19876, 156, 193, 47, 206, 50, 207, 116, 137);
@@ -25799,8 +25799,8 @@ impl ISpeechRecognitionCompilationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionCompilationResult: ISpeechRecognitionCompilationResult}
-RT_ENUM! { enum SpeechRecognitionConfidence: i32 {
+RT_CLASS!{class SpeechRecognitionCompilationResult: ISpeechRecognitionCompilationResult ["Windows.Media.SpeechRecognition.SpeechRecognitionCompilationResult"]}
+RT_ENUM! { enum SpeechRecognitionConfidence: i32 ["Windows.Media.SpeechRecognition.SpeechRecognitionConfidence"] {
     High (SpeechRecognitionConfidence_High) = 0, Medium (SpeechRecognitionConfidence_Medium) = 1, Low (SpeechRecognitionConfidence_Low) = 2, Rejected (SpeechRecognitionConfidence_Rejected) = 3,
 }}
 DEFINE_IID!(IID_ISpeechRecognitionConstraint, 2041321000, 19816, 17348, 137, 17, 64, 220, 65, 1, 181, 91);
@@ -25847,10 +25847,10 @@ impl ISpeechRecognitionConstraint {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpeechRecognitionConstraintProbability: i32 {
+RT_ENUM! { enum SpeechRecognitionConstraintProbability: i32 ["Windows.Media.SpeechRecognition.SpeechRecognitionConstraintProbability"] {
     Default (SpeechRecognitionConstraintProbability_Default) = 0, Min (SpeechRecognitionConstraintProbability_Min) = 1, Max (SpeechRecognitionConstraintProbability_Max) = 2,
 }}
-RT_ENUM! { enum SpeechRecognitionConstraintType: i32 {
+RT_ENUM! { enum SpeechRecognitionConstraintType: i32 ["Windows.Media.SpeechRecognition.SpeechRecognitionConstraintType"] {
     Topic (SpeechRecognitionConstraintType_Topic) = 0, List (SpeechRecognitionConstraintType_List) = 1, Grammar (SpeechRecognitionConstraintType_Grammar) = 2, VoiceCommandDefinition (SpeechRecognitionConstraintType_VoiceCommandDefinition) = 3,
 }}
 DEFINE_IID!(IID_ISpeechRecognitionGrammarFileConstraint, 3036879503, 34250, 20388, 177, 26, 71, 79, 196, 27, 56, 53);
@@ -25864,7 +25864,7 @@ impl ISpeechRecognitionGrammarFileConstraint {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionGrammarFileConstraint: ISpeechRecognitionGrammarFileConstraint}
+RT_CLASS!{class SpeechRecognitionGrammarFileConstraint: ISpeechRecognitionGrammarFileConstraint ["Windows.Media.SpeechRecognition.SpeechRecognitionGrammarFileConstraint"]}
 impl RtActivatable<ISpeechRecognitionGrammarFileConstraintFactory> for SpeechRecognitionGrammarFileConstraint {}
 impl SpeechRecognitionGrammarFileConstraint {
     #[cfg(feature="windows-storage")] #[inline] pub fn create(file: &super::super::storage::StorageFile) -> Result<ComPtr<SpeechRecognitionGrammarFileConstraint>> {
@@ -25903,7 +25903,7 @@ impl ISpeechRecognitionHypothesis {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionHypothesis: ISpeechRecognitionHypothesis}
+RT_CLASS!{class SpeechRecognitionHypothesis: ISpeechRecognitionHypothesis ["Windows.Media.SpeechRecognition.SpeechRecognitionHypothesis"]}
 DEFINE_IID!(IID_ISpeechRecognitionHypothesisGeneratedEventArgs, 1427511930, 32803, 22630, 65, 29, 18, 19, 187, 39, 20, 118);
 RT_INTERFACE!{interface ISpeechRecognitionHypothesisGeneratedEventArgs(ISpeechRecognitionHypothesisGeneratedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionHypothesisGeneratedEventArgs] {
     fn get_Hypothesis(&self, out: *mut *mut SpeechRecognitionHypothesis) -> HRESULT
@@ -25915,7 +25915,7 @@ impl ISpeechRecognitionHypothesisGeneratedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionHypothesisGeneratedEventArgs: ISpeechRecognitionHypothesisGeneratedEventArgs}
+RT_CLASS!{class SpeechRecognitionHypothesisGeneratedEventArgs: ISpeechRecognitionHypothesisGeneratedEventArgs ["Windows.Media.SpeechRecognition.SpeechRecognitionHypothesisGeneratedEventArgs"]}
 DEFINE_IID!(IID_ISpeechRecognitionListConstraint, 163874793, 58541, 17702, 129, 242, 73, 70, 251, 72, 29, 152);
 RT_INTERFACE!{interface ISpeechRecognitionListConstraint(ISpeechRecognitionListConstraintVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionListConstraint] {
     fn get_Commands(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT
@@ -25927,7 +25927,7 @@ impl ISpeechRecognitionListConstraint {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionListConstraint: ISpeechRecognitionListConstraint}
+RT_CLASS!{class SpeechRecognitionListConstraint: ISpeechRecognitionListConstraint ["Windows.Media.SpeechRecognition.SpeechRecognitionListConstraint"]}
 impl RtActivatable<ISpeechRecognitionListConstraintFactory> for SpeechRecognitionListConstraint {}
 impl SpeechRecognitionListConstraint {
     #[inline] pub fn create(commands: &foundation::collections::IIterable<HString>) -> Result<ComPtr<SpeechRecognitionListConstraint>> {
@@ -25966,7 +25966,7 @@ impl ISpeechRecognitionQualityDegradingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionQualityDegradingEventArgs: ISpeechRecognitionQualityDegradingEventArgs}
+RT_CLASS!{class SpeechRecognitionQualityDegradingEventArgs: ISpeechRecognitionQualityDegradingEventArgs ["Windows.Media.SpeechRecognition.SpeechRecognitionQualityDegradingEventArgs"]}
 DEFINE_IID!(IID_ISpeechRecognitionResult, 1311781207, 846, 18002, 133, 126, 208, 69, 76, 196, 190, 236);
 RT_INTERFACE!{interface ISpeechRecognitionResult(ISpeechRecognitionResultVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionResult] {
     fn get_Status(&self, out: *mut SpeechRecognitionResultStatus) -> HRESULT,
@@ -26020,7 +26020,7 @@ impl ISpeechRecognitionResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionResult: ISpeechRecognitionResult}
+RT_CLASS!{class SpeechRecognitionResult: ISpeechRecognitionResult ["Windows.Media.SpeechRecognition.SpeechRecognitionResult"]}
 DEFINE_IID!(IID_ISpeechRecognitionResult2, 2944324026, 17691, 16742, 160, 193, 31, 254, 132, 3, 45, 3);
 RT_INTERFACE!{interface ISpeechRecognitionResult2(ISpeechRecognitionResult2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionResult2] {
     fn get_PhraseStartTime(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -26038,10 +26038,10 @@ impl ISpeechRecognitionResult2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpeechRecognitionResultStatus: i32 {
+RT_ENUM! { enum SpeechRecognitionResultStatus: i32 ["Windows.Media.SpeechRecognition.SpeechRecognitionResultStatus"] {
     Success (SpeechRecognitionResultStatus_Success) = 0, TopicLanguageNotSupported (SpeechRecognitionResultStatus_TopicLanguageNotSupported) = 1, GrammarLanguageMismatch (SpeechRecognitionResultStatus_GrammarLanguageMismatch) = 2, GrammarCompilationFailure (SpeechRecognitionResultStatus_GrammarCompilationFailure) = 3, AudioQualityFailure (SpeechRecognitionResultStatus_AudioQualityFailure) = 4, UserCanceled (SpeechRecognitionResultStatus_UserCanceled) = 5, Unknown (SpeechRecognitionResultStatus_Unknown) = 6, TimeoutExceeded (SpeechRecognitionResultStatus_TimeoutExceeded) = 7, PauseLimitExceeded (SpeechRecognitionResultStatus_PauseLimitExceeded) = 8, NetworkFailure (SpeechRecognitionResultStatus_NetworkFailure) = 9, MicrophoneUnavailable (SpeechRecognitionResultStatus_MicrophoneUnavailable) = 10,
 }}
-RT_ENUM! { enum SpeechRecognitionScenario: i32 {
+RT_ENUM! { enum SpeechRecognitionScenario: i32 ["Windows.Media.SpeechRecognition.SpeechRecognitionScenario"] {
     WebSearch (SpeechRecognitionScenario_WebSearch) = 0, Dictation (SpeechRecognitionScenario_Dictation) = 1, FormFilling (SpeechRecognitionScenario_FormFilling) = 2,
 }}
 DEFINE_IID!(IID_ISpeechRecognitionSemanticInterpretation, 2866928283, 32306, 19487, 137, 254, 12, 101, 244, 134, 245, 46);
@@ -26055,7 +26055,7 @@ impl ISpeechRecognitionSemanticInterpretation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionSemanticInterpretation: ISpeechRecognitionSemanticInterpretation}
+RT_CLASS!{class SpeechRecognitionSemanticInterpretation: ISpeechRecognitionSemanticInterpretation ["Windows.Media.SpeechRecognition.SpeechRecognitionSemanticInterpretation"]}
 DEFINE_IID!(IID_ISpeechRecognitionTopicConstraint, 3211779865, 33373, 20073, 166, 129, 54, 228, 140, 241, 201, 62);
 RT_INTERFACE!{interface ISpeechRecognitionTopicConstraint(ISpeechRecognitionTopicConstraintVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionTopicConstraint] {
     fn get_Scenario(&self, out: *mut SpeechRecognitionScenario) -> HRESULT,
@@ -26073,7 +26073,7 @@ impl ISpeechRecognitionTopicConstraint {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognitionTopicConstraint: ISpeechRecognitionTopicConstraint}
+RT_CLASS!{class SpeechRecognitionTopicConstraint: ISpeechRecognitionTopicConstraint ["Windows.Media.SpeechRecognition.SpeechRecognitionTopicConstraint"]}
 impl RtActivatable<ISpeechRecognitionTopicConstraintFactory> for SpeechRecognitionTopicConstraint {}
 impl SpeechRecognitionTopicConstraint {
     #[inline] pub fn create(scenario: SpeechRecognitionScenario, topicHint: &HStringArg) -> Result<ComPtr<SpeechRecognitionTopicConstraint>> {
@@ -26105,7 +26105,7 @@ DEFINE_IID!(IID_ISpeechRecognitionVoiceCommandDefinitionConstraint, 4068023339, 
 RT_INTERFACE!{interface ISpeechRecognitionVoiceCommandDefinitionConstraint(ISpeechRecognitionVoiceCommandDefinitionConstraintVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognitionVoiceCommandDefinitionConstraint] {
     
 }}
-RT_CLASS!{class SpeechRecognitionVoiceCommandDefinitionConstraint: ISpeechRecognitionVoiceCommandDefinitionConstraint}
+RT_CLASS!{class SpeechRecognitionVoiceCommandDefinitionConstraint: ISpeechRecognitionVoiceCommandDefinitionConstraint ["Windows.Media.SpeechRecognition.SpeechRecognitionVoiceCommandDefinitionConstraint"]}
 DEFINE_IID!(IID_ISpeechRecognizer, 197380555, 49770, 16626, 174, 181, 128, 150, 178, 228, 128, 115);
 RT_INTERFACE!{interface ISpeechRecognizer(ISpeechRecognizerVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognizer] {
     #[cfg(not(feature="windows-globalization"))] fn __Dummy0(&self) -> (),
@@ -26176,7 +26176,7 @@ impl ISpeechRecognizer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognizer: ISpeechRecognizer}
+RT_CLASS!{class SpeechRecognizer: ISpeechRecognizer ["Windows.Media.SpeechRecognition.SpeechRecognizer"]}
 impl RtActivatable<ISpeechRecognizerFactory> for SpeechRecognizer {}
 impl RtActivatable<ISpeechRecognizerStatics> for SpeechRecognizer {}
 impl RtActivatable<ISpeechRecognizerStatics2> for SpeechRecognizer {}
@@ -26244,7 +26244,7 @@ impl ISpeechRecognizerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpeechRecognizerState: i32 {
+RT_ENUM! { enum SpeechRecognizerState: i32 ["Windows.Media.SpeechRecognition.SpeechRecognizerState"] {
     Idle (SpeechRecognizerState_Idle) = 0, Capturing (SpeechRecognizerState_Capturing) = 1, Processing (SpeechRecognizerState_Processing) = 2, SoundStarted (SpeechRecognizerState_SoundStarted) = 3, SoundEnded (SpeechRecognizerState_SoundEnded) = 4, SpeechDetected (SpeechRecognizerState_SpeechDetected) = 5, Paused (SpeechRecognizerState_Paused) = 6,
 }}
 DEFINE_IID!(IID_ISpeechRecognizerStateChangedEventArgs, 1446858505, 47619, 19373, 173, 129, 221, 198, 196, 218, 176, 195);
@@ -26258,7 +26258,7 @@ impl ISpeechRecognizerStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognizerStateChangedEventArgs: ISpeechRecognizerStateChangedEventArgs}
+RT_CLASS!{class SpeechRecognizerStateChangedEventArgs: ISpeechRecognizerStateChangedEventArgs ["Windows.Media.SpeechRecognition.SpeechRecognizerStateChangedEventArgs"]}
 DEFINE_IID!(IID_ISpeechRecognizerStatics, 2275630764, 42972, 19211, 188, 201, 36, 244, 124, 11, 126, 191);
 RT_INTERFACE!{static interface ISpeechRecognizerStatics(ISpeechRecognizerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognizerStatics] {
     #[cfg(feature="windows-globalization")] fn get_SystemSpeechLanguage(&self, out: *mut *mut super::super::globalization::Language) -> HRESULT,
@@ -26331,7 +26331,7 @@ impl ISpeechRecognizerTimeouts {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognizerTimeouts: ISpeechRecognizerTimeouts}
+RT_CLASS!{class SpeechRecognizerTimeouts: ISpeechRecognizerTimeouts ["Windows.Media.SpeechRecognition.SpeechRecognizerTimeouts"]}
 DEFINE_IID!(IID_ISpeechRecognizerUIOptions, 2022233665, 47403, 17594, 162, 95, 209, 134, 70, 48, 100, 31);
 RT_INTERFACE!{interface ISpeechRecognizerUIOptions(ISpeechRecognizerUIOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechRecognizerUIOptions] {
     fn get_ExampleText(&self, out: *mut HSTRING) -> HRESULT,
@@ -26381,7 +26381,7 @@ impl ISpeechRecognizerUIOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechRecognizerUIOptions: ISpeechRecognizerUIOptions}
+RT_CLASS!{class SpeechRecognizerUIOptions: ISpeechRecognizerUIOptions ["Windows.Media.SpeechRecognition.SpeechRecognizerUIOptions"]}
 } // Windows.Media.SpeechRecognition
 pub mod speechsynthesis { // Windows.Media.SpeechSynthesis
 use ::prelude::*;
@@ -26413,10 +26413,10 @@ impl IInstalledVoicesStatic2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpeechAppendedSilence: i32 {
+RT_ENUM! { enum SpeechAppendedSilence: i32 ["Windows.Media.SpeechSynthesis.SpeechAppendedSilence"] {
     Default (SpeechAppendedSilence_Default) = 0, Min (SpeechAppendedSilence_Min) = 1,
 }}
-RT_ENUM! { enum SpeechPunctuationSilence: i32 {
+RT_ENUM! { enum SpeechPunctuationSilence: i32 ["Windows.Media.SpeechSynthesis.SpeechPunctuationSilence"] {
     Default (SpeechPunctuationSilence_Default) = 0, Min (SpeechPunctuationSilence_Min) = 1,
 }}
 DEFINE_IID!(IID_ISpeechSynthesisStream, 2212785811, 9292, 17954, 186, 11, 98, 41, 196, 208, 214, 93);
@@ -26430,7 +26430,7 @@ impl ISpeechSynthesisStream {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechSynthesisStream: ISpeechSynthesisStream}
+RT_CLASS!{class SpeechSynthesisStream: ISpeechSynthesisStream ["Windows.Media.SpeechSynthesis.SpeechSynthesisStream"]}
 DEFINE_IID!(IID_ISpeechSynthesizer, 3466558582, 38900, 19693, 173, 104, 213, 28, 69, 142, 69, 198);
 RT_INTERFACE!{interface ISpeechSynthesizer(ISpeechSynthesizerVtbl): IInspectable(IInspectableVtbl) [IID_ISpeechSynthesizer] {
     fn SynthesizeTextToStreamAsync(&self, text: HSTRING, out: *mut *mut foundation::IAsyncOperation<SpeechSynthesisStream>) -> HRESULT,
@@ -26459,7 +26459,7 @@ impl ISpeechSynthesizer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechSynthesizer: ISpeechSynthesizer}
+RT_CLASS!{class SpeechSynthesizer: ISpeechSynthesizer ["Windows.Media.SpeechSynthesis.SpeechSynthesizer"]}
 impl RtActivatable<IInstalledVoicesStatic> for SpeechSynthesizer {}
 impl RtActivatable<IInstalledVoicesStatic2> for SpeechSynthesizer {}
 impl RtActivatable<IActivationFactory> for SpeechSynthesizer {}
@@ -26513,7 +26513,7 @@ impl ISpeechSynthesizerOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpeechSynthesizerOptions: ISpeechSynthesizerOptions}
+RT_CLASS!{class SpeechSynthesizerOptions: ISpeechSynthesizerOptions ["Windows.Media.SpeechSynthesis.SpeechSynthesizerOptions"]}
 DEFINE_IID!(IID_ISpeechSynthesizerOptions2, 482276878, 4508, 19437, 177, 24, 210, 80, 195, 162, 87, 147);
 RT_INTERFACE!{interface ISpeechSynthesizerOptions2(ISpeechSynthesizerOptions2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpeechSynthesizerOptions2] {
     fn get_AudioVolume(&self, out: *mut f64) -> HRESULT,
@@ -26579,7 +26579,7 @@ impl ISpeechSynthesizerOptions3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VoiceGender: i32 {
+RT_ENUM! { enum VoiceGender: i32 ["Windows.Media.SpeechSynthesis.VoiceGender"] {
     Male (VoiceGender_Male) = 0, Female (VoiceGender_Female) = 1,
 }}
 DEFINE_IID!(IID_IVoiceInformation, 2972178084, 4753, 17924, 170, 156, 131, 19, 64, 131, 53, 44);
@@ -26617,7 +26617,7 @@ impl IVoiceInformation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VoiceInformation: IVoiceInformation}
+RT_CLASS!{class VoiceInformation: IVoiceInformation ["Windows.Media.SpeechSynthesis.VoiceInformation"]}
 } // Windows.Media.SpeechSynthesis
 pub mod streaming { // Windows.Media.Streaming
 pub mod adaptive { // Windows.Media.Streaming.Adaptive
@@ -26773,7 +26773,7 @@ impl IAdaptiveMediaSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSource: IAdaptiveMediaSource}
+RT_CLASS!{class AdaptiveMediaSource: IAdaptiveMediaSource ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSource"]}
 impl RtActivatable<IAdaptiveMediaSourceStatics> for AdaptiveMediaSource {}
 impl AdaptiveMediaSource {
     #[inline] pub fn is_content_type_supported(contentType: &HStringArg) -> Result<bool> {
@@ -26882,7 +26882,7 @@ impl IAdaptiveMediaSourceAdvancedSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceAdvancedSettings: IAdaptiveMediaSourceAdvancedSettings}
+RT_CLASS!{class AdaptiveMediaSourceAdvancedSettings: IAdaptiveMediaSourceAdvancedSettings ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceAdvancedSettings"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceCorrelatedTimes, 84969351, 57394, 18657, 171, 141, 0, 43, 11, 48, 81, 223);
 RT_INTERFACE!{interface IAdaptiveMediaSourceCorrelatedTimes(IAdaptiveMediaSourceCorrelatedTimesVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceCorrelatedTimes] {
     fn get_Position(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -26906,7 +26906,7 @@ impl IAdaptiveMediaSourceCorrelatedTimes {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceCorrelatedTimes: IAdaptiveMediaSourceCorrelatedTimes}
+RT_CLASS!{class AdaptiveMediaSourceCorrelatedTimes: IAdaptiveMediaSourceCorrelatedTimes ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceCorrelatedTimes"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceCreationResult, 1183233714, 32783, 20017, 144, 147, 118, 212, 120, 32, 19, 231);
 RT_INTERFACE!{interface IAdaptiveMediaSourceCreationResult(IAdaptiveMediaSourceCreationResultVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceCreationResult] {
     fn get_Status(&self, out: *mut AdaptiveMediaSourceCreationStatus) -> HRESULT,
@@ -26930,7 +26930,7 @@ impl IAdaptiveMediaSourceCreationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceCreationResult: IAdaptiveMediaSourceCreationResult}
+RT_CLASS!{class AdaptiveMediaSourceCreationResult: IAdaptiveMediaSourceCreationResult ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceCreationResult"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceCreationResult2, 473056191, 7236, 16459, 162, 1, 223, 69, 172, 120, 152, 232);
 RT_INTERFACE!{interface IAdaptiveMediaSourceCreationResult2(IAdaptiveMediaSourceCreationResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceCreationResult2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -26942,7 +26942,7 @@ impl IAdaptiveMediaSourceCreationResult2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AdaptiveMediaSourceCreationStatus: i32 {
+RT_ENUM! { enum AdaptiveMediaSourceCreationStatus: i32 ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceCreationStatus"] {
     Success (AdaptiveMediaSourceCreationStatus_Success) = 0, ManifestDownloadFailure (AdaptiveMediaSourceCreationStatus_ManifestDownloadFailure) = 1, ManifestParseFailure (AdaptiveMediaSourceCreationStatus_ManifestParseFailure) = 2, UnsupportedManifestContentType (AdaptiveMediaSourceCreationStatus_UnsupportedManifestContentType) = 3, UnsupportedManifestVersion (AdaptiveMediaSourceCreationStatus_UnsupportedManifestVersion) = 4, UnsupportedManifestProfile (AdaptiveMediaSourceCreationStatus_UnsupportedManifestProfile) = 5, UnknownFailure (AdaptiveMediaSourceCreationStatus_UnknownFailure) = 6,
 }}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDiagnosticAvailableEventArgs, 989220614, 28060, 18762, 183, 169, 179, 165, 222, 230, 173, 104);
@@ -27004,7 +27004,7 @@ impl IAdaptiveMediaSourceDiagnosticAvailableEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDiagnosticAvailableEventArgs: IAdaptiveMediaSourceDiagnosticAvailableEventArgs}
+RT_CLASS!{class AdaptiveMediaSourceDiagnosticAvailableEventArgs: IAdaptiveMediaSourceDiagnosticAvailableEventArgs ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDiagnosticAvailableEventArgs"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDiagnosticAvailableEventArgs2, 2356009047, 5797, 19871, 129, 14, 0, 189, 144, 27, 62, 249);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDiagnosticAvailableEventArgs2(IAdaptiveMediaSourceDiagnosticAvailableEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDiagnosticAvailableEventArgs2] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT
@@ -27049,8 +27049,8 @@ impl IAdaptiveMediaSourceDiagnostics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDiagnostics: IAdaptiveMediaSourceDiagnostics}
-RT_ENUM! { enum AdaptiveMediaSourceDiagnosticType: i32 {
+RT_CLASS!{class AdaptiveMediaSourceDiagnostics: IAdaptiveMediaSourceDiagnostics ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDiagnostics"]}
+RT_ENUM! { enum AdaptiveMediaSourceDiagnosticType: i32 ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDiagnosticType"] {
     ManifestUnchangedUponReload (AdaptiveMediaSourceDiagnosticType_ManifestUnchangedUponReload) = 0, ManifestMismatchUponReload (AdaptiveMediaSourceDiagnosticType_ManifestMismatchUponReload) = 1, ManifestSignaledEndOfLiveEventUponReload (AdaptiveMediaSourceDiagnosticType_ManifestSignaledEndOfLiveEventUponReload) = 2, MediaSegmentSkipped (AdaptiveMediaSourceDiagnosticType_MediaSegmentSkipped) = 3, ResourceNotFound (AdaptiveMediaSourceDiagnosticType_ResourceNotFound) = 4, ResourceTimedOut (AdaptiveMediaSourceDiagnosticType_ResourceTimedOut) = 5, ResourceParsingError (AdaptiveMediaSourceDiagnosticType_ResourceParsingError) = 6, BitrateDisabled (AdaptiveMediaSourceDiagnosticType_BitrateDisabled) = 7, FatalMediaSourceError (AdaptiveMediaSourceDiagnosticType_FatalMediaSourceError) = 8,
 }}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadBitrateChangedEventArgs, 1728842308, 57422, 20223, 129, 106, 23, 57, 159, 120, 244, 186);
@@ -27070,7 +27070,7 @@ impl IAdaptiveMediaSourceDownloadBitrateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadBitrateChangedEventArgs: IAdaptiveMediaSourceDownloadBitrateChangedEventArgs}
+RT_CLASS!{class AdaptiveMediaSourceDownloadBitrateChangedEventArgs: IAdaptiveMediaSourceDownloadBitrateChangedEventArgs ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadBitrateChangedEventArgs"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2, 4092720196, 38574, 19936, 181, 64, 43, 50, 70, 230, 150, 140);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2(IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2] {
     fn get_Reason(&self, out: *mut AdaptiveMediaSourceDownloadBitrateChangedReason) -> HRESULT
@@ -27082,7 +27082,7 @@ impl IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AdaptiveMediaSourceDownloadBitrateChangedReason: i32 {
+RT_ENUM! { enum AdaptiveMediaSourceDownloadBitrateChangedReason: i32 ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadBitrateChangedReason"] {
     SufficientInboundBitsPerSecond (AdaptiveMediaSourceDownloadBitrateChangedReason_SufficientInboundBitsPerSecond) = 0, InsufficientInboundBitsPerSecond (AdaptiveMediaSourceDownloadBitrateChangedReason_InsufficientInboundBitsPerSecond) = 1, LowBufferLevel (AdaptiveMediaSourceDownloadBitrateChangedReason_LowBufferLevel) = 2, PositionChanged (AdaptiveMediaSourceDownloadBitrateChangedReason_PositionChanged) = 3, TrackSelectionChanged (AdaptiveMediaSourceDownloadBitrateChangedReason_TrackSelectionChanged) = 4, DesiredBitratesChanged (AdaptiveMediaSourceDownloadBitrateChangedReason_DesiredBitratesChanged) = 5, ErrorInPreviousBitrate (AdaptiveMediaSourceDownloadBitrateChangedReason_ErrorInPreviousBitrate) = 6,
 }}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadCompletedEventArgs, 421793219, 23351, 18970, 137, 112, 214, 33, 203, 108, 168, 59);
@@ -27120,7 +27120,7 @@ impl IAdaptiveMediaSourceDownloadCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadCompletedEventArgs: IAdaptiveMediaSourceDownloadCompletedEventArgs}
+RT_CLASS!{class AdaptiveMediaSourceDownloadCompletedEventArgs: IAdaptiveMediaSourceDownloadCompletedEventArgs ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadCompletedEventArgs"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadCompletedEventArgs2, 1883718852, 38474, 16612, 175, 149, 145, 119, 221, 109, 250, 0);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadCompletedEventArgs2(IAdaptiveMediaSourceDownloadCompletedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDownloadCompletedEventArgs2] {
     fn get_RequestId(&self, out: *mut i32) -> HRESULT,
@@ -27196,7 +27196,7 @@ impl IAdaptiveMediaSourceDownloadFailedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadFailedEventArgs: IAdaptiveMediaSourceDownloadFailedEventArgs}
+RT_CLASS!{class AdaptiveMediaSourceDownloadFailedEventArgs: IAdaptiveMediaSourceDownloadFailedEventArgs ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadFailedEventArgs"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadFailedEventArgs2, 1888589160, 38524, 18822, 144, 197, 198, 252, 75, 49, 226, 216);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadFailedEventArgs2(IAdaptiveMediaSourceDownloadFailedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDownloadFailedEventArgs2] {
     fn get_RequestId(&self, out: *mut i32) -> HRESULT,
@@ -27253,7 +27253,7 @@ impl IAdaptiveMediaSourceDownloadRequestedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadRequestedDeferral: IAdaptiveMediaSourceDownloadRequestedDeferral}
+RT_CLASS!{class AdaptiveMediaSourceDownloadRequestedDeferral: IAdaptiveMediaSourceDownloadRequestedDeferral ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadRequestedDeferral"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadRequestedEventArgs, 3359629309, 17577, 18338, 191, 150, 3, 57, 139, 75, 250, 175);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadRequestedEventArgs(IAdaptiveMediaSourceDownloadRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDownloadRequestedEventArgs] {
     fn get_ResourceType(&self, out: *mut AdaptiveMediaSourceResourceType) -> HRESULT,
@@ -27295,7 +27295,7 @@ impl IAdaptiveMediaSourceDownloadRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadRequestedEventArgs: IAdaptiveMediaSourceDownloadRequestedEventArgs}
+RT_CLASS!{class AdaptiveMediaSourceDownloadRequestedEventArgs: IAdaptiveMediaSourceDownloadRequestedEventArgs ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadRequestedEventArgs"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadRequestedEventArgs2, 3011349502, 43588, 19842, 130, 91, 97, 29, 227, 188, 254, 203);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadRequestedEventArgs2(IAdaptiveMediaSourceDownloadRequestedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDownloadRequestedEventArgs2] {
     fn get_RequestId(&self, out: *mut i32) -> HRESULT,
@@ -27394,7 +27394,7 @@ impl IAdaptiveMediaSourceDownloadResult {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadResult: IAdaptiveMediaSourceDownloadResult}
+RT_CLASS!{class AdaptiveMediaSourceDownloadResult: IAdaptiveMediaSourceDownloadResult ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadResult"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourceDownloadResult2, 357903543, 31616, 19140, 134, 96, 164, 185, 127, 124, 112, 240);
 RT_INTERFACE!{interface IAdaptiveMediaSourceDownloadResult2(IAdaptiveMediaSourceDownloadResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourceDownloadResult2] {
     fn get_ResourceByteRangeOffset(&self, out: *mut *mut foundation::IReference<u64>) -> HRESULT,
@@ -27451,7 +27451,7 @@ impl IAdaptiveMediaSourceDownloadStatistics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourceDownloadStatistics: IAdaptiveMediaSourceDownloadStatistics}
+RT_CLASS!{class AdaptiveMediaSourceDownloadStatistics: IAdaptiveMediaSourceDownloadStatistics ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadStatistics"]}
 DEFINE_IID!(IID_IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs, 597860205, 32218, 19025, 135, 169, 111, 168, 197, 178, 146, 190);
 RT_INTERFACE!{interface IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs(IAdaptiveMediaSourcePlaybackBitrateChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs] {
     fn get_OldValue(&self, out: *mut u32) -> HRESULT,
@@ -27475,8 +27475,8 @@ impl IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveMediaSourcePlaybackBitrateChangedEventArgs: IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs}
-RT_ENUM! { enum AdaptiveMediaSourceResourceType: i32 {
+RT_CLASS!{class AdaptiveMediaSourcePlaybackBitrateChangedEventArgs: IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourcePlaybackBitrateChangedEventArgs"]}
+RT_ENUM! { enum AdaptiveMediaSourceResourceType: i32 ["Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceResourceType"] {
     Manifest (AdaptiveMediaSourceResourceType_Manifest) = 0, InitializationSegment (AdaptiveMediaSourceResourceType_InitializationSegment) = 1, MediaSegment (AdaptiveMediaSourceResourceType_MediaSegment) = 2, Key (AdaptiveMediaSourceResourceType_Key) = 3, InitializationVector (AdaptiveMediaSourceResourceType_InitializationVector) = 4, MediaSegmentIndex (AdaptiveMediaSourceResourceType_MediaSegmentIndex) = 5,
 }}
 DEFINE_IID!(IID_IAdaptiveMediaSourceStatics, 1353104733, 26351, 19667, 149, 121, 158, 102, 5, 7, 220, 63);
@@ -27606,7 +27606,7 @@ impl IMediaTranscoder {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MediaTranscoder: IMediaTranscoder}
+RT_CLASS!{class MediaTranscoder: IMediaTranscoder ["Windows.Media.Transcoding.MediaTranscoder"]}
 impl RtActivatable<IActivationFactory> for MediaTranscoder {}
 DEFINE_CLSID!(MediaTranscoder(&[87,105,110,100,111,119,115,46,77,101,100,105,97,46,84,114,97,110,115,99,111,100,105,110,103,46,77,101,100,105,97,84,114,97,110,115,99,111,100,101,114,0]) [CLSID_MediaTranscoder]);
 DEFINE_IID!(IID_IMediaTranscoder2, 1079188852, 13792, 20228, 133, 116, 202, 139, 196, 229, 160, 130);
@@ -27632,7 +27632,7 @@ impl IMediaTranscoder2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MediaVideoProcessingAlgorithm: i32 {
+RT_ENUM! { enum MediaVideoProcessingAlgorithm: i32 ["Windows.Media.Transcoding.MediaVideoProcessingAlgorithm"] {
     Default (MediaVideoProcessingAlgorithm_Default) = 0, MrfCrf444 (MediaVideoProcessingAlgorithm_MrfCrf444) = 1,
 }}
 DEFINE_IID!(IID_IPrepareTranscodeResult, 99769806, 39247, 18996, 157, 104, 151, 204, 206, 23, 48, 214);
@@ -27658,8 +27658,8 @@ impl IPrepareTranscodeResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PrepareTranscodeResult: IPrepareTranscodeResult}
-RT_ENUM! { enum TranscodeFailureReason: i32 {
+RT_CLASS!{class PrepareTranscodeResult: IPrepareTranscodeResult ["Windows.Media.Transcoding.PrepareTranscodeResult"]}
+RT_ENUM! { enum TranscodeFailureReason: i32 ["Windows.Media.Transcoding.TranscodeFailureReason"] {
     None (TranscodeFailureReason_None) = 0, Unknown (TranscodeFailureReason_Unknown) = 1, InvalidProfile (TranscodeFailureReason_InvalidProfile) = 2, CodecNotFound (TranscodeFailureReason_CodecNotFound) = 3,
 }}
 } // Windows.Media.Transcoding

--- a/src/rt/gen/windows/networking.rs
+++ b/src/rt/gen/windows/networking.rs
@@ -1,5 +1,5 @@
 use ::prelude::*;
-RT_ENUM! { enum DomainNameType: i32 {
+RT_ENUM! { enum DomainNameType: i32 ["Windows.Networking.DomainNameType"] {
     Suffix (DomainNameType_Suffix) = 0, FullyQualified (DomainNameType_FullyQualified) = 1,
 }}
 DEFINE_IID!(IID_IEndpointPair, 866167350, 63738, 19248, 184, 86, 118, 81, 124, 59, 208, 109);
@@ -51,7 +51,7 @@ impl IEndpointPair {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EndpointPair: IEndpointPair}
+RT_CLASS!{class EndpointPair: IEndpointPair ["Windows.Networking.EndpointPair"]}
 impl RtActivatable<IEndpointPairFactory> for EndpointPair {}
 impl EndpointPair {
     #[inline] pub fn create_endpoint_pair(localHostName: &HostName, localServiceName: &HStringArg, remoteHostName: &HostName, remoteServiceName: &HStringArg) -> Result<ComPtr<EndpointPair>> {
@@ -111,7 +111,7 @@ impl IHostName {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HostName: IHostName}
+RT_CLASS!{class HostName: IHostName ["Windows.Networking.HostName"]}
 impl RtActivatable<IHostNameFactory> for HostName {}
 impl RtActivatable<IHostNameStatics> for HostName {}
 impl HostName {
@@ -134,7 +134,7 @@ impl IHostNameFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HostNameSortOptions: u32 {
+RT_ENUM! { enum HostNameSortOptions: u32 ["Windows.Networking.HostNameSortOptions"] {
     None (HostNameSortOptions_None) = 0, OptimizeForLongConnections (HostNameSortOptions_OptimizeForLongConnections) = 2,
 }}
 DEFINE_IID!(IID_IHostNameStatics, 4136424639, 41864, 20107, 145, 234, 84, 221, 109, 217, 1, 192);
@@ -148,7 +148,7 @@ impl IHostNameStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HostNameType: i32 {
+RT_ENUM! { enum HostNameType: i32 ["Windows.Networking.HostNameType"] {
     DomainName (HostNameType_DomainName) = 0, Ipv4 (HostNameType_Ipv4) = 1, Ipv6 (HostNameType_Ipv6) = 2, Bluetooth (HostNameType_Bluetooth) = 3,
 }}
 pub mod backgroundtransfer { // Windows.Networking.BackgroundTransfer
@@ -176,7 +176,7 @@ impl IBackgroundDownloader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundDownloader: IBackgroundDownloader}
+RT_CLASS!{class BackgroundDownloader: IBackgroundDownloader ["Windows.Networking.BackgroundTransfer.BackgroundDownloader"]}
 impl RtActivatable<IBackgroundDownloaderFactory> for BackgroundDownloader {}
 impl RtActivatable<IBackgroundDownloaderStaticMethods> for BackgroundDownloader {}
 impl RtActivatable<IBackgroundDownloaderStaticMethods2> for BackgroundDownloader {}
@@ -321,7 +321,7 @@ impl IBackgroundDownloaderUserConsent {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct BackgroundDownloadProgress {
+RT_STRUCT! { struct BackgroundDownloadProgress ["Windows.Networking.BackgroundTransfer.BackgroundDownloadProgress"] {
     BytesReceived: u64, TotalBytesToReceive: u64, Status: BackgroundTransferStatus, HasResponseChanged: bool, HasRestarted: bool,
 }}
 DEFINE_IID!(IID_IBackgroundTransferBase, 714973776, 51049, 17804, 175, 232, 254, 184, 212, 211, 178, 239);
@@ -393,7 +393,7 @@ impl IBackgroundTransferBase {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BackgroundTransferBehavior: i32 {
+RT_ENUM! { enum BackgroundTransferBehavior: i32 ["Windows.Networking.BackgroundTransfer.BackgroundTransferBehavior"] {
     Parallel (BackgroundTransferBehavior_Parallel) = 0, Serialized (BackgroundTransferBehavior_Serialized) = 1,
 }}
 DEFINE_IID!(IID_IBackgroundTransferCompletionGroup, 764609061, 39019, 22349, 121, 80, 10, 221, 71, 245, 215, 6);
@@ -419,7 +419,7 @@ impl IBackgroundTransferCompletionGroup {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTransferCompletionGroup: IBackgroundTransferCompletionGroup}
+RT_CLASS!{class BackgroundTransferCompletionGroup: IBackgroundTransferCompletionGroup ["Windows.Networking.BackgroundTransfer.BackgroundTransferCompletionGroup"]}
 impl RtActivatable<IActivationFactory> for BackgroundTransferCompletionGroup {}
 DEFINE_CLSID!(BackgroundTransferCompletionGroup(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,46,66,97,99,107,103,114,111,117,110,100,84,114,97,110,115,102,101,114,67,111,109,112,108,101,116,105,111,110,71,114,111,117,112,0]) [CLSID_BackgroundTransferCompletionGroup]);
 DEFINE_IID!(IID_IBackgroundTransferCompletionGroupTriggerDetails, 2070667910, 28231, 20790, 127, 203, 250, 67, 137, 244, 111, 91);
@@ -439,7 +439,7 @@ impl IBackgroundTransferCompletionGroupTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTransferCompletionGroupTriggerDetails: IBackgroundTransferCompletionGroupTriggerDetails}
+RT_CLASS!{class BackgroundTransferCompletionGroupTriggerDetails: IBackgroundTransferCompletionGroupTriggerDetails ["Windows.Networking.BackgroundTransfer.BackgroundTransferCompletionGroupTriggerDetails"]}
 DEFINE_IID!(IID_IBackgroundTransferContentPart, 3907081815, 55249, 20184, 131, 142, 103, 74, 194, 23, 172, 230);
 RT_INTERFACE!{interface IBackgroundTransferContentPart(IBackgroundTransferContentPartVtbl): IInspectable(IInspectableVtbl) [IID_IBackgroundTransferContentPart] {
     fn SetHeader(&self, headerName: HSTRING, headerValue: HSTRING) -> HRESULT,
@@ -460,7 +460,7 @@ impl IBackgroundTransferContentPart {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTransferContentPart: IBackgroundTransferContentPart}
+RT_CLASS!{class BackgroundTransferContentPart: IBackgroundTransferContentPart ["Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart"]}
 impl RtActivatable<IBackgroundTransferContentPartFactory> for BackgroundTransferContentPart {}
 impl RtActivatable<IActivationFactory> for BackgroundTransferContentPart {}
 impl BackgroundTransferContentPart {
@@ -489,7 +489,7 @@ impl IBackgroundTransferContentPartFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BackgroundTransferCostPolicy: i32 {
+RT_ENUM! { enum BackgroundTransferCostPolicy: i32 ["Windows.Networking.BackgroundTransfer.BackgroundTransferCostPolicy"] {
     Default (BackgroundTransferCostPolicy_Default) = 0, UnrestrictedOnly (BackgroundTransferCostPolicy_UnrestrictedOnly) = 1, Always (BackgroundTransferCostPolicy_Always) = 2,
 }}
 RT_CLASS!{static class BackgroundTransferError}
@@ -511,7 +511,7 @@ impl IBackgroundTransferErrorStaticMethods {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct BackgroundTransferFileRange {
+RT_STRUCT! { struct BackgroundTransferFileRange ["Windows.Networking.BackgroundTransfer.BackgroundTransferFileRange"] {
     Offset: u64, Length: u64,
 }}
 DEFINE_IID!(IID_IBackgroundTransferGroup, 3636716516, 25689, 17728, 133, 235, 170, 161, 200, 144, 54, 119);
@@ -536,7 +536,7 @@ impl IBackgroundTransferGroup {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTransferGroup: IBackgroundTransferGroup}
+RT_CLASS!{class BackgroundTransferGroup: IBackgroundTransferGroup ["Windows.Networking.BackgroundTransfer.BackgroundTransferGroup"]}
 impl RtActivatable<IBackgroundTransferGroupStatics> for BackgroundTransferGroup {}
 impl BackgroundTransferGroup {
     #[inline] pub fn create_group(name: &HStringArg) -> Result<Option<ComPtr<BackgroundTransferGroup>>> {
@@ -624,7 +624,7 @@ impl IBackgroundTransferOperationPriority {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BackgroundTransferPriority: i32 {
+RT_ENUM! { enum BackgroundTransferPriority: i32 ["Windows.Networking.BackgroundTransfer.BackgroundTransferPriority"] {
     Default (BackgroundTransferPriority_Default) = 0, High (BackgroundTransferPriority_High) = 1, Low (BackgroundTransferPriority_Low) = 2,
 }}
 DEFINE_IID!(IID_IBackgroundTransferRangesDownloadedEventArgs, 1052537939, 48968, 19080, 146, 72, 176, 193, 101, 24, 79, 92);
@@ -650,8 +650,8 @@ impl IBackgroundTransferRangesDownloadedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundTransferRangesDownloadedEventArgs: IBackgroundTransferRangesDownloadedEventArgs}
-RT_ENUM! { enum BackgroundTransferStatus: i32 {
+RT_CLASS!{class BackgroundTransferRangesDownloadedEventArgs: IBackgroundTransferRangesDownloadedEventArgs ["Windows.Networking.BackgroundTransfer.BackgroundTransferRangesDownloadedEventArgs"]}
+RT_ENUM! { enum BackgroundTransferStatus: i32 ["Windows.Networking.BackgroundTransfer.BackgroundTransferStatus"] {
     Idle (BackgroundTransferStatus_Idle) = 0, Running (BackgroundTransferStatus_Running) = 1, PausedByApplication (BackgroundTransferStatus_PausedByApplication) = 2, PausedCostedNetwork (BackgroundTransferStatus_PausedCostedNetwork) = 3, PausedNoNetwork (BackgroundTransferStatus_PausedNoNetwork) = 4, Completed (BackgroundTransferStatus_Completed) = 5, Canceled (BackgroundTransferStatus_Canceled) = 6, Error (BackgroundTransferStatus_Error) = 7, PausedRecoverableWebErrorStatus (BackgroundTransferStatus_PausedRecoverableWebErrorStatus) = 8, PausedSystemPolicy (BackgroundTransferStatus_PausedSystemPolicy) = 32,
 }}
 DEFINE_IID!(IID_IBackgroundUploader, 3314928046, 52909, 18011, 136, 1, 197, 90, 201, 10, 1, 206);
@@ -691,7 +691,7 @@ impl IBackgroundUploader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackgroundUploader: IBackgroundUploader}
+RT_CLASS!{class BackgroundUploader: IBackgroundUploader ["Windows.Networking.BackgroundTransfer.BackgroundUploader"]}
 impl RtActivatable<IBackgroundUploaderFactory> for BackgroundUploader {}
 impl RtActivatable<IBackgroundUploaderStaticMethods> for BackgroundUploader {}
 impl RtActivatable<IBackgroundUploaderStaticMethods2> for BackgroundUploader {}
@@ -836,7 +836,7 @@ impl IBackgroundUploaderUserConsent {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct BackgroundUploadProgress {
+RT_STRUCT! { struct BackgroundUploadProgress ["Windows.Networking.BackgroundTransfer.BackgroundUploadProgress"] {
     BytesReceived: u64, BytesSent: u64, TotalBytesToReceive: u64, TotalBytesToSend: u64, Status: BackgroundTransferStatus, HasResponseChanged: bool, HasRestarted: bool,
 }}
 DEFINE_IID!(IID_IContentPrefetcher, 2832660308, 32193, 19673, 136, 16, 42, 106, 169, 65, 126, 17);
@@ -930,7 +930,7 @@ impl IDownloadOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DownloadOperation: IDownloadOperation}
+RT_CLASS!{class DownloadOperation: IDownloadOperation ["Windows.Networking.BackgroundTransfer.DownloadOperation"]}
 DEFINE_IID!(IID_IDownloadOperation2, 2748116288, 36764, 17235, 156, 212, 41, 13, 238, 56, 124, 56);
 RT_INTERFACE!{interface IDownloadOperation2(IDownloadOperation2Vtbl): IInspectable(IInspectableVtbl) [IID_IDownloadOperation2] {
     fn get_TransferGroup(&self, out: *mut *mut BackgroundTransferGroup) -> HRESULT
@@ -1038,7 +1038,7 @@ impl IResponseInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResponseInformation: IResponseInformation}
+RT_CLASS!{class ResponseInformation: IResponseInformation ["Windows.Networking.BackgroundTransfer.ResponseInformation"]}
 DEFINE_IID!(IID_IUnconstrainedTransferRequestResult, 1277474847, 55620, 16658, 169, 142, 106, 105, 82, 43, 126, 187);
 RT_INTERFACE!{interface IUnconstrainedTransferRequestResult(IUnconstrainedTransferRequestResultVtbl): IInspectable(IInspectableVtbl) [IID_IUnconstrainedTransferRequestResult] {
     fn get_IsUnconstrained(&self, out: *mut bool) -> HRESULT
@@ -1050,7 +1050,7 @@ impl IUnconstrainedTransferRequestResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UnconstrainedTransferRequestResult: IUnconstrainedTransferRequestResult}
+RT_CLASS!{class UnconstrainedTransferRequestResult: IUnconstrainedTransferRequestResult ["Windows.Networking.BackgroundTransfer.UnconstrainedTransferRequestResult"]}
 DEFINE_IID!(IID_IUploadOperation, 1045832928, 29577, 17228, 139, 53, 66, 127, 211, 107, 189, 174);
 RT_INTERFACE!{interface IUploadOperation(IUploadOperationVtbl): IInspectable(IInspectableVtbl) [IID_IUploadOperation] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -1081,7 +1081,7 @@ impl IUploadOperation {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UploadOperation: IUploadOperation}
+RT_CLASS!{class UploadOperation: IUploadOperation ["Windows.Networking.BackgroundTransfer.UploadOperation"]}
 DEFINE_IID!(IID_IUploadOperation2, 1432455666, 10100, 19958, 159, 165, 32, 159, 43, 251, 18, 247);
 RT_INTERFACE!{interface IUploadOperation2(IUploadOperation2Vtbl): IInspectable(IInspectableVtbl) [IID_IUploadOperation2] {
     fn get_TransferGroup(&self, out: *mut *mut BackgroundTransferGroup) -> HRESULT
@@ -1141,8 +1141,8 @@ impl IAttributedNetworkUsage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AttributedNetworkUsage: IAttributedNetworkUsage}
-RT_ENUM! { enum CellularApnAuthenticationType: i32 {
+RT_CLASS!{class AttributedNetworkUsage: IAttributedNetworkUsage ["Windows.Networking.Connectivity.AttributedNetworkUsage"]}
+RT_ENUM! { enum CellularApnAuthenticationType: i32 ["Windows.Networking.Connectivity.CellularApnAuthenticationType"] {
     None (CellularApnAuthenticationType_None) = 0, Pap (CellularApnAuthenticationType_Pap) = 1, Chap (CellularApnAuthenticationType_Chap) = 2, Mschapv2 (CellularApnAuthenticationType_Mschapv2) = 3,
 }}
 DEFINE_IID!(IID_ICellularApnContext, 1873095156, 61437, 17730, 154, 178, 112, 91, 191, 148, 148, 58);
@@ -1216,7 +1216,7 @@ impl ICellularApnContext {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CellularApnContext: ICellularApnContext}
+RT_CLASS!{class CellularApnContext: ICellularApnContext ["Windows.Networking.Connectivity.CellularApnContext"]}
 impl RtActivatable<IActivationFactory> for CellularApnContext {}
 DEFINE_CLSID!(CellularApnContext(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,67,101,108,108,117,108,97,114,65,112,110,67,111,110,116,101,120,116,0]) [CLSID_CellularApnContext]);
 DEFINE_IID!(IID_ICellularApnContext2, 1991306010, 44105, 17232, 177, 229, 220, 71, 99, 188, 105, 199);
@@ -1264,7 +1264,7 @@ impl IConnectionCost {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConnectionCost: IConnectionCost}
+RT_CLASS!{class ConnectionCost: IConnectionCost ["Windows.Networking.Connectivity.ConnectionCost"]}
 DEFINE_IID!(IID_IConnectionCost2, 2383493637, 57865, 17737, 187, 37, 94, 13, 182, 145, 203, 5);
 RT_INTERFACE!{interface IConnectionCost2(IConnectionCost2Vtbl): IInspectable(IInspectableVtbl) [IID_IConnectionCost2] {
     fn get_BackgroundDataUsageRestricted(&self, out: *mut bool) -> HRESULT
@@ -1335,7 +1335,7 @@ impl IConnectionProfile {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConnectionProfile: IConnectionProfile}
+RT_CLASS!{class ConnectionProfile: IConnectionProfile ["Windows.Networking.Connectivity.ConnectionProfile"]}
 DEFINE_IID!(IID_IConnectionProfile2, 3791933765, 19615, 16396, 145, 80, 126, 199, 214, 226, 136, 138);
 RT_INTERFACE!{interface IConnectionProfile2(IConnectionProfile2Vtbl): IInspectable(IInspectableVtbl) [IID_IConnectionProfile2] {
     fn get_IsWwanConnectionProfile(&self, out: *mut bool) -> HRESULT,
@@ -1434,7 +1434,7 @@ impl IConnectionProfile5 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ConnectionProfileDeleteStatus: i32 {
+RT_ENUM! { enum ConnectionProfileDeleteStatus: i32 ["Windows.Networking.Connectivity.ConnectionProfileDeleteStatus"] {
     Success (ConnectionProfileDeleteStatus_Success) = 0, DeniedByUser (ConnectionProfileDeleteStatus_DeniedByUser) = 1, DeniedBySystem (ConnectionProfileDeleteStatus_DeniedBySystem) = 2, UnknownError (ConnectionProfileDeleteStatus_UnknownError) = 3,
 }}
 DEFINE_IID!(IID_IConnectionProfileFilter, 541883592, 48429, 20109, 164, 179, 69, 94, 195, 55, 56, 138);
@@ -1497,7 +1497,7 @@ impl IConnectionProfileFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConnectionProfileFilter: IConnectionProfileFilter}
+RT_CLASS!{class ConnectionProfileFilter: IConnectionProfileFilter ["Windows.Networking.Connectivity.ConnectionProfileFilter"]}
 impl RtActivatable<IActivationFactory> for ConnectionProfileFilter {}
 DEFINE_CLSID!(ConnectionProfileFilter(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,67,111,110,110,101,99,116,105,118,105,116,121,46,67,111,110,110,101,99,116,105,111,110,80,114,111,102,105,108,101,70,105,108,116,101,114,0]) [CLSID_ConnectionProfileFilter]);
 DEFINE_IID!(IID_IConnectionProfileFilter2, 3439759073, 50172, 20397, 157, 220, 89, 63, 170, 75, 120, 133);
@@ -1571,7 +1571,7 @@ impl IConnectionSession {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConnectionSession: IConnectionSession}
+RT_CLASS!{class ConnectionSession: IConnectionSession ["Windows.Networking.Connectivity.ConnectionSession"]}
 DEFINE_IID!(IID_IConnectivityInterval, 1336557567, 26438, 18468, 169, 100, 238, 216, 232, 127, 135, 9);
 RT_INTERFACE!{interface IConnectivityInterval(IConnectivityIntervalVtbl): IInspectable(IInspectableVtbl) [IID_IConnectivityInterval] {
     fn get_StartTime(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -1589,7 +1589,7 @@ impl IConnectivityInterval {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConnectivityInterval: IConnectivityInterval}
+RT_CLASS!{class ConnectivityInterval: IConnectivityInterval ["Windows.Networking.Connectivity.ConnectivityInterval"]}
 RT_CLASS!{static class ConnectivityManager}
 impl RtActivatable<IConnectivityManagerStatics> for ConnectivityManager {}
 impl ConnectivityManager {
@@ -1666,7 +1666,7 @@ impl IDataPlanStatus {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataPlanStatus: IDataPlanStatus}
+RT_CLASS!{class DataPlanStatus: IDataPlanStatus ["Windows.Networking.Connectivity.DataPlanStatus"]}
 DEFINE_IID!(IID_IDataPlanUsage, 3105966381, 15172, 18431, 179, 97, 190, 89, 230, 158, 209, 176);
 RT_INTERFACE!{interface IDataPlanUsage(IDataPlanUsageVtbl): IInspectable(IInspectableVtbl) [IID_IDataPlanUsage] {
     fn get_MegabytesUsed(&self, out: *mut u32) -> HRESULT,
@@ -1684,7 +1684,7 @@ impl IDataPlanUsage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataPlanUsage: IDataPlanUsage}
+RT_CLASS!{class DataPlanUsage: IDataPlanUsage ["Windows.Networking.Connectivity.DataPlanUsage"]}
 DEFINE_IID!(IID_IDataUsage, 3242401235, 45382, 19769, 185, 89, 12, 105, 176, 150, 197, 18);
 RT_INTERFACE!{interface IDataUsage(IDataUsageVtbl): IInspectable(IInspectableVtbl) [IID_IDataUsage] {
     fn get_BytesSent(&self, out: *mut u64) -> HRESULT,
@@ -1702,11 +1702,11 @@ impl IDataUsage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataUsage: IDataUsage}
-RT_ENUM! { enum DataUsageGranularity: i32 {
+RT_CLASS!{class DataUsage: IDataUsage ["Windows.Networking.Connectivity.DataUsage"]}
+RT_ENUM! { enum DataUsageGranularity: i32 ["Windows.Networking.Connectivity.DataUsageGranularity"] {
     PerMinute (DataUsageGranularity_PerMinute) = 0, PerHour (DataUsageGranularity_PerHour) = 1, PerDay (DataUsageGranularity_PerDay) = 2, Total (DataUsageGranularity_Total) = 3,
 }}
-RT_ENUM! { enum DomainConnectivityLevel: i32 {
+RT_ENUM! { enum DomainConnectivityLevel: i32 ["Windows.Networking.Connectivity.DomainConnectivityLevel"] {
     None (DomainConnectivityLevel_None) = 0, Unauthenticated (DomainConnectivityLevel_Unauthenticated) = 1, Authenticated (DomainConnectivityLevel_Authenticated) = 2,
 }}
 DEFINE_IID!(IID_IIPInformation, 3629204960, 5007, 18391, 155, 58, 54, 187, 72, 140, 239, 51);
@@ -1749,7 +1749,7 @@ impl ILanIdentifier {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LanIdentifier: ILanIdentifier}
+RT_CLASS!{class LanIdentifier: ILanIdentifier ["Windows.Networking.Connectivity.LanIdentifier"]}
 DEFINE_IID!(IID_ILanIdentifierData, 2806940611, 54841, 17854, 163, 106, 196, 228, 174, 175, 109, 155);
 RT_INTERFACE!{interface ILanIdentifierData(ILanIdentifierDataVtbl): IInspectable(IInspectableVtbl) [IID_ILanIdentifierData] {
     fn get_Type(&self, out: *mut u32) -> HRESULT,
@@ -1767,7 +1767,7 @@ impl ILanIdentifierData {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LanIdentifierData: ILanIdentifierData}
+RT_CLASS!{class LanIdentifierData: ILanIdentifierData ["Windows.Networking.Connectivity.LanIdentifierData"]}
 DEFINE_IID!(IID_INetworkAdapter, 995372547, 21384, 18796, 168, 163, 175, 253, 57, 174, 194, 230);
 RT_INTERFACE!{interface INetworkAdapter(INetworkAdapterVtbl): IInspectable(IInspectableVtbl) [IID_INetworkAdapter] {
     fn get_OutboundMaxBitsPerSecond(&self, out: *mut u64) -> HRESULT,
@@ -1809,17 +1809,17 @@ impl INetworkAdapter {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkAdapter: INetworkAdapter}
-RT_ENUM! { enum NetworkAuthenticationType: i32 {
+RT_CLASS!{class NetworkAdapter: INetworkAdapter ["Windows.Networking.Connectivity.NetworkAdapter"]}
+RT_ENUM! { enum NetworkAuthenticationType: i32 ["Windows.Networking.Connectivity.NetworkAuthenticationType"] {
     None (NetworkAuthenticationType_None) = 0, Unknown (NetworkAuthenticationType_Unknown) = 1, Open80211 (NetworkAuthenticationType_Open80211) = 2, SharedKey80211 (NetworkAuthenticationType_SharedKey80211) = 3, Wpa (NetworkAuthenticationType_Wpa) = 4, WpaPsk (NetworkAuthenticationType_WpaPsk) = 5, WpaNone (NetworkAuthenticationType_WpaNone) = 6, Rsna (NetworkAuthenticationType_Rsna) = 7, RsnaPsk (NetworkAuthenticationType_RsnaPsk) = 8, Ihv (NetworkAuthenticationType_Ihv) = 9,
 }}
-RT_ENUM! { enum NetworkConnectivityLevel: i32 {
+RT_ENUM! { enum NetworkConnectivityLevel: i32 ["Windows.Networking.Connectivity.NetworkConnectivityLevel"] {
     None (NetworkConnectivityLevel_None) = 0, LocalAccess (NetworkConnectivityLevel_LocalAccess) = 1, ConstrainedInternetAccess (NetworkConnectivityLevel_ConstrainedInternetAccess) = 2, InternetAccess (NetworkConnectivityLevel_InternetAccess) = 3,
 }}
-RT_ENUM! { enum NetworkCostType: i32 {
+RT_ENUM! { enum NetworkCostType: i32 ["Windows.Networking.Connectivity.NetworkCostType"] {
     Unknown (NetworkCostType_Unknown) = 0, Unrestricted (NetworkCostType_Unrestricted) = 1, Fixed (NetworkCostType_Fixed) = 2, Variable (NetworkCostType_Variable) = 3,
 }}
-RT_ENUM! { enum NetworkEncryptionType: i32 {
+RT_ENUM! { enum NetworkEncryptionType: i32 ["Windows.Networking.Connectivity.NetworkEncryptionType"] {
     None (NetworkEncryptionType_None) = 0, Unknown (NetworkEncryptionType_Unknown) = 1, Wep (NetworkEncryptionType_Wep) = 2, Wep40 (NetworkEncryptionType_Wep40) = 3, Wep104 (NetworkEncryptionType_Wep104) = 4, Tkip (NetworkEncryptionType_Tkip) = 5, Ccmp (NetworkEncryptionType_Ccmp) = 6, WpaUseGroup (NetworkEncryptionType_WpaUseGroup) = 7, RsnUseGroup (NetworkEncryptionType_RsnUseGroup) = 8, Ihv (NetworkEncryptionType_Ihv) = 9,
 }}
 RT_CLASS!{static class NetworkInformation}
@@ -1935,7 +1935,7 @@ impl INetworkItem {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkItem: INetworkItem}
+RT_CLASS!{class NetworkItem: INetworkItem ["Windows.Networking.Connectivity.NetworkItem"]}
 DEFINE_IID!(IID_INetworkSecuritySettings, 2090892941, 37243, 19295, 184, 77, 40, 247, 165, 172, 84, 2);
 RT_INTERFACE!{interface INetworkSecuritySettings(INetworkSecuritySettingsVtbl): IInspectable(IInspectableVtbl) [IID_INetworkSecuritySettings] {
     fn get_NetworkAuthenticationType(&self, out: *mut NetworkAuthenticationType) -> HRESULT,
@@ -1953,7 +1953,7 @@ impl INetworkSecuritySettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkSecuritySettings: INetworkSecuritySettings}
+RT_CLASS!{class NetworkSecuritySettings: INetworkSecuritySettings ["Windows.Networking.Connectivity.NetworkSecuritySettings"]}
 DEFINE_IID!(IID_INetworkStateChangeEventDetails, 520942387, 55206, 17629, 164, 233, 104, 124, 71, 107, 144, 61);
 RT_INTERFACE!{interface INetworkStateChangeEventDetails(INetworkStateChangeEventDetailsVtbl): IInspectable(IInspectableVtbl) [IID_INetworkStateChangeEventDetails] {
     fn get_HasNewInternetConnectionProfile(&self, out: *mut bool) -> HRESULT,
@@ -1995,7 +1995,7 @@ impl INetworkStateChangeEventDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkStateChangeEventDetails: INetworkStateChangeEventDetails}
+RT_CLASS!{class NetworkStateChangeEventDetails: INetworkStateChangeEventDetails ["Windows.Networking.Connectivity.NetworkStateChangeEventDetails"]}
 DEFINE_IID!(IID_INetworkStateChangeEventDetails2, 3594764520, 12499, 20330, 173, 71, 106, 24, 115, 206, 179, 193);
 RT_INTERFACE!{interface INetworkStateChangeEventDetails2(INetworkStateChangeEventDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_INetworkStateChangeEventDetails2] {
     fn get_HasNewTetheringOperationalState(&self, out: *mut bool) -> HRESULT,
@@ -2023,7 +2023,7 @@ impl NetworkStatusChangedEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum NetworkTypes: u32 {
+RT_ENUM! { enum NetworkTypes: u32 ["Windows.Networking.Connectivity.NetworkTypes"] {
     None (NetworkTypes_None) = 0, Internet (NetworkTypes_Internet) = 1, PrivateNetwork (NetworkTypes_PrivateNetwork) = 2,
 }}
 DEFINE_IID!(IID_INetworkUsage, 1239060430, 39301, 18727, 191, 91, 7, 43, 92, 101, 248, 217);
@@ -2049,11 +2049,11 @@ impl INetworkUsage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkUsage: INetworkUsage}
-RT_STRUCT! { struct NetworkUsageStates {
+RT_CLASS!{class NetworkUsage: INetworkUsage ["Windows.Networking.Connectivity.NetworkUsage"]}
+RT_STRUCT! { struct NetworkUsageStates ["Windows.Networking.Connectivity.NetworkUsageStates"] {
     Roaming: TriStates, Shared: TriStates,
 }}
-RT_CLASS!{class IPInformation: IIPInformation}
+RT_CLASS!{class IPInformation: IIPInformation ["Windows.Networking.Connectivity.IPInformation"]}
 DEFINE_IID!(IID_IProviderNetworkUsage, 1590074884, 31025, 18632, 184, 243, 70, 48, 15, 164, 39, 40);
 RT_INTERFACE!{interface IProviderNetworkUsage(IProviderNetworkUsageVtbl): IInspectable(IInspectableVtbl) [IID_IProviderNetworkUsage] {
     fn get_BytesSent(&self, out: *mut u64) -> HRESULT,
@@ -2077,7 +2077,7 @@ impl IProviderNetworkUsage {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProviderNetworkUsage: IProviderNetworkUsage}
+RT_CLASS!{class ProviderNetworkUsage: IProviderNetworkUsage ["Windows.Networking.Connectivity.ProviderNetworkUsage"]}
 DEFINE_IID!(IID_IProxyConfiguration, 4013580468, 36868, 19926, 183, 216, 179, 229, 2, 244, 170, 208);
 RT_INTERFACE!{interface IProxyConfiguration(IProxyConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IProxyConfiguration] {
     fn get_ProxyUris(&self, out: *mut *mut foundation::collections::IVectorView<foundation::Uri>) -> HRESULT,
@@ -2095,8 +2095,8 @@ impl IProxyConfiguration {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProxyConfiguration: IProxyConfiguration}
-RT_ENUM! { enum RoamingStates: u32 {
+RT_CLASS!{class ProxyConfiguration: IProxyConfiguration ["Windows.Networking.Connectivity.ProxyConfiguration"]}
+RT_ENUM! { enum RoamingStates: u32 ["Windows.Networking.Connectivity.RoamingStates"] {
     None (RoamingStates_None) = 0, NotRoaming (RoamingStates_NotRoaming) = 1, Roaming (RoamingStates_Roaming) = 2,
 }}
 DEFINE_IID!(IID_IRoutePolicy, 296469676, 4039, 17124, 135, 66, 86, 153, 35, 177, 202, 17);
@@ -2122,7 +2122,7 @@ impl IRoutePolicy {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RoutePolicy: IRoutePolicy}
+RT_CLASS!{class RoutePolicy: IRoutePolicy ["Windows.Networking.Connectivity.RoutePolicy"]}
 impl RtActivatable<IRoutePolicyFactory> for RoutePolicy {}
 impl RoutePolicy {
     #[inline] pub fn create_route_policy(connectionProfile: &ConnectionProfile, hostName: &super::HostName, type_: super::DomainNameType) -> Result<ComPtr<RoutePolicy>> {
@@ -2141,7 +2141,7 @@ impl IRoutePolicyFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TriStates: i32 {
+RT_ENUM! { enum TriStates: i32 ["Windows.Networking.Connectivity.TriStates"] {
     DoNotCare (TriStates_DoNotCare) = 0, No (TriStates_No) = 1, Yes (TriStates_Yes) = 2,
 }}
 DEFINE_IID!(IID_IWlanConnectionProfileDetails, 1444976843, 45914, 19441, 168, 132, 183, 85, 126, 136, 255, 134);
@@ -2155,7 +2155,7 @@ impl IWlanConnectionProfileDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WlanConnectionProfileDetails: IWlanConnectionProfileDetails}
+RT_CLASS!{class WlanConnectionProfileDetails: IWlanConnectionProfileDetails ["Windows.Networking.Connectivity.WlanConnectionProfileDetails"]}
 DEFINE_IID!(IID_IWwanConnectionProfileDetails, 239970558, 33631, 19955, 130, 253, 223, 85, 110, 188, 9, 239);
 RT_INTERFACE!{interface IWwanConnectionProfileDetails(IWwanConnectionProfileDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IWwanConnectionProfileDetails] {
     fn get_HomeProviderId(&self, out: *mut HSTRING) -> HRESULT,
@@ -2185,7 +2185,7 @@ impl IWwanConnectionProfileDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WwanConnectionProfileDetails: IWwanConnectionProfileDetails}
+RT_CLASS!{class WwanConnectionProfileDetails: IWwanConnectionProfileDetails ["Windows.Networking.Connectivity.WwanConnectionProfileDetails"]}
 DEFINE_IID!(IID_IWwanConnectionProfileDetails2, 2054508254, 41453, 18610, 142, 146, 180, 96, 3, 61, 82, 226);
 RT_INTERFACE!{interface IWwanConnectionProfileDetails2(IWwanConnectionProfileDetails2Vtbl): IInspectable(IInspectableVtbl) [IID_IWwanConnectionProfileDetails2] {
     fn get_IPKind(&self, out: *mut WwanNetworkIPKind) -> HRESULT,
@@ -2203,19 +2203,19 @@ impl IWwanConnectionProfileDetails2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WwanDataClass: u32 {
+RT_ENUM! { enum WwanDataClass: u32 ["Windows.Networking.Connectivity.WwanDataClass"] {
     None (WwanDataClass_None) = 0, Gprs (WwanDataClass_Gprs) = 1, Edge (WwanDataClass_Edge) = 2, Umts (WwanDataClass_Umts) = 4, Hsdpa (WwanDataClass_Hsdpa) = 8, Hsupa (WwanDataClass_Hsupa) = 16, LteAdvanced (WwanDataClass_LteAdvanced) = 32, Cdma1xRtt (WwanDataClass_Cdma1xRtt) = 65536, Cdma1xEvdo (WwanDataClass_Cdma1xEvdo) = 131072, Cdma1xEvdoRevA (WwanDataClass_Cdma1xEvdoRevA) = 262144, Cdma1xEvdv (WwanDataClass_Cdma1xEvdv) = 524288, Cdma3xRtt (WwanDataClass_Cdma3xRtt) = 1048576, Cdma1xEvdoRevB (WwanDataClass_Cdma1xEvdoRevB) = 2097152, CdmaUmb (WwanDataClass_CdmaUmb) = 4194304, Custom (WwanDataClass_Custom) = 2147483648,
 }}
-RT_ENUM! { enum WwanNetworkIPKind: i32 {
+RT_ENUM! { enum WwanNetworkIPKind: i32 ["Windows.Networking.Connectivity.WwanNetworkIPKind"] {
     None (WwanNetworkIPKind_None) = 0, Ipv4 (WwanNetworkIPKind_Ipv4) = 1, Ipv6 (WwanNetworkIPKind_Ipv6) = 2, Ipv4v6 (WwanNetworkIPKind_Ipv4v6) = 3, Ipv4v6v4Xlat (WwanNetworkIPKind_Ipv4v6v4Xlat) = 4,
 }}
-RT_ENUM! { enum WwanNetworkRegistrationState: i32 {
+RT_ENUM! { enum WwanNetworkRegistrationState: i32 ["Windows.Networking.Connectivity.WwanNetworkRegistrationState"] {
     None (WwanNetworkRegistrationState_None) = 0, Deregistered (WwanNetworkRegistrationState_Deregistered) = 1, Searching (WwanNetworkRegistrationState_Searching) = 2, Home (WwanNetworkRegistrationState_Home) = 3, Roaming (WwanNetworkRegistrationState_Roaming) = 4, Partner (WwanNetworkRegistrationState_Partner) = 5, Denied (WwanNetworkRegistrationState_Denied) = 6,
 }}
 } // Windows.Networking.Connectivity
 pub mod networkoperators { // Windows.Networking.NetworkOperators
 use ::prelude::*;
-RT_ENUM! { enum DataClasses: u32 {
+RT_ENUM! { enum DataClasses: u32 ["Windows.Networking.NetworkOperators.DataClasses"] {
     None (DataClasses_None) = 0, Gprs (DataClasses_Gprs) = 1, Edge (DataClasses_Edge) = 2, Umts (DataClasses_Umts) = 4, Hsdpa (DataClasses_Hsdpa) = 8, Hsupa (DataClasses_Hsupa) = 16, LteAdvanced (DataClasses_LteAdvanced) = 32, Cdma1xRtt (DataClasses_Cdma1xRtt) = 65536, Cdma1xEvdo (DataClasses_Cdma1xEvdo) = 131072, Cdma1xEvdoRevA (DataClasses_Cdma1xEvdoRevA) = 262144, Cdma1xEvdv (DataClasses_Cdma1xEvdv) = 524288, Cdma3xRtt (DataClasses_Cdma3xRtt) = 1048576, Cdma1xEvdoRevB (DataClasses_Cdma1xEvdoRevB) = 2097152, CdmaUmb (DataClasses_CdmaUmb) = 4194304, Custom (DataClasses_Custom) = 2147483648,
 }}
 DEFINE_IID!(IID_IESim, 1869508134, 61731, 17277, 140, 237, 220, 29, 43, 192, 195, 169);
@@ -2294,7 +2294,7 @@ impl IESim {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESim: IESim}
+RT_CLASS!{class ESim: IESim ["Windows.Networking.NetworkOperators.ESim"]}
 DEFINE_IID!(IID_IESimAddedEventArgs, 951913048, 19802, 19720, 141, 167, 231, 62, 255, 54, 157, 221);
 RT_INTERFACE!{interface IESimAddedEventArgs(IESimAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IESimAddedEventArgs] {
     fn get_ESim(&self, out: *mut *mut ESim) -> HRESULT
@@ -2306,8 +2306,8 @@ impl IESimAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimAddedEventArgs: IESimAddedEventArgs}
-RT_ENUM! { enum ESimAuthenticationPreference: i32 {
+RT_CLASS!{class ESimAddedEventArgs: IESimAddedEventArgs ["Windows.Networking.NetworkOperators.ESimAddedEventArgs"]}
+RT_ENUM! { enum ESimAuthenticationPreference: i32 ["Windows.Networking.NetworkOperators.ESimAuthenticationPreference"] {
     OnEntry (ESimAuthenticationPreference_OnEntry) = 0, OnAction (ESimAuthenticationPreference_OnAction) = 1, Never (ESimAuthenticationPreference_Never) = 2,
 }}
 DEFINE_IID!(IID_IESimDownloadProfileMetadataResult, 3290647966, 23254, 17005, 141, 0, 68, 52, 244, 73, 175, 236);
@@ -2327,7 +2327,7 @@ impl IESimDownloadProfileMetadataResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimDownloadProfileMetadataResult: IESimDownloadProfileMetadataResult}
+RT_CLASS!{class ESimDownloadProfileMetadataResult: IESimDownloadProfileMetadataResult ["Windows.Networking.NetworkOperators.ESimDownloadProfileMetadataResult"]}
 RT_CLASS!{static class ESimManager}
 impl RtActivatable<IESimManagerStatics> for ESimManager {}
 impl ESimManager {
@@ -2384,8 +2384,8 @@ impl IESimOperationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimOperationResult: IESimOperationResult}
-RT_ENUM! { enum ESimOperationStatus: i32 {
+RT_CLASS!{class ESimOperationResult: IESimOperationResult ["Windows.Networking.NetworkOperators.ESimOperationResult"]}
+RT_ENUM! { enum ESimOperationStatus: i32 ["Windows.Networking.NetworkOperators.ESimOperationStatus"] {
     Success (ESimOperationStatus_Success) = 0, NotAuthorized (ESimOperationStatus_NotAuthorized) = 1, NotFound (ESimOperationStatus_NotFound) = 2, PolicyViolation (ESimOperationStatus_PolicyViolation) = 3, InsufficientSpaceOnCard (ESimOperationStatus_InsufficientSpaceOnCard) = 4, ServerFailure (ESimOperationStatus_ServerFailure) = 5, ServerNotReachable (ESimOperationStatus_ServerNotReachable) = 6, TimeoutWaitingForUserConsent (ESimOperationStatus_TimeoutWaitingForUserConsent) = 7, IncorrectConfirmationCode (ESimOperationStatus_IncorrectConfirmationCode) = 8, ConfirmationCodeMaxRetriesExceeded (ESimOperationStatus_ConfirmationCodeMaxRetriesExceeded) = 9, CardRemoved (ESimOperationStatus_CardRemoved) = 10, CardBusy (ESimOperationStatus_CardBusy) = 11, Other (ESimOperationStatus_Other) = 12, CardGeneralFailure (ESimOperationStatus_CardGeneralFailure) = 13, ConfirmationCodeMissing (ESimOperationStatus_ConfirmationCodeMissing) = 14, InvalidMatchingId (ESimOperationStatus_InvalidMatchingId) = 15, NoEligibleProfileForThisDevice (ESimOperationStatus_NoEligibleProfileForThisDevice) = 16, OperationAborted (ESimOperationStatus_OperationAborted) = 17, EidMismatch (ESimOperationStatus_EidMismatch) = 18, ProfileNotAvailableForNewBinding (ESimOperationStatus_ProfileNotAvailableForNewBinding) = 19, ProfileNotReleasedByOperator (ESimOperationStatus_ProfileNotReleasedByOperator) = 20, OperationProhibitedByProfileClass (ESimOperationStatus_OperationProhibitedByProfileClass) = 21, ProfileNotPresent (ESimOperationStatus_ProfileNotPresent) = 22, NoCorrespondingRequest (ESimOperationStatus_NoCorrespondingRequest) = 23,
 }}
 DEFINE_IID!(IID_IESimPolicy, 1105312157, 53118, 17173, 136, 43, 111, 30, 116, 176, 211, 143);
@@ -2399,7 +2399,7 @@ impl IESimPolicy {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimPolicy: IESimPolicy}
+RT_CLASS!{class ESimPolicy: IESimPolicy ["Windows.Networking.NetworkOperators.ESimPolicy"]}
 DEFINE_IID!(IID_IESimProfile, 3994974336, 1705, 16423, 180, 248, 221, 178, 61, 120, 16, 224);
 RT_INTERFACE!{interface IESimProfile(IESimProfileVtbl): IInspectable(IInspectableVtbl) [IID_IESimProfile] {
     fn get_Class(&self, out: *mut ESimProfileClass) -> HRESULT,
@@ -2472,11 +2472,11 @@ impl IESimProfile {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimProfile: IESimProfile}
-RT_ENUM! { enum ESimProfileClass: i32 {
+RT_CLASS!{class ESimProfile: IESimProfile ["Windows.Networking.NetworkOperators.ESimProfile"]}
+RT_ENUM! { enum ESimProfileClass: i32 ["Windows.Networking.NetworkOperators.ESimProfileClass"] {
     Operational (ESimProfileClass_Operational) = 0, Test (ESimProfileClass_Test) = 1, Provisioning (ESimProfileClass_Provisioning) = 2,
 }}
-RT_STRUCT! { struct ESimProfileInstallProgress {
+RT_STRUCT! { struct ESimProfileInstallProgress ["Windows.Networking.NetworkOperators.ESimProfileInstallProgress"] {
     TotalSizeInBytes: i32, InstalledSizeInBytes: i32,
 }}
 DEFINE_IID!(IID_IESimProfileMetadata, 3978658591, 37083, 18829, 167, 180, 235, 206, 128, 125, 60, 35);
@@ -2562,8 +2562,8 @@ impl IESimProfileMetadata {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimProfileMetadata: IESimProfileMetadata}
-RT_ENUM! { enum ESimProfileMetadataState: i32 {
+RT_CLASS!{class ESimProfileMetadata: IESimProfileMetadata ["Windows.Networking.NetworkOperators.ESimProfileMetadata"]}
+RT_ENUM! { enum ESimProfileMetadataState: i32 ["Windows.Networking.NetworkOperators.ESimProfileMetadataState"] {
     Unknown (ESimProfileMetadataState_Unknown) = 0, WaitingForInstall (ESimProfileMetadataState_WaitingForInstall) = 1, Downloading (ESimProfileMetadataState_Downloading) = 2, Installing (ESimProfileMetadataState_Installing) = 3, Expired (ESimProfileMetadataState_Expired) = 4, RejectingDownload (ESimProfileMetadataState_RejectingDownload) = 5, NoLongerAvailable (ESimProfileMetadataState_NoLongerAvailable) = 6, DeniedByPolicy (ESimProfileMetadataState_DeniedByPolicy) = 7,
 }}
 DEFINE_IID!(IID_IESimProfilePolicy, 3873247005, 40028, 18117, 162, 137, 169, 72, 153, 155, 240, 98);
@@ -2589,8 +2589,8 @@ impl IESimProfilePolicy {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimProfilePolicy: IESimProfilePolicy}
-RT_ENUM! { enum ESimProfileState: i32 {
+RT_CLASS!{class ESimProfilePolicy: IESimProfilePolicy ["Windows.Networking.NetworkOperators.ESimProfilePolicy"]}
+RT_ENUM! { enum ESimProfileState: i32 ["Windows.Networking.NetworkOperators.ESimProfileState"] {
     Unknown (ESimProfileState_Unknown) = 0, Disabled (ESimProfileState_Disabled) = 1, Enabled (ESimProfileState_Enabled) = 2, Deleted (ESimProfileState_Deleted) = 3,
 }}
 DEFINE_IID!(IID_IESimRemovedEventArgs, 3737462651, 12249, 20185, 131, 118, 217, 181, 228, 18, 120, 163);
@@ -2604,7 +2604,7 @@ impl IESimRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimRemovedEventArgs: IESimRemovedEventArgs}
+RT_CLASS!{class ESimRemovedEventArgs: IESimRemovedEventArgs ["Windows.Networking.NetworkOperators.ESimRemovedEventArgs"]}
 DEFINE_IID!(IID_IESimServiceInfo, 4050299855, 32601, 19025, 132, 148, 189, 137, 213, 255, 80, 238);
 RT_INTERFACE!{interface IESimServiceInfo(IESimServiceInfoVtbl): IInspectable(IInspectableVtbl) [IID_IESimServiceInfo] {
     fn get_AuthenticationPreference(&self, out: *mut ESimAuthenticationPreference) -> HRESULT,
@@ -2622,8 +2622,8 @@ impl IESimServiceInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimServiceInfo: IESimServiceInfo}
-RT_ENUM! { enum ESimState: i32 {
+RT_CLASS!{class ESimServiceInfo: IESimServiceInfo ["Windows.Networking.NetworkOperators.ESimServiceInfo"]}
+RT_ENUM! { enum ESimState: i32 ["Windows.Networking.NetworkOperators.ESimState"] {
     Unknown (ESimState_Unknown) = 0, Idle (ESimState_Idle) = 1, Removed (ESimState_Removed) = 2, Busy (ESimState_Busy) = 3,
 }}
 DEFINE_IID!(IID_IESimUpdatedEventArgs, 1276271852, 20621, 19336, 131, 203, 104, 190, 248, 22, 141, 18);
@@ -2637,7 +2637,7 @@ impl IESimUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimUpdatedEventArgs: IESimUpdatedEventArgs}
+RT_CLASS!{class ESimUpdatedEventArgs: IESimUpdatedEventArgs ["Windows.Networking.NetworkOperators.ESimUpdatedEventArgs"]}
 DEFINE_IID!(IID_IESimWatcher, 3254275307, 41613, 20415, 151, 113, 110, 49, 184, 28, 207, 34);
 RT_INTERFACE!{interface IESimWatcher(IESimWatcherVtbl): IInspectable(IInspectableVtbl) [IID_IESimWatcher] {
     fn get_Status(&self, out: *mut ESimWatcherStatus) -> HRESULT,
@@ -2714,8 +2714,8 @@ impl IESimWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ESimWatcher: IESimWatcher}
-RT_ENUM! { enum ESimWatcherStatus: i32 {
+RT_CLASS!{class ESimWatcher: IESimWatcher ["Windows.Networking.NetworkOperators.ESimWatcher"]}
+RT_ENUM! { enum ESimWatcherStatus: i32 ["Windows.Networking.NetworkOperators.ESimWatcherStatus"] {
     Created (ESimWatcherStatus_Created) = 0, Started (ESimWatcherStatus_Started) = 1, EnumerationCompleted (ESimWatcherStatus_EnumerationCompleted) = 2, Stopping (ESimWatcherStatus_Stopping) = 3, Stopped (ESimWatcherStatus_Stopped) = 4,
 }}
 DEFINE_IID!(IID_IHotspotAuthenticationContext, 3881224081, 4099, 19941, 131, 199, 222, 97, 216, 136, 49, 208);
@@ -2774,7 +2774,7 @@ impl IHotspotAuthenticationContext {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HotspotAuthenticationContext: IHotspotAuthenticationContext}
+RT_CLASS!{class HotspotAuthenticationContext: IHotspotAuthenticationContext ["Windows.Networking.NetworkOperators.HotspotAuthenticationContext"]}
 impl RtActivatable<IHotspotAuthenticationContextStatics> for HotspotAuthenticationContext {}
 impl HotspotAuthenticationContext {
     #[inline] pub fn try_get_authentication_context(evenToken: &HStringArg) -> Result<(Option<ComPtr<HotspotAuthenticationContext>>, bool)> {
@@ -2815,8 +2815,8 @@ impl IHotspotAuthenticationEventDetails {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HotspotAuthenticationEventDetails: IHotspotAuthenticationEventDetails}
-RT_ENUM! { enum HotspotAuthenticationResponseCode: i32 {
+RT_CLASS!{class HotspotAuthenticationEventDetails: IHotspotAuthenticationEventDetails ["Windows.Networking.NetworkOperators.HotspotAuthenticationEventDetails"]}
+RT_ENUM! { enum HotspotAuthenticationResponseCode: i32 ["Windows.Networking.NetworkOperators.HotspotAuthenticationResponseCode"] {
     NoError (HotspotAuthenticationResponseCode_NoError) = 0, LoginSucceeded (HotspotAuthenticationResponseCode_LoginSucceeded) = 50, LoginFailed (HotspotAuthenticationResponseCode_LoginFailed) = 100, RadiusServerError (HotspotAuthenticationResponseCode_RadiusServerError) = 102, NetworkAdministratorError (HotspotAuthenticationResponseCode_NetworkAdministratorError) = 105, LoginAborted (HotspotAuthenticationResponseCode_LoginAborted) = 151, AccessGatewayInternalError (HotspotAuthenticationResponseCode_AccessGatewayInternalError) = 255,
 }}
 DEFINE_IID!(IID_IHotspotCredentialsAuthenticationResult, 3881224081, 4101, 19941, 131, 199, 222, 97, 216, 136, 49, 208);
@@ -2848,7 +2848,7 @@ impl IHotspotCredentialsAuthenticationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HotspotCredentialsAuthenticationResult: IHotspotCredentialsAuthenticationResult}
+RT_CLASS!{class HotspotCredentialsAuthenticationResult: IHotspotCredentialsAuthenticationResult ["Windows.Networking.NetworkOperators.HotspotCredentialsAuthenticationResult"]}
 RT_CLASS!{static class KnownCSimFilePaths}
 impl RtActivatable<IKnownCSimFilePathsStatics> for KnownCSimFilePaths {}
 impl KnownCSimFilePaths {
@@ -3059,7 +3059,7 @@ impl IMobileBroadbandAccount {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandAccount: IMobileBroadbandAccount}
+RT_CLASS!{class MobileBroadbandAccount: IMobileBroadbandAccount ["Windows.Networking.NetworkOperators.MobileBroadbandAccount"]}
 impl RtActivatable<IMobileBroadbandAccountStatics> for MobileBroadbandAccount {}
 impl MobileBroadbandAccount {
     #[inline] pub fn get_available_network_account_ids() -> Result<Option<ComPtr<foundation::collections::IVectorView<HString>>>> {
@@ -3103,7 +3103,7 @@ impl IMobileBroadbandAccountEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandAccountEventArgs: IMobileBroadbandAccountEventArgs}
+RT_CLASS!{class MobileBroadbandAccountEventArgs: IMobileBroadbandAccountEventArgs ["Windows.Networking.NetworkOperators.MobileBroadbandAccountEventArgs"]}
 DEFINE_IID!(IID_IMobileBroadbandAccountStatics, 2860469540, 44993, 20424, 174, 154, 169, 23, 83, 16, 250, 173);
 RT_INTERFACE!{static interface IMobileBroadbandAccountStatics(IMobileBroadbandAccountStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandAccountStatics] {
     fn get_AvailableNetworkAccountIds(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -3144,7 +3144,7 @@ impl IMobileBroadbandAccountUpdatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandAccountUpdatedEventArgs: IMobileBroadbandAccountUpdatedEventArgs}
+RT_CLASS!{class MobileBroadbandAccountUpdatedEventArgs: IMobileBroadbandAccountUpdatedEventArgs ["Windows.Networking.NetworkOperators.MobileBroadbandAccountUpdatedEventArgs"]}
 DEFINE_IID!(IID_IMobileBroadbandAccountWatcher, 1811100510, 9141, 17567, 146, 141, 94, 13, 62, 4, 71, 29);
 RT_INTERFACE!{interface IMobileBroadbandAccountWatcher(IMobileBroadbandAccountWatcherVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandAccountWatcher] {
     fn add_AccountAdded(&self, handler: *mut foundation::TypedEventHandler<MobileBroadbandAccountWatcher, MobileBroadbandAccountEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -3221,10 +3221,10 @@ impl IMobileBroadbandAccountWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandAccountWatcher: IMobileBroadbandAccountWatcher}
+RT_CLASS!{class MobileBroadbandAccountWatcher: IMobileBroadbandAccountWatcher ["Windows.Networking.NetworkOperators.MobileBroadbandAccountWatcher"]}
 impl RtActivatable<IActivationFactory> for MobileBroadbandAccountWatcher {}
 DEFINE_CLSID!(MobileBroadbandAccountWatcher(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,77,111,98,105,108,101,66,114,111,97,100,98,97,110,100,65,99,99,111,117,110,116,87,97,116,99,104,101,114,0]) [CLSID_MobileBroadbandAccountWatcher]);
-RT_ENUM! { enum MobileBroadbandAccountWatcherStatus: i32 {
+RT_ENUM! { enum MobileBroadbandAccountWatcherStatus: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandAccountWatcherStatus"] {
     Created (MobileBroadbandAccountWatcherStatus_Created) = 0, Started (MobileBroadbandAccountWatcherStatus_Started) = 1, EnumerationCompleted (MobileBroadbandAccountWatcherStatus_EnumerationCompleted) = 2, Stopped (MobileBroadbandAccountWatcherStatus_Stopped) = 3, Aborted (MobileBroadbandAccountWatcherStatus_Aborted) = 4,
 }}
 DEFINE_IID!(IID_IMobileBroadbandAntennaSar, 3115273086, 52217, 16649, 144, 190, 92, 6, 191, 213, 19, 182);
@@ -3244,7 +3244,7 @@ impl IMobileBroadbandAntennaSar {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandAntennaSar: IMobileBroadbandAntennaSar}
+RT_CLASS!{class MobileBroadbandAntennaSar: IMobileBroadbandAntennaSar ["Windows.Networking.NetworkOperators.MobileBroadbandAntennaSar"]}
 impl RtActivatable<IMobileBroadbandAntennaSarFactory> for MobileBroadbandAntennaSar {}
 impl MobileBroadbandAntennaSar {
     #[inline] pub fn create_with_index(antennaIndex: i32, sarBackoffIndex: i32) -> Result<ComPtr<MobileBroadbandAntennaSar>> {
@@ -3316,7 +3316,7 @@ impl IMobileBroadbandCellCdma {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandCellCdma: IMobileBroadbandCellCdma}
+RT_CLASS!{class MobileBroadbandCellCdma: IMobileBroadbandCellCdma ["Windows.Networking.NetworkOperators.MobileBroadbandCellCdma"]}
 DEFINE_IID!(IID_IMobileBroadbandCellGsm, 3432087302, 32480, 18360, 158, 31, 195, 180, 141, 249, 223, 91);
 RT_INTERFACE!{interface IMobileBroadbandCellGsm(IMobileBroadbandCellGsmVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandCellGsm] {
     fn get_BaseStationId(&self, out: *mut *mut foundation::IReference<i32>) -> HRESULT,
@@ -3364,7 +3364,7 @@ impl IMobileBroadbandCellGsm {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandCellGsm: IMobileBroadbandCellGsm}
+RT_CLASS!{class MobileBroadbandCellGsm: IMobileBroadbandCellGsm ["Windows.Networking.NetworkOperators.MobileBroadbandCellGsm"]}
 DEFINE_IID!(IID_IMobileBroadbandCellLte, 2442643579, 11128, 17773, 139, 83, 170, 162, 93, 10, 247, 65);
 RT_INTERFACE!{interface IMobileBroadbandCellLte(IMobileBroadbandCellLteVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandCellLte] {
     fn get_CellId(&self, out: *mut *mut foundation::IReference<i32>) -> HRESULT,
@@ -3418,7 +3418,7 @@ impl IMobileBroadbandCellLte {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandCellLte: IMobileBroadbandCellLte}
+RT_CLASS!{class MobileBroadbandCellLte: IMobileBroadbandCellLte ["Windows.Networking.NetworkOperators.MobileBroadbandCellLte"]}
 DEFINE_IID!(IID_IMobileBroadbandCellsInfo, 2309576234, 58482, 19877, 146, 156, 222, 97, 113, 29, 210, 97);
 RT_INTERFACE!{interface IMobileBroadbandCellsInfo(IMobileBroadbandCellsInfoVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandCellsInfo] {
     fn get_NeighboringCellsCdma(&self, out: *mut *mut foundation::collections::IVectorView<MobileBroadbandCellCdma>) -> HRESULT,
@@ -3484,7 +3484,7 @@ impl IMobileBroadbandCellsInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandCellsInfo: IMobileBroadbandCellsInfo}
+RT_CLASS!{class MobileBroadbandCellsInfo: IMobileBroadbandCellsInfo ["Windows.Networking.NetworkOperators.MobileBroadbandCellsInfo"]}
 DEFINE_IID!(IID_IMobileBroadbandCellTdscdma, 249173589, 56078, 16770, 140, 218, 204, 65, 154, 123, 222, 8);
 RT_INTERFACE!{interface IMobileBroadbandCellTdscdma(IMobileBroadbandCellTdscdmaVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandCellTdscdma] {
     fn get_CellId(&self, out: *mut *mut foundation::IReference<i32>) -> HRESULT,
@@ -3538,7 +3538,7 @@ impl IMobileBroadbandCellTdscdma {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandCellTdscdma: IMobileBroadbandCellTdscdma}
+RT_CLASS!{class MobileBroadbandCellTdscdma: IMobileBroadbandCellTdscdma ["Windows.Networking.NetworkOperators.MobileBroadbandCellTdscdma"]}
 DEFINE_IID!(IID_IMobileBroadbandCellUmts, 2008331694, 18888, 20245, 178, 133, 76, 38, 167, 246, 114, 21);
 RT_INTERFACE!{interface IMobileBroadbandCellUmts(IMobileBroadbandCellUmtsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandCellUmts] {
     fn get_CellId(&self, out: *mut *mut foundation::IReference<i32>) -> HRESULT,
@@ -3592,7 +3592,7 @@ impl IMobileBroadbandCellUmts {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandCellUmts: IMobileBroadbandCellUmts}
+RT_CLASS!{class MobileBroadbandCellUmts: IMobileBroadbandCellUmts ["Windows.Networking.NetworkOperators.MobileBroadbandCellUmts"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceInformation, 3872424296, 58241, 19566, 155, 232, 254, 21, 105, 105, 164, 70);
 RT_INTERFACE!{interface IMobileBroadbandDeviceInformation(IMobileBroadbandDeviceInformationVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceInformation] {
     fn get_NetworkDeviceStatus(&self, out: *mut NetworkDeviceStatus) -> HRESULT,
@@ -3683,7 +3683,7 @@ impl IMobileBroadbandDeviceInformation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceInformation: IMobileBroadbandDeviceInformation}
+RT_CLASS!{class MobileBroadbandDeviceInformation: IMobileBroadbandDeviceInformation ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceInformation"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceInformation2, 776370929, 63794, 18231, 167, 34, 3, 186, 114, 55, 12, 184);
 RT_INTERFACE!{interface IMobileBroadbandDeviceInformation2(IMobileBroadbandDeviceInformation2Vtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceInformation2] {
     fn get_PinManager(&self, out: *mut *mut MobileBroadbandPinManager) -> HRESULT,
@@ -3759,7 +3759,7 @@ impl IMobileBroadbandDeviceService {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceService: IMobileBroadbandDeviceService}
+RT_CLASS!{class MobileBroadbandDeviceService: IMobileBroadbandDeviceService ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceService"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceServiceCommandResult, 2968808123, 38102, 17593, 165, 56, 240, 129, 11, 100, 83, 137);
 RT_INTERFACE!{interface IMobileBroadbandDeviceServiceCommandResult(IMobileBroadbandDeviceServiceCommandResultVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceServiceCommandResult] {
     fn get_StatusCode(&self, out: *mut u32) -> HRESULT,
@@ -3777,7 +3777,7 @@ impl IMobileBroadbandDeviceServiceCommandResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceServiceCommandResult: IMobileBroadbandDeviceServiceCommandResult}
+RT_CLASS!{class MobileBroadbandDeviceServiceCommandResult: IMobileBroadbandDeviceServiceCommandResult ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceCommandResult"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceServiceCommandSession, 4228483653, 37179, 18708, 182, 195, 174, 99, 4, 89, 62, 117);
 RT_INTERFACE!{interface IMobileBroadbandDeviceServiceCommandSession(IMobileBroadbandDeviceServiceCommandSessionVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceServiceCommandSession] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -3802,7 +3802,7 @@ impl IMobileBroadbandDeviceServiceCommandSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceServiceCommandSession: IMobileBroadbandDeviceServiceCommandSession}
+RT_CLASS!{class MobileBroadbandDeviceServiceCommandSession: IMobileBroadbandDeviceServiceCommandSession ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceCommandSession"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceServiceDataReceivedEventArgs, 3064599518, 4992, 16611, 134, 24, 115, 203, 202, 72, 19, 140);
 RT_INTERFACE!{interface IMobileBroadbandDeviceServiceDataReceivedEventArgs(IMobileBroadbandDeviceServiceDataReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceServiceDataReceivedEventArgs] {
     #[cfg(feature="windows-storage")] fn get_ReceivedData(&self, out: *mut *mut super::super::storage::streams::IBuffer) -> HRESULT
@@ -3814,7 +3814,7 @@ impl IMobileBroadbandDeviceServiceDataReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceServiceDataReceivedEventArgs: IMobileBroadbandDeviceServiceDataReceivedEventArgs}
+RT_CLASS!{class MobileBroadbandDeviceServiceDataReceivedEventArgs: IMobileBroadbandDeviceServiceDataReceivedEventArgs ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceDataReceivedEventArgs"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceServiceDataSession, 3671466803, 35791, 17033, 138, 55, 4, 92, 33, 105, 72, 106);
 RT_INTERFACE!{interface IMobileBroadbandDeviceServiceDataSession(IMobileBroadbandDeviceServiceDataSessionVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceServiceDataSession] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -3843,7 +3843,7 @@ impl IMobileBroadbandDeviceServiceDataSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceServiceDataSession: IMobileBroadbandDeviceServiceDataSession}
+RT_CLASS!{class MobileBroadbandDeviceServiceDataSession: IMobileBroadbandDeviceServiceDataSession ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceDataSession"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceServiceInformation, 1406573403, 50413, 17904, 128, 58, 217, 65, 122, 109, 152, 70);
 RT_INTERFACE!{interface IMobileBroadbandDeviceServiceInformation(IMobileBroadbandDeviceServiceInformationVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceServiceInformation] {
     fn get_DeviceServiceId(&self, out: *mut Guid) -> HRESULT,
@@ -3867,7 +3867,7 @@ impl IMobileBroadbandDeviceServiceInformation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceServiceInformation: IMobileBroadbandDeviceServiceInformation}
+RT_CLASS!{class MobileBroadbandDeviceServiceInformation: IMobileBroadbandDeviceServiceInformation ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceInformation"]}
 DEFINE_IID!(IID_IMobileBroadbandDeviceServiceTriggerDetails, 1241865072, 47534, 17496, 146, 65, 166, 165, 251, 241, 138, 12);
 RT_INTERFACE!{interface IMobileBroadbandDeviceServiceTriggerDetails(IMobileBroadbandDeviceServiceTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandDeviceServiceTriggerDetails] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT,
@@ -3891,8 +3891,8 @@ impl IMobileBroadbandDeviceServiceTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandDeviceServiceTriggerDetails: IMobileBroadbandDeviceServiceTriggerDetails}
-RT_ENUM! { enum MobileBroadbandDeviceType: i32 {
+RT_CLASS!{class MobileBroadbandDeviceServiceTriggerDetails: IMobileBroadbandDeviceServiceTriggerDetails ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceTriggerDetails"]}
+RT_ENUM! { enum MobileBroadbandDeviceType: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandDeviceType"] {
     Unknown (MobileBroadbandDeviceType_Unknown) = 0, Embedded (MobileBroadbandDeviceType_Embedded) = 1, Removable (MobileBroadbandDeviceType_Removable) = 2, Remote (MobileBroadbandDeviceType_Remote) = 3,
 }}
 DEFINE_IID!(IID_IMobileBroadbandModem, 3493161234, 59897, 20327, 160, 61, 67, 24, 154, 49, 107, 241);
@@ -3960,7 +3960,7 @@ impl IMobileBroadbandModem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandModem: IMobileBroadbandModem}
+RT_CLASS!{class MobileBroadbandModem: IMobileBroadbandModem ["Windows.Networking.NetworkOperators.MobileBroadbandModem"]}
 impl RtActivatable<IMobileBroadbandModemStatics> for MobileBroadbandModem {}
 impl MobileBroadbandModem {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -4042,7 +4042,7 @@ impl IMobileBroadbandModemConfiguration {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandModemConfiguration: IMobileBroadbandModemConfiguration}
+RT_CLASS!{class MobileBroadbandModemConfiguration: IMobileBroadbandModemConfiguration ["Windows.Networking.NetworkOperators.MobileBroadbandModemConfiguration"]}
 DEFINE_IID!(IID_IMobileBroadbandModemConfiguration2, 839906757, 58464, 17070, 170, 81, 105, 98, 30, 122, 68, 119);
 RT_INTERFACE!{interface IMobileBroadbandModemConfiguration2(IMobileBroadbandModemConfiguration2Vtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandModemConfiguration2] {
     fn get_SarManager(&self, out: *mut *mut MobileBroadbandSarManager) -> HRESULT
@@ -4081,7 +4081,7 @@ impl IMobileBroadbandModemIsolation {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandModemIsolation: IMobileBroadbandModemIsolation}
+RT_CLASS!{class MobileBroadbandModemIsolation: IMobileBroadbandModemIsolation ["Windows.Networking.NetworkOperators.MobileBroadbandModemIsolation"]}
 impl RtActivatable<IMobileBroadbandModemIsolationFactory> for MobileBroadbandModemIsolation {}
 impl MobileBroadbandModemIsolation {
     #[inline] pub fn create(modemDeviceId: &HStringArg, ruleGroupId: &HStringArg) -> Result<ComPtr<MobileBroadbandModemIsolation>> {
@@ -4123,7 +4123,7 @@ impl IMobileBroadbandModemStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MobileBroadbandModemStatus: i32 {
+RT_ENUM! { enum MobileBroadbandModemStatus: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandModemStatus"] {
     Success (MobileBroadbandModemStatus_Success) = 0, OtherFailure (MobileBroadbandModemStatus_OtherFailure) = 1, Busy (MobileBroadbandModemStatus_Busy) = 2, NoDeviceSupport (MobileBroadbandModemStatus_NoDeviceSupport) = 3,
 }}
 DEFINE_IID!(IID_IMobileBroadbandNetwork, 3412300428, 777, 19638, 168, 193, 106, 90, 60, 142, 31, 246);
@@ -4190,7 +4190,7 @@ impl IMobileBroadbandNetwork {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandNetwork: IMobileBroadbandNetwork}
+RT_CLASS!{class MobileBroadbandNetwork: IMobileBroadbandNetwork ["Windows.Networking.NetworkOperators.MobileBroadbandNetwork"]}
 DEFINE_IID!(IID_IMobileBroadbandNetwork2, 1515576098, 25335, 19421, 186, 29, 71, 116, 65, 150, 11, 160);
 RT_INTERFACE!{interface IMobileBroadbandNetwork2(IMobileBroadbandNetwork2Vtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandNetwork2] {
     fn GetVoiceCallSupportAsync(&self, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -4236,7 +4236,7 @@ impl IMobileBroadbandNetworkRegistrationStateChange {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandNetworkRegistrationStateChange: IMobileBroadbandNetworkRegistrationStateChange}
+RT_CLASS!{class MobileBroadbandNetworkRegistrationStateChange: IMobileBroadbandNetworkRegistrationStateChange ["Windows.Networking.NetworkOperators.MobileBroadbandNetworkRegistrationStateChange"]}
 DEFINE_IID!(IID_IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails, 2299747583, 10424, 18090, 177, 55, 28, 75, 15, 33, 237, 254);
 RT_INTERFACE!{interface IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails(IMobileBroadbandNetworkRegistrationStateChangeTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails] {
     fn get_NetworkRegistrationStateChanges(&self, out: *mut *mut foundation::collections::IVectorView<MobileBroadbandNetworkRegistrationStateChange>) -> HRESULT
@@ -4248,7 +4248,7 @@ impl IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandNetworkRegistrationStateChangeTriggerDetails: IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails}
+RT_CLASS!{class MobileBroadbandNetworkRegistrationStateChangeTriggerDetails: IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails ["Windows.Networking.NetworkOperators.MobileBroadbandNetworkRegistrationStateChangeTriggerDetails"]}
 DEFINE_IID!(IID_IMobileBroadbandPco, 3571776702, 58275, 17349, 168, 123, 108, 134, 210, 41, 215, 250);
 RT_INTERFACE!{interface IMobileBroadbandPco(IMobileBroadbandPcoVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandPco] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -4273,7 +4273,7 @@ impl IMobileBroadbandPco {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPco: IMobileBroadbandPco}
+RT_CLASS!{class MobileBroadbandPco: IMobileBroadbandPco ["Windows.Networking.NetworkOperators.MobileBroadbandPco"]}
 DEFINE_IID!(IID_IMobileBroadbandPcoDataChangeTriggerDetails, 641683732, 25824, 17555, 144, 155, 45, 20, 160, 25, 98, 177);
 RT_INTERFACE!{interface IMobileBroadbandPcoDataChangeTriggerDetails(IMobileBroadbandPcoDataChangeTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandPcoDataChangeTriggerDetails] {
     fn get_UpdatedData(&self, out: *mut *mut MobileBroadbandPco) -> HRESULT
@@ -4285,7 +4285,7 @@ impl IMobileBroadbandPcoDataChangeTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPcoDataChangeTriggerDetails: IMobileBroadbandPcoDataChangeTriggerDetails}
+RT_CLASS!{class MobileBroadbandPcoDataChangeTriggerDetails: IMobileBroadbandPcoDataChangeTriggerDetails ["Windows.Networking.NetworkOperators.MobileBroadbandPcoDataChangeTriggerDetails"]}
 DEFINE_IID!(IID_IMobileBroadbandPin, 3865171721, 59257, 17855, 130, 129, 117, 50, 61, 249, 227, 33);
 RT_INTERFACE!{interface IMobileBroadbandPin(IMobileBroadbandPinVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandPin] {
     fn get_Type(&self, out: *mut MobileBroadbandPinType) -> HRESULT,
@@ -4363,11 +4363,11 @@ impl IMobileBroadbandPin {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPin: IMobileBroadbandPin}
-RT_ENUM! { enum MobileBroadbandPinFormat: i32 {
+RT_CLASS!{class MobileBroadbandPin: IMobileBroadbandPin ["Windows.Networking.NetworkOperators.MobileBroadbandPin"]}
+RT_ENUM! { enum MobileBroadbandPinFormat: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandPinFormat"] {
     Unknown (MobileBroadbandPinFormat_Unknown) = 0, Numeric (MobileBroadbandPinFormat_Numeric) = 1, Alphanumeric (MobileBroadbandPinFormat_Alphanumeric) = 2,
 }}
-RT_ENUM! { enum MobileBroadbandPinLockState: i32 {
+RT_ENUM! { enum MobileBroadbandPinLockState: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandPinLockState"] {
     Unknown (MobileBroadbandPinLockState_Unknown) = 0, Unlocked (MobileBroadbandPinLockState_Unlocked) = 1, PinRequired (MobileBroadbandPinLockState_PinRequired) = 2, PinUnblockKeyRequired (MobileBroadbandPinLockState_PinUnblockKeyRequired) = 3,
 }}
 DEFINE_IID!(IID_IMobileBroadbandPinLockStateChange, 3189139262, 7940, 20373, 139, 144, 231, 245, 89, 221, 231, 229);
@@ -4393,7 +4393,7 @@ impl IMobileBroadbandPinLockStateChange {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPinLockStateChange: IMobileBroadbandPinLockStateChange}
+RT_CLASS!{class MobileBroadbandPinLockStateChange: IMobileBroadbandPinLockStateChange ["Windows.Networking.NetworkOperators.MobileBroadbandPinLockStateChange"]}
 DEFINE_IID!(IID_IMobileBroadbandPinLockStateChangeTriggerDetails, 3543711889, 16017, 19768, 144, 54, 174, 232, 58, 110, 121, 173);
 RT_INTERFACE!{interface IMobileBroadbandPinLockStateChangeTriggerDetails(IMobileBroadbandPinLockStateChangeTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandPinLockStateChangeTriggerDetails] {
     fn get_PinLockStateChanges(&self, out: *mut *mut foundation::collections::IVectorView<MobileBroadbandPinLockStateChange>) -> HRESULT
@@ -4405,7 +4405,7 @@ impl IMobileBroadbandPinLockStateChangeTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPinLockStateChangeTriggerDetails: IMobileBroadbandPinLockStateChangeTriggerDetails}
+RT_CLASS!{class MobileBroadbandPinLockStateChangeTriggerDetails: IMobileBroadbandPinLockStateChangeTriggerDetails ["Windows.Networking.NetworkOperators.MobileBroadbandPinLockStateChangeTriggerDetails"]}
 DEFINE_IID!(IID_IMobileBroadbandPinManager, 2203483869, 28191, 19355, 164, 19, 43, 31, 80, 204, 54, 223);
 RT_INTERFACE!{interface IMobileBroadbandPinManager(IMobileBroadbandPinManagerVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandPinManager] {
     fn get_SupportedPins(&self, out: *mut *mut foundation::collections::IVectorView<MobileBroadbandPinType>) -> HRESULT,
@@ -4423,7 +4423,7 @@ impl IMobileBroadbandPinManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPinManager: IMobileBroadbandPinManager}
+RT_CLASS!{class MobileBroadbandPinManager: IMobileBroadbandPinManager ["Windows.Networking.NetworkOperators.MobileBroadbandPinManager"]}
 DEFINE_IID!(IID_IMobileBroadbandPinOperationResult, 299752498, 12775, 18933, 182, 99, 18, 61, 59, 239, 3, 98);
 RT_INTERFACE!{interface IMobileBroadbandPinOperationResult(IMobileBroadbandPinOperationResultVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandPinOperationResult] {
     fn get_IsSuccessful(&self, out: *mut bool) -> HRESULT,
@@ -4441,11 +4441,11 @@ impl IMobileBroadbandPinOperationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandPinOperationResult: IMobileBroadbandPinOperationResult}
-RT_ENUM! { enum MobileBroadbandPinType: i32 {
+RT_CLASS!{class MobileBroadbandPinOperationResult: IMobileBroadbandPinOperationResult ["Windows.Networking.NetworkOperators.MobileBroadbandPinOperationResult"]}
+RT_ENUM! { enum MobileBroadbandPinType: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandPinType"] {
     None (MobileBroadbandPinType_None) = 0, Custom (MobileBroadbandPinType_Custom) = 1, Pin1 (MobileBroadbandPinType_Pin1) = 2, Pin2 (MobileBroadbandPinType_Pin2) = 3, SimPin (MobileBroadbandPinType_SimPin) = 4, FirstSimPin (MobileBroadbandPinType_FirstSimPin) = 5, NetworkPin (MobileBroadbandPinType_NetworkPin) = 6, NetworkSubsetPin (MobileBroadbandPinType_NetworkSubsetPin) = 7, ServiceProviderPin (MobileBroadbandPinType_ServiceProviderPin) = 8, CorporatePin (MobileBroadbandPinType_CorporatePin) = 9, SubsidyLock (MobileBroadbandPinType_SubsidyLock) = 10,
 }}
-RT_ENUM! { enum MobileBroadbandRadioState: i32 {
+RT_ENUM! { enum MobileBroadbandRadioState: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandRadioState"] {
     Off (MobileBroadbandRadioState_Off) = 0, On (MobileBroadbandRadioState_On) = 1,
 }}
 DEFINE_IID!(IID_IMobileBroadbandRadioStateChange, 2958337377, 38963, 19181, 151, 23, 67, 72, 178, 26, 36, 179);
@@ -4465,7 +4465,7 @@ impl IMobileBroadbandRadioStateChange {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandRadioStateChange: IMobileBroadbandRadioStateChange}
+RT_CLASS!{class MobileBroadbandRadioStateChange: IMobileBroadbandRadioStateChange ["Windows.Networking.NetworkOperators.MobileBroadbandRadioStateChange"]}
 DEFINE_IID!(IID_IMobileBroadbandRadioStateChangeTriggerDetails, 1898977998, 2364, 17094, 176, 219, 173, 31, 117, 166, 84, 69);
 RT_INTERFACE!{interface IMobileBroadbandRadioStateChangeTriggerDetails(IMobileBroadbandRadioStateChangeTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandRadioStateChangeTriggerDetails] {
     fn get_RadioStateChanges(&self, out: *mut *mut foundation::collections::IVectorView<MobileBroadbandRadioStateChange>) -> HRESULT
@@ -4477,7 +4477,7 @@ impl IMobileBroadbandRadioStateChangeTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandRadioStateChangeTriggerDetails: IMobileBroadbandRadioStateChangeTriggerDetails}
+RT_CLASS!{class MobileBroadbandRadioStateChangeTriggerDetails: IMobileBroadbandRadioStateChangeTriggerDetails ["Windows.Networking.NetworkOperators.MobileBroadbandRadioStateChangeTriggerDetails"]}
 DEFINE_IID!(IID_IMobileBroadbandSarManager, 3853674547, 38526, 16585, 164, 133, 25, 192, 221, 32, 158, 34);
 RT_INTERFACE!{interface IMobileBroadbandSarManager(IMobileBroadbandSarManagerVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandSarManager] {
     fn get_IsBackoffEnabled(&self, out: *mut bool) -> HRESULT,
@@ -4570,7 +4570,7 @@ impl IMobileBroadbandSarManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandSarManager: IMobileBroadbandSarManager}
+RT_CLASS!{class MobileBroadbandSarManager: IMobileBroadbandSarManager ["Windows.Networking.NetworkOperators.MobileBroadbandSarManager"]}
 DEFINE_IID!(IID_IMobileBroadbandTransmissionStateChangedEventArgs, 1630419061, 1034, 20377, 164, 249, 97, 215, 195, 45, 161, 41);
 RT_INTERFACE!{interface IMobileBroadbandTransmissionStateChangedEventArgs(IMobileBroadbandTransmissionStateChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandTransmissionStateChangedEventArgs] {
     fn get_IsTransmitting(&self, out: *mut bool) -> HRESULT
@@ -4582,7 +4582,7 @@ impl IMobileBroadbandTransmissionStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandTransmissionStateChangedEventArgs: IMobileBroadbandTransmissionStateChangedEventArgs}
+RT_CLASS!{class MobileBroadbandTransmissionStateChangedEventArgs: IMobileBroadbandTransmissionStateChangedEventArgs ["Windows.Networking.NetworkOperators.MobileBroadbandTransmissionStateChangedEventArgs"]}
 DEFINE_IID!(IID_IMobileBroadbandUicc, 3862230673, 21082, 19682, 143, 206, 170, 65, 98, 87, 145, 84);
 RT_INTERFACE!{interface IMobileBroadbandUicc(IMobileBroadbandUiccVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandUicc] {
     fn get_SimIccId(&self, out: *mut HSTRING) -> HRESULT,
@@ -4600,7 +4600,7 @@ impl IMobileBroadbandUicc {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandUicc: IMobileBroadbandUicc}
+RT_CLASS!{class MobileBroadbandUicc: IMobileBroadbandUicc ["Windows.Networking.NetworkOperators.MobileBroadbandUicc"]}
 DEFINE_IID!(IID_IMobileBroadbandUiccApp, 1293354326, 39073, 17373, 178, 236, 80, 201, 12, 242, 72, 223);
 RT_INTERFACE!{interface IMobileBroadbandUiccApp(IMobileBroadbandUiccAppVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandUiccApp] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -4631,8 +4631,8 @@ impl IMobileBroadbandUiccApp {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandUiccApp: IMobileBroadbandUiccApp}
-RT_ENUM! { enum MobileBroadbandUiccAppOperationStatus: i32 {
+RT_CLASS!{class MobileBroadbandUiccApp: IMobileBroadbandUiccApp ["Windows.Networking.NetworkOperators.MobileBroadbandUiccApp"]}
+RT_ENUM! { enum MobileBroadbandUiccAppOperationStatus: i32 ["Windows.Networking.NetworkOperators.MobileBroadbandUiccAppOperationStatus"] {
     Success (MobileBroadbandUiccAppOperationStatus_Success) = 0, InvalidUiccFilePath (MobileBroadbandUiccAppOperationStatus_InvalidUiccFilePath) = 1, AccessConditionNotHeld (MobileBroadbandUiccAppOperationStatus_AccessConditionNotHeld) = 2, UiccBusy (MobileBroadbandUiccAppOperationStatus_UiccBusy) = 3,
 }}
 DEFINE_IID!(IID_IMobileBroadbandUiccAppReadRecordResult, 1690915461, 13710, 18373, 130, 73, 105, 95, 56, 59, 43, 219);
@@ -4652,7 +4652,7 @@ impl IMobileBroadbandUiccAppReadRecordResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandUiccAppReadRecordResult: IMobileBroadbandUiccAppReadRecordResult}
+RT_CLASS!{class MobileBroadbandUiccAppReadRecordResult: IMobileBroadbandUiccAppReadRecordResult ["Windows.Networking.NetworkOperators.MobileBroadbandUiccAppReadRecordResult"]}
 DEFINE_IID!(IID_IMobileBroadbandUiccAppRecordDetailsResult, 3642320943, 48660, 18740, 152, 29, 47, 87, 185, 237, 131, 230);
 RT_INTERFACE!{interface IMobileBroadbandUiccAppRecordDetailsResult(IMobileBroadbandUiccAppRecordDetailsResultVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandUiccAppRecordDetailsResult] {
     fn get_Status(&self, out: *mut MobileBroadbandUiccAppOperationStatus) -> HRESULT,
@@ -4694,7 +4694,7 @@ impl IMobileBroadbandUiccAppRecordDetailsResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandUiccAppRecordDetailsResult: IMobileBroadbandUiccAppRecordDetailsResult}
+RT_CLASS!{class MobileBroadbandUiccAppRecordDetailsResult: IMobileBroadbandUiccAppRecordDetailsResult ["Windows.Networking.NetworkOperators.MobileBroadbandUiccAppRecordDetailsResult"]}
 DEFINE_IID!(IID_IMobileBroadbandUiccAppsResult, 1950953707, 33111, 19009, 132, 148, 107, 245, 76, 155, 29, 43);
 RT_INTERFACE!{interface IMobileBroadbandUiccAppsResult(IMobileBroadbandUiccAppsResultVtbl): IInspectable(IInspectableVtbl) [IID_IMobileBroadbandUiccAppsResult] {
     fn get_Status(&self, out: *mut MobileBroadbandUiccAppOperationStatus) -> HRESULT,
@@ -4712,11 +4712,11 @@ impl IMobileBroadbandUiccAppsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MobileBroadbandUiccAppsResult: IMobileBroadbandUiccAppsResult}
-RT_ENUM! { enum NetworkDeviceStatus: i32 {
+RT_CLASS!{class MobileBroadbandUiccAppsResult: IMobileBroadbandUiccAppsResult ["Windows.Networking.NetworkOperators.MobileBroadbandUiccAppsResult"]}
+RT_ENUM! { enum NetworkDeviceStatus: i32 ["Windows.Networking.NetworkOperators.NetworkDeviceStatus"] {
     DeviceNotReady (NetworkDeviceStatus_DeviceNotReady) = 0, DeviceReady (NetworkDeviceStatus_DeviceReady) = 1, SimNotInserted (NetworkDeviceStatus_SimNotInserted) = 2, BadSim (NetworkDeviceStatus_BadSim) = 3, DeviceHardwareFailure (NetworkDeviceStatus_DeviceHardwareFailure) = 4, AccountNotActivated (NetworkDeviceStatus_AccountNotActivated) = 5, DeviceLocked (NetworkDeviceStatus_DeviceLocked) = 6, DeviceBlocked (NetworkDeviceStatus_DeviceBlocked) = 7,
 }}
-RT_ENUM! { enum NetworkOperatorDataUsageNotificationKind: i32 {
+RT_ENUM! { enum NetworkOperatorDataUsageNotificationKind: i32 ["Windows.Networking.NetworkOperators.NetworkOperatorDataUsageNotificationKind"] {
     DataUsageProgress (NetworkOperatorDataUsageNotificationKind_DataUsageProgress) = 0,
 }}
 DEFINE_IID!(IID_INetworkOperatorDataUsageTriggerDetails, 1357058669, 42085, 20203, 147, 23, 40, 161, 103, 99, 12, 234);
@@ -4730,8 +4730,8 @@ impl INetworkOperatorDataUsageTriggerDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorDataUsageTriggerDetails: INetworkOperatorDataUsageTriggerDetails}
-RT_ENUM! { enum NetworkOperatorEventMessageType: i32 {
+RT_CLASS!{class NetworkOperatorDataUsageTriggerDetails: INetworkOperatorDataUsageTriggerDetails ["Windows.Networking.NetworkOperators.NetworkOperatorDataUsageTriggerDetails"]}
+RT_ENUM! { enum NetworkOperatorEventMessageType: i32 ["Windows.Networking.NetworkOperators.NetworkOperatorEventMessageType"] {
     Gsm (NetworkOperatorEventMessageType_Gsm) = 0, Cdma (NetworkOperatorEventMessageType_Cdma) = 1, Ussd (NetworkOperatorEventMessageType_Ussd) = 2, DataPlanThresholdReached (NetworkOperatorEventMessageType_DataPlanThresholdReached) = 3, DataPlanReset (NetworkOperatorEventMessageType_DataPlanReset) = 4, DataPlanDeleted (NetworkOperatorEventMessageType_DataPlanDeleted) = 5, ProfileConnected (NetworkOperatorEventMessageType_ProfileConnected) = 6, ProfileDisconnected (NetworkOperatorEventMessageType_ProfileDisconnected) = 7, RegisteredRoaming (NetworkOperatorEventMessageType_RegisteredRoaming) = 8, RegisteredHome (NetworkOperatorEventMessageType_RegisteredHome) = 9, TetheringEntitlementCheck (NetworkOperatorEventMessageType_TetheringEntitlementCheck) = 10, TetheringOperationalStateChanged (NetworkOperatorEventMessageType_TetheringOperationalStateChanged) = 11, TetheringNumberOfClientsChanged (NetworkOperatorEventMessageType_TetheringNumberOfClientsChanged) = 12,
 }}
 DEFINE_IID!(IID_INetworkOperatorNotificationEventDetails, 3160975825, 33505, 17544, 159, 44, 18, 118, 194, 70, 143, 172);
@@ -4775,7 +4775,7 @@ impl INetworkOperatorNotificationEventDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorNotificationEventDetails: INetworkOperatorNotificationEventDetails}
+RT_CLASS!{class NetworkOperatorNotificationEventDetails: INetworkOperatorNotificationEventDetails ["Windows.Networking.NetworkOperators.NetworkOperatorNotificationEventDetails"]}
 DEFINE_IID!(IID_INetworkOperatorTetheringAccessPointConfiguration, 197919364, 16686, 16445, 172, 198, 183, 87, 227, 71, 116, 164);
 RT_INTERFACE!{interface INetworkOperatorTetheringAccessPointConfiguration(INetworkOperatorTetheringAccessPointConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorTetheringAccessPointConfiguration] {
     fn get_Ssid(&self, out: *mut HSTRING) -> HRESULT,
@@ -4803,7 +4803,7 @@ impl INetworkOperatorTetheringAccessPointConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorTetheringAccessPointConfiguration: INetworkOperatorTetheringAccessPointConfiguration}
+RT_CLASS!{class NetworkOperatorTetheringAccessPointConfiguration: INetworkOperatorTetheringAccessPointConfiguration ["Windows.Networking.NetworkOperators.NetworkOperatorTetheringAccessPointConfiguration"]}
 impl RtActivatable<IActivationFactory> for NetworkOperatorTetheringAccessPointConfiguration {}
 DEFINE_CLSID!(NetworkOperatorTetheringAccessPointConfiguration(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,115,46,78,101,116,119,111,114,107,79,112,101,114,97,116,111,114,84,101,116,104,101,114,105,110,103,65,99,99,101,115,115,80,111,105,110,116,67,111,110,102,105,103,117,114,97,116,105,111,110,0]) [CLSID_NetworkOperatorTetheringAccessPointConfiguration]);
 DEFINE_IID!(IID_INetworkOperatorTetheringClient, 1889346892, 22879, 18503, 187, 48, 100, 105, 53, 84, 41, 24);
@@ -4823,7 +4823,7 @@ impl INetworkOperatorTetheringClient {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorTetheringClient: INetworkOperatorTetheringClient}
+RT_CLASS!{class NetworkOperatorTetheringClient: INetworkOperatorTetheringClient ["Windows.Networking.NetworkOperators.NetworkOperatorTetheringClient"]}
 DEFINE_IID!(IID_INetworkOperatorTetheringClientManager, 2444312598, 36298, 16933, 187, 237, 238, 248, 184, 215, 24, 215);
 RT_INTERFACE!{interface INetworkOperatorTetheringClientManager(INetworkOperatorTetheringClientManagerVtbl): IInspectable(IInspectableVtbl) [IID_INetworkOperatorTetheringClientManager] {
     fn GetTetheringClients(&self, out: *mut *mut foundation::collections::IVectorView<NetworkOperatorTetheringClient>) -> HRESULT
@@ -4892,7 +4892,7 @@ impl INetworkOperatorTetheringManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorTetheringManager: INetworkOperatorTetheringManager}
+RT_CLASS!{class NetworkOperatorTetheringManager: INetworkOperatorTetheringManager ["Windows.Networking.NetworkOperators.NetworkOperatorTetheringManager"]}
 impl RtActivatable<INetworkOperatorTetheringManagerStatics> for NetworkOperatorTetheringManager {}
 impl RtActivatable<INetworkOperatorTetheringManagerStatics2> for NetworkOperatorTetheringManager {}
 impl RtActivatable<INetworkOperatorTetheringManagerStatics3> for NetworkOperatorTetheringManager {}
@@ -4976,14 +4976,14 @@ impl INetworkOperatorTetheringOperationResult {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NetworkOperatorTetheringOperationResult: INetworkOperatorTetheringOperationResult}
-RT_ENUM! { enum NetworkRegistrationState: i32 {
+RT_CLASS!{class NetworkOperatorTetheringOperationResult: INetworkOperatorTetheringOperationResult ["Windows.Networking.NetworkOperators.NetworkOperatorTetheringOperationResult"]}
+RT_ENUM! { enum NetworkRegistrationState: i32 ["Windows.Networking.NetworkOperators.NetworkRegistrationState"] {
     None (NetworkRegistrationState_None) = 0, Deregistered (NetworkRegistrationState_Deregistered) = 1, Searching (NetworkRegistrationState_Searching) = 2, Home (NetworkRegistrationState_Home) = 3, Roaming (NetworkRegistrationState_Roaming) = 4, Partner (NetworkRegistrationState_Partner) = 5, Denied (NetworkRegistrationState_Denied) = 6,
 }}
-RT_ENUM! { enum ProfileMediaType: i32 {
+RT_ENUM! { enum ProfileMediaType: i32 ["Windows.Networking.NetworkOperators.ProfileMediaType"] {
     Wlan (ProfileMediaType_Wlan) = 0, Wwan (ProfileMediaType_Wwan) = 1,
 }}
-RT_STRUCT! { struct ProfileUsage {
+RT_STRUCT! { struct ProfileUsage ["Windows.Networking.NetworkOperators.ProfileUsage"] {
     UsageInMegabytes: u32, LastSyncTime: foundation::DateTime,
 }}
 DEFINE_IID!(IID_IProvisionedProfile, 561447136, 33282, 4575, 173, 185, 244, 206, 70, 45, 145, 55);
@@ -5001,7 +5001,7 @@ impl IProvisionedProfile {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProvisionedProfile: IProvisionedProfile}
+RT_CLASS!{class ProvisionedProfile: IProvisionedProfile ["Windows.Networking.NetworkOperators.ProvisionedProfile"]}
 DEFINE_IID!(IID_IProvisionFromXmlDocumentResults, 561447136, 33283, 4575, 173, 185, 244, 206, 70, 45, 145, 55);
 RT_INTERFACE!{interface IProvisionFromXmlDocumentResults(IProvisionFromXmlDocumentResultsVtbl): IInspectable(IInspectableVtbl) [IID_IProvisionFromXmlDocumentResults] {
     fn get_AllElementsProvisioned(&self, out: *mut bool) -> HRESULT,
@@ -5019,7 +5019,7 @@ impl IProvisionFromXmlDocumentResults {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProvisionFromXmlDocumentResults: IProvisionFromXmlDocumentResults}
+RT_CLASS!{class ProvisionFromXmlDocumentResults: IProvisionFromXmlDocumentResults ["Windows.Networking.NetworkOperators.ProvisionFromXmlDocumentResults"]}
 DEFINE_IID!(IID_IProvisioningAgent, 561447136, 33281, 4575, 173, 185, 244, 206, 70, 45, 145, 55);
 RT_INTERFACE!{interface IProvisioningAgent(IProvisioningAgentVtbl): IInspectable(IInspectableVtbl) [IID_IProvisioningAgent] {
     fn ProvisionFromXmlDocumentAsync(&self, provisioningXmlDocument: HSTRING, out: *mut *mut foundation::IAsyncOperation<ProvisionFromXmlDocumentResults>) -> HRESULT,
@@ -5037,7 +5037,7 @@ impl IProvisioningAgent {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProvisioningAgent: IProvisioningAgent}
+RT_CLASS!{class ProvisioningAgent: IProvisioningAgent ["Windows.Networking.NetworkOperators.ProvisioningAgent"]}
 impl RtActivatable<IProvisioningAgentStaticMethods> for ProvisioningAgent {}
 impl RtActivatable<IActivationFactory> for ProvisioningAgent {}
 impl ProvisioningAgent {
@@ -5057,7 +5057,7 @@ impl IProvisioningAgentStaticMethods {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TetheringCapability: i32 {
+RT_ENUM! { enum TetheringCapability: i32 ["Windows.Networking.NetworkOperators.TetheringCapability"] {
     Enabled (TetheringCapability_Enabled) = 0, DisabledByGroupPolicy (TetheringCapability_DisabledByGroupPolicy) = 1, DisabledByHardwareLimitation (TetheringCapability_DisabledByHardwareLimitation) = 2, DisabledByOperator (TetheringCapability_DisabledByOperator) = 3, DisabledBySku (TetheringCapability_DisabledBySku) = 4, DisabledByRequiredAppNotInstalled (TetheringCapability_DisabledByRequiredAppNotInstalled) = 5, DisabledDueToUnknownCause (TetheringCapability_DisabledDueToUnknownCause) = 6, DisabledBySystemCapability (TetheringCapability_DisabledBySystemCapability) = 7,
 }}
 DEFINE_IID!(IID_ITetheringEntitlementCheckTriggerDetails, 63331997, 22822, 16883, 169, 78, 181, 9, 38, 252, 66, 27);
@@ -5081,20 +5081,20 @@ impl ITetheringEntitlementCheckTriggerDetails {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TetheringEntitlementCheckTriggerDetails: ITetheringEntitlementCheckTriggerDetails}
-RT_ENUM! { enum TetheringOperationalState: i32 {
+RT_CLASS!{class TetheringEntitlementCheckTriggerDetails: ITetheringEntitlementCheckTriggerDetails ["Windows.Networking.NetworkOperators.TetheringEntitlementCheckTriggerDetails"]}
+RT_ENUM! { enum TetheringOperationalState: i32 ["Windows.Networking.NetworkOperators.TetheringOperationalState"] {
     Unknown (TetheringOperationalState_Unknown) = 0, On (TetheringOperationalState_On) = 1, Off (TetheringOperationalState_Off) = 2, InTransition (TetheringOperationalState_InTransition) = 3,
 }}
-RT_ENUM! { enum TetheringOperationStatus: i32 {
+RT_ENUM! { enum TetheringOperationStatus: i32 ["Windows.Networking.NetworkOperators.TetheringOperationStatus"] {
     Success (TetheringOperationStatus_Success) = 0, Unknown (TetheringOperationStatus_Unknown) = 1, MobileBroadbandDeviceOff (TetheringOperationStatus_MobileBroadbandDeviceOff) = 2, WiFiDeviceOff (TetheringOperationStatus_WiFiDeviceOff) = 3, EntitlementCheckTimeout (TetheringOperationStatus_EntitlementCheckTimeout) = 4, EntitlementCheckFailure (TetheringOperationStatus_EntitlementCheckFailure) = 5, OperationInProgress (TetheringOperationStatus_OperationInProgress) = 6, BluetoothDeviceOff (TetheringOperationStatus_BluetoothDeviceOff) = 7, NetworkLimitedConnectivity (TetheringOperationStatus_NetworkLimitedConnectivity) = 8,
 }}
-RT_ENUM! { enum UiccAccessCondition: i32 {
+RT_ENUM! { enum UiccAccessCondition: i32 ["Windows.Networking.NetworkOperators.UiccAccessCondition"] {
     AlwaysAllowed (UiccAccessCondition_AlwaysAllowed) = 0, Pin1 (UiccAccessCondition_Pin1) = 1, Pin2 (UiccAccessCondition_Pin2) = 2, Pin3 (UiccAccessCondition_Pin3) = 3, Pin4 (UiccAccessCondition_Pin4) = 4, Administrative5 (UiccAccessCondition_Administrative5) = 5, Administrative6 (UiccAccessCondition_Administrative6) = 6, NeverAllowed (UiccAccessCondition_NeverAllowed) = 7,
 }}
-RT_ENUM! { enum UiccAppKind: i32 {
+RT_ENUM! { enum UiccAppKind: i32 ["Windows.Networking.NetworkOperators.UiccAppKind"] {
     Unknown (UiccAppKind_Unknown) = 0, MF (UiccAppKind_MF) = 1, MFSim (UiccAppKind_MFSim) = 2, MFRuim (UiccAppKind_MFRuim) = 3, USim (UiccAppKind_USim) = 4, CSim (UiccAppKind_CSim) = 5, ISim (UiccAppKind_ISim) = 6,
 }}
-RT_ENUM! { enum UiccAppRecordKind: i32 {
+RT_ENUM! { enum UiccAppRecordKind: i32 ["Windows.Networking.NetworkOperators.UiccAppRecordKind"] {
     Unknown (UiccAppRecordKind_Unknown) = 0, Transparent (UiccAppRecordKind_Transparent) = 1, RecordOriented (UiccAppRecordKind_RecordOriented) = 2,
 }}
 DEFINE_IID!(IID_IUssdMessage, 798674818, 8196, 19805, 191, 129, 42, 186, 27, 75, 228, 168);
@@ -5135,7 +5135,7 @@ impl IUssdMessage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UssdMessage: IUssdMessage}
+RT_CLASS!{class UssdMessage: IUssdMessage ["Windows.Networking.NetworkOperators.UssdMessage"]}
 impl RtActivatable<IUssdMessageFactory> for UssdMessage {}
 impl UssdMessage {
     #[inline] pub fn create_message(messageText: &HStringArg) -> Result<ComPtr<UssdMessage>> {
@@ -5171,8 +5171,8 @@ impl IUssdReply {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UssdReply: IUssdReply}
-RT_ENUM! { enum UssdResultCode: i32 {
+RT_CLASS!{class UssdReply: IUssdReply ["Windows.Networking.NetworkOperators.UssdReply"]}
+RT_ENUM! { enum UssdResultCode: i32 ["Windows.Networking.NetworkOperators.UssdResultCode"] {
     NoActionRequired (UssdResultCode_NoActionRequired) = 0, ActionRequired (UssdResultCode_ActionRequired) = 1, Terminated (UssdResultCode_Terminated) = 2, OtherLocalClient (UssdResultCode_OtherLocalClient) = 3, OperationNotSupported (UssdResultCode_OperationNotSupported) = 4, NetworkTimeout (UssdResultCode_NetworkTimeout) = 5,
 }}
 DEFINE_IID!(IID_IUssdSession, 798674818, 8194, 19805, 191, 129, 42, 186, 27, 75, 228, 168);
@@ -5191,7 +5191,7 @@ impl IUssdSession {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UssdSession: IUssdSession}
+RT_CLASS!{class UssdSession: IUssdSession ["Windows.Networking.NetworkOperators.UssdSession"]}
 impl RtActivatable<IUssdSessionStatics> for UssdSession {}
 impl UssdSession {
     #[inline] pub fn create_from_network_account_id(networkAccountId: &HStringArg) -> Result<Option<ComPtr<UssdSession>>> {
@@ -5233,7 +5233,7 @@ impl IConnectionRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ConnectionRequestedEventArgs: IConnectionRequestedEventArgs}
+RT_CLASS!{class ConnectionRequestedEventArgs: IConnectionRequestedEventArgs ["Windows.Networking.Proximity.ConnectionRequestedEventArgs"]}
 DEFINE_IID!(IID_DeviceArrivedEventHandler, 4020886121, 63201, 18889, 164, 158, 142, 15, 197, 143, 185, 17);
 RT_DELEGATE!{delegate DeviceArrivedEventHandler(DeviceArrivedEventHandlerVtbl, DeviceArrivedEventHandlerImpl) [IID_DeviceArrivedEventHandler] {
     fn Invoke(&self, sender: *mut ProximityDevice) -> HRESULT
@@ -5274,7 +5274,7 @@ impl MessageTransmittedHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PeerDiscoveryTypes: u32 {
+RT_ENUM! { enum PeerDiscoveryTypes: u32 ["Windows.Networking.Proximity.PeerDiscoveryTypes"] {
     None (PeerDiscoveryTypes_None) = 0, Browse (PeerDiscoveryTypes_Browse) = 1, Triggered (PeerDiscoveryTypes_Triggered) = 2,
 }}
 RT_CLASS!{static class PeerFinder}
@@ -5511,7 +5511,7 @@ impl IPeerInformation {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PeerInformation: IPeerInformation}
+RT_CLASS!{class PeerInformation: IPeerInformation ["Windows.Networking.Proximity.PeerInformation"]}
 DEFINE_IID!(IID_IPeerInformation3, 2987352362, 56272, 16632, 149, 189, 45, 66, 9, 199, 131, 111);
 RT_INTERFACE!{interface IPeerInformation3(IPeerInformation3Vtbl): IInspectable(IInspectableVtbl) [IID_IPeerInformation3] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -5546,7 +5546,7 @@ impl IPeerInformationWithHostAndService {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PeerRole: i32 {
+RT_ENUM! { enum PeerRole: i32 ["Windows.Networking.Proximity.PeerRole"] {
     Peer (PeerRole_Peer) = 0, Host (PeerRole_Host) = 1, Client (PeerRole_Client) = 2,
 }}
 DEFINE_IID!(IID_IPeerWatcher, 1022239224, 12198, 18041, 150, 145, 3, 201, 74, 66, 15, 52);
@@ -5625,8 +5625,8 @@ impl IPeerWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PeerWatcher: IPeerWatcher}
-RT_ENUM! { enum PeerWatcherStatus: i32 {
+RT_CLASS!{class PeerWatcher: IPeerWatcher ["Windows.Networking.Proximity.PeerWatcher"]}
+RT_ENUM! { enum PeerWatcherStatus: i32 ["Windows.Networking.Proximity.PeerWatcherStatus"] {
     Created (PeerWatcherStatus_Created) = 0, Started (PeerWatcherStatus_Started) = 1, EnumerationCompleted (PeerWatcherStatus_EnumerationCompleted) = 2, Stopping (PeerWatcherStatus_Stopping) = 3, Stopped (PeerWatcherStatus_Stopped) = 4, Aborted (PeerWatcherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IProximityDevice, 4020806994, 63201, 17193, 160, 252, 171, 107, 15, 210, 130, 98);
@@ -5728,7 +5728,7 @@ impl IProximityDevice {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProximityDevice: IProximityDevice}
+RT_CLASS!{class ProximityDevice: IProximityDevice ["Windows.Networking.Proximity.ProximityDevice"]}
 impl RtActivatable<IProximityDeviceStatics> for ProximityDevice {}
 impl ProximityDevice {
     #[inline] pub fn get_device_selector() -> Result<HString> {
@@ -5795,7 +5795,7 @@ impl IProximityMessage {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProximityMessage: IProximityMessage}
+RT_CLASS!{class ProximityMessage: IProximityMessage ["Windows.Networking.Proximity.ProximityMessage"]}
 DEFINE_IID!(IID_ITriggeredConnectionStateChangedEventArgs, 3332866221, 63201, 19796, 150, 226, 51, 246, 32, 188, 168, 138);
 RT_INTERFACE!{interface ITriggeredConnectionStateChangedEventArgs(ITriggeredConnectionStateChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITriggeredConnectionStateChangedEventArgs] {
     fn get_State(&self, out: *mut TriggeredConnectState) -> HRESULT,
@@ -5819,8 +5819,8 @@ impl ITriggeredConnectionStateChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TriggeredConnectionStateChangedEventArgs: ITriggeredConnectionStateChangedEventArgs}
-RT_ENUM! { enum TriggeredConnectState: i32 {
+RT_CLASS!{class TriggeredConnectionStateChangedEventArgs: ITriggeredConnectionStateChangedEventArgs ["Windows.Networking.Proximity.TriggeredConnectionStateChangedEventArgs"]}
+RT_ENUM! { enum TriggeredConnectState: i32 ["Windows.Networking.Proximity.TriggeredConnectState"] {
     PeerFound (TriggeredConnectState_PeerFound) = 0, Listening (TriggeredConnectState_Listening) = 1, Connecting (TriggeredConnectState_Connecting) = 2, Completed (TriggeredConnectState_Completed) = 3, Canceled (TriggeredConnectState_Canceled) = 4, Failed (TriggeredConnectState_Failed) = 5,
 }}
 } // Windows.Networking.Proximity
@@ -5859,7 +5859,7 @@ impl IPushNotificationChannel {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PushNotificationChannel: IPushNotificationChannel}
+RT_CLASS!{class PushNotificationChannel: IPushNotificationChannel ["Windows.Networking.PushNotifications.PushNotificationChannel"]}
 RT_CLASS!{static class PushNotificationChannelManager}
 impl RtActivatable<IPushNotificationChannelManagerStatics> for PushNotificationChannelManager {}
 impl RtActivatable<IPushNotificationChannelManagerStatics2> for PushNotificationChannelManager {}
@@ -5911,7 +5911,7 @@ impl IPushNotificationChannelManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PushNotificationChannelManagerForUser: IPushNotificationChannelManagerForUser}
+RT_CLASS!{class PushNotificationChannelManagerForUser: IPushNotificationChannelManagerForUser ["Windows.Networking.PushNotifications.PushNotificationChannelManagerForUser"]}
 DEFINE_IID!(IID_IPushNotificationChannelManagerForUser2, 3280668266, 31937, 19884, 135, 253, 190, 110, 146, 4, 20, 164);
 RT_INTERFACE!{interface IPushNotificationChannelManagerForUser2(IPushNotificationChannelManagerForUser2Vtbl): IInspectable(IInspectableVtbl) [IID_IPushNotificationChannelManagerForUser2] {
     #[cfg(feature="windows-storage")] fn CreateRawPushNotificationChannelWithAlternateKeyForApplicationAsync(&self, appServerKey: *mut super::super::storage::streams::IBuffer, channelId: HSTRING, out: *mut *mut foundation::IAsyncOperation<PushNotificationChannel>) -> HRESULT,
@@ -6023,8 +6023,8 @@ impl IPushNotificationReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PushNotificationReceivedEventArgs: IPushNotificationReceivedEventArgs}
-RT_ENUM! { enum PushNotificationType: i32 {
+RT_CLASS!{class PushNotificationReceivedEventArgs: IPushNotificationReceivedEventArgs ["Windows.Networking.PushNotifications.PushNotificationReceivedEventArgs"]}
+RT_ENUM! { enum PushNotificationType: i32 ["Windows.Networking.PushNotifications.PushNotificationType"] {
     Toast (PushNotificationType_Toast) = 0, Tile (PushNotificationType_Tile) = 1, Badge (PushNotificationType_Badge) = 2, Raw (PushNotificationType_Raw) = 3, TileFlyout (PushNotificationType_TileFlyout) = 4,
 }}
 DEFINE_IID!(IID_IRawNotification, 438465153, 15225, 17068, 153, 99, 34, 171, 0, 212, 240, 183);
@@ -6038,7 +6038,7 @@ impl IRawNotification {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RawNotification: IRawNotification}
+RT_CLASS!{class RawNotification: IRawNotification ["Windows.Networking.PushNotifications.RawNotification"]}
 DEFINE_IID!(IID_IRawNotification2, 3872444185, 3183, 19677, 148, 36, 238, 197, 190, 1, 77, 38);
 RT_INTERFACE!{interface IRawNotification2(IRawNotification2Vtbl): IInspectable(IInspectableVtbl) [IID_IRawNotification2] {
     fn get_Headers(&self, out: *mut *mut foundation::collections::IMapView<HString, HString>) -> HRESULT,
@@ -6083,10 +6083,10 @@ impl IDnssdRegistrationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DnssdRegistrationResult: IDnssdRegistrationResult}
+RT_CLASS!{class DnssdRegistrationResult: IDnssdRegistrationResult ["Windows.Networking.ServiceDiscovery.Dnssd.DnssdRegistrationResult"]}
 impl RtActivatable<IActivationFactory> for DnssdRegistrationResult {}
 DEFINE_CLSID!(DnssdRegistrationResult(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,101,114,118,105,99,101,68,105,115,99,111,118,101,114,121,46,68,110,115,115,100,46,68,110,115,115,100,82,101,103,105,115,116,114,97,116,105,111,110,82,101,115,117,108,116,0]) [CLSID_DnssdRegistrationResult]);
-RT_ENUM! { enum DnssdRegistrationStatus: i32 {
+RT_ENUM! { enum DnssdRegistrationStatus: i32 ["Windows.Networking.ServiceDiscovery.Dnssd.DnssdRegistrationStatus"] {
     Success (DnssdRegistrationStatus_Success) = 0, InvalidServiceName (DnssdRegistrationStatus_InvalidServiceName) = 1, ServerError (DnssdRegistrationStatus_ServerError) = 2, SecurityError (DnssdRegistrationStatus_SecurityError) = 3,
 }}
 DEFINE_IID!(IID_IDnssdServiceInstance, 3796294526, 39077, 19617, 185, 228, 194, 83, 211, 60, 53, 255);
@@ -6179,7 +6179,7 @@ impl IDnssdServiceInstance {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DnssdServiceInstance: IDnssdServiceInstance}
+RT_CLASS!{class DnssdServiceInstance: IDnssdServiceInstance ["Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceInstance"]}
 impl RtActivatable<IDnssdServiceInstanceFactory> for DnssdServiceInstance {}
 impl DnssdServiceInstance {
     #[inline] pub fn create(dnssdServiceInstanceName: &HStringArg, hostName: &super::super::HostName, port: u16) -> Result<ComPtr<DnssdServiceInstance>> {
@@ -6187,7 +6187,7 @@ impl DnssdServiceInstance {
     }
 }
 DEFINE_CLSID!(DnssdServiceInstance(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,101,114,118,105,99,101,68,105,115,99,111,118,101,114,121,46,68,110,115,115,100,46,68,110,115,115,100,83,101,114,118,105,99,101,73,110,115,116,97,110,99,101,0]) [CLSID_DnssdServiceInstance]);
-RT_CLASS!{class DnssdServiceInstanceCollection: foundation::collections::IVectorView<DnssdServiceInstance>}
+RT_CLASS!{class DnssdServiceInstanceCollection: foundation::collections::IVectorView<DnssdServiceInstance> ["Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceInstanceCollection"]}
 DEFINE_IID!(IID_IDnssdServiceInstanceFactory, 1823498657, 50296, 17201, 150, 132, 74, 242, 24, 108, 10, 43);
 RT_INTERFACE!{static interface IDnssdServiceInstanceFactory(IDnssdServiceInstanceFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IDnssdServiceInstanceFactory] {
     fn Create(&self, dnssdServiceInstanceName: HSTRING, hostName: *mut super::super::HostName, port: u16, out: *mut *mut DnssdServiceInstance) -> HRESULT
@@ -6253,15 +6253,15 @@ impl IDnssdServiceWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DnssdServiceWatcher: IDnssdServiceWatcher}
-RT_ENUM! { enum DnssdServiceWatcherStatus: i32 {
+RT_CLASS!{class DnssdServiceWatcher: IDnssdServiceWatcher ["Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceWatcher"]}
+RT_ENUM! { enum DnssdServiceWatcherStatus: i32 ["Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceWatcherStatus"] {
     Created (DnssdServiceWatcherStatus_Created) = 0, Started (DnssdServiceWatcherStatus_Started) = 1, EnumerationCompleted (DnssdServiceWatcherStatus_EnumerationCompleted) = 2, Stopping (DnssdServiceWatcherStatus_Stopping) = 3, Stopped (DnssdServiceWatcherStatus_Stopped) = 4, Aborted (DnssdServiceWatcherStatus_Aborted) = 5,
 }}
 } // Windows.Networking.ServiceDiscovery.Dnssd
 } // Windows.Networking.ServiceDiscovery
 pub mod sockets { // Windows.Networking.Sockets
 use ::prelude::*;
-RT_STRUCT! { struct BandwidthStatistics {
+RT_STRUCT! { struct BandwidthStatistics ["Windows.Networking.Sockets.BandwidthStatistics"] {
     OutboundBitsPerSecond: u64, InboundBitsPerSecond: u64, OutboundBitsPerSecondInstability: u64, InboundBitsPerSecondInstability: u64, OutboundBandwidthPeaked: bool, InboundBandwidthPeaked: bool,
 }}
 DEFINE_IID!(IID_IControlChannelTrigger, 2098475431, 61078, 16616, 161, 153, 135, 3, 205, 150, 158, 195);
@@ -6333,7 +6333,7 @@ impl IControlChannelTrigger {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ControlChannelTrigger: IControlChannelTrigger}
+RT_CLASS!{class ControlChannelTrigger: IControlChannelTrigger ["Windows.Networking.Sockets.ControlChannelTrigger"]}
 impl RtActivatable<IControlChannelTriggerFactory> for ControlChannelTrigger {}
 impl ControlChannelTrigger {
     #[inline] pub fn create_control_channel_trigger(channelId: &HStringArg, serverKeepAliveIntervalInMinutes: u32) -> Result<ComPtr<ControlChannelTrigger>> {
@@ -6406,13 +6406,13 @@ impl IControlChannelTriggerResetEventDetails {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ControlChannelTriggerResetReason: i32 {
+RT_ENUM! { enum ControlChannelTriggerResetReason: i32 ["Windows.Networking.Sockets.ControlChannelTriggerResetReason"] {
     FastUserSwitched (ControlChannelTriggerResetReason_FastUserSwitched) = 0, LowPowerExit (ControlChannelTriggerResetReason_LowPowerExit) = 1, QuietHoursExit (ControlChannelTriggerResetReason_QuietHoursExit) = 2, ApplicationRestart (ControlChannelTriggerResetReason_ApplicationRestart) = 3,
 }}
-RT_ENUM! { enum ControlChannelTriggerResourceType: i32 {
+RT_ENUM! { enum ControlChannelTriggerResourceType: i32 ["Windows.Networking.Sockets.ControlChannelTriggerResourceType"] {
     RequestSoftwareSlot (ControlChannelTriggerResourceType_RequestSoftwareSlot) = 0, RequestHardwareSlot (ControlChannelTriggerResourceType_RequestHardwareSlot) = 1,
 }}
-RT_ENUM! { enum ControlChannelTriggerStatus: i32 {
+RT_ENUM! { enum ControlChannelTriggerStatus: i32 ["Windows.Networking.Sockets.ControlChannelTriggerStatus"] {
     HardwareSlotRequested (ControlChannelTriggerStatus_HardwareSlotRequested) = 0, SoftwareSlotAllocated (ControlChannelTriggerStatus_SoftwareSlotAllocated) = 1, HardwareSlotAllocated (ControlChannelTriggerStatus_HardwareSlotAllocated) = 2, PolicyError (ControlChannelTriggerStatus_PolicyError) = 3, SystemError (ControlChannelTriggerStatus_SystemError) = 4, TransportDisconnected (ControlChannelTriggerStatus_TransportDisconnected) = 5, ServiceUnavailable (ControlChannelTriggerStatus_ServiceUnavailable) = 6,
 }}
 DEFINE_IID!(IID_IDatagramSocket, 2145541051, 50108, 18039, 132, 70, 202, 40, 164, 101, 163, 175);
@@ -6493,7 +6493,7 @@ impl IDatagramSocket {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DatagramSocket: IDatagramSocket}
+RT_CLASS!{class DatagramSocket: IDatagramSocket ["Windows.Networking.Sockets.DatagramSocket"]}
 impl RtActivatable<IDatagramSocketStatics> for DatagramSocket {}
 impl RtActivatable<IActivationFactory> for DatagramSocket {}
 impl DatagramSocket {
@@ -6579,7 +6579,7 @@ impl IDatagramSocketControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DatagramSocketControl: IDatagramSocketControl}
+RT_CLASS!{class DatagramSocketControl: IDatagramSocketControl ["Windows.Networking.Sockets.DatagramSocketControl"]}
 DEFINE_IID!(IID_IDatagramSocketControl2, 871028162, 38812, 17429, 130, 161, 60, 250, 246, 70, 193, 146);
 RT_INTERFACE!{interface IDatagramSocketControl2(IDatagramSocketControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IDatagramSocketControl2] {
     fn get_InboundBufferSizeInBytes(&self, out: *mut u32) -> HRESULT,
@@ -6652,7 +6652,7 @@ impl IDatagramSocketInformation {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DatagramSocketInformation: IDatagramSocketInformation}
+RT_CLASS!{class DatagramSocketInformation: IDatagramSocketInformation ["Windows.Networking.Sockets.DatagramSocketInformation"]}
 DEFINE_IID!(IID_IDatagramSocketMessageReceivedEventArgs, 2653805730, 5906, 19684, 177, 121, 140, 101, 44, 109, 16, 126);
 RT_INTERFACE!{interface IDatagramSocketMessageReceivedEventArgs(IDatagramSocketMessageReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IDatagramSocketMessageReceivedEventArgs] {
     fn get_RemoteAddress(&self, out: *mut *mut super::HostName) -> HRESULT,
@@ -6688,7 +6688,7 @@ impl IDatagramSocketMessageReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DatagramSocketMessageReceivedEventArgs: IDatagramSocketMessageReceivedEventArgs}
+RT_CLASS!{class DatagramSocketMessageReceivedEventArgs: IDatagramSocketMessageReceivedEventArgs ["Windows.Networking.Sockets.DatagramSocketMessageReceivedEventArgs"]}
 DEFINE_IID!(IID_IDatagramSocketStatics, 3922078446, 5268, 18977, 187, 126, 133, 137, 252, 117, 29, 157);
 RT_INTERFACE!{static interface IDatagramSocketStatics(IDatagramSocketStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDatagramSocketStatics] {
     fn GetEndpointPairsAsync(&self, remoteHostName: *mut super::HostName, remoteServiceName: HSTRING, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::EndpointPair>>) -> HRESULT,
@@ -6734,7 +6734,7 @@ impl IMessageWebSocket {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MessageWebSocket: IMessageWebSocket}
+RT_CLASS!{class MessageWebSocket: IMessageWebSocket ["Windows.Networking.Sockets.MessageWebSocket"]}
 impl RtActivatable<IActivationFactory> for MessageWebSocket {}
 DEFINE_CLSID!(MessageWebSocket(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,77,101,115,115,97,103,101,87,101,98,83,111,99,107,101,116,0]) [CLSID_MessageWebSocket]);
 DEFINE_IID!(IID_IMessageWebSocket2, 3201355495, 63944, 17418, 154, 213, 115, 114, 129, 217, 116, 46);
@@ -6797,7 +6797,7 @@ impl IMessageWebSocketControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MessageWebSocketControl: IMessageWebSocketControl}
+RT_CLASS!{class MessageWebSocketControl: IMessageWebSocketControl ["Windows.Networking.Sockets.MessageWebSocketControl"]}
 DEFINE_IID!(IID_IMessageWebSocketControl2, 3809466257, 2060, 16394, 167, 18, 39, 223, 169, 231, 68, 216);
 RT_INTERFACE!{interface IMessageWebSocketControl2(IMessageWebSocketControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IMessageWebSocketControl2] {
     fn get_DesiredUnsolicitedPongInterval(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -6842,7 +6842,7 @@ impl IMessageWebSocketControl2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MessageWebSocketInformation: IWebSocketInformation}
+RT_CLASS!{class MessageWebSocketInformation: IWebSocketInformation ["Windows.Networking.Sockets.MessageWebSocketInformation"]}
 DEFINE_IID!(IID_IMessageWebSocketMessageReceivedEventArgs, 1200366252, 19531, 17133, 158, 215, 30, 249, 249, 79, 163, 213);
 RT_INTERFACE!{interface IMessageWebSocketMessageReceivedEventArgs(IMessageWebSocketMessageReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IMessageWebSocketMessageReceivedEventArgs] {
     fn get_MessageType(&self, out: *mut SocketMessageType) -> HRESULT,
@@ -6866,7 +6866,7 @@ impl IMessageWebSocketMessageReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MessageWebSocketMessageReceivedEventArgs: IMessageWebSocketMessageReceivedEventArgs}
+RT_CLASS!{class MessageWebSocketMessageReceivedEventArgs: IMessageWebSocketMessageReceivedEventArgs ["Windows.Networking.Sockets.MessageWebSocketMessageReceivedEventArgs"]}
 DEFINE_IID!(IID_IMessageWebSocketMessageReceivedEventArgs2, 2311980797, 56687, 18951, 135, 249, 249, 235, 77, 137, 216, 61);
 RT_INTERFACE!{interface IMessageWebSocketMessageReceivedEventArgs2(IMessageWebSocketMessageReceivedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IMessageWebSocketMessageReceivedEventArgs2] {
     fn get_IsMessageComplete(&self, out: *mut bool) -> HRESULT
@@ -6878,10 +6878,10 @@ impl IMessageWebSocketMessageReceivedEventArgs2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MessageWebSocketReceiveMode: i32 {
+RT_ENUM! { enum MessageWebSocketReceiveMode: i32 ["Windows.Networking.Sockets.MessageWebSocketReceiveMode"] {
     FullMessage (MessageWebSocketReceiveMode_FullMessage) = 0, PartialMessage (MessageWebSocketReceiveMode_PartialMessage) = 1,
 }}
-RT_STRUCT! { struct RoundTripTimeStatistics {
+RT_STRUCT! { struct RoundTripTimeStatistics ["Windows.Networking.Sockets.RoundTripTimeStatistics"] {
     Variance: u32, Max: u32, Min: u32, Sum: u32,
 }}
 DEFINE_IID!(IID_IServerMessageWebSocket, 3819737664, 33083, 24317, 126, 17, 174, 35, 5, 252, 119, 241);
@@ -6935,7 +6935,7 @@ impl IServerMessageWebSocket {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServerMessageWebSocket: IServerMessageWebSocket}
+RT_CLASS!{class ServerMessageWebSocket: IServerMessageWebSocket ["Windows.Networking.Sockets.ServerMessageWebSocket"]}
 DEFINE_IID!(IID_IServerMessageWebSocketControl, 1774383185, 7199, 22650, 69, 25, 33, 129, 97, 1, 146, 183);
 RT_INTERFACE!{interface IServerMessageWebSocketControl(IServerMessageWebSocketControlVtbl): IInspectable(IInspectableVtbl) [IID_IServerMessageWebSocketControl] {
     fn get_MessageType(&self, out: *mut SocketMessageType) -> HRESULT,
@@ -6952,7 +6952,7 @@ impl IServerMessageWebSocketControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServerMessageWebSocketControl: IServerMessageWebSocketControl}
+RT_CLASS!{class ServerMessageWebSocketControl: IServerMessageWebSocketControl ["Windows.Networking.Sockets.ServerMessageWebSocketControl"]}
 DEFINE_IID!(IID_IServerMessageWebSocketInformation, 4231181407, 17480, 21765, 108, 201, 9, 175, 168, 145, 95, 93);
 RT_INTERFACE!{interface IServerMessageWebSocketInformation(IServerMessageWebSocketInformationVtbl): IInspectable(IInspectableVtbl) [IID_IServerMessageWebSocketInformation] {
     fn get_BandwidthStatistics(&self, out: *mut BandwidthStatistics) -> HRESULT,
@@ -6976,7 +6976,7 @@ impl IServerMessageWebSocketInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServerMessageWebSocketInformation: IServerMessageWebSocketInformation}
+RT_CLASS!{class ServerMessageWebSocketInformation: IServerMessageWebSocketInformation ["Windows.Networking.Sockets.ServerMessageWebSocketInformation"]}
 DEFINE_IID!(IID_IServerStreamWebSocket, 753753023, 29942, 21988, 121, 223, 145, 50, 104, 13, 254, 232);
 RT_INTERFACE!{interface IServerStreamWebSocket(IServerStreamWebSocketVtbl): IInspectable(IInspectableVtbl) [IID_IServerStreamWebSocket] {
     fn get_Information(&self, out: *mut *mut ServerStreamWebSocketInformation) -> HRESULT,
@@ -7018,7 +7018,7 @@ impl IServerStreamWebSocket {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServerStreamWebSocket: IServerStreamWebSocket}
+RT_CLASS!{class ServerStreamWebSocket: IServerStreamWebSocket ["Windows.Networking.Sockets.ServerStreamWebSocket"]}
 DEFINE_IID!(IID_IServerStreamWebSocketInformation, 4231181407, 17480, 21765, 108, 201, 9, 171, 168, 145, 95, 93);
 RT_INTERFACE!{interface IServerStreamWebSocketInformation(IServerStreamWebSocketInformationVtbl): IInspectable(IInspectableVtbl) [IID_IServerStreamWebSocketInformation] {
     fn get_BandwidthStatistics(&self, out: *mut BandwidthStatistics) -> HRESULT,
@@ -7042,8 +7042,8 @@ impl IServerStreamWebSocketInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServerStreamWebSocketInformation: IServerStreamWebSocketInformation}
-RT_ENUM! { enum SocketActivityConnectedStandbyAction: i32 {
+RT_CLASS!{class ServerStreamWebSocketInformation: IServerStreamWebSocketInformation ["Windows.Networking.Sockets.ServerStreamWebSocketInformation"]}
+RT_ENUM! { enum SocketActivityConnectedStandbyAction: i32 ["Windows.Networking.Sockets.SocketActivityConnectedStandbyAction"] {
     DoNotWake (SocketActivityConnectedStandbyAction_DoNotWake) = 0, Wake (SocketActivityConnectedStandbyAction_Wake) = 1,
 }}
 DEFINE_IID!(IID_ISocketActivityContext, 1135627620, 19589, 17302, 166, 55, 29, 151, 63, 110, 189, 73);
@@ -7057,7 +7057,7 @@ impl ISocketActivityContext {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocketActivityContext: ISocketActivityContext}
+RT_CLASS!{class SocketActivityContext: ISocketActivityContext ["Windows.Networking.Sockets.SocketActivityContext"]}
 impl RtActivatable<ISocketActivityContextFactory> for SocketActivityContext {}
 impl SocketActivityContext {
     #[cfg(feature="windows-storage")] #[inline] pub fn create(data: &super::super::storage::streams::IBuffer) -> Result<ComPtr<SocketActivityContext>> {
@@ -7123,7 +7123,7 @@ impl ISocketActivityInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocketActivityInformation: ISocketActivityInformation}
+RT_CLASS!{class SocketActivityInformation: ISocketActivityInformation ["Windows.Networking.Sockets.SocketActivityInformation"]}
 impl RtActivatable<ISocketActivityInformationStatics> for SocketActivityInformation {}
 impl SocketActivityInformation {
     #[inline] pub fn get_all_sockets() -> Result<Option<ComPtr<foundation::collections::IMapView<HString, SocketActivityInformation>>>> {
@@ -7142,7 +7142,7 @@ impl ISocketActivityInformationStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SocketActivityKind: i32 {
+RT_ENUM! { enum SocketActivityKind: i32 ["Windows.Networking.Sockets.SocketActivityKind"] {
     None (SocketActivityKind_None) = 0, StreamSocketListener (SocketActivityKind_StreamSocketListener) = 1, DatagramSocket (SocketActivityKind_DatagramSocket) = 2, StreamSocket (SocketActivityKind_StreamSocket) = 3,
 }}
 DEFINE_IID!(IID_ISocketActivityTriggerDetails, 1173620391, 64671, 20353, 172, 173, 53, 95, 239, 81, 230, 123);
@@ -7162,8 +7162,8 @@ impl ISocketActivityTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SocketActivityTriggerDetails: ISocketActivityTriggerDetails}
-RT_ENUM! { enum SocketActivityTriggerReason: i32 {
+RT_CLASS!{class SocketActivityTriggerDetails: ISocketActivityTriggerDetails ["Windows.Networking.Sockets.SocketActivityTriggerDetails"]}
+RT_ENUM! { enum SocketActivityTriggerReason: i32 ["Windows.Networking.Sockets.SocketActivityTriggerReason"] {
     None (SocketActivityTriggerReason_None) = 0, SocketActivity (SocketActivityTriggerReason_SocketActivity) = 1, ConnectionAccepted (SocketActivityTriggerReason_ConnectionAccepted) = 2, KeepAliveTimerExpired (SocketActivityTriggerReason_KeepAliveTimerExpired) = 3, SocketClosed (SocketActivityTriggerReason_SocketClosed) = 4,
 }}
 RT_CLASS!{static class SocketError}
@@ -7185,19 +7185,19 @@ impl ISocketErrorStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SocketErrorStatus: i32 {
+RT_ENUM! { enum SocketErrorStatus: i32 ["Windows.Networking.Sockets.SocketErrorStatus"] {
     Unknown (SocketErrorStatus_Unknown) = 0, OperationAborted (SocketErrorStatus_OperationAborted) = 1, HttpInvalidServerResponse (SocketErrorStatus_HttpInvalidServerResponse) = 2, ConnectionTimedOut (SocketErrorStatus_ConnectionTimedOut) = 3, AddressFamilyNotSupported (SocketErrorStatus_AddressFamilyNotSupported) = 4, SocketTypeNotSupported (SocketErrorStatus_SocketTypeNotSupported) = 5, HostNotFound (SocketErrorStatus_HostNotFound) = 6, NoDataRecordOfRequestedType (SocketErrorStatus_NoDataRecordOfRequestedType) = 7, NonAuthoritativeHostNotFound (SocketErrorStatus_NonAuthoritativeHostNotFound) = 8, ClassTypeNotFound (SocketErrorStatus_ClassTypeNotFound) = 9, AddressAlreadyInUse (SocketErrorStatus_AddressAlreadyInUse) = 10, CannotAssignRequestedAddress (SocketErrorStatus_CannotAssignRequestedAddress) = 11, ConnectionRefused (SocketErrorStatus_ConnectionRefused) = 12, NetworkIsUnreachable (SocketErrorStatus_NetworkIsUnreachable) = 13, UnreachableHost (SocketErrorStatus_UnreachableHost) = 14, NetworkIsDown (SocketErrorStatus_NetworkIsDown) = 15, NetworkDroppedConnectionOnReset (SocketErrorStatus_NetworkDroppedConnectionOnReset) = 16, SoftwareCausedConnectionAbort (SocketErrorStatus_SoftwareCausedConnectionAbort) = 17, ConnectionResetByPeer (SocketErrorStatus_ConnectionResetByPeer) = 18, HostIsDown (SocketErrorStatus_HostIsDown) = 19, NoAddressesFound (SocketErrorStatus_NoAddressesFound) = 20, TooManyOpenFiles (SocketErrorStatus_TooManyOpenFiles) = 21, MessageTooLong (SocketErrorStatus_MessageTooLong) = 22, CertificateExpired (SocketErrorStatus_CertificateExpired) = 23, CertificateUntrustedRoot (SocketErrorStatus_CertificateUntrustedRoot) = 24, CertificateCommonNameIsIncorrect (SocketErrorStatus_CertificateCommonNameIsIncorrect) = 25, CertificateWrongUsage (SocketErrorStatus_CertificateWrongUsage) = 26, CertificateRevoked (SocketErrorStatus_CertificateRevoked) = 27, CertificateNoRevocationCheck (SocketErrorStatus_CertificateNoRevocationCheck) = 28, CertificateRevocationServerOffline (SocketErrorStatus_CertificateRevocationServerOffline) = 29, CertificateIsInvalid (SocketErrorStatus_CertificateIsInvalid) = 30,
 }}
-RT_ENUM! { enum SocketMessageType: i32 {
+RT_ENUM! { enum SocketMessageType: i32 ["Windows.Networking.Sockets.SocketMessageType"] {
     Binary (SocketMessageType_Binary) = 0, Utf8 (SocketMessageType_Utf8) = 1,
 }}
-RT_ENUM! { enum SocketProtectionLevel: i32 {
+RT_ENUM! { enum SocketProtectionLevel: i32 ["Windows.Networking.Sockets.SocketProtectionLevel"] {
     PlainSocket (SocketProtectionLevel_PlainSocket) = 0, Ssl (SocketProtectionLevel_Ssl) = 1, SslAllowNullEncryption (SocketProtectionLevel_SslAllowNullEncryption) = 2, BluetoothEncryptionAllowNullAuthentication (SocketProtectionLevel_BluetoothEncryptionAllowNullAuthentication) = 3, BluetoothEncryptionWithAuthentication (SocketProtectionLevel_BluetoothEncryptionWithAuthentication) = 4, Ssl3AllowWeakEncryption (SocketProtectionLevel_Ssl3AllowWeakEncryption) = 5, Tls10 (SocketProtectionLevel_Tls10) = 6, Tls11 (SocketProtectionLevel_Tls11) = 7, Tls12 (SocketProtectionLevel_Tls12) = 8, Unspecified (SocketProtectionLevel_Unspecified) = 9,
 }}
-RT_ENUM! { enum SocketQualityOfService: i32 {
+RT_ENUM! { enum SocketQualityOfService: i32 ["Windows.Networking.Sockets.SocketQualityOfService"] {
     Normal (SocketQualityOfService_Normal) = 0, LowLatency (SocketQualityOfService_LowLatency) = 1,
 }}
-RT_ENUM! { enum SocketSslErrorSeverity: i32 {
+RT_ENUM! { enum SocketSslErrorSeverity: i32 ["Windows.Networking.Sockets.SocketSslErrorSeverity"] {
     None (SocketSslErrorSeverity_None) = 0, Ignorable (SocketSslErrorSeverity_Ignorable) = 1, Fatal (SocketSslErrorSeverity_Fatal) = 2,
 }}
 DEFINE_IID!(IID_IStreamSocket, 1772236019, 64635, 18519, 175, 56, 246, 231, 222, 106, 91, 73);
@@ -7261,7 +7261,7 @@ impl IStreamSocket {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocket: IStreamSocket}
+RT_CLASS!{class StreamSocket: IStreamSocket ["Windows.Networking.Sockets.StreamSocket"]}
 impl RtActivatable<IStreamSocketStatics> for StreamSocket {}
 impl RtActivatable<IActivationFactory> for StreamSocket {}
 impl StreamSocket {
@@ -7380,7 +7380,7 @@ impl IStreamSocketControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocketControl: IStreamSocketControl}
+RT_CLASS!{class StreamSocketControl: IStreamSocketControl ["Windows.Networking.Sockets.StreamSocketControl"]}
 DEFINE_IID!(IID_IStreamSocketControl2, 3268450902, 1551, 17601, 184, 226, 31, 191, 96, 189, 98, 197);
 RT_INTERFACE!{interface IStreamSocketControl2(IStreamSocketControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocketControl2] {
     #[cfg(feature="windows-security")] fn get_IgnorableServerCertificateErrors(&self, out: *mut *mut foundation::collections::IVector<super::super::security::cryptography::certificates::ChainValidationResult>) -> HRESULT
@@ -7500,7 +7500,7 @@ impl IStreamSocketInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocketInformation: IStreamSocketInformation}
+RT_CLASS!{class StreamSocketInformation: IStreamSocketInformation ["Windows.Networking.Sockets.StreamSocketInformation"]}
 DEFINE_IID!(IID_IStreamSocketInformation2, 314737746, 19420, 20196, 151, 106, 207, 19, 14, 157, 146, 227);
 RT_INTERFACE!{interface IStreamSocketInformation2(IStreamSocketInformation2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocketInformation2] {
     fn get_ServerCertificateErrorSeverity(&self, out: *mut SocketSslErrorSeverity) -> HRESULT,
@@ -7570,7 +7570,7 @@ impl IStreamSocketListener {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocketListener: IStreamSocketListener}
+RT_CLASS!{class StreamSocketListener: IStreamSocketListener ["Windows.Networking.Sockets.StreamSocketListener"]}
 impl RtActivatable<IActivationFactory> for StreamSocketListener {}
 DEFINE_CLSID!(StreamSocketListener(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,116,114,101,97,109,83,111,99,107,101,116,76,105,115,116,101,110,101,114,0]) [CLSID_StreamSocketListener]);
 DEFINE_IID!(IID_IStreamSocketListener2, 1703788862, 47934, 17496, 178, 50, 237, 16, 136, 105, 75, 152);
@@ -7632,7 +7632,7 @@ impl IStreamSocketListenerConnectionReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocketListenerConnectionReceivedEventArgs: IStreamSocketListenerConnectionReceivedEventArgs}
+RT_CLASS!{class StreamSocketListenerConnectionReceivedEventArgs: IStreamSocketListenerConnectionReceivedEventArgs ["Windows.Networking.Sockets.StreamSocketListenerConnectionReceivedEventArgs"]}
 DEFINE_IID!(IID_IStreamSocketListenerControl, 551077238, 36234, 19898, 151, 34, 161, 108, 77, 152, 73, 128);
 RT_INTERFACE!{interface IStreamSocketListenerControl(IStreamSocketListenerControlVtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocketListenerControl] {
     fn get_QualityOfService(&self, out: *mut SocketQualityOfService) -> HRESULT,
@@ -7649,7 +7649,7 @@ impl IStreamSocketListenerControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocketListenerControl: IStreamSocketListenerControl}
+RT_CLASS!{class StreamSocketListenerControl: IStreamSocketListenerControl ["Windows.Networking.Sockets.StreamSocketListenerControl"]}
 DEFINE_IID!(IID_IStreamSocketListenerControl2, 2492184165, 11326, 16459, 184, 176, 142, 178, 73, 162, 176, 161);
 RT_INTERFACE!{interface IStreamSocketListenerControl2(IStreamSocketListenerControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocketListenerControl2] {
     fn get_NoDelay(&self, out: *mut bool) -> HRESULT,
@@ -7710,7 +7710,7 @@ impl IStreamSocketListenerInformation {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamSocketListenerInformation: IStreamSocketListenerInformation}
+RT_CLASS!{class StreamSocketListenerInformation: IStreamSocketListenerInformation ["Windows.Networking.Sockets.StreamSocketListenerInformation"]}
 DEFINE_IID!(IID_IStreamSocketStatics, 2753608778, 28206, 19189, 181, 86, 53, 90, 224, 205, 79, 41);
 RT_INTERFACE!{static interface IStreamSocketStatics(IStreamSocketStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IStreamSocketStatics] {
     fn GetEndpointPairsAsync(&self, remoteHostName: *mut super::HostName, remoteServiceName: HSTRING, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::EndpointPair>>) -> HRESULT,
@@ -7751,7 +7751,7 @@ impl IStreamWebSocket {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamWebSocket: IStreamWebSocket}
+RT_CLASS!{class StreamWebSocket: IStreamWebSocket ["Windows.Networking.Sockets.StreamWebSocket"]}
 impl RtActivatable<IActivationFactory> for StreamWebSocket {}
 DEFINE_CLSID!(StreamWebSocket(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,83,116,114,101,97,109,87,101,98,83,111,99,107,101,116,0]) [CLSID_StreamWebSocket]);
 DEFINE_IID!(IID_IStreamWebSocket2, 2857175243, 37877, 18040, 130, 54, 87, 204, 229, 65, 126, 213);
@@ -7786,7 +7786,7 @@ impl IStreamWebSocketControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamWebSocketControl: IStreamWebSocketControl}
+RT_CLASS!{class StreamWebSocketControl: IStreamWebSocketControl ["Windows.Networking.Sockets.StreamWebSocketControl"]}
 DEFINE_IID!(IID_IStreamWebSocketControl2, 559783806, 64088, 16602, 159, 17, 164, 141, 175, 233, 80, 55);
 RT_INTERFACE!{interface IStreamWebSocketControl2(IStreamWebSocketControl2Vtbl): IInspectable(IInspectableVtbl) [IID_IStreamWebSocketControl2] {
     fn get_DesiredUnsolicitedPongInterval(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -7820,7 +7820,7 @@ impl IStreamWebSocketControl2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamWebSocketInformation: IWebSocketInformation}
+RT_CLASS!{class StreamWebSocketInformation: IWebSocketInformation ["Windows.Networking.Sockets.StreamWebSocketInformation"]}
 DEFINE_IID!(IID_IWebSocket, 4168563055, 39345, 19992, 188, 8, 133, 12, 154, 223, 21, 110);
 RT_INTERFACE!{interface IWebSocket(IWebSocketVtbl): IInspectable(IInspectableVtbl) [IID_IWebSocket] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -7877,7 +7877,7 @@ impl IWebSocketClosedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebSocketClosedEventArgs: IWebSocketClosedEventArgs}
+RT_CLASS!{class WebSocketClosedEventArgs: IWebSocketClosedEventArgs ["Windows.Networking.Sockets.WebSocketClosedEventArgs"]}
 DEFINE_IID!(IID_IWebSocketControl, 784645571, 55717, 17754, 152, 17, 222, 36, 212, 83, 55, 233);
 RT_INTERFACE!{interface IWebSocketControl(IWebSocketControlVtbl): IInspectable(IInspectableVtbl) [IID_IWebSocketControl] {
     fn get_OutboundBufferSizeInBytes(&self, out: *mut u32) -> HRESULT,
@@ -8008,8 +8008,8 @@ impl IWebSocketInformation2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebSocketKeepAlive: super::super::applicationmodel::background::IBackgroundTask}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebSocketKeepAlive: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebSocketKeepAlive: super::super::applicationmodel::background::IBackgroundTask ["Windows.Networking.Sockets.WebSocketKeepAlive"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebSocketKeepAlive: IInspectable ["Windows.Networking.Sockets.WebSocketKeepAlive"]}
 impl RtActivatable<IActivationFactory> for WebSocketKeepAlive {}
 DEFINE_CLSID!(WebSocketKeepAlive(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,83,111,99,107,101,116,115,46,87,101,98,83,111,99,107,101,116,75,101,101,112,65,108,105,118,101,0]) [CLSID_WebSocketKeepAlive]);
 DEFINE_IID!(IID_IWebSocketServerCustomValidationRequestedEventArgs, 4293918280, 554, 19127, 139, 54, 225, 10, 244, 100, 14, 107);
@@ -8055,7 +8055,7 @@ impl IWebSocketServerCustomValidationRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebSocketServerCustomValidationRequestedEventArgs: IWebSocketServerCustomValidationRequestedEventArgs}
+RT_CLASS!{class WebSocketServerCustomValidationRequestedEventArgs: IWebSocketServerCustomValidationRequestedEventArgs ["Windows.Networking.Sockets.WebSocketServerCustomValidationRequestedEventArgs"]}
 } // Windows.Networking.Sockets
 pub mod vpn { // Windows.Networking.Vpn
 use ::prelude::*;
@@ -8086,7 +8086,7 @@ impl IVpnAppId {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnAppId: IVpnAppId}
+RT_CLASS!{class VpnAppId: IVpnAppId ["Windows.Networking.Vpn.VpnAppId"]}
 impl RtActivatable<IVpnAppIdFactory> for VpnAppId {}
 impl VpnAppId {
     #[inline] pub fn create(type_: VpnAppIdType, value: &HStringArg) -> Result<ComPtr<VpnAppId>> {
@@ -8105,10 +8105,10 @@ impl IVpnAppIdFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnAppIdType: i32 {
+RT_ENUM! { enum VpnAppIdType: i32 ["Windows.Networking.Vpn.VpnAppIdType"] {
     PackageFamilyName (VpnAppIdType_PackageFamilyName) = 0, FullyQualifiedBinaryName (VpnAppIdType_FullyQualifiedBinaryName) = 1, FilePath (VpnAppIdType_FilePath) = 2,
 }}
-RT_ENUM! { enum VpnAuthenticationMethod: i32 {
+RT_ENUM! { enum VpnAuthenticationMethod: i32 ["Windows.Networking.Vpn.VpnAuthenticationMethod"] {
     Mschapv2 (VpnAuthenticationMethod_Mschapv2) = 0, Eap (VpnAuthenticationMethod_Eap) = 1, Certificate (VpnAuthenticationMethod_Certificate) = 2, PresharedKey (VpnAuthenticationMethod_PresharedKey) = 3,
 }}
 DEFINE_IID!(IID_IVpnChannel, 1254591751, 53672, 17155, 160, 145, 200, 210, 224, 145, 91, 195);
@@ -8204,7 +8204,7 @@ impl IVpnChannel {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnChannel: IVpnChannel}
+RT_CLASS!{class VpnChannel: IVpnChannel ["Windows.Networking.Vpn.VpnChannel"]}
 impl RtActivatable<IVpnChannelStatics> for VpnChannel {}
 impl VpnChannel {
     #[inline] pub fn process_event_async(thirdPartyPlugIn: &IInspectable, event: &IInspectable) -> Result<()> {
@@ -8333,8 +8333,8 @@ impl IVpnChannelActivityEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnChannelActivityEventArgs: IVpnChannelActivityEventArgs}
-RT_ENUM! { enum VpnChannelActivityEventType: i32 {
+RT_CLASS!{class VpnChannelActivityEventArgs: IVpnChannelActivityEventArgs ["Windows.Networking.Vpn.VpnChannelActivityEventArgs"]}
+RT_ENUM! { enum VpnChannelActivityEventType: i32 ["Windows.Networking.Vpn.VpnChannelActivityEventType"] {
     Idle (VpnChannelActivityEventType_Idle) = 0, Active (VpnChannelActivityEventType_Active) = 1,
 }}
 DEFINE_IID!(IID_IVpnChannelActivityStateChangedArgs, 1031079269, 64960, 19390, 162, 59, 69, 255, 252, 109, 151, 161);
@@ -8348,7 +8348,7 @@ impl IVpnChannelActivityStateChangedArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnChannelActivityStateChangedArgs: IVpnChannelActivityStateChangedArgs}
+RT_CLASS!{class VpnChannelActivityStateChangedArgs: IVpnChannelActivityStateChangedArgs ["Windows.Networking.Vpn.VpnChannelActivityStateChangedArgs"]}
 DEFINE_IID!(IID_IVpnChannelConfiguration, 237886626, 8210, 20452, 177, 121, 140, 101, 44, 109, 16, 126);
 RT_INTERFACE!{interface IVpnChannelConfiguration(IVpnChannelConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IVpnChannelConfiguration] {
     fn get_ServerServiceName(&self, out: *mut HSTRING) -> HRESULT,
@@ -8372,7 +8372,7 @@ impl IVpnChannelConfiguration {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnChannelConfiguration: IVpnChannelConfiguration}
+RT_CLASS!{class VpnChannelConfiguration: IVpnChannelConfiguration ["Windows.Networking.Vpn.VpnChannelConfiguration"]}
 DEFINE_IID!(IID_IVpnChannelConfiguration2, 4077606732, 30756, 18204, 161, 24, 99, 219, 201, 58, 228, 199);
 RT_INTERFACE!{interface IVpnChannelConfiguration2(IVpnChannelConfiguration2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnChannelConfiguration2] {
     fn get_ServerUris(&self, out: *mut *mut foundation::collections::IVectorView<foundation::Uri>) -> HRESULT
@@ -8384,7 +8384,7 @@ impl IVpnChannelConfiguration2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnChannelRequestCredentialsOptions: u32 {
+RT_ENUM! { enum VpnChannelRequestCredentialsOptions: u32 ["Windows.Networking.Vpn.VpnChannelRequestCredentialsOptions"] {
     None (VpnChannelRequestCredentialsOptions_None) = 0, Retrying (VpnChannelRequestCredentialsOptions_Retrying) = 1, UseForSingleSignIn (VpnChannelRequestCredentialsOptions_UseForSingleSignIn) = 2,
 }}
 DEFINE_IID!(IID_IVpnChannelStatics, 2297103917, 59416, 20477, 152, 166, 54, 62, 55, 54, 201, 93);
@@ -8426,8 +8426,8 @@ impl IVpnCredential {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCredential: IVpnCredential}
-RT_ENUM! { enum VpnCredentialType: i32 {
+RT_CLASS!{class VpnCredential: IVpnCredential ["Windows.Networking.Vpn.VpnCredential"]}
+RT_ENUM! { enum VpnCredentialType: i32 ["Windows.Networking.Vpn.VpnCredentialType"] {
     UsernamePassword (VpnCredentialType_UsernamePassword) = 0, UsernameOtpPin (VpnCredentialType_UsernameOtpPin) = 1, UsernamePasswordAndPin (VpnCredentialType_UsernamePasswordAndPin) = 2, UsernamePasswordChange (VpnCredentialType_UsernamePasswordChange) = 3, SmartCard (VpnCredentialType_SmartCard) = 4, ProtectedCertificate (VpnCredentialType_ProtectedCertificate) = 5, UnProtectedCertificate (VpnCredentialType_UnProtectedCertificate) = 6,
 }}
 DEFINE_IID!(IID_IVpnCustomCheckBox, 1132955475, 965, 20065, 147, 215, 169, 87, 113, 76, 66, 130);
@@ -8452,7 +8452,7 @@ impl IVpnCustomCheckBox {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomCheckBox: IVpnCustomCheckBox}
+RT_CLASS!{class VpnCustomCheckBox: IVpnCustomCheckBox ["Windows.Networking.Vpn.VpnCustomCheckBox"]}
 impl RtActivatable<IActivationFactory> for VpnCustomCheckBox {}
 DEFINE_CLSID!(VpnCustomCheckBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,67,104,101,99,107,66,111,120,0]) [CLSID_VpnCustomCheckBox]);
 DEFINE_IID!(IID_IVpnCustomComboBox, 2586056078, 56225, 19567, 130, 112, 220, 243, 201, 118, 28, 76);
@@ -8477,7 +8477,7 @@ impl IVpnCustomComboBox {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomComboBox: IVpnCustomComboBox}
+RT_CLASS!{class VpnCustomComboBox: IVpnCustomComboBox ["Windows.Networking.Vpn.VpnCustomComboBox"]}
 impl RtActivatable<IActivationFactory> for VpnCustomComboBox {}
 DEFINE_CLSID!(VpnCustomComboBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,67,111,109,98,111,66,111,120,0]) [CLSID_VpnCustomComboBox]);
 DEFINE_IID!(IID_IVpnCustomEditBox, 805493152, 53183, 19467, 143, 60, 102, 245, 3, 194, 11, 57);
@@ -8513,14 +8513,14 @@ impl IVpnCustomEditBox {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomEditBox: IVpnCustomEditBox}
+RT_CLASS!{class VpnCustomEditBox: IVpnCustomEditBox ["Windows.Networking.Vpn.VpnCustomEditBox"]}
 impl RtActivatable<IActivationFactory> for VpnCustomEditBox {}
 DEFINE_CLSID!(VpnCustomEditBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,69,100,105,116,66,111,120,0]) [CLSID_VpnCustomEditBox]);
 DEFINE_IID!(IID_IVpnCustomErrorBox, 2663706546, 51522, 17071, 178, 35, 88, 139, 72, 50, 135, 33);
 RT_INTERFACE!{interface IVpnCustomErrorBox(IVpnCustomErrorBoxVtbl): IInspectable(IInspectableVtbl) [IID_IVpnCustomErrorBox] {
     
 }}
-RT_CLASS!{class VpnCustomErrorBox: IVpnCustomErrorBox}
+RT_CLASS!{class VpnCustomErrorBox: IVpnCustomErrorBox ["Windows.Networking.Vpn.VpnCustomErrorBox"]}
 impl RtActivatable<IActivationFactory> for VpnCustomErrorBox {}
 DEFINE_CLSID!(VpnCustomErrorBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,69,114,114,111,114,66,111,120,0]) [CLSID_VpnCustomErrorBox]);
 DEFINE_IID!(IID_IVpnCustomPrompt, 2603531899, 34773, 17212, 180, 246, 238, 230, 170, 104, 162, 68);
@@ -8583,7 +8583,7 @@ impl IVpnCustomPromptBooleanInput {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomPromptBooleanInput: IVpnCustomPromptBooleanInput}
+RT_CLASS!{class VpnCustomPromptBooleanInput: IVpnCustomPromptBooleanInput ["Windows.Networking.Vpn.VpnCustomPromptBooleanInput"]}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptBooleanInput {}
 DEFINE_CLSID!(VpnCustomPromptBooleanInput(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,66,111,111,108,101,97,110,73,110,112,117,116,0]) [CLSID_VpnCustomPromptBooleanInput]);
 DEFINE_IID!(IID_IVpnCustomPromptElement, 1941788216, 28420, 16461, 147, 221, 80, 164, 73, 36, 163, 139);
@@ -8641,7 +8641,7 @@ impl IVpnCustomPromptOptionSelector {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomPromptOptionSelector: IVpnCustomPromptOptionSelector}
+RT_CLASS!{class VpnCustomPromptOptionSelector: IVpnCustomPromptOptionSelector ["Windows.Networking.Vpn.VpnCustomPromptOptionSelector"]}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptOptionSelector {}
 DEFINE_CLSID!(VpnCustomPromptOptionSelector(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,79,112,116,105,111,110,83,101,108,101,99,116,111,114,0]) [CLSID_VpnCustomPromptOptionSelector]);
 DEFINE_IID!(IID_IVpnCustomPromptText, 1003011566, 14914, 18851, 171, 221, 7, 178, 237, 234, 117, 45);
@@ -8660,7 +8660,7 @@ impl IVpnCustomPromptText {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomPromptText: IVpnCustomPromptText}
+RT_CLASS!{class VpnCustomPromptText: IVpnCustomPromptText ["Windows.Networking.Vpn.VpnCustomPromptText"]}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptText {}
 DEFINE_CLSID!(VpnCustomPromptText(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,84,101,120,116,0]) [CLSID_VpnCustomPromptText]);
 DEFINE_IID!(IID_IVpnCustomPromptTextInput, 3386547317, 37180, 18389, 136, 186, 72, 252, 72, 147, 2, 53);
@@ -8696,7 +8696,7 @@ impl IVpnCustomPromptTextInput {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomPromptTextInput: IVpnCustomPromptTextInput}
+RT_CLASS!{class VpnCustomPromptTextInput: IVpnCustomPromptTextInput ["Windows.Networking.Vpn.VpnCustomPromptTextInput"]}
 impl RtActivatable<IActivationFactory> for VpnCustomPromptTextInput {}
 DEFINE_CLSID!(VpnCustomPromptTextInput(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,80,114,111,109,112,116,84,101,120,116,73,110,112,117,116,0]) [CLSID_VpnCustomPromptTextInput]);
 DEFINE_IID!(IID_IVpnCustomTextBox, 3668231114, 36643, 19766, 145, 241, 118, 217, 55, 130, 121, 66);
@@ -8715,10 +8715,10 @@ impl IVpnCustomTextBox {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnCustomTextBox: IVpnCustomTextBox}
+RT_CLASS!{class VpnCustomTextBox: IVpnCustomTextBox ["Windows.Networking.Vpn.VpnCustomTextBox"]}
 impl RtActivatable<IActivationFactory> for VpnCustomTextBox {}
 DEFINE_CLSID!(VpnCustomTextBox(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,67,117,115,116,111,109,84,101,120,116,66,111,120,0]) [CLSID_VpnCustomTextBox]);
-RT_ENUM! { enum VpnDataPathType: i32 {
+RT_ENUM! { enum VpnDataPathType: i32 ["Windows.Networking.Vpn.VpnDataPathType"] {
     Send (VpnDataPathType_Send) = 0, Receive (VpnDataPathType_Receive) = 1,
 }}
 DEFINE_IID!(IID_IVpnDomainNameAssignment, 1094037825, 52443, 18869, 148, 1, 3, 154, 138, 231, 103, 233);
@@ -8743,7 +8743,7 @@ impl IVpnDomainNameAssignment {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnDomainNameAssignment: IVpnDomainNameAssignment}
+RT_CLASS!{class VpnDomainNameAssignment: IVpnDomainNameAssignment ["Windows.Networking.Vpn.VpnDomainNameAssignment"]}
 impl RtActivatable<IActivationFactory> for VpnDomainNameAssignment {}
 DEFINE_CLSID!(VpnDomainNameAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,68,111,109,97,105,110,78,97,109,101,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnDomainNameAssignment]);
 DEFINE_IID!(IID_IVpnDomainNameInfo, 2905520175, 60046, 20346, 132, 62, 26, 135, 227, 46, 27, 154);
@@ -8785,7 +8785,7 @@ impl IVpnDomainNameInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnDomainNameInfo: IVpnDomainNameInfo}
+RT_CLASS!{class VpnDomainNameInfo: IVpnDomainNameInfo ["Windows.Networking.Vpn.VpnDomainNameInfo"]}
 impl RtActivatable<IVpnDomainNameInfoFactory> for VpnDomainNameInfo {}
 impl VpnDomainNameInfo {
     #[inline] pub fn create_vpn_domain_name_info(name: &HStringArg, nameType: VpnDomainNameType, dnsServerList: &foundation::collections::IIterable<super::HostName>, proxyServerList: &foundation::collections::IIterable<super::HostName>) -> Result<ComPtr<VpnDomainNameInfo>> {
@@ -8815,7 +8815,7 @@ impl IVpnDomainNameInfoFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnDomainNameType: i32 {
+RT_ENUM! { enum VpnDomainNameType: i32 ["Windows.Networking.Vpn.VpnDomainNameType"] {
     Suffix (VpnDomainNameType_Suffix) = 0, FullyQualified (VpnDomainNameType_FullyQualified) = 1, Reserved (VpnDomainNameType_Reserved) = 65535,
 }}
 DEFINE_IID!(IID_IVpnInterfaceId, 2653805730, 5906, 19684, 177, 121, 140, 101, 44, 109, 16, 17);
@@ -8829,7 +8829,7 @@ impl IVpnInterfaceId {
         if hr == S_OK { Ok(ComArray::from_raw(idSize, id)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnInterfaceId: IVpnInterfaceId}
+RT_CLASS!{class VpnInterfaceId: IVpnInterfaceId ["Windows.Networking.Vpn.VpnInterfaceId"]}
 impl RtActivatable<IVpnInterfaceIdFactory> for VpnInterfaceId {}
 impl VpnInterfaceId {
     #[inline] pub fn create_vpn_interface_id(address: &[u8]) -> Result<ComPtr<VpnInterfaceId>> {
@@ -8848,7 +8848,7 @@ impl IVpnInterfaceIdFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnIPProtocol: i32 {
+RT_ENUM! { enum VpnIPProtocol: i32 ["Windows.Networking.Vpn.VpnIPProtocol"] {
     None (VpnIPProtocol_None) = 0, Tcp (VpnIPProtocol_Tcp) = 6, Udp (VpnIPProtocol_Udp) = 17, Icmp (VpnIPProtocol_Icmp) = 1, Ipv6Icmp (VpnIPProtocol_Ipv6Icmp) = 58, Igmp (VpnIPProtocol_Igmp) = 2, Pgm (VpnIPProtocol_Pgm) = 113,
 }}
 DEFINE_IID!(IID_IVpnManagementAgent, 423007949, 42436, 19134, 133, 43, 120, 91, 228, 203, 62, 52);
@@ -8911,13 +8911,13 @@ impl IVpnManagementAgent {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnManagementAgent: IVpnManagementAgent}
+RT_CLASS!{class VpnManagementAgent: IVpnManagementAgent ["Windows.Networking.Vpn.VpnManagementAgent"]}
 impl RtActivatable<IActivationFactory> for VpnManagementAgent {}
 DEFINE_CLSID!(VpnManagementAgent(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,77,97,110,97,103,101,109,101,110,116,65,103,101,110,116,0]) [CLSID_VpnManagementAgent]);
-RT_ENUM! { enum VpnManagementConnectionStatus: i32 {
+RT_ENUM! { enum VpnManagementConnectionStatus: i32 ["Windows.Networking.Vpn.VpnManagementConnectionStatus"] {
     Disconnected (VpnManagementConnectionStatus_Disconnected) = 0, Disconnecting (VpnManagementConnectionStatus_Disconnecting) = 1, Connected (VpnManagementConnectionStatus_Connected) = 2, Connecting (VpnManagementConnectionStatus_Connecting) = 3,
 }}
-RT_ENUM! { enum VpnManagementErrorStatus: i32 {
+RT_ENUM! { enum VpnManagementErrorStatus: i32 ["Windows.Networking.Vpn.VpnManagementErrorStatus"] {
     Ok (VpnManagementErrorStatus_Ok) = 0, Other (VpnManagementErrorStatus_Other) = 1, InvalidXmlSyntax (VpnManagementErrorStatus_InvalidXmlSyntax) = 2, ProfileNameTooLong (VpnManagementErrorStatus_ProfileNameTooLong) = 3, ProfileInvalidAppId (VpnManagementErrorStatus_ProfileInvalidAppId) = 4, AccessDenied (VpnManagementErrorStatus_AccessDenied) = 5, CannotFindProfile (VpnManagementErrorStatus_CannotFindProfile) = 6, AlreadyDisconnecting (VpnManagementErrorStatus_AlreadyDisconnecting) = 7, AlreadyConnected (VpnManagementErrorStatus_AlreadyConnected) = 8, GeneralAuthenticationFailure (VpnManagementErrorStatus_GeneralAuthenticationFailure) = 9, EapFailure (VpnManagementErrorStatus_EapFailure) = 10, SmartCardFailure (VpnManagementErrorStatus_SmartCardFailure) = 11, CertificateFailure (VpnManagementErrorStatus_CertificateFailure) = 12, ServerConfiguration (VpnManagementErrorStatus_ServerConfiguration) = 13, NoConnection (VpnManagementErrorStatus_NoConnection) = 14, ServerConnection (VpnManagementErrorStatus_ServerConnection) = 15, UserNamePassword (VpnManagementErrorStatus_UserNamePassword) = 16, DnsNotResolvable (VpnManagementErrorStatus_DnsNotResolvable) = 17, InvalidIP (VpnManagementErrorStatus_InvalidIP) = 18,
 }}
 DEFINE_IID!(IID_IVpnNamespaceAssignment, 3623344920, 12413, 19470, 189, 98, 143, 162, 112, 187, 173, 214);
@@ -8947,7 +8947,7 @@ impl IVpnNamespaceAssignment {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnNamespaceAssignment: IVpnNamespaceAssignment}
+RT_CLASS!{class VpnNamespaceAssignment: IVpnNamespaceAssignment ["Windows.Networking.Vpn.VpnNamespaceAssignment"]}
 impl RtActivatable<IActivationFactory> for VpnNamespaceAssignment {}
 DEFINE_CLSID!(VpnNamespaceAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,78,97,109,101,115,112,97,99,101,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnNamespaceAssignment]);
 DEFINE_IID!(IID_IVpnNamespaceInfo, 820902723, 17487, 17605, 129, 103, 163, 90, 145, 241, 175, 148);
@@ -8988,7 +8988,7 @@ impl IVpnNamespaceInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnNamespaceInfo: IVpnNamespaceInfo}
+RT_CLASS!{class VpnNamespaceInfo: IVpnNamespaceInfo ["Windows.Networking.Vpn.VpnNamespaceInfo"]}
 impl RtActivatable<IVpnNamespaceInfoFactory> for VpnNamespaceInfo {}
 impl VpnNamespaceInfo {
     #[inline] pub fn create_vpn_namespace_info(name: &HStringArg, dnsServerList: &foundation::collections::IVector<super::HostName>, proxyServerList: &foundation::collections::IVector<super::HostName>) -> Result<ComPtr<VpnNamespaceInfo>> {
@@ -9073,7 +9073,7 @@ impl IVpnNativeProfile {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnNativeProfile: IVpnNativeProfile}
+RT_CLASS!{class VpnNativeProfile: IVpnNativeProfile ["Windows.Networking.Vpn.VpnNativeProfile"]}
 impl RtActivatable<IActivationFactory> for VpnNativeProfile {}
 DEFINE_CLSID!(VpnNativeProfile(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,78,97,116,105,118,101,80,114,111,102,105,108,101,0]) [CLSID_VpnNativeProfile]);
 DEFINE_IID!(IID_IVpnNativeProfile2, 267134055, 52661, 19143, 181, 163, 10, 251, 94, 196, 118, 130);
@@ -9098,7 +9098,7 @@ impl IVpnNativeProfile2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnNativeProtocolType: i32 {
+RT_ENUM! { enum VpnNativeProtocolType: i32 ["Windows.Networking.Vpn.VpnNativeProtocolType"] {
     Pptp (VpnNativeProtocolType_Pptp) = 0, L2tp (VpnNativeProtocolType_L2tp) = 1, IpsecIkev2 (VpnNativeProtocolType_IpsecIkev2) = 2,
 }}
 DEFINE_IID!(IID_IVpnPacketBuffer, 3271070204, 19804, 19043, 183, 13, 78, 48, 126, 172, 206, 85);
@@ -9135,7 +9135,7 @@ impl IVpnPacketBuffer {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnPacketBuffer: IVpnPacketBuffer}
+RT_CLASS!{class VpnPacketBuffer: IVpnPacketBuffer ["Windows.Networking.Vpn.VpnPacketBuffer"]}
 impl RtActivatable<IVpnPacketBufferFactory> for VpnPacketBuffer {}
 impl VpnPacketBuffer {
     #[inline] pub fn create_vpn_packet_buffer(parentBuffer: &VpnPacketBuffer, offset: u32, length: u32) -> Result<ComPtr<VpnPacketBuffer>> {
@@ -9230,7 +9230,7 @@ impl IVpnPacketBufferList {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnPacketBufferList: IVpnPacketBufferList}
+RT_CLASS!{class VpnPacketBufferList: IVpnPacketBufferList ["Windows.Networking.Vpn.VpnPacketBufferList"]}
 DEFINE_IID!(IID_IVpnPacketBufferList2, 1048236005, 59934, 18474, 141, 152, 192, 101, 245, 125, 137, 234);
 RT_INTERFACE!{interface IVpnPacketBufferList2(IVpnPacketBufferList2Vtbl): IInspectable(IInspectableVtbl) [IID_IVpnPacketBufferList2] {
     fn AddLeadingPacket(&self, nextVpnPacketBuffer: *mut VpnPacketBuffer) -> HRESULT,
@@ -9258,7 +9258,7 @@ impl IVpnPacketBufferList2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnPacketBufferStatus: i32 {
+RT_ENUM! { enum VpnPacketBufferStatus: i32 ["Windows.Networking.Vpn.VpnPacketBufferStatus"] {
     Ok (VpnPacketBufferStatus_Ok) = 0, InvalidBufferSize (VpnPacketBufferStatus_InvalidBufferSize) = 1,
 }}
 DEFINE_IID!(IID_IVpnPickedCredential, 2591636167, 34900, 20050, 173, 151, 36, 221, 154, 132, 43, 206);
@@ -9284,7 +9284,7 @@ impl IVpnPickedCredential {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnPickedCredential: IVpnPickedCredential}
+RT_CLASS!{class VpnPickedCredential: IVpnPickedCredential ["Windows.Networking.Vpn.VpnPickedCredential"]}
 DEFINE_IID!(IID_IVpnPlugIn, 3468135687, 53416, 18179, 160, 145, 200, 194, 192, 145, 91, 196);
 RT_INTERFACE!{interface IVpnPlugIn(IVpnPlugInVtbl): IInspectable(IInspectableVtbl) [IID_IVpnPlugIn] {
     fn Connect(&self, channel: *mut VpnChannel) -> HRESULT,
@@ -9349,7 +9349,7 @@ impl IVpnPlugInProfile {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnPlugInProfile: IVpnPlugInProfile}
+RT_CLASS!{class VpnPlugInProfile: IVpnPlugInProfile ["Windows.Networking.Vpn.VpnPlugInProfile"]}
 impl RtActivatable<IActivationFactory> for VpnPlugInProfile {}
 DEFINE_CLSID!(VpnPlugInProfile(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,80,108,117,103,73,110,80,114,111,102,105,108,101,0]) [CLSID_VpnPlugInProfile]);
 DEFINE_IID!(IID_IVpnPlugInProfile2, 1629243538, 53140, 19158, 186, 153, 0, 244, 255, 52, 86, 94);
@@ -9463,7 +9463,7 @@ impl IVpnRoute {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnRoute: IVpnRoute}
+RT_CLASS!{class VpnRoute: IVpnRoute ["Windows.Networking.Vpn.VpnRoute"]}
 impl RtActivatable<IVpnRouteFactory> for VpnRoute {}
 impl VpnRoute {
     #[inline] pub fn create_vpn_route(address: &super::HostName, prefixSize: u8) -> Result<ComPtr<VpnRoute>> {
@@ -9531,7 +9531,7 @@ impl IVpnRouteAssignment {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnRouteAssignment: IVpnRouteAssignment}
+RT_CLASS!{class VpnRouteAssignment: IVpnRouteAssignment ["Windows.Networking.Vpn.VpnRouteAssignment"]}
 impl RtActivatable<IActivationFactory> for VpnRouteAssignment {}
 DEFINE_CLSID!(VpnRouteAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,82,111,117,116,101,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnRouteAssignment]);
 DEFINE_IID!(IID_IVpnRouteFactory, 3186275839, 17871, 19353, 131, 251, 219, 59, 194, 103, 43, 2);
@@ -9545,7 +9545,7 @@ impl IVpnRouteFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum VpnRoutingPolicyType: i32 {
+RT_ENUM! { enum VpnRoutingPolicyType: i32 ["Windows.Networking.Vpn.VpnRoutingPolicyType"] {
     SplitRouting (VpnRoutingPolicyType_SplitRouting) = 0, ForceAllTrafficOverVpn (VpnRoutingPolicyType_ForceAllTrafficOverVpn) = 1,
 }}
 DEFINE_IID!(IID_IVpnSystemHealth, 2577987759, 49390, 20085, 129, 122, 242, 49, 174, 229, 18, 61);
@@ -9559,7 +9559,7 @@ impl IVpnSystemHealth {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnSystemHealth: IVpnSystemHealth}
+RT_CLASS!{class VpnSystemHealth: IVpnSystemHealth ["Windows.Networking.Vpn.VpnSystemHealth"]}
 DEFINE_IID!(IID_IVpnTrafficFilter, 795417440, 27807, 18421, 172, 54, 187, 27, 4, 46, 44, 80);
 RT_INTERFACE!{interface IVpnTrafficFilter(IVpnTrafficFilterVtbl): IInspectable(IInspectableVtbl) [IID_IVpnTrafficFilter] {
     fn get_AppId(&self, out: *mut *mut VpnAppId) -> HRESULT,
@@ -9628,7 +9628,7 @@ impl IVpnTrafficFilter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnTrafficFilter: IVpnTrafficFilter}
+RT_CLASS!{class VpnTrafficFilter: IVpnTrafficFilter ["Windows.Networking.Vpn.VpnTrafficFilter"]}
 impl RtActivatable<IVpnTrafficFilterFactory> for VpnTrafficFilter {}
 impl VpnTrafficFilter {
     #[inline] pub fn create(appId: &VpnAppId) -> Result<ComPtr<VpnTrafficFilter>> {
@@ -9669,7 +9669,7 @@ impl IVpnTrafficFilterAssignment {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VpnTrafficFilterAssignment: IVpnTrafficFilterAssignment}
+RT_CLASS!{class VpnTrafficFilterAssignment: IVpnTrafficFilterAssignment ["Windows.Networking.Vpn.VpnTrafficFilterAssignment"]}
 impl RtActivatable<IActivationFactory> for VpnTrafficFilterAssignment {}
 DEFINE_CLSID!(VpnTrafficFilterAssignment(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,86,112,110,46,86,112,110,84,114,97,102,102,105,99,70,105,108,116,101,114,65,115,115,105,103,110,109,101,110,116,0]) [CLSID_VpnTrafficFilterAssignment]);
 DEFINE_IID!(IID_IVpnTrafficFilterFactory, 1208828373, 32665, 18252, 134, 238, 150, 223, 22, 131, 24, 241);
@@ -9745,7 +9745,7 @@ impl IXboxLiveDeviceAddress {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveDeviceAddress: IXboxLiveDeviceAddress}
+RT_CLASS!{class XboxLiveDeviceAddress: IXboxLiveDeviceAddress ["Windows.Networking.XboxLive.XboxLiveDeviceAddress"]}
 impl RtActivatable<IXboxLiveDeviceAddressStatics> for XboxLiveDeviceAddress {}
 impl XboxLiveDeviceAddress {
     #[inline] pub fn create_from_snapshot_base64(base64: &HStringArg) -> Result<Option<ComPtr<XboxLiveDeviceAddress>>> {
@@ -9875,7 +9875,7 @@ impl IXboxLiveEndpointPair {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveEndpointPair: IXboxLiveEndpointPair}
+RT_CLASS!{class XboxLiveEndpointPair: IXboxLiveEndpointPair ["Windows.Networking.XboxLive.XboxLiveEndpointPair"]}
 impl RtActivatable<IXboxLiveEndpointPairStatics> for XboxLiveEndpointPair {}
 impl XboxLiveEndpointPair {
     #[inline] pub fn find_endpoint_pair_by_socket_address_bytes(localSocketAddress: &[u8], remoteSocketAddress: &[u8]) -> Result<Option<ComPtr<XboxLiveEndpointPair>>> {
@@ -9886,7 +9886,7 @@ impl XboxLiveEndpointPair {
     }
 }
 DEFINE_CLSID!(XboxLiveEndpointPair(&[87,105,110,100,111,119,115,46,78,101,116,119,111,114,107,105,110,103,46,88,98,111,120,76,105,118,101,46,88,98,111,120,76,105,118,101,69,110,100,112,111,105,110,116,80,97,105,114,0]) [CLSID_XboxLiveEndpointPair]);
-RT_ENUM! { enum XboxLiveEndpointPairCreationBehaviors: u32 {
+RT_ENUM! { enum XboxLiveEndpointPairCreationBehaviors: u32 ["Windows.Networking.XboxLive.XboxLiveEndpointPairCreationBehaviors"] {
     None (XboxLiveEndpointPairCreationBehaviors_None) = 0, ReevaluatePath (XboxLiveEndpointPairCreationBehaviors_ReevaluatePath) = 1,
 }}
 DEFINE_IID!(IID_IXboxLiveEndpointPairCreationResult, 3651713941, 10923, 19742, 151, 148, 51, 236, 192, 220, 240, 254);
@@ -9918,11 +9918,11 @@ impl IXboxLiveEndpointPairCreationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveEndpointPairCreationResult: IXboxLiveEndpointPairCreationResult}
-RT_ENUM! { enum XboxLiveEndpointPairCreationStatus: i32 {
+RT_CLASS!{class XboxLiveEndpointPairCreationResult: IXboxLiveEndpointPairCreationResult ["Windows.Networking.XboxLive.XboxLiveEndpointPairCreationResult"]}
+RT_ENUM! { enum XboxLiveEndpointPairCreationStatus: i32 ["Windows.Networking.XboxLive.XboxLiveEndpointPairCreationStatus"] {
     Succeeded (XboxLiveEndpointPairCreationStatus_Succeeded) = 0, NoLocalNetworks (XboxLiveEndpointPairCreationStatus_NoLocalNetworks) = 1, NoCompatibleNetworkPaths (XboxLiveEndpointPairCreationStatus_NoCompatibleNetworkPaths) = 2, LocalSystemNotAuthorized (XboxLiveEndpointPairCreationStatus_LocalSystemNotAuthorized) = 3, Canceled (XboxLiveEndpointPairCreationStatus_Canceled) = 4, TimedOut (XboxLiveEndpointPairCreationStatus_TimedOut) = 5, RemoteSystemNotAuthorized (XboxLiveEndpointPairCreationStatus_RemoteSystemNotAuthorized) = 6, RefusedDueToConfiguration (XboxLiveEndpointPairCreationStatus_RefusedDueToConfiguration) = 7, UnexpectedInternalError (XboxLiveEndpointPairCreationStatus_UnexpectedInternalError) = 8,
 }}
-RT_ENUM! { enum XboxLiveEndpointPairState: i32 {
+RT_ENUM! { enum XboxLiveEndpointPairState: i32 ["Windows.Networking.XboxLive.XboxLiveEndpointPairState"] {
     Invalid (XboxLiveEndpointPairState_Invalid) = 0, CreatingOutbound (XboxLiveEndpointPairState_CreatingOutbound) = 1, CreatingInbound (XboxLiveEndpointPairState_CreatingInbound) = 2, Ready (XboxLiveEndpointPairState_Ready) = 3, DeletingLocally (XboxLiveEndpointPairState_DeletingLocally) = 4, RemoteEndpointTerminating (XboxLiveEndpointPairState_RemoteEndpointTerminating) = 5, Deleted (XboxLiveEndpointPairState_Deleted) = 6,
 }}
 DEFINE_IID!(IID_IXboxLiveEndpointPairStateChangedEventArgs, 1496202069, 56840, 17639, 172, 59, 185, 185, 161, 105, 88, 58);
@@ -9942,7 +9942,7 @@ impl IXboxLiveEndpointPairStateChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveEndpointPairStateChangedEventArgs: IXboxLiveEndpointPairStateChangedEventArgs}
+RT_CLASS!{class XboxLiveEndpointPairStateChangedEventArgs: IXboxLiveEndpointPairStateChangedEventArgs ["Windows.Networking.XboxLive.XboxLiveEndpointPairStateChangedEventArgs"]}
 DEFINE_IID!(IID_IXboxLiveEndpointPairStatics, 1680960304, 8570, 16963, 142, 225, 103, 41, 40, 29, 39, 219);
 RT_INTERFACE!{static interface IXboxLiveEndpointPairStatics(IXboxLiveEndpointPairStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IXboxLiveEndpointPairStatics] {
     fn FindEndpointPairBySocketAddressBytes(&self, localSocketAddressSize: u32, localSocketAddress: *mut u8, remoteSocketAddressSize: u32, remoteSocketAddress: *mut u8, out: *mut *mut XboxLiveEndpointPair) -> HRESULT,
@@ -10042,7 +10042,7 @@ impl IXboxLiveEndpointPairTemplate {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveEndpointPairTemplate: IXboxLiveEndpointPairTemplate}
+RT_CLASS!{class XboxLiveEndpointPairTemplate: IXboxLiveEndpointPairTemplate ["Windows.Networking.XboxLive.XboxLiveEndpointPairTemplate"]}
 impl RtActivatable<IXboxLiveEndpointPairTemplateStatics> for XboxLiveEndpointPairTemplate {}
 impl XboxLiveEndpointPairTemplate {
     #[inline] pub fn get_template_by_name(name: &HStringArg) -> Result<Option<ComPtr<XboxLiveEndpointPairTemplate>>> {
@@ -10081,8 +10081,8 @@ impl IXboxLiveInboundEndpointPairCreatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveInboundEndpointPairCreatedEventArgs: IXboxLiveInboundEndpointPairCreatedEventArgs}
-RT_ENUM! { enum XboxLiveNetworkAccessKind: i32 {
+RT_CLASS!{class XboxLiveInboundEndpointPairCreatedEventArgs: IXboxLiveInboundEndpointPairCreatedEventArgs ["Windows.Networking.XboxLive.XboxLiveInboundEndpointPairCreatedEventArgs"]}
+RT_ENUM! { enum XboxLiveNetworkAccessKind: i32 ["Windows.Networking.XboxLive.XboxLiveNetworkAccessKind"] {
     Open (XboxLiveNetworkAccessKind_Open) = 0, Moderate (XboxLiveNetworkAccessKind_Moderate) = 1, Strict (XboxLiveNetworkAccessKind_Strict) = 2,
 }}
 DEFINE_IID!(IID_IXboxLiveQualityOfServiceMeasurement, 1298672590, 42454, 18406, 162, 54, 207, 222, 95, 189, 242, 237);
@@ -10183,7 +10183,7 @@ impl IXboxLiveQualityOfServiceMeasurement {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveQualityOfServiceMeasurement: IXboxLiveQualityOfServiceMeasurement}
+RT_CLASS!{class XboxLiveQualityOfServiceMeasurement: IXboxLiveQualityOfServiceMeasurement ["Windows.Networking.XboxLive.XboxLiveQualityOfServiceMeasurement"]}
 impl RtActivatable<IXboxLiveQualityOfServiceMeasurementStatics> for XboxLiveQualityOfServiceMeasurement {}
 impl RtActivatable<IActivationFactory> for XboxLiveQualityOfServiceMeasurement {}
 impl XboxLiveQualityOfServiceMeasurement {
@@ -10289,10 +10289,10 @@ impl IXboxLiveQualityOfServiceMeasurementStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum XboxLiveQualityOfServiceMeasurementStatus: i32 {
+RT_ENUM! { enum XboxLiveQualityOfServiceMeasurementStatus: i32 ["Windows.Networking.XboxLive.XboxLiveQualityOfServiceMeasurementStatus"] {
     NotStarted (XboxLiveQualityOfServiceMeasurementStatus_NotStarted) = 0, InProgress (XboxLiveQualityOfServiceMeasurementStatus_InProgress) = 1, InProgressWithProvisionalResults (XboxLiveQualityOfServiceMeasurementStatus_InProgressWithProvisionalResults) = 2, Succeeded (XboxLiveQualityOfServiceMeasurementStatus_Succeeded) = 3, NoLocalNetworks (XboxLiveQualityOfServiceMeasurementStatus_NoLocalNetworks) = 4, NoCompatibleNetworkPaths (XboxLiveQualityOfServiceMeasurementStatus_NoCompatibleNetworkPaths) = 5, LocalSystemNotAuthorized (XboxLiveQualityOfServiceMeasurementStatus_LocalSystemNotAuthorized) = 6, Canceled (XboxLiveQualityOfServiceMeasurementStatus_Canceled) = 7, TimedOut (XboxLiveQualityOfServiceMeasurementStatus_TimedOut) = 8, RemoteSystemNotAuthorized (XboxLiveQualityOfServiceMeasurementStatus_RemoteSystemNotAuthorized) = 9, RefusedDueToConfiguration (XboxLiveQualityOfServiceMeasurementStatus_RefusedDueToConfiguration) = 10, UnexpectedInternalError (XboxLiveQualityOfServiceMeasurementStatus_UnexpectedInternalError) = 11,
 }}
-RT_ENUM! { enum XboxLiveQualityOfServiceMetric: i32 {
+RT_ENUM! { enum XboxLiveQualityOfServiceMetric: i32 ["Windows.Networking.XboxLive.XboxLiveQualityOfServiceMetric"] {
     AverageLatencyInMilliseconds (XboxLiveQualityOfServiceMetric_AverageLatencyInMilliseconds) = 0, MinLatencyInMilliseconds (XboxLiveQualityOfServiceMetric_MinLatencyInMilliseconds) = 1, MaxLatencyInMilliseconds (XboxLiveQualityOfServiceMetric_MaxLatencyInMilliseconds) = 2, AverageOutboundBitsPerSecond (XboxLiveQualityOfServiceMetric_AverageOutboundBitsPerSecond) = 3, MinOutboundBitsPerSecond (XboxLiveQualityOfServiceMetric_MinOutboundBitsPerSecond) = 4, MaxOutboundBitsPerSecond (XboxLiveQualityOfServiceMetric_MaxOutboundBitsPerSecond) = 5, AverageInboundBitsPerSecond (XboxLiveQualityOfServiceMetric_AverageInboundBitsPerSecond) = 6, MinInboundBitsPerSecond (XboxLiveQualityOfServiceMetric_MinInboundBitsPerSecond) = 7, MaxInboundBitsPerSecond (XboxLiveQualityOfServiceMetric_MaxInboundBitsPerSecond) = 8,
 }}
 DEFINE_IID!(IID_IXboxLiveQualityOfServiceMetricResult, 2934723537, 13665, 18306, 176, 207, 211, 174, 41, 217, 250, 135);
@@ -10324,7 +10324,7 @@ impl IXboxLiveQualityOfServiceMetricResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveQualityOfServiceMetricResult: IXboxLiveQualityOfServiceMetricResult}
+RT_CLASS!{class XboxLiveQualityOfServiceMetricResult: IXboxLiveQualityOfServiceMetricResult ["Windows.Networking.XboxLive.XboxLiveQualityOfServiceMetricResult"]}
 DEFINE_IID!(IID_IXboxLiveQualityOfServicePrivatePayloadResult, 1516438190, 28472, 16832, 159, 204, 234, 108, 185, 120, 202, 252);
 RT_INTERFACE!{interface IXboxLiveQualityOfServicePrivatePayloadResult(IXboxLiveQualityOfServicePrivatePayloadResultVtbl): IInspectable(IInspectableVtbl) [IID_IXboxLiveQualityOfServicePrivatePayloadResult] {
     fn get_Status(&self, out: *mut XboxLiveQualityOfServiceMeasurementStatus) -> HRESULT,
@@ -10348,8 +10348,8 @@ impl IXboxLiveQualityOfServicePrivatePayloadResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class XboxLiveQualityOfServicePrivatePayloadResult: IXboxLiveQualityOfServicePrivatePayloadResult}
-RT_ENUM! { enum XboxLiveSocketKind: i32 {
+RT_CLASS!{class XboxLiveQualityOfServicePrivatePayloadResult: IXboxLiveQualityOfServicePrivatePayloadResult ["Windows.Networking.XboxLive.XboxLiveQualityOfServicePrivatePayloadResult"]}
+RT_ENUM! { enum XboxLiveSocketKind: i32 ["Windows.Networking.XboxLive.XboxLiveSocketKind"] {
     None (XboxLiveSocketKind_None) = 0, Datagram (XboxLiveSocketKind_Datagram) = 1, Stream (XboxLiveSocketKind_Stream) = 2,
 }}
 } // Windows.Networking.XboxLive

--- a/src/rt/gen/windows/perception.rs
+++ b/src/rt/gen/windows/perception.rs
@@ -16,7 +16,7 @@ impl IPerceptionTimestamp {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PerceptionTimestamp: IPerceptionTimestamp}
+RT_CLASS!{class PerceptionTimestamp: IPerceptionTimestamp ["Windows.Perception.PerceptionTimestamp"]}
 DEFINE_IID!(IID_IPerceptionTimestamp2, 3813980141, 11217, 16823, 158, 208, 116, 161, 92, 53, 69, 55);
 RT_INTERFACE!{interface IPerceptionTimestamp2(IPerceptionTimestamp2Vtbl): IInspectable(IInspectableVtbl) [IID_IPerceptionTimestamp2] {
     fn get_SystemRelativeTargetTime(&self, out: *mut foundation::TimeSpan) -> HRESULT
@@ -110,7 +110,7 @@ impl IHeadPose {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HeadPose: IHeadPose}
+RT_CLASS!{class HeadPose: IHeadPose ["Windows.Perception.People.HeadPose"]}
 } // Windows.Perception.People
 pub mod spatial { // Windows.Perception.Spatial
 use ::prelude::*;
@@ -142,7 +142,7 @@ impl ISpatialAnchor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAnchor: ISpatialAnchor}
+RT_CLASS!{class SpatialAnchor: ISpatialAnchor ["Windows.Perception.Spatial.SpatialAnchor"]}
 impl RtActivatable<ISpatialAnchorStatics> for SpatialAnchor {}
 impl SpatialAnchor {
     #[inline] pub fn try_create_relative_to(coordinateSystem: &SpatialCoordinateSystem) -> Result<Option<ComPtr<SpatialAnchor>>> {
@@ -184,7 +184,7 @@ impl ISpatialAnchorExporter {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAnchorExporter: ISpatialAnchorExporter}
+RT_CLASS!{class SpatialAnchorExporter: ISpatialAnchorExporter ["Windows.Perception.Spatial.SpatialAnchorExporter"]}
 impl RtActivatable<ISpatialAnchorExporterStatics> for SpatialAnchorExporter {}
 impl SpatialAnchorExporter {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<SpatialAnchorExporter>>> {
@@ -212,7 +212,7 @@ impl ISpatialAnchorExporterStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialAnchorExportPurpose: i32 {
+RT_ENUM! { enum SpatialAnchorExportPurpose: i32 ["Windows.Perception.Spatial.SpatialAnchorExportPurpose"] {
     Relocalization (SpatialAnchorExportPurpose_Relocalization) = 0, Sharing (SpatialAnchorExportPurpose_Sharing) = 1,
 }}
 DEFINE_IID!(IID_ISpatialAnchorExportSufficiency, 2009226027, 13321, 16520, 185, 27, 253, 253, 5, 209, 100, 143);
@@ -238,7 +238,7 @@ impl ISpatialAnchorExportSufficiency {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAnchorExportSufficiency: ISpatialAnchorExportSufficiency}
+RT_CLASS!{class SpatialAnchorExportSufficiency: ISpatialAnchorExportSufficiency ["Windows.Perception.Spatial.SpatialAnchorExportSufficiency"]}
 RT_CLASS!{static class SpatialAnchorManager}
 impl RtActivatable<ISpatialAnchorManagerStatics> for SpatialAnchorManager {}
 impl SpatialAnchorManager {
@@ -269,7 +269,7 @@ impl ISpatialAnchorRawCoordinateSystemAdjustedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAnchorRawCoordinateSystemAdjustedEventArgs: ISpatialAnchorRawCoordinateSystemAdjustedEventArgs}
+RT_CLASS!{class SpatialAnchorRawCoordinateSystemAdjustedEventArgs: ISpatialAnchorRawCoordinateSystemAdjustedEventArgs ["Windows.Perception.Spatial.SpatialAnchorRawCoordinateSystemAdjustedEventArgs"]}
 DEFINE_IID!(IID_ISpatialAnchorStatics, 2844952130, 372, 12572, 174, 121, 14, 81, 7, 102, 159, 22);
 RT_INTERFACE!{static interface ISpatialAnchorStatics(ISpatialAnchorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialAnchorStatics] {
     fn TryCreateRelativeTo(&self, coordinateSystem: *mut SpatialCoordinateSystem, out: *mut *mut SpatialAnchor) -> HRESULT,
@@ -320,7 +320,7 @@ impl ISpatialAnchorStore {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialAnchorStore: ISpatialAnchorStore}
+RT_CLASS!{class SpatialAnchorStore: ISpatialAnchorStore ["Windows.Perception.Spatial.SpatialAnchorStore"]}
 RT_CLASS!{static class SpatialAnchorTransferManager}
 impl RtActivatable<ISpatialAnchorTransferManagerStatics> for SpatialAnchorTransferManager {}
 impl SpatialAnchorTransferManager {
@@ -360,23 +360,23 @@ impl ISpatialAnchorTransferManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct SpatialBoundingBox {
+RT_STRUCT! { struct SpatialBoundingBox ["Windows.Perception.Spatial.SpatialBoundingBox"] {
     Center: foundation::numerics::Vector3, Extents: foundation::numerics::Vector3,
 }}
-RT_STRUCT! { struct SpatialBoundingFrustum {
+RT_STRUCT! { struct SpatialBoundingFrustum ["Windows.Perception.Spatial.SpatialBoundingFrustum"] {
     Near: foundation::numerics::Plane, Far: foundation::numerics::Plane, Right: foundation::numerics::Plane, Left: foundation::numerics::Plane, Top: foundation::numerics::Plane, Bottom: foundation::numerics::Plane,
 }}
-RT_STRUCT! { struct SpatialBoundingOrientedBox {
+RT_STRUCT! { struct SpatialBoundingOrientedBox ["Windows.Perception.Spatial.SpatialBoundingOrientedBox"] {
     Center: foundation::numerics::Vector3, Extents: foundation::numerics::Vector3, Orientation: foundation::numerics::Quaternion,
 }}
-RT_STRUCT! { struct SpatialBoundingSphere {
+RT_STRUCT! { struct SpatialBoundingSphere ["Windows.Perception.Spatial.SpatialBoundingSphere"] {
     Center: foundation::numerics::Vector3, Radius: f32,
 }}
 DEFINE_IID!(IID_ISpatialBoundingVolume, 4213204442, 26819, 13279, 183, 175, 76, 120, 114, 7, 153, 156);
 RT_INTERFACE!{interface ISpatialBoundingVolume(ISpatialBoundingVolumeVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialBoundingVolume] {
     
 }}
-RT_CLASS!{class SpatialBoundingVolume: ISpatialBoundingVolume}
+RT_CLASS!{class SpatialBoundingVolume: ISpatialBoundingVolume ["Windows.Perception.Spatial.SpatialBoundingVolume"]}
 impl RtActivatable<ISpatialBoundingVolumeStatics> for SpatialBoundingVolume {}
 impl SpatialBoundingVolume {
     #[inline] pub fn from_box(coordinateSystem: &SpatialCoordinateSystem, box_: SpatialBoundingBox) -> Result<Option<ComPtr<SpatialBoundingVolume>>> {
@@ -433,7 +433,7 @@ impl ISpatialCoordinateSystem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialCoordinateSystem: ISpatialCoordinateSystem}
+RT_CLASS!{class SpatialCoordinateSystem: ISpatialCoordinateSystem ["Windows.Perception.Spatial.SpatialCoordinateSystem"]}
 DEFINE_IID!(IID_ISpatialEntity, 376301909, 57835, 17740, 186, 8, 230, 192, 102, 141, 220, 101);
 RT_INTERFACE!{interface ISpatialEntity(ISpatialEntityVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialEntity] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -457,7 +457,7 @@ impl ISpatialEntity {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialEntity: ISpatialEntity}
+RT_CLASS!{class SpatialEntity: ISpatialEntity ["Windows.Perception.Spatial.SpatialEntity"]}
 impl RtActivatable<ISpatialEntityFactory> for SpatialEntity {}
 impl SpatialEntity {
     #[inline] pub fn create_with_spatial_anchor(spatialAnchor: &SpatialAnchor) -> Result<ComPtr<SpatialEntity>> {
@@ -479,7 +479,7 @@ impl ISpatialEntityAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialEntityAddedEventArgs: ISpatialEntityAddedEventArgs}
+RT_CLASS!{class SpatialEntityAddedEventArgs: ISpatialEntityAddedEventArgs ["Windows.Perception.Spatial.SpatialEntityAddedEventArgs"]}
 DEFINE_IID!(IID_ISpatialEntityFactory, 3790725925, 13471, 16933, 162, 243, 75, 1, 193, 95, 224, 86);
 RT_INTERFACE!{static interface ISpatialEntityFactory(ISpatialEntityFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialEntityFactory] {
     fn CreateWithSpatialAnchor(&self, spatialAnchor: *mut SpatialAnchor, out: *mut *mut SpatialEntity) -> HRESULT,
@@ -508,7 +508,7 @@ impl ISpatialEntityRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialEntityRemovedEventArgs: ISpatialEntityRemovedEventArgs}
+RT_CLASS!{class SpatialEntityRemovedEventArgs: ISpatialEntityRemovedEventArgs ["Windows.Perception.Spatial.SpatialEntityRemovedEventArgs"]}
 DEFINE_IID!(IID_ISpatialEntityStore, 848791738, 58643, 20230, 136, 157, 27, 227, 14, 207, 67, 230);
 RT_INTERFACE!{interface ISpatialEntityStore(ISpatialEntityStoreVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialEntityStore] {
     fn SaveAsync(&self, entity: *mut SpatialEntity, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -532,7 +532,7 @@ impl ISpatialEntityStore {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialEntityStore: ISpatialEntityStore}
+RT_CLASS!{class SpatialEntityStore: ISpatialEntityStore ["Windows.Perception.Spatial.SpatialEntityStore"]}
 impl RtActivatable<ISpatialEntityStoreStatics> for SpatialEntityStore {}
 impl SpatialEntityStore {
     #[inline] pub fn get_is_supported() -> Result<bool> {
@@ -571,7 +571,7 @@ impl ISpatialEntityUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialEntityUpdatedEventArgs: ISpatialEntityUpdatedEventArgs}
+RT_CLASS!{class SpatialEntityUpdatedEventArgs: ISpatialEntityUpdatedEventArgs ["Windows.Perception.Spatial.SpatialEntityUpdatedEventArgs"]}
 DEFINE_IID!(IID_ISpatialEntityWatcher, 3015204768, 27998, 19388, 128, 93, 95, 229, 185, 186, 25, 89);
 RT_INTERFACE!{interface ISpatialEntityWatcher(ISpatialEntityWatcherVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialEntityWatcher] {
     fn get_Status(&self, out: *mut SpatialEntityWatcherStatus) -> HRESULT,
@@ -637,11 +637,11 @@ impl ISpatialEntityWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialEntityWatcher: ISpatialEntityWatcher}
-RT_ENUM! { enum SpatialEntityWatcherStatus: i32 {
+RT_CLASS!{class SpatialEntityWatcher: ISpatialEntityWatcher ["Windows.Perception.Spatial.SpatialEntityWatcher"]}
+RT_ENUM! { enum SpatialEntityWatcherStatus: i32 ["Windows.Perception.Spatial.SpatialEntityWatcherStatus"] {
     Created (SpatialEntityWatcherStatus_Created) = 0, Started (SpatialEntityWatcherStatus_Started) = 1, EnumerationCompleted (SpatialEntityWatcherStatus_EnumerationCompleted) = 2, Stopping (SpatialEntityWatcherStatus_Stopping) = 3, Stopped (SpatialEntityWatcherStatus_Stopped) = 4, Aborted (SpatialEntityWatcherStatus_Aborted) = 5,
 }}
-RT_ENUM! { enum SpatialLocatability: i32 {
+RT_ENUM! { enum SpatialLocatability: i32 ["Windows.Perception.Spatial.SpatialLocatability"] {
     Unavailable (SpatialLocatability_Unavailable) = 0, OrientationOnly (SpatialLocatability_OrientationOnly) = 1, PositionalTrackingActivating (SpatialLocatability_PositionalTrackingActivating) = 2, PositionalTrackingActive (SpatialLocatability_PositionalTrackingActive) = 3, PositionalTrackingInhibited (SpatialLocatability_PositionalTrackingInhibited) = 4,
 }}
 DEFINE_IID!(IID_ISpatialLocation, 495047325, 9377, 14293, 143, 161, 57, 180, 249, 173, 103, 226);
@@ -685,7 +685,7 @@ impl ISpatialLocation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialLocation: ISpatialLocation}
+RT_CLASS!{class SpatialLocation: ISpatialLocation ["Windows.Perception.Spatial.SpatialLocation"]}
 DEFINE_IID!(IID_ISpatialLocation2, 293544982, 14503, 18968, 180, 4, 171, 143, 171, 225, 215, 139);
 RT_INTERFACE!{interface ISpatialLocation2(ISpatialLocation2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialLocation2] {
     fn get_AbsoluteAngularVelocityAxisAngle(&self, out: *mut foundation::numerics::Vector3) -> HRESULT,
@@ -790,7 +790,7 @@ impl ISpatialLocator {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialLocator: ISpatialLocator}
+RT_CLASS!{class SpatialLocator: ISpatialLocator ["Windows.Perception.Spatial.SpatialLocator"]}
 impl RtActivatable<ISpatialLocatorStatics> for SpatialLocator {}
 impl SpatialLocator {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<SpatialLocator>>> {
@@ -842,7 +842,7 @@ impl ISpatialLocatorAttachedFrameOfReference {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialLocatorAttachedFrameOfReference: ISpatialLocatorAttachedFrameOfReference}
+RT_CLASS!{class SpatialLocatorAttachedFrameOfReference: ISpatialLocatorAttachedFrameOfReference ["Windows.Perception.Spatial.SpatialLocatorAttachedFrameOfReference"]}
 DEFINE_IID!(IID_ISpatialLocatorPositionalTrackingDeactivatingEventArgs, 3098034275, 58356, 13963, 144, 97, 158, 169, 209, 214, 204, 22);
 RT_INTERFACE!{interface ISpatialLocatorPositionalTrackingDeactivatingEventArgs(ISpatialLocatorPositionalTrackingDeactivatingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialLocatorPositionalTrackingDeactivatingEventArgs] {
     fn get_Canceled(&self, out: *mut bool) -> HRESULT,
@@ -859,7 +859,7 @@ impl ISpatialLocatorPositionalTrackingDeactivatingEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialLocatorPositionalTrackingDeactivatingEventArgs: ISpatialLocatorPositionalTrackingDeactivatingEventArgs}
+RT_CLASS!{class SpatialLocatorPositionalTrackingDeactivatingEventArgs: ISpatialLocatorPositionalTrackingDeactivatingEventArgs ["Windows.Perception.Spatial.SpatialLocatorPositionalTrackingDeactivatingEventArgs"]}
 DEFINE_IID!(IID_ISpatialLocatorStatics, 3077452608, 42946, 13851, 187, 130, 86, 233, 59, 137, 177, 187);
 RT_INTERFACE!{static interface ISpatialLocatorStatics(ISpatialLocatorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialLocatorStatics] {
     fn GetDefault(&self, out: *mut *mut SpatialLocator) -> HRESULT
@@ -871,13 +871,13 @@ impl ISpatialLocatorStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialLookDirectionRange: i32 {
+RT_ENUM! { enum SpatialLookDirectionRange: i32 ["Windows.Perception.Spatial.SpatialLookDirectionRange"] {
     ForwardOnly (SpatialLookDirectionRange_ForwardOnly) = 0, Omnidirectional (SpatialLookDirectionRange_Omnidirectional) = 1,
 }}
-RT_ENUM! { enum SpatialMovementRange: i32 {
+RT_ENUM! { enum SpatialMovementRange: i32 ["Windows.Perception.Spatial.SpatialMovementRange"] {
     NoMovement (SpatialMovementRange_NoMovement) = 0, Bounded (SpatialMovementRange_Bounded) = 1,
 }}
-RT_ENUM! { enum SpatialPerceptionAccessStatus: i32 {
+RT_ENUM! { enum SpatialPerceptionAccessStatus: i32 ["Windows.Perception.Spatial.SpatialPerceptionAccessStatus"] {
     Unspecified (SpatialPerceptionAccessStatus_Unspecified) = 0, Allowed (SpatialPerceptionAccessStatus_Allowed) = 1, DeniedByUser (SpatialPerceptionAccessStatus_DeniedByUser) = 2, DeniedBySystem (SpatialPerceptionAccessStatus_DeniedBySystem) = 3,
 }}
 DEFINE_IID!(IID_ISpatialStageFrameOfReference, 2055877732, 44301, 17808, 171, 134, 51, 6, 43, 103, 73, 38);
@@ -915,7 +915,7 @@ impl ISpatialStageFrameOfReference {
         if hr == S_OK { Ok(ComArray::from_raw(outSize, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialStageFrameOfReference: ISpatialStageFrameOfReference}
+RT_CLASS!{class SpatialStageFrameOfReference: ISpatialStageFrameOfReference ["Windows.Perception.Spatial.SpatialStageFrameOfReference"]}
 impl RtActivatable<ISpatialStageFrameOfReferenceStatics> for SpatialStageFrameOfReference {}
 impl SpatialStageFrameOfReference {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<SpatialStageFrameOfReference>>> {
@@ -971,7 +971,7 @@ impl ISpatialStationaryFrameOfReference {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialStationaryFrameOfReference: ISpatialStationaryFrameOfReference}
+RT_CLASS!{class SpatialStationaryFrameOfReference: ISpatialStationaryFrameOfReference ["Windows.Perception.Spatial.SpatialStationaryFrameOfReference"]}
 pub mod preview { // Windows.Perception.Spatial.Preview
 use ::prelude::*;
 RT_CLASS!{static class SpatialGraphInteropPreview}
@@ -1058,7 +1058,7 @@ impl ISpatialSurfaceInfo {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialSurfaceInfo: ISpatialSurfaceInfo}
+RT_CLASS!{class SpatialSurfaceInfo: ISpatialSurfaceInfo ["Windows.Perception.Spatial.Surfaces.SpatialSurfaceInfo"]}
 DEFINE_IID!(IID_ISpatialSurfaceMesh, 277829593, 57101, 14672, 160, 253, 249, 114, 199, 124, 39, 180);
 RT_INTERFACE!{interface ISpatialSurfaceMesh(ISpatialSurfaceMeshVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMesh] {
     fn get_SurfaceInfo(&self, out: *mut *mut SpatialSurfaceInfo) -> HRESULT,
@@ -1100,7 +1100,7 @@ impl ISpatialSurfaceMesh {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialSurfaceMesh: ISpatialSurfaceMesh}
+RT_CLASS!{class SpatialSurfaceMesh: ISpatialSurfaceMesh ["Windows.Perception.Spatial.Surfaces.SpatialSurfaceMesh"]}
 DEFINE_IID!(IID_ISpatialSurfaceMeshBuffer, 2479839712, 34591, 13304, 152, 178, 3, 209, 1, 69, 143, 111);
 RT_INTERFACE!{interface ISpatialSurfaceMeshBuffer(ISpatialSurfaceMeshBufferVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMeshBuffer] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -1131,7 +1131,7 @@ impl ISpatialSurfaceMeshBuffer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialSurfaceMeshBuffer: ISpatialSurfaceMeshBuffer}
+RT_CLASS!{class SpatialSurfaceMeshBuffer: ISpatialSurfaceMeshBuffer ["Windows.Perception.Spatial.Surfaces.SpatialSurfaceMeshBuffer"]}
 DEFINE_IID!(IID_ISpatialSurfaceMeshOptions, 3530923913, 13682, 15661, 161, 13, 95, 238, 147, 148, 170, 55);
 RT_INTERFACE!{interface ISpatialSurfaceMeshOptions(ISpatialSurfaceMeshOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialSurfaceMeshOptions] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -1187,7 +1187,7 @@ impl ISpatialSurfaceMeshOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialSurfaceMeshOptions: ISpatialSurfaceMeshOptions}
+RT_CLASS!{class SpatialSurfaceMeshOptions: ISpatialSurfaceMeshOptions ["Windows.Perception.Spatial.Surfaces.SpatialSurfaceMeshOptions"]}
 impl RtActivatable<ISpatialSurfaceMeshOptionsStatics> for SpatialSurfaceMeshOptions {}
 impl RtActivatable<IActivationFactory> for SpatialSurfaceMeshOptions {}
 impl SpatialSurfaceMeshOptions {
@@ -1257,7 +1257,7 @@ impl ISpatialSurfaceObserver {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialSurfaceObserver: ISpatialSurfaceObserver}
+RT_CLASS!{class SpatialSurfaceObserver: ISpatialSurfaceObserver ["Windows.Perception.Spatial.Surfaces.SpatialSurfaceObserver"]}
 impl RtActivatable<ISpatialSurfaceObserverStatics> for SpatialSurfaceObserver {}
 impl RtActivatable<ISpatialSurfaceObserverStatics2> for SpatialSurfaceObserver {}
 impl RtActivatable<IActivationFactory> for SpatialSurfaceObserver {}

--- a/src/rt/gen/windows/security.rs
+++ b/src/rt/gen/windows/security.rs
@@ -36,7 +36,7 @@ impl IEnterpriseKeyCredentialRegistrationInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EnterpriseKeyCredentialRegistrationInfo: IEnterpriseKeyCredentialRegistrationInfo}
+RT_CLASS!{class EnterpriseKeyCredentialRegistrationInfo: IEnterpriseKeyCredentialRegistrationInfo ["Windows.Security.Authentication.Identity.EnterpriseKeyCredentialRegistrationInfo"]}
 DEFINE_IID!(IID_IEnterpriseKeyCredentialRegistrationManager, 2213789247, 41567, 19642, 187, 142, 189, 195, 45, 3, 194, 151);
 RT_INTERFACE!{interface IEnterpriseKeyCredentialRegistrationManager(IEnterpriseKeyCredentialRegistrationManagerVtbl): IInspectable(IInspectableVtbl) [IID_IEnterpriseKeyCredentialRegistrationManager] {
     fn GetRegistrationsAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<EnterpriseKeyCredentialRegistrationInfo>>) -> HRESULT
@@ -48,7 +48,7 @@ impl IEnterpriseKeyCredentialRegistrationManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EnterpriseKeyCredentialRegistrationManager: IEnterpriseKeyCredentialRegistrationManager}
+RT_CLASS!{class EnterpriseKeyCredentialRegistrationManager: IEnterpriseKeyCredentialRegistrationManager ["Windows.Security.Authentication.Identity.EnterpriseKeyCredentialRegistrationManager"]}
 impl RtActivatable<IEnterpriseKeyCredentialRegistrationManagerStatics> for EnterpriseKeyCredentialRegistrationManager {}
 impl EnterpriseKeyCredentialRegistrationManager {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<EnterpriseKeyCredentialRegistrationManager>>> {
@@ -134,7 +134,7 @@ impl IMicrosoftAccountMultiFactorAuthenticationManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MicrosoftAccountMultiFactorAuthenticationManager: IMicrosoftAccountMultiFactorAuthenticationManager}
+RT_CLASS!{class MicrosoftAccountMultiFactorAuthenticationManager: IMicrosoftAccountMultiFactorAuthenticationManager ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorAuthenticationManager"]}
 impl RtActivatable<IMicrosoftAccountMultiFactorAuthenticatorStatics> for MicrosoftAccountMultiFactorAuthenticationManager {}
 impl MicrosoftAccountMultiFactorAuthenticationManager {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<MicrosoftAccountMultiFactorAuthenticationManager>>> {
@@ -142,7 +142,7 @@ impl MicrosoftAccountMultiFactorAuthenticationManager {
     }
 }
 DEFINE_CLSID!(MicrosoftAccountMultiFactorAuthenticationManager(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,73,100,101,110,116,105,116,121,46,67,111,114,101,46,77,105,99,114,111,115,111,102,116,65,99,99,111,117,110,116,77,117,108,116,105,70,97,99,116,111,114,65,117,116,104,101,110,116,105,99,97,116,105,111,110,77,97,110,97,103,101,114,0]) [CLSID_MicrosoftAccountMultiFactorAuthenticationManager]);
-RT_ENUM! { enum MicrosoftAccountMultiFactorAuthenticationType: i32 {
+RT_ENUM! { enum MicrosoftAccountMultiFactorAuthenticationType: i32 ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorAuthenticationType"] {
     User (MicrosoftAccountMultiFactorAuthenticationType_User) = 0, Device (MicrosoftAccountMultiFactorAuthenticationType_Device) = 1,
 }}
 DEFINE_IID!(IID_IMicrosoftAccountMultiFactorAuthenticatorStatics, 3647259366, 62534, 19569, 139, 121, 110, 164, 2, 74, 169, 184);
@@ -173,7 +173,7 @@ impl IMicrosoftAccountMultiFactorGetSessionsResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MicrosoftAccountMultiFactorGetSessionsResult: IMicrosoftAccountMultiFactorGetSessionsResult}
+RT_CLASS!{class MicrosoftAccountMultiFactorGetSessionsResult: IMicrosoftAccountMultiFactorGetSessionsResult ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorGetSessionsResult"]}
 DEFINE_IID!(IID_IMicrosoftAccountMultiFactorOneTimeCodedInfo, 2193237579, 55420, 18024, 169, 118, 64, 207, 174, 84, 125, 8);
 RT_INTERFACE!{interface IMicrosoftAccountMultiFactorOneTimeCodedInfo(IMicrosoftAccountMultiFactorOneTimeCodedInfoVtbl): IInspectable(IInspectableVtbl) [IID_IMicrosoftAccountMultiFactorOneTimeCodedInfo] {
     fn get_Code(&self, out: *mut HSTRING) -> HRESULT,
@@ -203,14 +203,14 @@ impl IMicrosoftAccountMultiFactorOneTimeCodedInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MicrosoftAccountMultiFactorOneTimeCodedInfo: IMicrosoftAccountMultiFactorOneTimeCodedInfo}
-RT_ENUM! { enum MicrosoftAccountMultiFactorServiceResponse: i32 {
+RT_CLASS!{class MicrosoftAccountMultiFactorOneTimeCodedInfo: IMicrosoftAccountMultiFactorOneTimeCodedInfo ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorOneTimeCodedInfo"]}
+RT_ENUM! { enum MicrosoftAccountMultiFactorServiceResponse: i32 ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorServiceResponse"] {
     Success (MicrosoftAccountMultiFactorServiceResponse_Success) = 0, Error (MicrosoftAccountMultiFactorServiceResponse_Error) = 1, NoNetworkConnection (MicrosoftAccountMultiFactorServiceResponse_NoNetworkConnection) = 2, ServiceUnavailable (MicrosoftAccountMultiFactorServiceResponse_ServiceUnavailable) = 3, TotpSetupDenied (MicrosoftAccountMultiFactorServiceResponse_TotpSetupDenied) = 4, NgcNotSetup (MicrosoftAccountMultiFactorServiceResponse_NgcNotSetup) = 5, SessionAlreadyDenied (MicrosoftAccountMultiFactorServiceResponse_SessionAlreadyDenied) = 6, SessionAlreadyApproved (MicrosoftAccountMultiFactorServiceResponse_SessionAlreadyApproved) = 7, SessionExpired (MicrosoftAccountMultiFactorServiceResponse_SessionExpired) = 8, NgcNonceExpired (MicrosoftAccountMultiFactorServiceResponse_NgcNonceExpired) = 9, InvalidSessionId (MicrosoftAccountMultiFactorServiceResponse_InvalidSessionId) = 10, InvalidSessionType (MicrosoftAccountMultiFactorServiceResponse_InvalidSessionType) = 11, InvalidOperation (MicrosoftAccountMultiFactorServiceResponse_InvalidOperation) = 12, InvalidStateTransition (MicrosoftAccountMultiFactorServiceResponse_InvalidStateTransition) = 13, DeviceNotFound (MicrosoftAccountMultiFactorServiceResponse_DeviceNotFound) = 14, FlowDisabled (MicrosoftAccountMultiFactorServiceResponse_FlowDisabled) = 15, SessionNotApproved (MicrosoftAccountMultiFactorServiceResponse_SessionNotApproved) = 16, OperationCanceledByUser (MicrosoftAccountMultiFactorServiceResponse_OperationCanceledByUser) = 17, NgcDisabledByServer (MicrosoftAccountMultiFactorServiceResponse_NgcDisabledByServer) = 18, NgcKeyNotFoundOnServer (MicrosoftAccountMultiFactorServiceResponse_NgcKeyNotFoundOnServer) = 19, UIRequired (MicrosoftAccountMultiFactorServiceResponse_UIRequired) = 20, DeviceIdChanged (MicrosoftAccountMultiFactorServiceResponse_DeviceIdChanged) = 21,
 }}
-RT_ENUM! { enum MicrosoftAccountMultiFactorSessionApprovalStatus: i32 {
+RT_ENUM! { enum MicrosoftAccountMultiFactorSessionApprovalStatus: i32 ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorSessionApprovalStatus"] {
     Pending (MicrosoftAccountMultiFactorSessionApprovalStatus_Pending) = 0, Approved (MicrosoftAccountMultiFactorSessionApprovalStatus_Approved) = 1, Denied (MicrosoftAccountMultiFactorSessionApprovalStatus_Denied) = 2,
 }}
-RT_ENUM! { enum MicrosoftAccountMultiFactorSessionAuthenticationStatus: i32 {
+RT_ENUM! { enum MicrosoftAccountMultiFactorSessionAuthenticationStatus: i32 ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorSessionAuthenticationStatus"] {
     Authenticated (MicrosoftAccountMultiFactorSessionAuthenticationStatus_Authenticated) = 0, Unauthenticated (MicrosoftAccountMultiFactorSessionAuthenticationStatus_Unauthenticated) = 1,
 }}
 DEFINE_IID!(IID_IMicrosoftAccountMultiFactorSessionInfo, 1602137012, 41592, 17973, 183, 101, 180, 148, 235, 38, 10, 244);
@@ -260,7 +260,7 @@ impl IMicrosoftAccountMultiFactorSessionInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MicrosoftAccountMultiFactorSessionInfo: IMicrosoftAccountMultiFactorSessionInfo}
+RT_CLASS!{class MicrosoftAccountMultiFactorSessionInfo: IMicrosoftAccountMultiFactorSessionInfo ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorSessionInfo"]}
 DEFINE_IID!(IID_IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo, 2860434939, 55871, 16520, 162, 13, 86, 24, 175, 173, 178, 229);
 RT_INTERFACE!{interface IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo(IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfoVtbl): IInspectable(IInspectableVtbl) [IID_IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo] {
     fn get_Sessions(&self, out: *mut *mut foundation::collections::IVectorView<MicrosoftAccountMultiFactorSessionInfo>) -> HRESULT,
@@ -284,7 +284,7 @@ impl IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo: IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo}
+RT_CLASS!{class MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo: IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo ["Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo"]}
 } // Windows.Security.Authentication.Identity.Core
 pub mod provider { // Windows.Security.Authentication.Identity.Provider
 use ::prelude::*;
@@ -334,7 +334,7 @@ impl ISecondaryAuthenticationFactorAuthentication {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorAuthentication: ISecondaryAuthenticationFactorAuthentication}
+RT_CLASS!{class SecondaryAuthenticationFactorAuthentication: ISecondaryAuthenticationFactorAuthentication ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthentication"]}
 impl RtActivatable<ISecondaryAuthenticationFactorAuthenticationStatics> for SecondaryAuthenticationFactorAuthentication {}
 impl SecondaryAuthenticationFactorAuthentication {
     #[inline] pub fn show_notification_message_async(deviceName: &HStringArg, message: SecondaryAuthenticationFactorAuthenticationMessage) -> Result<ComPtr<foundation::IAsyncAction>> {
@@ -354,7 +354,7 @@ impl SecondaryAuthenticationFactorAuthentication {
     }
 }
 DEFINE_CLSID!(SecondaryAuthenticationFactorAuthentication(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,73,100,101,110,116,105,116,121,46,80,114,111,118,105,100,101,114,46,83,101,99,111,110,100,97,114,121,65,117,116,104,101,110,116,105,99,97,116,105,111,110,70,97,99,116,111,114,65,117,116,104,101,110,116,105,99,97,116,105,111,110,0]) [CLSID_SecondaryAuthenticationFactorAuthentication]);
-RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationMessage: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationMessage: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationMessage"] {
     Invalid (SecondaryAuthenticationFactorAuthenticationMessage_Invalid) = 0, SwipeUpWelcome (SecondaryAuthenticationFactorAuthenticationMessage_SwipeUpWelcome) = 1, TapWelcome (SecondaryAuthenticationFactorAuthenticationMessage_TapWelcome) = 2, DeviceNeedsAttention (SecondaryAuthenticationFactorAuthenticationMessage_DeviceNeedsAttention) = 3, LookingForDevice (SecondaryAuthenticationFactorAuthenticationMessage_LookingForDevice) = 4, LookingForDevicePluggedin (SecondaryAuthenticationFactorAuthenticationMessage_LookingForDevicePluggedin) = 5, BluetoothIsDisabled (SecondaryAuthenticationFactorAuthenticationMessage_BluetoothIsDisabled) = 6, NfcIsDisabled (SecondaryAuthenticationFactorAuthenticationMessage_NfcIsDisabled) = 7, WiFiIsDisabled (SecondaryAuthenticationFactorAuthenticationMessage_WiFiIsDisabled) = 8, ExtraTapIsRequired (SecondaryAuthenticationFactorAuthenticationMessage_ExtraTapIsRequired) = 9, DisabledByPolicy (SecondaryAuthenticationFactorAuthenticationMessage_DisabledByPolicy) = 10, TapOnDeviceRequired (SecondaryAuthenticationFactorAuthenticationMessage_TapOnDeviceRequired) = 11, HoldFinger (SecondaryAuthenticationFactorAuthenticationMessage_HoldFinger) = 12, ScanFinger (SecondaryAuthenticationFactorAuthenticationMessage_ScanFinger) = 13, UnauthorizedUser (SecondaryAuthenticationFactorAuthenticationMessage_UnauthorizedUser) = 14, ReregisterRequired (SecondaryAuthenticationFactorAuthenticationMessage_ReregisterRequired) = 15, TryAgain (SecondaryAuthenticationFactorAuthenticationMessage_TryAgain) = 16, SayPassphrase (SecondaryAuthenticationFactorAuthenticationMessage_SayPassphrase) = 17, ReadyToSignIn (SecondaryAuthenticationFactorAuthenticationMessage_ReadyToSignIn) = 18, UseAnotherSignInOption (SecondaryAuthenticationFactorAuthenticationMessage_UseAnotherSignInOption) = 19, ConnectionRequired (SecondaryAuthenticationFactorAuthenticationMessage_ConnectionRequired) = 20, TimeLimitExceeded (SecondaryAuthenticationFactorAuthenticationMessage_TimeLimitExceeded) = 21, CanceledByUser (SecondaryAuthenticationFactorAuthenticationMessage_CanceledByUser) = 22, CenterHand (SecondaryAuthenticationFactorAuthenticationMessage_CenterHand) = 23, MoveHandCloser (SecondaryAuthenticationFactorAuthenticationMessage_MoveHandCloser) = 24, MoveHandFarther (SecondaryAuthenticationFactorAuthenticationMessage_MoveHandFarther) = 25, PlaceHandAbove (SecondaryAuthenticationFactorAuthenticationMessage_PlaceHandAbove) = 26, RecognitionFailed (SecondaryAuthenticationFactorAuthenticationMessage_RecognitionFailed) = 27, DeviceUnavailable (SecondaryAuthenticationFactorAuthenticationMessage_DeviceUnavailable) = 28,
 }}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationResult, 2629523847, 61293, 19394, 191, 73, 70, 23, 81, 90, 15, 154);
@@ -374,11 +374,11 @@ impl ISecondaryAuthenticationFactorAuthenticationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationResult: ISecondaryAuthenticationFactorAuthenticationResult}
-RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationScenario: i32 {
+RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationResult: ISecondaryAuthenticationFactorAuthenticationResult ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationResult"]}
+RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationScenario: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationScenario"] {
     SignIn (SecondaryAuthenticationFactorAuthenticationScenario_SignIn) = 0, CredentialPrompt (SecondaryAuthenticationFactorAuthenticationScenario_CredentialPrompt) = 1,
 }}
-RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationStage: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationStage: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationStage"] {
     NotStarted (SecondaryAuthenticationFactorAuthenticationStage_NotStarted) = 0, WaitingForUserConfirmation (SecondaryAuthenticationFactorAuthenticationStage_WaitingForUserConfirmation) = 1, CollectingCredential (SecondaryAuthenticationFactorAuthenticationStage_CollectingCredential) = 2, SuspendingAuthentication (SecondaryAuthenticationFactorAuthenticationStage_SuspendingAuthentication) = 3, CredentialCollected (SecondaryAuthenticationFactorAuthenticationStage_CredentialCollected) = 4, CredentialAuthenticated (SecondaryAuthenticationFactorAuthenticationStage_CredentialAuthenticated) = 5, StoppingAuthentication (SecondaryAuthenticationFactorAuthenticationStage_StoppingAuthentication) = 6, ReadyForLock (SecondaryAuthenticationFactorAuthenticationStage_ReadyForLock) = 7, CheckingDevicePresence (SecondaryAuthenticationFactorAuthenticationStage_CheckingDevicePresence) = 8,
 }}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationStageChangedEventArgs, 3567644246, 29329, 16499, 188, 31, 204, 184, 245, 175, 223, 150);
@@ -392,7 +392,7 @@ impl ISecondaryAuthenticationFactorAuthenticationStageChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs: ISecondaryAuthenticationFactorAuthenticationStageChangedEventArgs}
+RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs: ISecondaryAuthenticationFactorAuthenticationStageChangedEventArgs ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs"]}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationStageInfo, 1459536523, 59562, 19471, 142, 76, 165, 89, 231, 58, 221, 136);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorAuthenticationStageInfo(ISecondaryAuthenticationFactorAuthenticationStageInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorAuthenticationStageInfo] {
     fn get_Stage(&self, out: *mut SecondaryAuthenticationFactorAuthenticationStage) -> HRESULT,
@@ -416,7 +416,7 @@ impl ISecondaryAuthenticationFactorAuthenticationStageInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationStageInfo: ISecondaryAuthenticationFactorAuthenticationStageInfo}
+RT_CLASS!{class SecondaryAuthenticationFactorAuthenticationStageInfo: ISecondaryAuthenticationFactorAuthenticationStageInfo ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationStageInfo"]}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorAuthenticationStatics, 1062741590, 10488, 19983, 174, 140, 88, 152, 185, 174, 36, 105);
 RT_INTERFACE!{static interface ISecondaryAuthenticationFactorAuthenticationStatics(ISecondaryAuthenticationFactorAuthenticationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorAuthenticationStatics] {
     fn ShowNotificationMessageAsync(&self, deviceName: HSTRING, message: SecondaryAuthenticationFactorAuthenticationMessage, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -452,19 +452,19 @@ impl ISecondaryAuthenticationFactorAuthenticationStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationStatus: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorAuthenticationStatus: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationStatus"] {
     Failed (SecondaryAuthenticationFactorAuthenticationStatus_Failed) = 0, Started (SecondaryAuthenticationFactorAuthenticationStatus_Started) = 1, UnknownDevice (SecondaryAuthenticationFactorAuthenticationStatus_UnknownDevice) = 2, DisabledByPolicy (SecondaryAuthenticationFactorAuthenticationStatus_DisabledByPolicy) = 3, InvalidAuthenticationStage (SecondaryAuthenticationFactorAuthenticationStatus_InvalidAuthenticationStage) = 4,
 }}
-RT_ENUM! { enum SecondaryAuthenticationFactorDeviceCapabilities: u32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorDeviceCapabilities: u32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorDeviceCapabilities"] {
     None (SecondaryAuthenticationFactorDeviceCapabilities_None) = 0, SecureStorage (SecondaryAuthenticationFactorDeviceCapabilities_SecureStorage) = 1, StoreKeys (SecondaryAuthenticationFactorDeviceCapabilities_StoreKeys) = 2, ConfirmUserIntentToAuthenticate (SecondaryAuthenticationFactorDeviceCapabilities_ConfirmUserIntentToAuthenticate) = 4, SupportSecureUserPresenceCheck (SecondaryAuthenticationFactorDeviceCapabilities_SupportSecureUserPresenceCheck) = 8, TransmittedDataIsEncrypted (SecondaryAuthenticationFactorDeviceCapabilities_TransmittedDataIsEncrypted) = 16, HMacSha256 (SecondaryAuthenticationFactorDeviceCapabilities_HMacSha256) = 32, CloseRangeDataTransmission (SecondaryAuthenticationFactorDeviceCapabilities_CloseRangeDataTransmission) = 64,
 }}
-RT_ENUM! { enum SecondaryAuthenticationFactorDeviceFindScope: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorDeviceFindScope: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorDeviceFindScope"] {
     User (SecondaryAuthenticationFactorDeviceFindScope_User) = 0, AllUsers (SecondaryAuthenticationFactorDeviceFindScope_AllUsers) = 1,
 }}
-RT_ENUM! { enum SecondaryAuthenticationFactorDevicePresence: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorDevicePresence: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorDevicePresence"] {
     Absent (SecondaryAuthenticationFactorDevicePresence_Absent) = 0, Present (SecondaryAuthenticationFactorDevicePresence_Present) = 1,
 }}
-RT_ENUM! { enum SecondaryAuthenticationFactorDevicePresenceMonitoringMode: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorDevicePresenceMonitoringMode: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorDevicePresenceMonitoringMode"] {
     Unsupported (SecondaryAuthenticationFactorDevicePresenceMonitoringMode_Unsupported) = 0, AppManaged (SecondaryAuthenticationFactorDevicePresenceMonitoringMode_AppManaged) = 1, SystemManaged (SecondaryAuthenticationFactorDevicePresenceMonitoringMode_SystemManaged) = 2,
 }}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics, 2420742681, 32498, 17699, 149, 28, 164, 23, 162, 74, 207, 147);
@@ -497,10 +497,10 @@ impl ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus"] {
     Unsupported (SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus_Unsupported) = 0, Succeeded (SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus_Succeeded) = 1, DisabledByPolicy (SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus_DisabledByPolicy) = 2,
 }}
-RT_ENUM! { enum SecondaryAuthenticationFactorFinishAuthenticationStatus: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorFinishAuthenticationStatus: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorFinishAuthenticationStatus"] {
     Failed (SecondaryAuthenticationFactorFinishAuthenticationStatus_Failed) = 0, Completed (SecondaryAuthenticationFactorFinishAuthenticationStatus_Completed) = 1, NonceExpired (SecondaryAuthenticationFactorFinishAuthenticationStatus_NonceExpired) = 2,
 }}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorInfo, 506177633, 34099, 20430, 131, 155, 236, 183, 36, 16, 172, 20);
@@ -532,7 +532,7 @@ impl ISecondaryAuthenticationFactorInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorInfo: ISecondaryAuthenticationFactorInfo}
+RT_CLASS!{class SecondaryAuthenticationFactorInfo: ISecondaryAuthenticationFactorInfo ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorInfo"]}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorInfo2, 349798819, 64550, 20471, 171, 195, 72, 232, 42, 81, 42, 10);
 RT_INTERFACE!{interface ISecondaryAuthenticationFactorInfo2(ISecondaryAuthenticationFactorInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorInfo2] {
     fn get_PresenceMonitoringMode(&self, out: *mut SecondaryAuthenticationFactorDevicePresenceMonitoringMode) -> HRESULT,
@@ -574,7 +574,7 @@ impl ISecondaryAuthenticationFactorRegistration {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorRegistration: ISecondaryAuthenticationFactorRegistration}
+RT_CLASS!{class SecondaryAuthenticationFactorRegistration: ISecondaryAuthenticationFactorRegistration ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorRegistration"]}
 impl RtActivatable<ISecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatics> for SecondaryAuthenticationFactorRegistration {}
 impl RtActivatable<ISecondaryAuthenticationFactorRegistrationStatics> for SecondaryAuthenticationFactorRegistration {}
 impl SecondaryAuthenticationFactorRegistration {
@@ -621,7 +621,7 @@ impl ISecondaryAuthenticationFactorRegistrationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryAuthenticationFactorRegistrationResult: ISecondaryAuthenticationFactorRegistrationResult}
+RT_CLASS!{class SecondaryAuthenticationFactorRegistrationResult: ISecondaryAuthenticationFactorRegistrationResult ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorRegistrationResult"]}
 DEFINE_IID!(IID_ISecondaryAuthenticationFactorRegistrationStatics, 450826085, 58295, 16725, 153, 127, 183, 86, 239, 101, 190, 186);
 RT_INTERFACE!{static interface ISecondaryAuthenticationFactorRegistrationStatics(ISecondaryAuthenticationFactorRegistrationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryAuthenticationFactorRegistrationStatics] {
     #[cfg(feature="windows-storage")] fn RequestStartRegisteringDeviceAsync(&self, deviceId: HSTRING, capabilities: SecondaryAuthenticationFactorDeviceCapabilities, deviceFriendlyName: HSTRING, deviceModelNumber: HSTRING, deviceKey: *mut ::rt::gen::windows::storage::streams::IBuffer, mutualAuthenticationKey: *mut ::rt::gen::windows::storage::streams::IBuffer, out: *mut *mut foundation::IAsyncOperation<SecondaryAuthenticationFactorRegistrationResult>) -> HRESULT,
@@ -651,14 +651,14 @@ impl ISecondaryAuthenticationFactorRegistrationStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SecondaryAuthenticationFactorRegistrationStatus: i32 {
+RT_ENUM! { enum SecondaryAuthenticationFactorRegistrationStatus: i32 ["Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorRegistrationStatus"] {
     Failed (SecondaryAuthenticationFactorRegistrationStatus_Failed) = 0, Started (SecondaryAuthenticationFactorRegistrationStatus_Started) = 1, CanceledByUser (SecondaryAuthenticationFactorRegistrationStatus_CanceledByUser) = 2, PinSetupRequired (SecondaryAuthenticationFactorRegistrationStatus_PinSetupRequired) = 3, DisabledByPolicy (SecondaryAuthenticationFactorRegistrationStatus_DisabledByPolicy) = 4,
 }}
 } // Windows.Security.Authentication.Identity.Provider
 } // Windows.Security.Authentication.Identity
 pub mod onlineid { // Windows.Security.Authentication.OnlineId
 use ::prelude::*;
-RT_ENUM! { enum CredentialPromptType: i32 {
+RT_ENUM! { enum CredentialPromptType: i32 ["Windows.Security.Authentication.OnlineId.CredentialPromptType"] {
     PromptIfNeeded (CredentialPromptType_PromptIfNeeded) = 0, RetypeCredentials (CredentialPromptType_RetypeCredentials) = 1, DoNotPrompt (CredentialPromptType_DoNotPrompt) = 2,
 }}
 DEFINE_IID!(IID_IOnlineIdAuthenticator, 2684614026, 10667, 18455, 184, 132, 215, 81, 109, 173, 24, 185);
@@ -707,7 +707,7 @@ impl IOnlineIdAuthenticator {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OnlineIdAuthenticator: IOnlineIdAuthenticator}
+RT_CLASS!{class OnlineIdAuthenticator: IOnlineIdAuthenticator ["Windows.Security.Authentication.OnlineId.OnlineIdAuthenticator"]}
 impl RtActivatable<IActivationFactory> for OnlineIdAuthenticator {}
 DEFINE_CLSID!(OnlineIdAuthenticator(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,65,117,116,104,101,110,116,105,99,97,116,105,111,110,46,79,110,108,105,110,101,73,100,46,79,110,108,105,110,101,73,100,65,117,116,104,101,110,116,105,99,97,116,111,114,0]) [CLSID_OnlineIdAuthenticator]);
 DEFINE_IID!(IID_IOnlineIdServiceTicket, 3378271359, 55169, 19092, 172, 184, 197, 152, 116, 35, 140, 38);
@@ -733,7 +733,7 @@ impl IOnlineIdServiceTicket {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OnlineIdServiceTicket: IOnlineIdServiceTicket}
+RT_CLASS!{class OnlineIdServiceTicket: IOnlineIdServiceTicket ["Windows.Security.Authentication.OnlineId.OnlineIdServiceTicket"]}
 DEFINE_IID!(IID_IOnlineIdServiceTicketRequest, 695485907, 64355, 16693, 137, 9, 78, 53, 76, 6, 20, 102);
 RT_INTERFACE!{interface IOnlineIdServiceTicketRequest(IOnlineIdServiceTicketRequestVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdServiceTicketRequest] {
     fn get_Service(&self, out: *mut HSTRING) -> HRESULT,
@@ -751,7 +751,7 @@ impl IOnlineIdServiceTicketRequest {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OnlineIdServiceTicketRequest: IOnlineIdServiceTicketRequest}
+RT_CLASS!{class OnlineIdServiceTicketRequest: IOnlineIdServiceTicketRequest ["Windows.Security.Authentication.OnlineId.OnlineIdServiceTicketRequest"]}
 impl RtActivatable<IOnlineIdServiceTicketRequestFactory> for OnlineIdServiceTicketRequest {}
 impl OnlineIdServiceTicketRequest {
     #[inline] pub fn create_online_id_service_ticket_request(service: &HStringArg, policy: &HStringArg) -> Result<ComPtr<OnlineIdServiceTicketRequest>> {
@@ -818,7 +818,7 @@ impl IOnlineIdSystemAuthenticatorForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OnlineIdSystemAuthenticatorForUser: IOnlineIdSystemAuthenticatorForUser}
+RT_CLASS!{class OnlineIdSystemAuthenticatorForUser: IOnlineIdSystemAuthenticatorForUser ["Windows.Security.Authentication.OnlineId.OnlineIdSystemAuthenticatorForUser"]}
 DEFINE_IID!(IID_IOnlineIdSystemAuthenticatorStatics, 2231662482, 63028, 16867, 150, 164, 81, 100, 233, 2, 199, 64);
 RT_INTERFACE!{static interface IOnlineIdSystemAuthenticatorStatics(IOnlineIdSystemAuthenticatorStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdSystemAuthenticatorStatics] {
     fn get_Default(&self, out: *mut *mut OnlineIdSystemAuthenticatorForUser) -> HRESULT,
@@ -853,7 +853,7 @@ impl IOnlineIdSystemIdentity {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OnlineIdSystemIdentity: IOnlineIdSystemIdentity}
+RT_CLASS!{class OnlineIdSystemIdentity: IOnlineIdSystemIdentity ["Windows.Security.Authentication.OnlineId.OnlineIdSystemIdentity"]}
 DEFINE_IID!(IID_IOnlineIdSystemTicketResult, 3674890232, 45208, 19149, 157, 19, 158, 100, 6, 82, 181, 182);
 RT_INTERFACE!{interface IOnlineIdSystemTicketResult(IOnlineIdSystemTicketResultVtbl): IInspectable(IInspectableVtbl) [IID_IOnlineIdSystemTicketResult] {
     fn get_Identity(&self, out: *mut *mut OnlineIdSystemIdentity) -> HRESULT,
@@ -877,12 +877,12 @@ impl IOnlineIdSystemTicketResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OnlineIdSystemTicketResult: IOnlineIdSystemTicketResult}
-RT_ENUM! { enum OnlineIdSystemTicketStatus: i32 {
+RT_CLASS!{class OnlineIdSystemTicketResult: IOnlineIdSystemTicketResult ["Windows.Security.Authentication.OnlineId.OnlineIdSystemTicketResult"]}
+RT_ENUM! { enum OnlineIdSystemTicketStatus: i32 ["Windows.Security.Authentication.OnlineId.OnlineIdSystemTicketStatus"] {
     Success (OnlineIdSystemTicketStatus_Success) = 0, Error (OnlineIdSystemTicketStatus_Error) = 1, ServiceConnectionError (OnlineIdSystemTicketStatus_ServiceConnectionError) = 2,
 }}
-RT_CLASS!{class SignOutUserOperation: foundation::IAsyncAction}
-RT_CLASS!{class UserAuthenticationOperation: foundation::IAsyncOperation<UserIdentity>}
+RT_CLASS!{class SignOutUserOperation: foundation::IAsyncAction ["Windows.Security.Authentication.OnlineId.SignOutUserOperation"]}
+RT_CLASS!{class UserAuthenticationOperation: foundation::IAsyncOperation<UserIdentity> ["Windows.Security.Authentication.OnlineId.UserAuthenticationOperation"]}
 DEFINE_IID!(IID_IUserIdentity, 558291405, 1858, 19427, 138, 28, 124, 122, 230, 121, 170, 136);
 RT_INTERFACE!{interface IUserIdentity(IUserIdentityVtbl): IInspectable(IInspectableVtbl) [IID_IUserIdentity] {
     fn get_Tickets(&self, out: *mut *mut foundation::collections::IVectorView<OnlineIdServiceTicket>) -> HRESULT,
@@ -936,11 +936,11 @@ impl IUserIdentity {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserIdentity: IUserIdentity}
+RT_CLASS!{class UserIdentity: IUserIdentity ["Windows.Security.Authentication.OnlineId.UserIdentity"]}
 } // Windows.Security.Authentication.OnlineId
 pub mod web { // Windows.Security.Authentication.Web
 use ::prelude::*;
-RT_ENUM! { enum TokenBindingKeyType: i32 {
+RT_ENUM! { enum TokenBindingKeyType: i32 ["Windows.Security.Authentication.Web.TokenBindingKeyType"] {
     Rsa2048 (TokenBindingKeyType_Rsa2048) = 0, EcdsaP256 (TokenBindingKeyType_EcdsaP256) = 1, AnyExisting (TokenBindingKeyType_AnyExisting) = 2,
 }}
 RT_CLASS!{static class WebAuthenticationBroker}
@@ -1028,7 +1028,7 @@ impl IWebAuthenticationBrokerStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAuthenticationOptions: u32 {
+RT_ENUM! { enum WebAuthenticationOptions: u32 ["Windows.Security.Authentication.Web.WebAuthenticationOptions"] {
     None (WebAuthenticationOptions_None) = 0, SilentMode (WebAuthenticationOptions_SilentMode) = 1, UseTitle (WebAuthenticationOptions_UseTitle) = 2, UseHttpPost (WebAuthenticationOptions_UseHttpPost) = 4, UseCorporateNetwork (WebAuthenticationOptions_UseCorporateNetwork) = 8,
 }}
 DEFINE_IID!(IID_IWebAuthenticationResult, 1677732683, 60905, 18186, 165, 205, 3, 35, 250, 246, 226, 98);
@@ -1054,8 +1054,8 @@ impl IWebAuthenticationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAuthenticationResult: IWebAuthenticationResult}
-RT_ENUM! { enum WebAuthenticationStatus: i32 {
+RT_CLASS!{class WebAuthenticationResult: IWebAuthenticationResult ["Windows.Security.Authentication.Web.WebAuthenticationResult"]}
+RT_ENUM! { enum WebAuthenticationStatus: i32 ["Windows.Security.Authentication.Web.WebAuthenticationStatus"] {
     Success (WebAuthenticationStatus_Success) = 0, UserCancel (WebAuthenticationStatus_UserCancel) = 1, ErrorHttp (WebAuthenticationStatus_ErrorHttp) = 2,
 }}
 pub mod core { // Windows.Security.Authentication.Web.Core
@@ -1083,8 +1083,8 @@ impl IFindAllAccountsResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FindAllAccountsResult: IFindAllAccountsResult}
-RT_ENUM! { enum FindAllWebAccountsStatus: i32 {
+RT_CLASS!{class FindAllAccountsResult: IFindAllAccountsResult ["Windows.Security.Authentication.Web.Core.FindAllAccountsResult"]}
+RT_ENUM! { enum FindAllWebAccountsStatus: i32 ["Windows.Security.Authentication.Web.Core.FindAllWebAccountsStatus"] {
     Success (FindAllWebAccountsStatus_Success) = 0, NotAllowedByProvider (FindAllWebAccountsStatus_NotAllowedByProvider) = 1, NotSupportedByProvider (FindAllWebAccountsStatus_NotSupportedByProvider) = 2, ProviderError (FindAllWebAccountsStatus_ProviderError) = 3,
 }}
 DEFINE_IID!(IID_IWebAccountEventArgs, 1874264957, 16974, 17644, 151, 124, 239, 36, 21, 70, 42, 90);
@@ -1098,7 +1098,7 @@ impl IWebAccountEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountEventArgs: IWebAccountEventArgs}
+RT_CLASS!{class WebAccountEventArgs: IWebAccountEventArgs ["Windows.Security.Authentication.Web.Core.WebAccountEventArgs"]}
 DEFINE_IID!(IID_IWebAccountMonitor, 1950742013, 43677, 17945, 141, 93, 193, 56, 164, 237, 227, 229);
 RT_INTERFACE!{interface IWebAccountMonitor(IWebAccountMonitorVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountMonitor] {
     fn add_Updated(&self, handler: *mut foundation::TypedEventHandler<WebAccountMonitor, WebAccountEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -1137,7 +1137,7 @@ impl IWebAccountMonitor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountMonitor: IWebAccountMonitor}
+RT_CLASS!{class WebAccountMonitor: IWebAccountMonitor ["Windows.Security.Authentication.Web.Core.WebAccountMonitor"]}
 RT_CLASS!{static class WebAuthenticationCoreManager}
 impl RtActivatable<IWebAuthenticationCoreManagerStatics> for WebAuthenticationCoreManager {}
 impl RtActivatable<IWebAuthenticationCoreManagerStatics2> for WebAuthenticationCoreManager {}
@@ -1315,7 +1315,7 @@ impl IWebProviderError {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebProviderError: IWebProviderError}
+RT_CLASS!{class WebProviderError: IWebProviderError ["Windows.Security.Authentication.Web.Core.WebProviderError"]}
 impl RtActivatable<IWebProviderErrorFactory> for WebProviderError {}
 impl WebProviderError {
     #[inline] pub fn create(errorCode: u32, errorMessage: &HStringArg) -> Result<ComPtr<WebProviderError>> {
@@ -1369,7 +1369,7 @@ impl IWebTokenRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebTokenRequest: IWebTokenRequest}
+RT_CLASS!{class WebTokenRequest: IWebTokenRequest ["Windows.Security.Authentication.Web.Core.WebTokenRequest"]}
 impl RtActivatable<IWebTokenRequestFactory> for WebTokenRequest {}
 impl WebTokenRequest {
     #[inline] pub fn create(provider: &super::super::super::credentials::WebAccountProvider, scope: &HStringArg, clientId: &HStringArg) -> Result<ComPtr<WebTokenRequest>> {
@@ -1442,7 +1442,7 @@ impl IWebTokenRequestFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebTokenRequestPromptType: i32 {
+RT_ENUM! { enum WebTokenRequestPromptType: i32 ["Windows.Security.Authentication.Web.Core.WebTokenRequestPromptType"] {
     Default (WebTokenRequestPromptType_Default) = 0, ForceAuthentication (WebTokenRequestPromptType_ForceAuthentication) = 1,
 }}
 DEFINE_IID!(IID_IWebTokenRequestResult, 3240788741, 53752, 17539, 141, 84, 56, 254, 41, 39, 132, 255);
@@ -1474,8 +1474,8 @@ impl IWebTokenRequestResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebTokenRequestResult: IWebTokenRequestResult}
-RT_ENUM! { enum WebTokenRequestStatus: i32 {
+RT_CLASS!{class WebTokenRequestResult: IWebTokenRequestResult ["Windows.Security.Authentication.Web.Core.WebTokenRequestResult"]}
+RT_ENUM! { enum WebTokenRequestStatus: i32 ["Windows.Security.Authentication.Web.Core.WebTokenRequestStatus"] {
     Success (WebTokenRequestStatus_Success) = 0, UserCancel (WebTokenRequestStatus_UserCancel) = 1, AccountSwitch (WebTokenRequestStatus_AccountSwitch) = 2, UserInteractionRequired (WebTokenRequestStatus_UserInteractionRequired) = 3, AccountProviderNotAvailable (WebTokenRequestStatus_AccountProviderNotAvailable) = 4, ProviderError (WebTokenRequestStatus_ProviderError) = 5,
 }}
 DEFINE_IID!(IID_IWebTokenResponse, 1739048394, 33782, 17606, 163, 177, 14, 182, 158, 65, 250, 138);
@@ -1507,7 +1507,7 @@ impl IWebTokenResponse {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebTokenResponse: IWebTokenResponse}
+RT_CLASS!{class WebTokenResponse: IWebTokenResponse ["Windows.Security.Authentication.Web.Core.WebTokenResponse"]}
 impl RtActivatable<IWebTokenResponseFactory> for WebTokenResponse {}
 impl RtActivatable<IActivationFactory> for WebTokenResponse {}
 impl WebTokenResponse {
@@ -1571,7 +1571,7 @@ impl IWebAccountClientView {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountClientView: IWebAccountClientView}
+RT_CLASS!{class WebAccountClientView: IWebAccountClientView ["Windows.Security.Authentication.Web.Provider.WebAccountClientView"]}
 impl RtActivatable<IWebAccountClientViewFactory> for WebAccountClientView {}
 impl WebAccountClientView {
     #[inline] pub fn create(viewType: WebAccountClientViewType, applicationCallbackUri: &foundation::Uri) -> Result<ComPtr<WebAccountClientView>> {
@@ -1599,7 +1599,7 @@ impl IWebAccountClientViewFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAccountClientViewType: i32 {
+RT_ENUM! { enum WebAccountClientViewType: i32 ["Windows.Security.Authentication.Web.Provider.WebAccountClientViewType"] {
     IdOnly (WebAccountClientViewType_IdOnly) = 0, IdAndProperties (WebAccountClientViewType_IdAndProperties) = 1,
 }}
 RT_CLASS!{static class WebAccountManager}
@@ -1847,7 +1847,7 @@ impl IWebAccountProviderAddAccountOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderAddAccountOperation: IWebAccountProviderAddAccountOperation}
+RT_CLASS!{class WebAccountProviderAddAccountOperation: IWebAccountProviderAddAccountOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderAddAccountOperation"]}
 DEFINE_IID!(IID_IWebAccountProviderBaseReportOperation, 3148131515, 39227, 19799, 187, 228, 20, 33, 227, 102, 139, 76);
 RT_INTERFACE!{interface IWebAccountProviderBaseReportOperation(IWebAccountProviderBaseReportOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderBaseReportOperation] {
     fn ReportCompleted(&self) -> HRESULT,
@@ -1874,8 +1874,8 @@ impl IWebAccountProviderDeleteAccountOperation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderDeleteAccountOperation: IWebAccountProviderDeleteAccountOperation}
-RT_CLASS!{class WebAccountProviderGetTokenSilentOperation: IWebAccountProviderTokenOperation}
+RT_CLASS!{class WebAccountProviderDeleteAccountOperation: IWebAccountProviderDeleteAccountOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderDeleteAccountOperation"]}
+RT_CLASS!{class WebAccountProviderGetTokenSilentOperation: IWebAccountProviderTokenOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderGetTokenSilentOperation"]}
 DEFINE_IID!(IID_IWebAccountProviderManageAccountOperation, 3978353756, 53787, 17982, 169, 183, 193, 253, 14, 218, 233, 120);
 RT_INTERFACE!{interface IWebAccountProviderManageAccountOperation(IWebAccountProviderManageAccountOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderManageAccountOperation] {
     fn get_WebAccount(&self, out: *mut *mut super::super::super::credentials::WebAccount) -> HRESULT,
@@ -1892,7 +1892,7 @@ impl IWebAccountProviderManageAccountOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderManageAccountOperation: IWebAccountProviderManageAccountOperation}
+RT_CLASS!{class WebAccountProviderManageAccountOperation: IWebAccountProviderManageAccountOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderManageAccountOperation"]}
 DEFINE_IID!(IID_IWebAccountProviderOperation, 1834820646, 4273, 16794, 164, 78, 249, 197, 22, 21, 116, 230);
 RT_INTERFACE!{interface IWebAccountProviderOperation(IWebAccountProviderOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderOperation] {
     fn get_Kind(&self, out: *mut WebAccountProviderOperationKind) -> HRESULT
@@ -1904,10 +1904,10 @@ impl IWebAccountProviderOperation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAccountProviderOperationKind: i32 {
+RT_ENUM! { enum WebAccountProviderOperationKind: i32 ["Windows.Security.Authentication.Web.Provider.WebAccountProviderOperationKind"] {
     RequestToken (WebAccountProviderOperationKind_RequestToken) = 0, GetTokenSilently (WebAccountProviderOperationKind_GetTokenSilently) = 1, AddAccount (WebAccountProviderOperationKind_AddAccount) = 2, ManageAccount (WebAccountProviderOperationKind_ManageAccount) = 3, DeleteAccount (WebAccountProviderOperationKind_DeleteAccount) = 4, RetrieveCookies (WebAccountProviderOperationKind_RetrieveCookies) = 5, SignOutAccount (WebAccountProviderOperationKind_SignOutAccount) = 6,
 }}
-RT_CLASS!{class WebAccountProviderRequestTokenOperation: IWebAccountProviderTokenOperation}
+RT_CLASS!{class WebAccountProviderRequestTokenOperation: IWebAccountProviderTokenOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderRequestTokenOperation"]}
 DEFINE_IID!(IID_IWebAccountProviderRetrieveCookiesOperation, 1510212673, 4003, 19121, 160, 28, 32, 177, 16, 53, 133, 148);
 RT_INTERFACE!{interface IWebAccountProviderRetrieveCookiesOperation(IWebAccountProviderRetrieveCookiesOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderRetrieveCookiesOperation] {
     fn get_Context(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -1943,7 +1943,7 @@ impl IWebAccountProviderRetrieveCookiesOperation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderRetrieveCookiesOperation: IWebAccountProviderRetrieveCookiesOperation}
+RT_CLASS!{class WebAccountProviderRetrieveCookiesOperation: IWebAccountProviderRetrieveCookiesOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderRetrieveCookiesOperation"]}
 DEFINE_IID!(IID_IWebAccountProviderSignOutAccountOperation, 3096502813, 3157, 18364, 140, 114, 4, 166, 252, 124, 172, 7);
 RT_INTERFACE!{interface IWebAccountProviderSignOutAccountOperation(IWebAccountProviderSignOutAccountOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderSignOutAccountOperation] {
     fn get_WebAccount(&self, out: *mut *mut super::super::super::credentials::WebAccount) -> HRESULT,
@@ -1967,7 +1967,7 @@ impl IWebAccountProviderSignOutAccountOperation {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderSignOutAccountOperation: IWebAccountProviderSignOutAccountOperation}
+RT_CLASS!{class WebAccountProviderSignOutAccountOperation: IWebAccountProviderSignOutAccountOperation ["Windows.Security.Authentication.Web.Provider.WebAccountProviderSignOutAccountOperation"]}
 DEFINE_IID!(IID_IWebAccountProviderSilentReportOperation, 3769976312, 15119, 17626, 146, 76, 123, 24, 186, 170, 98, 169);
 RT_INTERFACE!{interface IWebAccountProviderSilentReportOperation(IWebAccountProviderSilentReportOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderSilentReportOperation] {
     fn ReportUserInteractionRequired(&self) -> HRESULT,
@@ -2033,7 +2033,7 @@ impl IWebAccountProviderTokenOperation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderTriggerDetails: IWebAccountProviderTokenObjects}
+RT_CLASS!{class WebAccountProviderTriggerDetails: IWebAccountProviderTokenObjects ["Windows.Security.Authentication.Web.Provider.WebAccountProviderTriggerDetails"]}
 DEFINE_IID!(IID_IWebAccountProviderUIReportOperation, 687837907, 36736, 17147, 148, 79, 178, 16, 123, 189, 66, 230);
 RT_INTERFACE!{interface IWebAccountProviderUIReportOperation(IWebAccountProviderUIReportOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderUIReportOperation] {
     fn ReportUserCanceled(&self) -> HRESULT
@@ -2044,7 +2044,7 @@ impl IWebAccountProviderUIReportOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAccountScope: i32 {
+RT_ENUM! { enum WebAccountScope: i32 ["Windows.Security.Authentication.Web.Provider.WebAccountScope"] {
     PerUser (WebAccountScope_PerUser) = 0, PerApplication (WebAccountScope_PerApplication) = 1,
 }}
 DEFINE_IID!(IID_IWebAccountScopeManagerStatics, 1550639996, 4786, 16954, 191, 61, 133, 184, 215, 229, 54, 86);
@@ -2070,7 +2070,7 @@ impl IWebAccountScopeManagerStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAccountSelectionOptions: u32 {
+RT_ENUM! { enum WebAccountSelectionOptions: u32 ["Windows.Security.Authentication.Web.Provider.WebAccountSelectionOptions"] {
     Default (WebAccountSelectionOptions_Default) = 0, New (WebAccountSelectionOptions_New) = 1,
 }}
 DEFINE_IID!(IID_IWebProviderTokenRequest, 504919947, 34821, 17739, 159, 17, 70, 141, 42, 241, 9, 90);
@@ -2108,7 +2108,7 @@ impl IWebProviderTokenRequest {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebProviderTokenRequest: IWebProviderTokenRequest}
+RT_CLASS!{class WebProviderTokenRequest: IWebProviderTokenRequest ["Windows.Security.Authentication.Web.Provider.WebProviderTokenRequest"]}
 DEFINE_IID!(IID_IWebProviderTokenRequest2, 3050778188, 4273, 19110, 136, 177, 11, 108, 158, 12, 30, 70);
 RT_INTERFACE!{interface IWebProviderTokenRequest2(IWebProviderTokenRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebProviderTokenRequest2] {
     #[cfg(feature="windows-storage")] fn GetApplicationTokenBindingKeyIdAsync(&self, keyType: super::TokenBindingKeyType, target: *mut foundation::Uri, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IBuffer>) -> HRESULT
@@ -2154,7 +2154,7 @@ impl IWebProviderTokenResponse {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebProviderTokenResponse: IWebProviderTokenResponse}
+RT_CLASS!{class WebProviderTokenResponse: IWebProviderTokenResponse ["Windows.Security.Authentication.Web.Provider.WebProviderTokenResponse"]}
 impl RtActivatable<IWebProviderTokenResponseFactory> for WebProviderTokenResponse {}
 impl WebProviderTokenResponse {
     #[inline] pub fn create(webTokenResponse: &super::core::WebTokenResponse) -> Result<ComPtr<WebProviderTokenResponse>> {
@@ -2227,7 +2227,7 @@ impl IKeyCredential {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyCredential: IKeyCredential}
+RT_CLASS!{class KeyCredential: IKeyCredential ["Windows.Security.Credentials.KeyCredential"]}
 DEFINE_IID!(IID_IKeyCredentialAttestationResult, 2024453025, 41921, 16643, 182, 204, 71, 44, 68, 23, 28, 187);
 RT_INTERFACE!{interface IKeyCredentialAttestationResult(IKeyCredentialAttestationResultVtbl): IInspectable(IInspectableVtbl) [IID_IKeyCredentialAttestationResult] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -2253,11 +2253,11 @@ impl IKeyCredentialAttestationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyCredentialAttestationResult: IKeyCredentialAttestationResult}
-RT_ENUM! { enum KeyCredentialAttestationStatus: i32 {
+RT_CLASS!{class KeyCredentialAttestationResult: IKeyCredentialAttestationResult ["Windows.Security.Credentials.KeyCredentialAttestationResult"]}
+RT_ENUM! { enum KeyCredentialAttestationStatus: i32 ["Windows.Security.Credentials.KeyCredentialAttestationStatus"] {
     Success (KeyCredentialAttestationStatus_Success) = 0, UnknownError (KeyCredentialAttestationStatus_UnknownError) = 1, NotSupported (KeyCredentialAttestationStatus_NotSupported) = 2, TemporaryFailure (KeyCredentialAttestationStatus_TemporaryFailure) = 3,
 }}
-RT_ENUM! { enum KeyCredentialCreationOption: i32 {
+RT_ENUM! { enum KeyCredentialCreationOption: i32 ["Windows.Security.Credentials.KeyCredentialCreationOption"] {
     ReplaceExisting (KeyCredentialCreationOption_ReplaceExisting) = 0, FailIfExists (KeyCredentialCreationOption_FailIfExists) = 1,
 }}
 RT_CLASS!{static class KeyCredentialManager}
@@ -2333,7 +2333,7 @@ impl IKeyCredentialOperationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyCredentialOperationResult: IKeyCredentialOperationResult}
+RT_CLASS!{class KeyCredentialOperationResult: IKeyCredentialOperationResult ["Windows.Security.Credentials.KeyCredentialOperationResult"]}
 DEFINE_IID!(IID_IKeyCredentialRetrievalResult, 1489860355, 36231, 16969, 155, 88, 246, 89, 140, 201, 100, 78);
 RT_INTERFACE!{interface IKeyCredentialRetrievalResult(IKeyCredentialRetrievalResultVtbl): IInspectable(IInspectableVtbl) [IID_IKeyCredentialRetrievalResult] {
     fn get_Credential(&self, out: *mut *mut KeyCredential) -> HRESULT,
@@ -2351,8 +2351,8 @@ impl IKeyCredentialRetrievalResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyCredentialRetrievalResult: IKeyCredentialRetrievalResult}
-RT_ENUM! { enum KeyCredentialStatus: i32 {
+RT_CLASS!{class KeyCredentialRetrievalResult: IKeyCredentialRetrievalResult ["Windows.Security.Credentials.KeyCredentialRetrievalResult"]}
+RT_ENUM! { enum KeyCredentialStatus: i32 ["Windows.Security.Credentials.KeyCredentialStatus"] {
     Success (KeyCredentialStatus_Success) = 0, UnknownError (KeyCredentialStatus_UnknownError) = 1, NotFound (KeyCredentialStatus_NotFound) = 2, UserCanceled (KeyCredentialStatus_UserCanceled) = 3, UserPrefersPassword (KeyCredentialStatus_UserPrefersPassword) = 4, CredentialAlreadyExists (KeyCredentialStatus_CredentialAlreadyExists) = 5, SecurityDeviceLocked (KeyCredentialStatus_SecurityDeviceLocked) = 6,
 }}
 DEFINE_IID!(IID_IPasswordCredential, 1790019977, 50976, 16807, 166, 193, 254, 173, 179, 99, 41, 160);
@@ -2404,7 +2404,7 @@ impl IPasswordCredential {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PasswordCredential: IPasswordCredential}
+RT_CLASS!{class PasswordCredential: IPasswordCredential ["Windows.Security.Credentials.PasswordCredential"]}
 impl RtActivatable<ICredentialFactory> for PasswordCredential {}
 impl RtActivatable<IActivationFactory> for PasswordCredential {}
 impl PasswordCredential {
@@ -2413,7 +2413,7 @@ impl PasswordCredential {
     }
 }
 DEFINE_CLSID!(PasswordCredential(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,80,97,115,115,119,111,114,100,67,114,101,100,101,110,116,105,97,108,0]) [CLSID_PasswordCredential]);
-RT_CLASS!{class PasswordCredentialPropertyStore: foundation::collections::IPropertySet}
+RT_CLASS!{class PasswordCredentialPropertyStore: foundation::collections::IPropertySet ["Windows.Security.Credentials.PasswordCredentialPropertyStore"]}
 impl RtActivatable<IActivationFactory> for PasswordCredentialPropertyStore {}
 DEFINE_CLSID!(PasswordCredentialPropertyStore(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,80,97,115,115,119,111,114,100,67,114,101,100,101,110,116,105,97,108,80,114,111,112,101,114,116,121,83,116,111,114,101,0]) [CLSID_PasswordCredentialPropertyStore]);
 DEFINE_IID!(IID_IPasswordVault, 1643981835, 51412, 18625, 165, 79, 188, 90, 100, 32, 90, 242);
@@ -2455,7 +2455,7 @@ impl IPasswordVault {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PasswordVault: IPasswordVault}
+RT_CLASS!{class PasswordVault: IPasswordVault ["Windows.Security.Credentials.PasswordVault"]}
 impl RtActivatable<IActivationFactory> for PasswordVault {}
 DEFINE_CLSID!(PasswordVault(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,80,97,115,115,119,111,114,100,86,97,117,108,116,0]) [CLSID_PasswordVault]);
 DEFINE_IID!(IID_IWebAccount, 1766276786, 32817, 18878, 128, 187, 150, 203, 70, 217, 154, 186);
@@ -2481,7 +2481,7 @@ impl IWebAccount {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccount: IWebAccount}
+RT_CLASS!{class WebAccount: IWebAccount ["Windows.Security.Credentials.WebAccount"]}
 impl RtActivatable<IWebAccountFactory> for WebAccount {}
 impl WebAccount {
     #[inline] pub fn create_web_account(webAccountProvider: &WebAccountProvider, userName: &HStringArg, state: WebAccountState) -> Result<ComPtr<WebAccount>> {
@@ -2536,7 +2536,7 @@ impl IWebAccountFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAccountPictureSize: i32 {
+RT_ENUM! { enum WebAccountPictureSize: i32 ["Windows.Security.Credentials.WebAccountPictureSize"] {
     Size64x64 (WebAccountPictureSize_Size64x64) = 64, Size208x208 (WebAccountPictureSize_Size208x208) = 208, Size424x424 (WebAccountPictureSize_Size424x424) = 424, Size1080x1080 (WebAccountPictureSize_Size1080x1080) = 1080,
 }}
 DEFINE_IID!(IID_IWebAccountProvider, 702335171, 31417, 19068, 163, 54, 185, 66, 249, 219, 247, 199);
@@ -2562,7 +2562,7 @@ impl IWebAccountProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProvider: IWebAccountProvider}
+RT_CLASS!{class WebAccountProvider: IWebAccountProvider ["Windows.Security.Credentials.WebAccountProvider"]}
 impl RtActivatable<IWebAccountProviderFactory> for WebAccountProvider {}
 impl WebAccountProvider {
     #[inline] pub fn create_web_account_provider(id: &HStringArg, displayName: &HStringArg, iconUri: &foundation::Uri) -> Result<ComPtr<WebAccountProvider>> {
@@ -2620,12 +2620,12 @@ impl IWebAccountProviderFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebAccountState: i32 {
+RT_ENUM! { enum WebAccountState: i32 ["Windows.Security.Credentials.WebAccountState"] {
     None (WebAccountState_None) = 0, Connected (WebAccountState_Connected) = 1, Error (WebAccountState_Error) = 2,
 }}
 pub mod ui { // Windows.Security.Credentials.UI
 use ::prelude::*;
-RT_ENUM! { enum AuthenticationProtocol: i32 {
+RT_ENUM! { enum AuthenticationProtocol: i32 ["Windows.Security.Credentials.UI.AuthenticationProtocol"] {
     Basic (AuthenticationProtocol_Basic) = 0, Digest (AuthenticationProtocol_Digest) = 1, Ntlm (AuthenticationProtocol_Ntlm) = 2, Kerberos (AuthenticationProtocol_Kerberos) = 3, Negotiate (AuthenticationProtocol_Negotiate) = 4, CredSsp (AuthenticationProtocol_CredSsp) = 5, Custom (AuthenticationProtocol_Custom) = 6,
 }}
 RT_CLASS!{static class CredentialPicker}
@@ -2759,7 +2759,7 @@ impl ICredentialPickerOptions {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CredentialPickerOptions: ICredentialPickerOptions}
+RT_CLASS!{class CredentialPickerOptions: ICredentialPickerOptions ["Windows.Security.Credentials.UI.CredentialPickerOptions"]}
 impl RtActivatable<IActivationFactory> for CredentialPickerOptions {}
 DEFINE_CLSID!(CredentialPickerOptions(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,85,73,46,67,114,101,100,101,110,116,105,97,108,80,105,99,107,101,114,79,112,116,105,111,110,115,0]) [CLSID_CredentialPickerOptions]);
 DEFINE_IID!(IID_ICredentialPickerResults, 424212890, 52272, 16652, 156, 56, 204, 8, 132, 197, 179, 215);
@@ -2810,7 +2810,7 @@ impl ICredentialPickerResults {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CredentialPickerResults: ICredentialPickerResults}
+RT_CLASS!{class CredentialPickerResults: ICredentialPickerResults ["Windows.Security.Credentials.UI.CredentialPickerResults"]}
 DEFINE_IID!(IID_ICredentialPickerStatics, 2855951475, 51690, 18306, 153, 251, 230, 215, 233, 56, 225, 45);
 RT_INTERFACE!{static interface ICredentialPickerStatics(ICredentialPickerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICredentialPickerStatics] {
     fn PickWithOptionsAsync(&self, options: *mut CredentialPickerOptions, out: *mut *mut foundation::IAsyncOperation<CredentialPickerResults>) -> HRESULT,
@@ -2834,10 +2834,10 @@ impl ICredentialPickerStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CredentialSaveOption: i32 {
+RT_ENUM! { enum CredentialSaveOption: i32 ["Windows.Security.Credentials.UI.CredentialSaveOption"] {
     Unselected (CredentialSaveOption_Unselected) = 0, Selected (CredentialSaveOption_Selected) = 1, Hidden (CredentialSaveOption_Hidden) = 2,
 }}
-RT_ENUM! { enum UserConsentVerificationResult: i32 {
+RT_ENUM! { enum UserConsentVerificationResult: i32 ["Windows.Security.Credentials.UI.UserConsentVerificationResult"] {
     Verified (UserConsentVerificationResult_Verified) = 0, DeviceNotPresent (UserConsentVerificationResult_DeviceNotPresent) = 1, NotConfiguredForUser (UserConsentVerificationResult_NotConfiguredForUser) = 2, DisabledByPolicy (UserConsentVerificationResult_DisabledByPolicy) = 3, DeviceBusy (UserConsentVerificationResult_DeviceBusy) = 4, RetriesExhausted (UserConsentVerificationResult_RetriesExhausted) = 5, Canceled (UserConsentVerificationResult_Canceled) = 6,
 }}
 RT_CLASS!{static class UserConsentVerifier}
@@ -2851,7 +2851,7 @@ impl UserConsentVerifier {
     }
 }
 DEFINE_CLSID!(UserConsentVerifier(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,101,100,101,110,116,105,97,108,115,46,85,73,46,85,115,101,114,67,111,110,115,101,110,116,86,101,114,105,102,105,101,114,0]) [CLSID_UserConsentVerifier]);
-RT_ENUM! { enum UserConsentVerifierAvailability: i32 {
+RT_ENUM! { enum UserConsentVerifierAvailability: i32 ["Windows.Security.Credentials.UI.UserConsentVerifierAvailability"] {
     Available (UserConsentVerifierAvailability_Available) = 0, DeviceNotPresent (UserConsentVerifierAvailability_DeviceNotPresent) = 1, NotConfiguredForUser (UserConsentVerifierAvailability_NotConfiguredForUser) = 2, DisabledByPolicy (UserConsentVerifierAvailability_DisabledByPolicy) = 3, DeviceBusy (UserConsentVerifierAvailability_DeviceBusy) = 4,
 }}
 DEFINE_IID!(IID_IUserConsentVerifierStatics, 2941206417, 22092, 19932, 184, 181, 151, 52, 71, 98, 124, 101);
@@ -2875,7 +2875,7 @@ impl IUserConsentVerifierStatics {
 } // Windows.Security.Credentials
 pub mod cryptography { // Windows.Security.Cryptography
 use ::prelude::*;
-RT_ENUM! { enum BinaryStringEncoding: i32 {
+RT_ENUM! { enum BinaryStringEncoding: i32 ["Windows.Security.Cryptography.BinaryStringEncoding"] {
     Utf8 (BinaryStringEncoding_Utf8) = 0, Utf16LE (BinaryStringEncoding_Utf16LE) = 1, Utf16BE (BinaryStringEncoding_Utf16BE) = 2,
 }}
 RT_CLASS!{static class CryptographicBuffer}
@@ -3084,7 +3084,7 @@ impl ICertificate {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Certificate: ICertificate}
+RT_CLASS!{class Certificate: ICertificate ["Windows.Security.Cryptography.Certificates.Certificate"]}
 impl RtActivatable<ICertificateFactory> for Certificate {}
 impl Certificate {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_certificate(certBlob: &::rt::gen::windows::storage::streams::IBuffer) -> Result<ComPtr<Certificate>> {
@@ -3179,8 +3179,8 @@ impl ICertificateChain {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CertificateChain: ICertificateChain}
-RT_ENUM! { enum CertificateChainPolicy: i32 {
+RT_CLASS!{class CertificateChain: ICertificateChain ["Windows.Security.Cryptography.Certificates.CertificateChain"]}
+RT_ENUM! { enum CertificateChainPolicy: i32 ["Windows.Security.Cryptography.Certificates.CertificateChainPolicy"] {
     Base (CertificateChainPolicy_Base) = 0, Ssl (CertificateChainPolicy_Ssl) = 1, NTAuthentication (CertificateChainPolicy_NTAuthentication) = 2, MicrosoftRoot (CertificateChainPolicy_MicrosoftRoot) = 3,
 }}
 RT_CLASS!{static class CertificateEnrollmentManager}
@@ -3302,7 +3302,7 @@ impl ICertificateExtension {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CertificateExtension: ICertificateExtension}
+RT_CLASS!{class CertificateExtension: ICertificateExtension ["Windows.Security.Cryptography.Certificates.CertificateExtension"]}
 impl RtActivatable<IActivationFactory> for CertificateExtension {}
 DEFINE_CLSID!(CertificateExtension(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,69,120,116,101,110,115,105,111,110,0]) [CLSID_CertificateExtension]);
 DEFINE_IID!(IID_ICertificateFactory, 397681180, 19375, 17570, 150, 8, 4, 251, 98, 177, 105, 66);
@@ -3409,7 +3409,7 @@ impl ICertificateKeyUsages {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CertificateKeyUsages: ICertificateKeyUsages}
+RT_CLASS!{class CertificateKeyUsages: ICertificateKeyUsages ["Windows.Security.Cryptography.Certificates.CertificateKeyUsages"]}
 impl RtActivatable<IActivationFactory> for CertificateKeyUsages {}
 DEFINE_CLSID!(CertificateKeyUsages(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,75,101,121,85,115,97,103,101,115,0]) [CLSID_CertificateKeyUsages]);
 DEFINE_IID!(IID_ICertificateQuery, 1527261745, 42792, 18710, 181, 238, 255, 203, 138, 207, 36, 23);
@@ -3467,7 +3467,7 @@ impl ICertificateQuery {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CertificateQuery: ICertificateQuery}
+RT_CLASS!{class CertificateQuery: ICertificateQuery ["Windows.Security.Cryptography.Certificates.CertificateQuery"]}
 impl RtActivatable<IActivationFactory> for CertificateQuery {}
 DEFINE_CLSID!(CertificateQuery(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,81,117,101,114,121,0]) [CLSID_CertificateQuery]);
 DEFINE_IID!(IID_ICertificateQuery2, 2472151799, 3033, 20341, 184, 194, 226, 122, 127, 116, 238, 205);
@@ -3612,7 +3612,7 @@ impl ICertificateRequestProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CertificateRequestProperties: ICertificateRequestProperties}
+RT_CLASS!{class CertificateRequestProperties: ICertificateRequestProperties ["Windows.Security.Cryptography.Certificates.CertificateRequestProperties"]}
 impl RtActivatable<IActivationFactory> for CertificateRequestProperties {}
 DEFINE_CLSID!(CertificateRequestProperties(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,101,114,116,105,102,105,99,97,116,101,82,101,113,117,101,115,116,80,114,111,112,101,114,116,105,101,115,0]) [CLSID_CertificateRequestProperties]);
 DEFINE_IID!(IID_ICertificateRequestProperties2, 1033947476, 55103, 20467, 160, 166, 6, 119, 192, 173, 160, 91);
@@ -3751,7 +3751,7 @@ impl ICertificateStore {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CertificateStore: ICertificateStore}
+RT_CLASS!{class CertificateStore: ICertificateStore ["Windows.Security.Cryptography.Certificates.CertificateStore"]}
 DEFINE_IID!(IID_ICertificateStore2, 3353775690, 16765, 19738, 186, 189, 21, 104, 126, 84, 153, 116);
 RT_INTERFACE!{interface ICertificateStore2(ICertificateStore2Vtbl): IInspectable(IInspectableVtbl) [IID_ICertificateStore2] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT
@@ -3905,7 +3905,7 @@ impl IChainBuildingParameters {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChainBuildingParameters: IChainBuildingParameters}
+RT_CLASS!{class ChainBuildingParameters: IChainBuildingParameters ["Windows.Security.Cryptography.Certificates.ChainBuildingParameters"]}
 impl RtActivatable<IActivationFactory> for ChainBuildingParameters {}
 DEFINE_CLSID!(ChainBuildingParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,104,97,105,110,66,117,105,108,100,105,110,103,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_ChainBuildingParameters]);
 DEFINE_IID!(IID_IChainValidationParameters, 3295951690, 32432, 19286, 160, 64, 185, 200, 230, 85, 221, 243);
@@ -3935,10 +3935,10 @@ impl IChainValidationParameters {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ChainValidationParameters: IChainValidationParameters}
+RT_CLASS!{class ChainValidationParameters: IChainValidationParameters ["Windows.Security.Cryptography.Certificates.ChainValidationParameters"]}
 impl RtActivatable<IActivationFactory> for ChainValidationParameters {}
 DEFINE_CLSID!(ChainValidationParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,104,97,105,110,86,97,108,105,100,97,116,105,111,110,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_ChainValidationParameters]);
-RT_ENUM! { enum ChainValidationResult: i32 {
+RT_ENUM! { enum ChainValidationResult: i32 ["Windows.Security.Cryptography.Certificates.ChainValidationResult"] {
     Success (ChainValidationResult_Success) = 0, Untrusted (ChainValidationResult_Untrusted) = 1, Revoked (ChainValidationResult_Revoked) = 2, Expired (ChainValidationResult_Expired) = 3, IncompleteChain (ChainValidationResult_IncompleteChain) = 4, InvalidSignature (ChainValidationResult_InvalidSignature) = 5, WrongUsage (ChainValidationResult_WrongUsage) = 6, InvalidName (ChainValidationResult_InvalidName) = 7, InvalidCertificateAuthorityPolicy (ChainValidationResult_InvalidCertificateAuthorityPolicy) = 8, BasicConstraintsError (ChainValidationResult_BasicConstraintsError) = 9, UnknownCriticalExtension (ChainValidationResult_UnknownCriticalExtension) = 10, RevocationInformationMissing (ChainValidationResult_RevocationInformationMissing) = 11, RevocationFailure (ChainValidationResult_RevocationFailure) = 12, OtherErrors (ChainValidationResult_OtherErrors) = 13,
 }}
 DEFINE_IID!(IID_ICmsAttachedSignature, 1636408733, 14167, 20171, 189, 220, 12, 163, 87, 215, 169, 54);
@@ -3970,7 +3970,7 @@ impl ICmsAttachedSignature {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CmsAttachedSignature: ICmsAttachedSignature}
+RT_CLASS!{class CmsAttachedSignature: ICmsAttachedSignature ["Windows.Security.Cryptography.Certificates.CmsAttachedSignature"]}
 impl RtActivatable<ICmsAttachedSignatureFactory> for CmsAttachedSignature {}
 impl RtActivatable<ICmsAttachedSignatureStatics> for CmsAttachedSignature {}
 impl CmsAttachedSignature {
@@ -4027,7 +4027,7 @@ impl ICmsDetachedSignature {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CmsDetachedSignature: ICmsDetachedSignature}
+RT_CLASS!{class CmsDetachedSignature: ICmsDetachedSignature ["Windows.Security.Cryptography.Certificates.CmsDetachedSignature"]}
 impl RtActivatable<ICmsDetachedSignatureFactory> for CmsDetachedSignature {}
 impl RtActivatable<ICmsDetachedSignatureStatics> for CmsDetachedSignature {}
 impl CmsDetachedSignature {
@@ -4094,7 +4094,7 @@ impl ICmsSignerInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CmsSignerInfo: ICmsSignerInfo}
+RT_CLASS!{class CmsSignerInfo: ICmsSignerInfo ["Windows.Security.Cryptography.Certificates.CmsSignerInfo"]}
 impl RtActivatable<IActivationFactory> for CmsSignerInfo {}
 DEFINE_CLSID!(CmsSignerInfo(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,67,109,115,83,105,103,110,101,114,73,110,102,111,0]) [CLSID_CmsSignerInfo]);
 DEFINE_IID!(IID_ICmsTimestampInfo, 794755314, 11288, 20360, 132, 53, 197, 52, 8, 96, 118, 245);
@@ -4120,14 +4120,14 @@ impl ICmsTimestampInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CmsTimestampInfo: ICmsTimestampInfo}
-RT_ENUM! { enum EnrollKeyUsages: u32 {
+RT_CLASS!{class CmsTimestampInfo: ICmsTimestampInfo ["Windows.Security.Cryptography.Certificates.CmsTimestampInfo"]}
+RT_ENUM! { enum EnrollKeyUsages: u32 ["Windows.Security.Cryptography.Certificates.EnrollKeyUsages"] {
     None (EnrollKeyUsages_None) = 0, Decryption (EnrollKeyUsages_Decryption) = 1, Signing (EnrollKeyUsages_Signing) = 2, KeyAgreement (EnrollKeyUsages_KeyAgreement) = 4, All (EnrollKeyUsages_All) = 16777215,
 }}
-RT_ENUM! { enum ExportOption: i32 {
+RT_ENUM! { enum ExportOption: i32 ["Windows.Security.Cryptography.Certificates.ExportOption"] {
     NotExportable (ExportOption_NotExportable) = 0, Exportable (ExportOption_Exportable) = 1,
 }}
-RT_ENUM! { enum InstallOptions: u32 {
+RT_ENUM! { enum InstallOptions: u32 ["Windows.Security.Cryptography.Certificates.InstallOptions"] {
     None (InstallOptions_None) = 0, DeleteExpired (InstallOptions_DeleteExpired) = 1,
 }}
 RT_CLASS!{static class KeyAlgorithmNames}
@@ -4279,10 +4279,10 @@ impl IKeyAttestationHelperStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum KeyProtectionLevel: i32 {
+RT_ENUM! { enum KeyProtectionLevel: i32 ["Windows.Security.Cryptography.Certificates.KeyProtectionLevel"] {
     NoConsent (KeyProtectionLevel_NoConsent) = 0, ConsentOnly (KeyProtectionLevel_ConsentOnly) = 1, ConsentWithPassword (KeyProtectionLevel_ConsentWithPassword) = 2, ConsentWithFingerprint (KeyProtectionLevel_ConsentWithFingerprint) = 3,
 }}
-RT_ENUM! { enum KeySize: i32 {
+RT_ENUM! { enum KeySize: i32 ["Windows.Security.Cryptography.Certificates.KeySize"] {
     Invalid (KeySize_Invalid) = 0, Rsa2048 (KeySize_Rsa2048) = 2048, Rsa4096 (KeySize_Rsa4096) = 4096,
 }}
 RT_CLASS!{static class KeyStorageProviderNames}
@@ -4419,10 +4419,10 @@ impl IPfxImportParameters {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PfxImportParameters: IPfxImportParameters}
+RT_CLASS!{class PfxImportParameters: IPfxImportParameters ["Windows.Security.Cryptography.Certificates.PfxImportParameters"]}
 impl RtActivatable<IActivationFactory> for PfxImportParameters {}
 DEFINE_CLSID!(PfxImportParameters(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,80,102,120,73,109,112,111,114,116,80,97,114,97,109,101,116,101,114,115,0]) [CLSID_PfxImportParameters]);
-RT_ENUM! { enum SignatureValidationResult: i32 {
+RT_ENUM! { enum SignatureValidationResult: i32 ["Windows.Security.Cryptography.Certificates.SignatureValidationResult"] {
     Success (SignatureValidationResult_Success) = 0, InvalidParameter (SignatureValidationResult_InvalidParameter) = 1, BadMessage (SignatureValidationResult_BadMessage) = 2, InvalidSignature (SignatureValidationResult_InvalidSignature) = 3, OtherErrors (SignatureValidationResult_OtherErrors) = 4,
 }}
 RT_CLASS!{static class StandardCertificateStoreNames}
@@ -4503,7 +4503,7 @@ impl ISubjectAlternativeNameInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SubjectAlternativeNameInfo: ISubjectAlternativeNameInfo}
+RT_CLASS!{class SubjectAlternativeNameInfo: ISubjectAlternativeNameInfo ["Windows.Security.Cryptography.Certificates.SubjectAlternativeNameInfo"]}
 impl RtActivatable<IActivationFactory> for SubjectAlternativeNameInfo {}
 DEFINE_CLSID!(SubjectAlternativeNameInfo(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,67,114,121,112,116,111,103,114,97,112,104,121,46,67,101,114,116,105,102,105,99,97,116,101,115,46,83,117,98,106,101,99,116,65,108,116,101,114,110,97,116,105,118,101,78,97,109,101,73,110,102,111,0]) [CLSID_SubjectAlternativeNameInfo]);
 DEFINE_IID!(IID_ISubjectAlternativeNameInfo2, 1132099782, 7249, 16874, 179, 74, 61, 101, 67, 152, 163, 112);
@@ -4582,7 +4582,7 @@ impl IUserCertificateEnrollmentManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserCertificateEnrollmentManager: IUserCertificateEnrollmentManager}
+RT_CLASS!{class UserCertificateEnrollmentManager: IUserCertificateEnrollmentManager ["Windows.Security.Cryptography.Certificates.UserCertificateEnrollmentManager"]}
 DEFINE_IID!(IID_IUserCertificateEnrollmentManager2, 229481649, 26078, 18730, 184, 109, 252, 92, 72, 44, 55, 71);
 RT_INTERFACE!{interface IUserCertificateEnrollmentManager2(IUserCertificateEnrollmentManager2Vtbl): IInspectable(IInspectableVtbl) [IID_IUserCertificateEnrollmentManager2] {
     fn ImportPfxDataToKspWithParametersAsync(&self, pfxData: HSTRING, password: HSTRING, pfxImportParameters: *mut PfxImportParameters, out: *mut *mut foundation::IAsyncAction) -> HRESULT
@@ -4617,7 +4617,7 @@ impl IUserCertificateStore {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserCertificateStore: IUserCertificateStore}
+RT_CLASS!{class UserCertificateStore: IUserCertificateStore ["Windows.Security.Cryptography.Certificates.UserCertificateStore"]}
 } // Windows.Security.Cryptography.Certificates
 pub mod core { // Windows.Security.Cryptography.Core
 use ::prelude::*;
@@ -4867,7 +4867,7 @@ impl IAsymmetricKeyAlgorithmProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AsymmetricKeyAlgorithmProvider: IAsymmetricKeyAlgorithmProvider}
+RT_CLASS!{class AsymmetricKeyAlgorithmProvider: IAsymmetricKeyAlgorithmProvider ["Windows.Security.Cryptography.Core.AsymmetricKeyAlgorithmProvider"]}
 impl RtActivatable<IAsymmetricKeyAlgorithmProviderStatics> for AsymmetricKeyAlgorithmProvider {}
 impl AsymmetricKeyAlgorithmProvider {
     #[inline] pub fn open_algorithm(algorithm: &HStringArg) -> Result<Option<ComPtr<AsymmetricKeyAlgorithmProvider>>> {
@@ -4903,7 +4903,7 @@ impl IAsymmetricKeyAlgorithmProviderStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum Capi1KdfTargetAlgorithm: i32 {
+RT_ENUM! { enum Capi1KdfTargetAlgorithm: i32 ["Windows.Security.Cryptography.Core.Capi1KdfTargetAlgorithm"] {
     NotAes (Capi1KdfTargetAlgorithm_NotAes) = 0, Aes (Capi1KdfTargetAlgorithm_Aes) = 1,
 }}
 RT_CLASS!{static class CryptographicEngine}
@@ -5030,7 +5030,7 @@ impl ICryptographicEngineStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CryptographicHash: IHashComputation}
+RT_CLASS!{class CryptographicHash: IHashComputation ["Windows.Security.Cryptography.Core.CryptographicHash"]}
 DEFINE_IID!(IID_ICryptographicKey, 3978967920, 36475, 16393, 132, 1, 255, 209, 166, 46, 235, 39);
 RT_INTERFACE!{interface ICryptographicKey(ICryptographicKeyVtbl): IInspectable(IInspectableVtbl) [IID_ICryptographicKey] {
     fn get_KeySize(&self, out: *mut u32) -> HRESULT,
@@ -5066,14 +5066,14 @@ impl ICryptographicKey {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CryptographicKey: ICryptographicKey}
-RT_ENUM! { enum CryptographicPadding: i32 {
+RT_CLASS!{class CryptographicKey: ICryptographicKey ["Windows.Security.Cryptography.Core.CryptographicKey"]}
+RT_ENUM! { enum CryptographicPadding: i32 ["Windows.Security.Cryptography.Core.CryptographicPadding"] {
     None (CryptographicPadding_None) = 0, RsaOaep (CryptographicPadding_RsaOaep) = 1, RsaPkcs1V15 (CryptographicPadding_RsaPkcs1V15) = 2, RsaPss (CryptographicPadding_RsaPss) = 3,
 }}
-RT_ENUM! { enum CryptographicPrivateKeyBlobType: i32 {
+RT_ENUM! { enum CryptographicPrivateKeyBlobType: i32 ["Windows.Security.Cryptography.Core.CryptographicPrivateKeyBlobType"] {
     Pkcs8RawPrivateKeyInfo (CryptographicPrivateKeyBlobType_Pkcs8RawPrivateKeyInfo) = 0, Pkcs1RsaPrivateKey (CryptographicPrivateKeyBlobType_Pkcs1RsaPrivateKey) = 1, BCryptPrivateKey (CryptographicPrivateKeyBlobType_BCryptPrivateKey) = 2, Capi1PrivateKey (CryptographicPrivateKeyBlobType_Capi1PrivateKey) = 3, BCryptEccFullPrivateKey (CryptographicPrivateKeyBlobType_BCryptEccFullPrivateKey) = 4,
 }}
-RT_ENUM! { enum CryptographicPublicKeyBlobType: i32 {
+RT_ENUM! { enum CryptographicPublicKeyBlobType: i32 ["Windows.Security.Cryptography.Core.CryptographicPublicKeyBlobType"] {
     X509SubjectPublicKeyInfo (CryptographicPublicKeyBlobType_X509SubjectPublicKeyInfo) = 0, Pkcs1RsaPublicKey (CryptographicPublicKeyBlobType_Pkcs1RsaPublicKey) = 1, BCryptPublicKey (CryptographicPublicKeyBlobType_BCryptPublicKey) = 2, Capi1PublicKey (CryptographicPublicKeyBlobType_Capi1PublicKey) = 3, BCryptEccFullPublicKey (CryptographicPublicKeyBlobType_BCryptEccFullPublicKey) = 4,
 }}
 RT_CLASS!{static class EccCurveNames}
@@ -5517,7 +5517,7 @@ impl IEncryptedAndAuthenticatedData {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EncryptedAndAuthenticatedData: IEncryptedAndAuthenticatedData}
+RT_CLASS!{class EncryptedAndAuthenticatedData: IEncryptedAndAuthenticatedData ["Windows.Security.Cryptography.Core.EncryptedAndAuthenticatedData"]}
 RT_CLASS!{static class HashAlgorithmNames}
 impl RtActivatable<IHashAlgorithmNamesStatics> for HashAlgorithmNames {}
 impl HashAlgorithmNames {
@@ -5603,7 +5603,7 @@ impl IHashAlgorithmProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HashAlgorithmProvider: IHashAlgorithmProvider}
+RT_CLASS!{class HashAlgorithmProvider: IHashAlgorithmProvider ["Windows.Security.Cryptography.Core.HashAlgorithmProvider"]}
 impl RtActivatable<IHashAlgorithmProviderStatics> for HashAlgorithmProvider {}
 impl HashAlgorithmProvider {
     #[inline] pub fn open_algorithm(algorithm: &HStringArg) -> Result<Option<ComPtr<HashAlgorithmProvider>>> {
@@ -5851,7 +5851,7 @@ impl IKeyDerivationAlgorithmProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyDerivationAlgorithmProvider: IKeyDerivationAlgorithmProvider}
+RT_CLASS!{class KeyDerivationAlgorithmProvider: IKeyDerivationAlgorithmProvider ["Windows.Security.Cryptography.Core.KeyDerivationAlgorithmProvider"]}
 impl RtActivatable<IKeyDerivationAlgorithmProviderStatics> for KeyDerivationAlgorithmProvider {}
 impl KeyDerivationAlgorithmProvider {
     #[inline] pub fn open_algorithm(algorithm: &HStringArg) -> Result<Option<ComPtr<KeyDerivationAlgorithmProvider>>> {
@@ -5894,7 +5894,7 @@ impl IKeyDerivationParameters {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyDerivationParameters: IKeyDerivationParameters}
+RT_CLASS!{class KeyDerivationParameters: IKeyDerivationParameters ["Windows.Security.Cryptography.Core.KeyDerivationParameters"]}
 impl RtActivatable<IKeyDerivationParametersStatics> for KeyDerivationParameters {}
 impl RtActivatable<IKeyDerivationParametersStatics2> for KeyDerivationParameters {}
 impl KeyDerivationParameters {
@@ -6049,7 +6049,7 @@ impl IMacAlgorithmProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MacAlgorithmProvider: IMacAlgorithmProvider}
+RT_CLASS!{class MacAlgorithmProvider: IMacAlgorithmProvider ["Windows.Security.Cryptography.Core.MacAlgorithmProvider"]}
 impl RtActivatable<IMacAlgorithmProviderStatics> for MacAlgorithmProvider {}
 impl MacAlgorithmProvider {
     #[inline] pub fn open_algorithm(algorithm: &HStringArg) -> Result<Option<ComPtr<MacAlgorithmProvider>>> {
@@ -6311,7 +6311,7 @@ impl ISymmetricKeyAlgorithmProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SymmetricKeyAlgorithmProvider: ISymmetricKeyAlgorithmProvider}
+RT_CLASS!{class SymmetricKeyAlgorithmProvider: ISymmetricKeyAlgorithmProvider ["Windows.Security.Cryptography.Core.SymmetricKeyAlgorithmProvider"]}
 impl RtActivatable<ISymmetricKeyAlgorithmProviderStatics> for SymmetricKeyAlgorithmProvider {}
 impl SymmetricKeyAlgorithmProvider {
     #[inline] pub fn open_algorithm(algorithm: &HStringArg) -> Result<Option<ComPtr<SymmetricKeyAlgorithmProvider>>> {
@@ -6362,7 +6362,7 @@ impl IDataProtectionProvider {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataProtectionProvider: IDataProtectionProvider}
+RT_CLASS!{class DataProtectionProvider: IDataProtectionProvider ["Windows.Security.Cryptography.DataProtection.DataProtectionProvider"]}
 impl RtActivatable<IDataProtectionProviderFactory> for DataProtectionProvider {}
 impl RtActivatable<IActivationFactory> for DataProtectionProvider {}
 impl DataProtectionProvider {
@@ -6404,7 +6404,7 @@ impl IBufferProtectUnprotectResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BufferProtectUnprotectResult: IBufferProtectUnprotectResult}
+RT_CLASS!{class BufferProtectUnprotectResult: IBufferProtectUnprotectResult ["Windows.Security.EnterpriseData.BufferProtectUnprotectResult"]}
 DEFINE_IID!(IID_IDataProtectionInfo, 2216734913, 24113, 17413, 149, 64, 63, 148, 58, 240, 203, 38);
 RT_INTERFACE!{interface IDataProtectionInfo(IDataProtectionInfoVtbl): IInspectable(IInspectableVtbl) [IID_IDataProtectionInfo] {
     fn get_Status(&self, out: *mut DataProtectionStatus) -> HRESULT,
@@ -6422,7 +6422,7 @@ impl IDataProtectionInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataProtectionInfo: IDataProtectionInfo}
+RT_CLASS!{class DataProtectionInfo: IDataProtectionInfo ["Windows.Security.EnterpriseData.DataProtectionInfo"]}
 RT_CLASS!{static class DataProtectionManager}
 impl RtActivatable<IDataProtectionManagerStatics> for DataProtectionManager {}
 impl DataProtectionManager {
@@ -6487,10 +6487,10 @@ impl IDataProtectionManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DataProtectionStatus: i32 {
+RT_ENUM! { enum DataProtectionStatus: i32 ["Windows.Security.EnterpriseData.DataProtectionStatus"] {
     ProtectedToOtherIdentity (DataProtectionStatus_ProtectedToOtherIdentity) = 0, Protected (DataProtectionStatus_Protected) = 1, Revoked (DataProtectionStatus_Revoked) = 2, Unprotected (DataProtectionStatus_Unprotected) = 3, LicenseExpired (DataProtectionStatus_LicenseExpired) = 4, AccessSuspended (DataProtectionStatus_AccessSuspended) = 5,
 }}
-RT_ENUM! { enum EnforcementLevel: i32 {
+RT_ENUM! { enum EnforcementLevel: i32 ["Windows.Security.EnterpriseData.EnforcementLevel"] {
     NoProtection (EnforcementLevel_NoProtection) = 0, Silent (EnforcementLevel_Silent) = 1, Override (EnforcementLevel_Override) = 2, Block (EnforcementLevel_Block) = 3,
 }}
 DEFINE_IID!(IID_IFileProtectionInfo, 1323918470, 5246, 19920, 143, 175, 82, 83, 237, 145, 173, 12);
@@ -6516,7 +6516,7 @@ impl IFileProtectionInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileProtectionInfo: IFileProtectionInfo}
+RT_CLASS!{class FileProtectionInfo: IFileProtectionInfo ["Windows.Security.EnterpriseData.FileProtectionInfo"]}
 DEFINE_IID!(IID_IFileProtectionInfo2, 2182232652, 21882, 18829, 142, 148, 148, 76, 213, 131, 100, 50);
 RT_INTERFACE!{interface IFileProtectionInfo2(IFileProtectionInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IFileProtectionInfo2] {
     fn get_IsProtectWhileOpenSupported(&self, out: *mut bool) -> HRESULT
@@ -6658,7 +6658,7 @@ impl IFileProtectionManagerStatics3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum FileProtectionStatus: i32 {
+RT_ENUM! { enum FileProtectionStatus: i32 ["Windows.Security.EnterpriseData.FileProtectionStatus"] {
     Undetermined (FileProtectionStatus_Undetermined) = 0, Unknown (FileProtectionStatus_Unknown) = 0, Unprotected (FileProtectionStatus_Unprotected) = 1, Revoked (FileProtectionStatus_Revoked) = 2, Protected (FileProtectionStatus_Protected) = 3, ProtectedByOtherUser (FileProtectionStatus_ProtectedByOtherUser) = 4, ProtectedToOtherEnterprise (FileProtectionStatus_ProtectedToOtherEnterprise) = 5, NotProtectable (FileProtectionStatus_NotProtectable) = 6, ProtectedToOtherIdentity (FileProtectionStatus_ProtectedToOtherIdentity) = 7, LicenseExpired (FileProtectionStatus_LicenseExpired) = 8, AccessSuspended (FileProtectionStatus_AccessSuspended) = 9, FileInUse (FileProtectionStatus_FileInUse) = 10,
 }}
 RT_CLASS!{static class FileRevocationManager}
@@ -6722,7 +6722,7 @@ impl IFileUnprotectOptions {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileUnprotectOptions: IFileUnprotectOptions}
+RT_CLASS!{class FileUnprotectOptions: IFileUnprotectOptions ["Windows.Security.EnterpriseData.FileUnprotectOptions"]}
 impl RtActivatable<IFileUnprotectOptionsFactory> for FileUnprotectOptions {}
 impl FileUnprotectOptions {
     #[inline] pub fn create(audit: bool) -> Result<ComPtr<FileUnprotectOptions>> {
@@ -6752,7 +6752,7 @@ impl IProtectedAccessResumedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectedAccessResumedEventArgs: IProtectedAccessResumedEventArgs}
+RT_CLASS!{class ProtectedAccessResumedEventArgs: IProtectedAccessResumedEventArgs ["Windows.Security.EnterpriseData.ProtectedAccessResumedEventArgs"]}
 DEFINE_IID!(IID_IProtectedAccessSuspendingEventArgs, 1973523424, 41796, 17055, 185, 117, 4, 252, 31, 136, 193, 133);
 RT_INTERFACE!{interface IProtectedAccessSuspendingEventArgs(IProtectedAccessSuspendingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IProtectedAccessSuspendingEventArgs] {
     fn get_Identities(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -6776,7 +6776,7 @@ impl IProtectedAccessSuspendingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectedAccessSuspendingEventArgs: IProtectedAccessSuspendingEventArgs}
+RT_CLASS!{class ProtectedAccessSuspendingEventArgs: IProtectedAccessSuspendingEventArgs ["Windows.Security.EnterpriseData.ProtectedAccessSuspendingEventArgs"]}
 DEFINE_IID!(IID_IProtectedContainerExportResult, 961081237, 63483, 19266, 175, 176, 223, 112, 180, 21, 67, 193);
 RT_INTERFACE!{interface IProtectedContainerExportResult(IProtectedContainerExportResultVtbl): IInspectable(IInspectableVtbl) [IID_IProtectedContainerExportResult] {
     fn get_Status(&self, out: *mut ProtectedImportExportStatus) -> HRESULT,
@@ -6794,7 +6794,7 @@ impl IProtectedContainerExportResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectedContainerExportResult: IProtectedContainerExportResult}
+RT_CLASS!{class ProtectedContainerExportResult: IProtectedContainerExportResult ["Windows.Security.EnterpriseData.ProtectedContainerExportResult"]}
 DEFINE_IID!(IID_IProtectedContainerImportResult, 3451355345, 59323, 19738, 147, 57, 52, 220, 65, 20, 159, 155);
 RT_INTERFACE!{interface IProtectedContainerImportResult(IProtectedContainerImportResultVtbl): IInspectable(IInspectableVtbl) [IID_IProtectedContainerImportResult] {
     fn get_Status(&self, out: *mut ProtectedImportExportStatus) -> HRESULT,
@@ -6812,7 +6812,7 @@ impl IProtectedContainerImportResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectedContainerImportResult: IProtectedContainerImportResult}
+RT_CLASS!{class ProtectedContainerImportResult: IProtectedContainerImportResult ["Windows.Security.EnterpriseData.ProtectedContainerImportResult"]}
 DEFINE_IID!(IID_IProtectedContentRevokedEventArgs, 1667786785, 22713, 18414, 147, 217, 240, 247, 65, 207, 67, 240);
 RT_INTERFACE!{interface IProtectedContentRevokedEventArgs(IProtectedContentRevokedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IProtectedContentRevokedEventArgs] {
     fn get_Identities(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT
@@ -6824,7 +6824,7 @@ impl IProtectedContentRevokedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectedContentRevokedEventArgs: IProtectedContentRevokedEventArgs}
+RT_CLASS!{class ProtectedContentRevokedEventArgs: IProtectedContentRevokedEventArgs ["Windows.Security.EnterpriseData.ProtectedContentRevokedEventArgs"]}
 DEFINE_IID!(IID_IProtectedFileCreateResult, 686026090, 59879, 18947, 159, 83, 189, 177, 97, 114, 105, 155);
 RT_INTERFACE!{interface IProtectedFileCreateResult(IProtectedFileCreateResultVtbl): IInspectable(IInspectableVtbl) [IID_IProtectedFileCreateResult] {
     #[cfg(not(feature="windows-storage"))] fn __Dummy0(&self) -> (),
@@ -6850,11 +6850,11 @@ impl IProtectedFileCreateResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectedFileCreateResult: IProtectedFileCreateResult}
-RT_ENUM! { enum ProtectedImportExportStatus: i32 {
+RT_CLASS!{class ProtectedFileCreateResult: IProtectedFileCreateResult ["Windows.Security.EnterpriseData.ProtectedFileCreateResult"]}
+RT_ENUM! { enum ProtectedImportExportStatus: i32 ["Windows.Security.EnterpriseData.ProtectedImportExportStatus"] {
     Ok (ProtectedImportExportStatus_Ok) = 0, Undetermined (ProtectedImportExportStatus_Undetermined) = 1, Unprotected (ProtectedImportExportStatus_Unprotected) = 2, Revoked (ProtectedImportExportStatus_Revoked) = 3, NotRoamable (ProtectedImportExportStatus_NotRoamable) = 4, ProtectedToOtherIdentity (ProtectedImportExportStatus_ProtectedToOtherIdentity) = 5, LicenseExpired (ProtectedImportExportStatus_LicenseExpired) = 6, AccessSuspended (ProtectedImportExportStatus_AccessSuspended) = 7,
 }}
-RT_ENUM! { enum ProtectionPolicyAuditAction: i32 {
+RT_ENUM! { enum ProtectionPolicyAuditAction: i32 ["Windows.Security.EnterpriseData.ProtectionPolicyAuditAction"] {
     Decrypt (ProtectionPolicyAuditAction_Decrypt) = 0, CopyToLocation (ProtectionPolicyAuditAction_CopyToLocation) = 1, SendToRecipient (ProtectionPolicyAuditAction_SendToRecipient) = 2, Other (ProtectionPolicyAuditAction_Other) = 3,
 }}
 DEFINE_IID!(IID_IProtectionPolicyAuditInfo, 1113241572, 65207, 17660, 179, 187, 195, 196, 215, 236, 190, 187);
@@ -6906,7 +6906,7 @@ impl IProtectionPolicyAuditInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectionPolicyAuditInfo: IProtectionPolicyAuditInfo}
+RT_CLASS!{class ProtectionPolicyAuditInfo: IProtectionPolicyAuditInfo ["Windows.Security.EnterpriseData.ProtectionPolicyAuditInfo"]}
 impl RtActivatable<IProtectionPolicyAuditInfoFactory> for ProtectionPolicyAuditInfo {}
 impl ProtectionPolicyAuditInfo {
     #[inline] pub fn create(action: ProtectionPolicyAuditAction, dataDescription: &HStringArg, sourceDescription: &HStringArg, targetDescription: &HStringArg) -> Result<ComPtr<ProtectionPolicyAuditInfo>> {
@@ -6934,7 +6934,7 @@ impl IProtectionPolicyAuditInfoFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProtectionPolicyEvaluationResult: i32 {
+RT_ENUM! { enum ProtectionPolicyEvaluationResult: i32 ["Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult"] {
     Allowed (ProtectionPolicyEvaluationResult_Allowed) = 0, Blocked (ProtectionPolicyEvaluationResult_Blocked) = 1, ConsentRequired (ProtectionPolicyEvaluationResult_ConsentRequired) = 2,
 }}
 DEFINE_IID!(IID_IProtectionPolicyManager, 3580902936, 41101, 18406, 162, 64, 153, 52, 215, 22, 94, 181);
@@ -6953,7 +6953,7 @@ impl IProtectionPolicyManager {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtectionPolicyManager: IProtectionPolicyManager}
+RT_CLASS!{class ProtectionPolicyManager: IProtectionPolicyManager ["Windows.Security.EnterpriseData.ProtectionPolicyManager"]}
 impl RtActivatable<IProtectionPolicyManagerStatics> for ProtectionPolicyManager {}
 impl RtActivatable<IProtectionPolicyManagerStatics2> for ProtectionPolicyManager {}
 impl RtActivatable<IProtectionPolicyManagerStatics3> for ProtectionPolicyManager {}
@@ -7357,14 +7357,14 @@ impl IProtectionPolicyManagerStatics4 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ProtectionPolicyRequestAccessBehavior: i32 {
+RT_ENUM! { enum ProtectionPolicyRequestAccessBehavior: i32 ["Windows.Security.EnterpriseData.ProtectionPolicyRequestAccessBehavior"] {
     Decrypt (ProtectionPolicyRequestAccessBehavior_Decrypt) = 0, TreatOverridePolicyAsBlock (ProtectionPolicyRequestAccessBehavior_TreatOverridePolicyAsBlock) = 1,
 }}
 DEFINE_IID!(IID_IThreadNetworkContext, 4199459049, 61203, 16474, 177, 44, 215, 52, 140, 111, 65, 252);
 RT_INTERFACE!{interface IThreadNetworkContext(IThreadNetworkContextVtbl): IInspectable(IInspectableVtbl) [IID_IThreadNetworkContext] {
     
 }}
-RT_CLASS!{class ThreadNetworkContext: IThreadNetworkContext}
+RT_CLASS!{class ThreadNetworkContext: IThreadNetworkContext ["Windows.Security.EnterpriseData.ThreadNetworkContext"]}
 } // Windows.Security.EnterpriseData
 pub mod exchangeactivesyncprovisioning { // Windows.Security.ExchangeActiveSyncProvisioning
 use ::prelude::*;
@@ -7409,7 +7409,7 @@ impl IEasClientDeviceInformation {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EasClientDeviceInformation: IEasClientDeviceInformation}
+RT_CLASS!{class EasClientDeviceInformation: IEasClientDeviceInformation ["Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation"]}
 impl RtActivatable<IActivationFactory> for EasClientDeviceInformation {}
 DEFINE_CLSID!(EasClientDeviceInformation(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,120,99,104,97,110,103,101,65,99,116,105,118,101,83,121,110,99,80,114,111,118,105,115,105,111,110,105,110,103,46,69,97,115,67,108,105,101,110,116,68,101,118,105,99,101,73,110,102,111,114,109,97,116,105,111,110,0]) [CLSID_EasClientDeviceInformation]);
 DEFINE_IID!(IID_IEasClientDeviceInformation2, 4289943843, 47910, 19818, 129, 188, 22, 90, 238, 10, 215, 84);
@@ -7534,7 +7534,7 @@ impl IEasClientSecurityPolicy {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EasClientSecurityPolicy: IEasClientSecurityPolicy}
+RT_CLASS!{class EasClientSecurityPolicy: IEasClientSecurityPolicy ["Windows.Security.ExchangeActiveSyncProvisioning.EasClientSecurityPolicy"]}
 impl RtActivatable<IActivationFactory> for EasClientSecurityPolicy {}
 DEFINE_CLSID!(EasClientSecurityPolicy(&[87,105,110,100,111,119,115,46,83,101,99,117,114,105,116,121,46,69,120,99,104,97,110,103,101,65,99,116,105,118,101,83,121,110,99,80,114,111,118,105,115,105,111,110,105,110,103,46,69,97,115,67,108,105,101,110,116,83,101,99,117,114,105,116,121,80,111,108,105,99,121,0]) [CLSID_EasClientSecurityPolicy]);
 DEFINE_IID!(IID_IEasComplianceResults, 1178347932, 32537, 19558, 180, 3, 203, 69, 221, 87, 162, 179);
@@ -7596,7 +7596,7 @@ impl IEasComplianceResults {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EasComplianceResults: IEasComplianceResults}
+RT_CLASS!{class EasComplianceResults: IEasComplianceResults ["Windows.Security.ExchangeActiveSyncProvisioning.EasComplianceResults"]}
 DEFINE_IID!(IID_IEasComplianceResults2, 801005769, 6824, 18421, 136, 187, 203, 62, 240, 191, 251, 21);
 RT_INTERFACE!{interface IEasComplianceResults2(IEasComplianceResults2Vtbl): IInspectable(IInspectableVtbl) [IID_IEasComplianceResults2] {
     fn get_EncryptionProviderType(&self, out: *mut EasEncryptionProviderType) -> HRESULT
@@ -7608,31 +7608,31 @@ impl IEasComplianceResults2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum EasDisallowConvenienceLogonResult: i32 {
+RT_ENUM! { enum EasDisallowConvenienceLogonResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasDisallowConvenienceLogonResult"] {
     NotEvaluated (EasDisallowConvenienceLogonResult_NotEvaluated) = 0, Compliant (EasDisallowConvenienceLogonResult_Compliant) = 1, CanBeCompliant (EasDisallowConvenienceLogonResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasDisallowConvenienceLogonResult_RequestedPolicyIsStricter) = 3,
 }}
-RT_ENUM! { enum EasEncryptionProviderType: i32 {
+RT_ENUM! { enum EasEncryptionProviderType: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasEncryptionProviderType"] {
     NotEvaluated (EasEncryptionProviderType_NotEvaluated) = 0, WindowsEncryption (EasEncryptionProviderType_WindowsEncryption) = 1, OtherEncryption (EasEncryptionProviderType_OtherEncryption) = 2,
 }}
-RT_ENUM! { enum EasMaxInactivityTimeLockResult: i32 {
+RT_ENUM! { enum EasMaxInactivityTimeLockResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasMaxInactivityTimeLockResult"] {
     NotEvaluated (EasMaxInactivityTimeLockResult_NotEvaluated) = 0, Compliant (EasMaxInactivityTimeLockResult_Compliant) = 1, CanBeCompliant (EasMaxInactivityTimeLockResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasMaxInactivityTimeLockResult_RequestedPolicyIsStricter) = 3, InvalidParameter (EasMaxInactivityTimeLockResult_InvalidParameter) = 4,
 }}
-RT_ENUM! { enum EasMaxPasswordFailedAttemptsResult: i32 {
+RT_ENUM! { enum EasMaxPasswordFailedAttemptsResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasMaxPasswordFailedAttemptsResult"] {
     NotEvaluated (EasMaxPasswordFailedAttemptsResult_NotEvaluated) = 0, Compliant (EasMaxPasswordFailedAttemptsResult_Compliant) = 1, CanBeCompliant (EasMaxPasswordFailedAttemptsResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasMaxPasswordFailedAttemptsResult_RequestedPolicyIsStricter) = 3, InvalidParameter (EasMaxPasswordFailedAttemptsResult_InvalidParameter) = 4,
 }}
-RT_ENUM! { enum EasMinPasswordComplexCharactersResult: i32 {
+RT_ENUM! { enum EasMinPasswordComplexCharactersResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasMinPasswordComplexCharactersResult"] {
     NotEvaluated (EasMinPasswordComplexCharactersResult_NotEvaluated) = 0, Compliant (EasMinPasswordComplexCharactersResult_Compliant) = 1, CanBeCompliant (EasMinPasswordComplexCharactersResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasMinPasswordComplexCharactersResult_RequestedPolicyIsStricter) = 3, RequestedPolicyNotEnforceable (EasMinPasswordComplexCharactersResult_RequestedPolicyNotEnforceable) = 4, InvalidParameter (EasMinPasswordComplexCharactersResult_InvalidParameter) = 5, CurrentUserHasBlankPassword (EasMinPasswordComplexCharactersResult_CurrentUserHasBlankPassword) = 6, AdminsHaveBlankPassword (EasMinPasswordComplexCharactersResult_AdminsHaveBlankPassword) = 7, UserCannotChangePassword (EasMinPasswordComplexCharactersResult_UserCannotChangePassword) = 8, AdminsCannotChangePassword (EasMinPasswordComplexCharactersResult_AdminsCannotChangePassword) = 9, LocalControlledUsersCannotChangePassword (EasMinPasswordComplexCharactersResult_LocalControlledUsersCannotChangePassword) = 10, ConnectedAdminsProviderPolicyIsWeak (EasMinPasswordComplexCharactersResult_ConnectedAdminsProviderPolicyIsWeak) = 11, ConnectedUserProviderPolicyIsWeak (EasMinPasswordComplexCharactersResult_ConnectedUserProviderPolicyIsWeak) = 12, ChangeConnectedAdminsPassword (EasMinPasswordComplexCharactersResult_ChangeConnectedAdminsPassword) = 13, ChangeConnectedUserPassword (EasMinPasswordComplexCharactersResult_ChangeConnectedUserPassword) = 14,
 }}
-RT_ENUM! { enum EasMinPasswordLengthResult: i32 {
+RT_ENUM! { enum EasMinPasswordLengthResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasMinPasswordLengthResult"] {
     NotEvaluated (EasMinPasswordLengthResult_NotEvaluated) = 0, Compliant (EasMinPasswordLengthResult_Compliant) = 1, CanBeCompliant (EasMinPasswordLengthResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasMinPasswordLengthResult_RequestedPolicyIsStricter) = 3, RequestedPolicyNotEnforceable (EasMinPasswordLengthResult_RequestedPolicyNotEnforceable) = 4, InvalidParameter (EasMinPasswordLengthResult_InvalidParameter) = 5, CurrentUserHasBlankPassword (EasMinPasswordLengthResult_CurrentUserHasBlankPassword) = 6, AdminsHaveBlankPassword (EasMinPasswordLengthResult_AdminsHaveBlankPassword) = 7, UserCannotChangePassword (EasMinPasswordLengthResult_UserCannotChangePassword) = 8, AdminsCannotChangePassword (EasMinPasswordLengthResult_AdminsCannotChangePassword) = 9, LocalControlledUsersCannotChangePassword (EasMinPasswordLengthResult_LocalControlledUsersCannotChangePassword) = 10, ConnectedAdminsProviderPolicyIsWeak (EasMinPasswordLengthResult_ConnectedAdminsProviderPolicyIsWeak) = 11, ConnectedUserProviderPolicyIsWeak (EasMinPasswordLengthResult_ConnectedUserProviderPolicyIsWeak) = 12, ChangeConnectedAdminsPassword (EasMinPasswordLengthResult_ChangeConnectedAdminsPassword) = 13, ChangeConnectedUserPassword (EasMinPasswordLengthResult_ChangeConnectedUserPassword) = 14,
 }}
-RT_ENUM! { enum EasPasswordExpirationResult: i32 {
+RT_ENUM! { enum EasPasswordExpirationResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasPasswordExpirationResult"] {
     NotEvaluated (EasPasswordExpirationResult_NotEvaluated) = 0, Compliant (EasPasswordExpirationResult_Compliant) = 1, CanBeCompliant (EasPasswordExpirationResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasPasswordExpirationResult_RequestedPolicyIsStricter) = 3, RequestedExpirationIncompatible (EasPasswordExpirationResult_RequestedExpirationIncompatible) = 4, InvalidParameter (EasPasswordExpirationResult_InvalidParameter) = 5, UserCannotChangePassword (EasPasswordExpirationResult_UserCannotChangePassword) = 6, AdminsCannotChangePassword (EasPasswordExpirationResult_AdminsCannotChangePassword) = 7, LocalControlledUsersCannotChangePassword (EasPasswordExpirationResult_LocalControlledUsersCannotChangePassword) = 8,
 }}
-RT_ENUM! { enum EasPasswordHistoryResult: i32 {
+RT_ENUM! { enum EasPasswordHistoryResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasPasswordHistoryResult"] {
     NotEvaluated (EasPasswordHistoryResult_NotEvaluated) = 0, Compliant (EasPasswordHistoryResult_Compliant) = 1, CanBeCompliant (EasPasswordHistoryResult_CanBeCompliant) = 2, RequestedPolicyIsStricter (EasPasswordHistoryResult_RequestedPolicyIsStricter) = 3, InvalidParameter (EasPasswordHistoryResult_InvalidParameter) = 4,
 }}
-RT_ENUM! { enum EasRequireEncryptionResult: i32 {
+RT_ENUM! { enum EasRequireEncryptionResult: i32 ["Windows.Security.ExchangeActiveSyncProvisioning.EasRequireEncryptionResult"] {
     NotEvaluated (EasRequireEncryptionResult_NotEvaluated) = 0, Compliant (EasRequireEncryptionResult_Compliant) = 1, CanBeCompliant (EasRequireEncryptionResult_CanBeCompliant) = 2, NotProvisionedOnAllVolumes (EasRequireEncryptionResult_NotProvisionedOnAllVolumes) = 3, DeFixedDataNotSupported (EasRequireEncryptionResult_DeFixedDataNotSupported) = 4, FixedDataNotSupported (EasRequireEncryptionResult_FixedDataNotSupported) = 4, DeHardwareNotCompliant (EasRequireEncryptionResult_DeHardwareNotCompliant) = 5, HardwareNotCompliant (EasRequireEncryptionResult_HardwareNotCompliant) = 5, DeWinReNotConfigured (EasRequireEncryptionResult_DeWinReNotConfigured) = 6, LockNotConfigured (EasRequireEncryptionResult_LockNotConfigured) = 6, DeProtectionSuspended (EasRequireEncryptionResult_DeProtectionSuspended) = 7, ProtectionSuspended (EasRequireEncryptionResult_ProtectionSuspended) = 7, DeOsVolumeNotProtected (EasRequireEncryptionResult_DeOsVolumeNotProtected) = 8, OsVolumeNotProtected (EasRequireEncryptionResult_OsVolumeNotProtected) = 8, DeProtectionNotYetEnabled (EasRequireEncryptionResult_DeProtectionNotYetEnabled) = 9, ProtectionNotYetEnabled (EasRequireEncryptionResult_ProtectionNotYetEnabled) = 9, NoFeatureLicense (EasRequireEncryptionResult_NoFeatureLicense) = 10, OsNotProtected (EasRequireEncryptionResult_OsNotProtected) = 11, UnexpectedFailure (EasRequireEncryptionResult_UnexpectedFailure) = 12,
 }}
 } // Windows.Security.ExchangeActiveSyncProvisioning

--- a/src/rt/gen/windows/services.rs
+++ b/src/rt/gen/windows/services.rs
@@ -56,7 +56,7 @@ impl ICortanaActionableInsights {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CortanaActionableInsights: ICortanaActionableInsights}
+RT_CLASS!{class CortanaActionableInsights: ICortanaActionableInsights ["Windows.Services.Cortana.CortanaActionableInsights"]}
 impl RtActivatable<ICortanaActionableInsightsStatics> for CortanaActionableInsights {}
 impl CortanaActionableInsights {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<CortanaActionableInsights>>> {
@@ -94,7 +94,7 @@ impl ICortanaActionableInsightsOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CortanaActionableInsightsOptions: ICortanaActionableInsightsOptions}
+RT_CLASS!{class CortanaActionableInsightsOptions: ICortanaActionableInsightsOptions ["Windows.Services.Cortana.CortanaActionableInsightsOptions"]}
 impl RtActivatable<IActivationFactory> for CortanaActionableInsightsOptions {}
 DEFINE_CLSID!(CortanaActionableInsightsOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,67,111,114,116,97,110,97,46,67,111,114,116,97,110,97,65,99,116,105,111,110,97,98,108,101,73,110,115,105,103,104,116,115,79,112,116,105,111,110,115,0]) [CLSID_CortanaActionableInsightsOptions]);
 DEFINE_IID!(IID_ICortanaActionableInsightsStatics, 3051279378, 40239, 23733, 155, 5, 53, 106, 11, 131, 108, 16);
@@ -114,10 +114,10 @@ impl ICortanaActionableInsightsStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CortanaPermission: i32 {
+RT_ENUM! { enum CortanaPermission: i32 ["Windows.Services.Cortana.CortanaPermission"] {
     BrowsingHistory (CortanaPermission_BrowsingHistory) = 0, Calendar (CortanaPermission_Calendar) = 1, CallHistory (CortanaPermission_CallHistory) = 2, Contacts (CortanaPermission_Contacts) = 3, Email (CortanaPermission_Email) = 4, InputPersonalization (CortanaPermission_InputPersonalization) = 5, Location (CortanaPermission_Location) = 6, Messaging (CortanaPermission_Messaging) = 7, Microphone (CortanaPermission_Microphone) = 8, Personalization (CortanaPermission_Personalization) = 9, PhoneCall (CortanaPermission_PhoneCall) = 10,
 }}
-RT_ENUM! { enum CortanaPermissionsChangeResult: i32 {
+RT_ENUM! { enum CortanaPermissionsChangeResult: i32 ["Windows.Services.Cortana.CortanaPermissionsChangeResult"] {
     Success (CortanaPermissionsChangeResult_Success) = 0, Unavailable (CortanaPermissionsChangeResult_Unavailable) = 1, DisabledByPolicy (CortanaPermissionsChangeResult_DisabledByPolicy) = 2,
 }}
 DEFINE_IID!(IID_ICortanaPermissionsManager, 420688096, 34453, 17290, 149, 69, 61, 164, 232, 34, 221, 180);
@@ -149,7 +149,7 @@ impl ICortanaPermissionsManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CortanaPermissionsManager: ICortanaPermissionsManager}
+RT_CLASS!{class CortanaPermissionsManager: ICortanaPermissionsManager ["Windows.Services.Cortana.CortanaPermissionsManager"]}
 impl RtActivatable<ICortanaPermissionsManagerStatics> for CortanaPermissionsManager {}
 impl CortanaPermissionsManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<CortanaPermissionsManager>>> {
@@ -190,7 +190,7 @@ impl ICortanaSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CortanaSettings: ICortanaSettings}
+RT_CLASS!{class CortanaSettings: ICortanaSettings ["Windows.Services.Cortana.CortanaSettings"]}
 impl RtActivatable<ICortanaSettingsStatics> for CortanaSettings {}
 impl CortanaSettings {
     #[inline] pub fn is_supported() -> Result<bool> {
@@ -239,7 +239,7 @@ impl IEnhancedWaypoint {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EnhancedWaypoint: IEnhancedWaypoint}
+RT_CLASS!{class EnhancedWaypoint: IEnhancedWaypoint ["Windows.Services.Maps.EnhancedWaypoint"]}
 impl RtActivatable<IEnhancedWaypointFactory> for EnhancedWaypoint {}
 impl EnhancedWaypoint {
     #[cfg(feature="windows-devices")] #[inline] pub fn create(point: &super::super::devices::geolocation::Geopoint, kind: WaypointKind) -> Result<ComPtr<EnhancedWaypoint>> {
@@ -275,11 +275,11 @@ impl IManeuverWarning {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ManeuverWarning: IManeuverWarning}
-RT_ENUM! { enum ManeuverWarningKind: i32 {
+RT_CLASS!{class ManeuverWarning: IManeuverWarning ["Windows.Services.Maps.ManeuverWarning"]}
+RT_ENUM! { enum ManeuverWarningKind: i32 ["Windows.Services.Maps.ManeuverWarningKind"] {
     None (ManeuverWarningKind_None) = 0, Accident (ManeuverWarningKind_Accident) = 1, AdministrativeDivisionChange (ManeuverWarningKind_AdministrativeDivisionChange) = 2, Alert (ManeuverWarningKind_Alert) = 3, BlockedRoad (ManeuverWarningKind_BlockedRoad) = 4, CheckTimetable (ManeuverWarningKind_CheckTimetable) = 5, Congestion (ManeuverWarningKind_Congestion) = 6, Construction (ManeuverWarningKind_Construction) = 7, CountryChange (ManeuverWarningKind_CountryChange) = 8, DisabledVehicle (ManeuverWarningKind_DisabledVehicle) = 9, GateAccess (ManeuverWarningKind_GateAccess) = 10, GetOffTransit (ManeuverWarningKind_GetOffTransit) = 11, GetOnTransit (ManeuverWarningKind_GetOnTransit) = 12, IllegalUTurn (ManeuverWarningKind_IllegalUTurn) = 13, MassTransit (ManeuverWarningKind_MassTransit) = 14, Miscellaneous (ManeuverWarningKind_Miscellaneous) = 15, NoIncident (ManeuverWarningKind_NoIncident) = 16, Other (ManeuverWarningKind_Other) = 17, OtherNews (ManeuverWarningKind_OtherNews) = 18, OtherTrafficIncidents (ManeuverWarningKind_OtherTrafficIncidents) = 19, PlannedEvent (ManeuverWarningKind_PlannedEvent) = 20, PrivateRoad (ManeuverWarningKind_PrivateRoad) = 21, RestrictedTurn (ManeuverWarningKind_RestrictedTurn) = 22, RoadClosures (ManeuverWarningKind_RoadClosures) = 23, RoadHazard (ManeuverWarningKind_RoadHazard) = 24, ScheduledConstruction (ManeuverWarningKind_ScheduledConstruction) = 25, SeasonalClosures (ManeuverWarningKind_SeasonalClosures) = 26, Tollbooth (ManeuverWarningKind_Tollbooth) = 27, TollRoad (ManeuverWarningKind_TollRoad) = 28, TollZoneEnter (ManeuverWarningKind_TollZoneEnter) = 29, TollZoneExit (ManeuverWarningKind_TollZoneExit) = 30, TrafficFlow (ManeuverWarningKind_TrafficFlow) = 31, TransitLineChange (ManeuverWarningKind_TransitLineChange) = 32, UnpavedRoad (ManeuverWarningKind_UnpavedRoad) = 33, UnscheduledConstruction (ManeuverWarningKind_UnscheduledConstruction) = 34, Weather (ManeuverWarningKind_Weather) = 35,
 }}
-RT_ENUM! { enum ManeuverWarningSeverity: i32 {
+RT_ENUM! { enum ManeuverWarningSeverity: i32 ["Windows.Services.Maps.ManeuverWarningSeverity"] {
     None (ManeuverWarningSeverity_None) = 0, LowImpact (ManeuverWarningSeverity_LowImpact) = 1, Minor (ManeuverWarningSeverity_Minor) = 2, Moderate (ManeuverWarningSeverity_Moderate) = 3, Serious (ManeuverWarningSeverity_Serious) = 4,
 }}
 DEFINE_IID!(IID_IMapAddress, 3483871603, 41908, 17556, 179, 255, 203, 169, 77, 182, 150, 153);
@@ -377,7 +377,7 @@ impl IMapAddress {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapAddress: IMapAddress}
+RT_CLASS!{class MapAddress: IMapAddress ["Windows.Services.Maps.MapAddress"]}
 DEFINE_IID!(IID_IMapAddress2, 1976397297, 58797, 17833, 191, 64, 108, 242, 86, 193, 221, 19);
 RT_INTERFACE!{interface IMapAddress2(IMapAddress2Vtbl): IInspectable(IInspectableVtbl) [IID_IMapAddress2] {
     fn get_FormattedAddress(&self, out: *mut HSTRING) -> HRESULT
@@ -419,8 +419,8 @@ impl IMapLocation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapLocation: IMapLocation}
-RT_ENUM! { enum MapLocationDesiredAccuracy: i32 {
+RT_CLASS!{class MapLocation: IMapLocation ["Windows.Services.Maps.MapLocation"]}
+RT_ENUM! { enum MapLocationDesiredAccuracy: i32 ["Windows.Services.Maps.MapLocationDesiredAccuracy"] {
     High (MapLocationDesiredAccuracy_High) = 0, Low (MapLocationDesiredAccuracy_Low) = 1,
 }}
 RT_CLASS!{static class MapLocationFinder}
@@ -458,7 +458,7 @@ impl IMapLocationFinderResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapLocationFinderResult: IMapLocationFinderResult}
+RT_CLASS!{class MapLocationFinderResult: IMapLocationFinderResult ["Windows.Services.Maps.MapLocationFinderResult"]}
 DEFINE_IID!(IID_IMapLocationFinderStatics, 831183709, 7261, 20277, 162, 223, 170, 202, 148, 149, 149, 23);
 RT_INTERFACE!{static interface IMapLocationFinderStatics(IMapLocationFinderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IMapLocationFinderStatics] {
     #[cfg(feature="windows-devices")] fn FindLocationsAtAsync(&self, queryPoint: *mut super::super::devices::geolocation::Geopoint, out: *mut *mut foundation::IAsyncOperation<MapLocationFinderResult>) -> HRESULT,
@@ -493,7 +493,7 @@ impl IMapLocationFinderStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MapLocationFinderStatus: i32 {
+RT_ENUM! { enum MapLocationFinderStatus: i32 ["Windows.Services.Maps.MapLocationFinderStatus"] {
     Success (MapLocationFinderStatus_Success) = 0, UnknownError (MapLocationFinderStatus_UnknownError) = 1, InvalidCredentials (MapLocationFinderStatus_InvalidCredentials) = 2, BadLocation (MapLocationFinderStatus_BadLocation) = 3, IndexFailure (MapLocationFinderStatus_IndexFailure) = 4, NetworkFailure (MapLocationFinderStatus_NetworkFailure) = 5, NotSupported (MapLocationFinderStatus_NotSupported) = 6,
 }}
 RT_CLASS!{static class MapManager}
@@ -522,7 +522,7 @@ impl IMapManagerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MapManeuverNotices: u32 {
+RT_ENUM! { enum MapManeuverNotices: u32 ["Windows.Services.Maps.MapManeuverNotices"] {
     None (MapManeuverNotices_None) = 0, Toll (MapManeuverNotices_Toll) = 1, Unpaved (MapManeuverNotices_Unpaved) = 2,
 }}
 DEFINE_IID!(IID_IMapRoute, 4211586866, 22605, 17795, 156, 96, 100, 31, 234, 39, 67, 73);
@@ -568,7 +568,7 @@ impl IMapRoute {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapRoute: IMapRoute}
+RT_CLASS!{class MapRoute: IMapRoute ["Windows.Services.Maps.MapRoute"]}
 DEFINE_IID!(IID_IMapRoute2, 3519403020, 8723, 19120, 162, 96, 70, 179, 129, 105, 190, 172);
 RT_INTERFACE!{interface IMapRoute2(IMapRoute2Vtbl): IInspectable(IInspectableVtbl) [IID_IMapRoute2] {
     fn get_ViolatedRestrictions(&self, out: *mut MapRouteRestrictions) -> HRESULT,
@@ -663,7 +663,7 @@ impl IMapRouteDrivingOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapRouteDrivingOptions: IMapRouteDrivingOptions}
+RT_CLASS!{class MapRouteDrivingOptions: IMapRouteDrivingOptions ["Windows.Services.Maps.MapRouteDrivingOptions"]}
 impl RtActivatable<IActivationFactory> for MapRouteDrivingOptions {}
 DEFINE_CLSID!(MapRouteDrivingOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,82,111,117,116,101,68,114,105,118,105,110,103,79,112,116,105,111,110,115,0]) [CLSID_MapRouteDrivingOptions]);
 DEFINE_IID!(IID_IMapRouteDrivingOptions2, 903644784, 49816, 18640, 181, 173, 130, 84, 96, 100, 86, 3);
@@ -745,7 +745,7 @@ impl IMapRouteFinderResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapRouteFinderResult: IMapRouteFinderResult}
+RT_CLASS!{class MapRouteFinderResult: IMapRouteFinderResult ["Windows.Services.Maps.MapRouteFinderResult"]}
 DEFINE_IID!(IID_IMapRouteFinderResult2, 544250989, 55564, 18120, 145, 198, 125, 75, 228, 239, 178, 21);
 RT_INTERFACE!{interface IMapRouteFinderResult2(IMapRouteFinderResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IMapRouteFinderResult2] {
     fn get_AlternateRoutes(&self, out: *mut *mut foundation::collections::IVectorView<MapRoute>) -> HRESULT
@@ -850,7 +850,7 @@ impl IMapRouteFinderStatics3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MapRouteFinderStatus: i32 {
+RT_ENUM! { enum MapRouteFinderStatus: i32 ["Windows.Services.Maps.MapRouteFinderStatus"] {
     Success (MapRouteFinderStatus_Success) = 0, UnknownError (MapRouteFinderStatus_UnknownError) = 1, InvalidCredentials (MapRouteFinderStatus_InvalidCredentials) = 2, NoRouteFound (MapRouteFinderStatus_NoRouteFound) = 3, NoRouteFoundWithGivenOptions (MapRouteFinderStatus_NoRouteFoundWithGivenOptions) = 4, StartPointNotFound (MapRouteFinderStatus_StartPointNotFound) = 5, EndPointNotFound (MapRouteFinderStatus_EndPointNotFound) = 6, NoPedestrianRouteFound (MapRouteFinderStatus_NoPedestrianRouteFound) = 7, NetworkFailure (MapRouteFinderStatus_NetworkFailure) = 8, NotSupported (MapRouteFinderStatus_NotSupported) = 9,
 }}
 DEFINE_IID!(IID_IMapRouteLeg, 2532881142, 23482, 19735, 157, 182, 26, 38, 63, 236, 116, 113);
@@ -890,7 +890,7 @@ impl IMapRouteLeg {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapRouteLeg: IMapRouteLeg}
+RT_CLASS!{class MapRouteLeg: IMapRouteLeg ["Windows.Services.Maps.MapRouteLeg"]}
 DEFINE_IID!(IID_IMapRouteLeg2, 48367149, 51654, 17848, 142, 84, 26, 16, 181, 122, 23, 232);
 RT_INTERFACE!{interface IMapRouteLeg2(IMapRouteLeg2Vtbl): IInspectable(IInspectableVtbl) [IID_IMapRouteLeg2] {
     fn get_DurationWithoutTraffic(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -950,7 +950,7 @@ impl IMapRouteManeuver {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MapRouteManeuver: IMapRouteManeuver}
+RT_CLASS!{class MapRouteManeuver: IMapRouteManeuver ["Windows.Services.Maps.MapRouteManeuver"]}
 DEFINE_IID!(IID_IMapRouteManeuver2, 1568394652, 31899, 16863, 131, 139, 234, 226, 30, 75, 5, 169);
 RT_INTERFACE!{interface IMapRouteManeuver2(IMapRouteManeuver2Vtbl): IInspectable(IInspectableVtbl) [IID_IMapRouteManeuver2] {
     fn get_StartHeading(&self, out: *mut f64) -> HRESULT,
@@ -985,13 +985,13 @@ impl IMapRouteManeuver3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MapRouteManeuverKind: i32 {
+RT_ENUM! { enum MapRouteManeuverKind: i32 ["Windows.Services.Maps.MapRouteManeuverKind"] {
     None (MapRouteManeuverKind_None) = 0, Start (MapRouteManeuverKind_Start) = 1, Stopover (MapRouteManeuverKind_Stopover) = 2, StopoverResume (MapRouteManeuverKind_StopoverResume) = 3, End (MapRouteManeuverKind_End) = 4, GoStraight (MapRouteManeuverKind_GoStraight) = 5, UTurnLeft (MapRouteManeuverKind_UTurnLeft) = 6, UTurnRight (MapRouteManeuverKind_UTurnRight) = 7, TurnKeepLeft (MapRouteManeuverKind_TurnKeepLeft) = 8, TurnKeepRight (MapRouteManeuverKind_TurnKeepRight) = 9, TurnLightLeft (MapRouteManeuverKind_TurnLightLeft) = 10, TurnLightRight (MapRouteManeuverKind_TurnLightRight) = 11, TurnLeft (MapRouteManeuverKind_TurnLeft) = 12, TurnRight (MapRouteManeuverKind_TurnRight) = 13, TurnHardLeft (MapRouteManeuverKind_TurnHardLeft) = 14, TurnHardRight (MapRouteManeuverKind_TurnHardRight) = 15, FreewayEnterLeft (MapRouteManeuverKind_FreewayEnterLeft) = 16, FreewayEnterRight (MapRouteManeuverKind_FreewayEnterRight) = 17, FreewayLeaveLeft (MapRouteManeuverKind_FreewayLeaveLeft) = 18, FreewayLeaveRight (MapRouteManeuverKind_FreewayLeaveRight) = 19, FreewayContinueLeft (MapRouteManeuverKind_FreewayContinueLeft) = 20, FreewayContinueRight (MapRouteManeuverKind_FreewayContinueRight) = 21, TrafficCircleLeft (MapRouteManeuverKind_TrafficCircleLeft) = 22, TrafficCircleRight (MapRouteManeuverKind_TrafficCircleRight) = 23, TakeFerry (MapRouteManeuverKind_TakeFerry) = 24,
 }}
-RT_ENUM! { enum MapRouteOptimization: i32 {
+RT_ENUM! { enum MapRouteOptimization: i32 ["Windows.Services.Maps.MapRouteOptimization"] {
     Time (MapRouteOptimization_Time) = 0, Distance (MapRouteOptimization_Distance) = 1, TimeWithTraffic (MapRouteOptimization_TimeWithTraffic) = 2, Scenic (MapRouteOptimization_Scenic) = 3,
 }}
-RT_ENUM! { enum MapRouteRestrictions: u32 {
+RT_ENUM! { enum MapRouteRestrictions: u32 ["Windows.Services.Maps.MapRouteRestrictions"] {
     None (MapRouteRestrictions_None) = 0, Highways (MapRouteRestrictions_Highways) = 1, TollRoads (MapRouteRestrictions_TollRoads) = 2, Ferries (MapRouteRestrictions_Ferries) = 4, Tunnels (MapRouteRestrictions_Tunnels) = 8, DirtRoads (MapRouteRestrictions_DirtRoads) = 16, Motorail (MapRouteRestrictions_Motorail) = 32,
 }}
 RT_CLASS!{static class MapService}
@@ -1020,7 +1020,7 @@ impl MapService {
     }
 }
 DEFINE_CLSID!(MapService(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,77,97,112,83,101,114,118,105,99,101,0]) [CLSID_MapService]);
-RT_ENUM! { enum MapServiceDataUsagePreference: i32 {
+RT_ENUM! { enum MapServiceDataUsagePreference: i32 ["Windows.Services.Maps.MapServiceDataUsagePreference"] {
     Default (MapServiceDataUsagePreference_Default) = 0, OfflineMapDataOnly (MapServiceDataUsagePreference_OfflineMapDataOnly) = 1,
 }}
 DEFINE_IID!(IID_IMapServiceStatics, 21278085, 49228, 19677, 135, 26, 160, 114, 109, 9, 124, 212);
@@ -1117,7 +1117,7 @@ impl IPlaceInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaceInfo: IPlaceInfo}
+RT_CLASS!{class PlaceInfo: IPlaceInfo ["Windows.Services.Maps.PlaceInfo"]}
 impl RtActivatable<IPlaceInfoStatics> for PlaceInfo {}
 impl RtActivatable<IPlaceInfoStatics2> for PlaceInfo {}
 impl PlaceInfo {
@@ -1174,7 +1174,7 @@ impl IPlaceInfoCreateOptions {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlaceInfoCreateOptions: IPlaceInfoCreateOptions}
+RT_CLASS!{class PlaceInfoCreateOptions: IPlaceInfoCreateOptions ["Windows.Services.Maps.PlaceInfoCreateOptions"]}
 impl RtActivatable<IActivationFactory> for PlaceInfoCreateOptions {}
 DEFINE_CLSID!(PlaceInfoCreateOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,77,97,112,115,46,80,108,97,99,101,73,110,102,111,67,114,101,97,116,101,79,112,116,105,111,110,115,0]) [CLSID_PlaceInfoCreateOptions]);
 DEFINE_IID!(IID_IPlaceInfoStatics, 2193227633, 27856, 18596, 175, 217, 94, 216, 32, 151, 147, 107);
@@ -1238,18 +1238,18 @@ impl IPlaceInfoStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TrafficCongestion: i32 {
+RT_ENUM! { enum TrafficCongestion: i32 ["Windows.Services.Maps.TrafficCongestion"] {
     Unknown (TrafficCongestion_Unknown) = 0, Light (TrafficCongestion_Light) = 1, Mild (TrafficCongestion_Mild) = 2, Medium (TrafficCongestion_Medium) = 3, Heavy (TrafficCongestion_Heavy) = 4,
 }}
-RT_ENUM! { enum WaypointKind: i32 {
+RT_ENUM! { enum WaypointKind: i32 ["Windows.Services.Maps.WaypointKind"] {
     Stop (WaypointKind_Stop) = 0, Via (WaypointKind_Via) = 1,
 }}
 pub mod guidance { // Windows.Services.Maps.Guidance
 use ::prelude::*;
-RT_ENUM! { enum GuidanceAudioMeasurementSystem: i32 {
+RT_ENUM! { enum GuidanceAudioMeasurementSystem: i32 ["Windows.Services.Maps.Guidance.GuidanceAudioMeasurementSystem"] {
     Meters (GuidanceAudioMeasurementSystem_Meters) = 0, MilesAndYards (GuidanceAudioMeasurementSystem_MilesAndYards) = 1, MilesAndFeet (GuidanceAudioMeasurementSystem_MilesAndFeet) = 2,
 }}
-RT_ENUM! { enum GuidanceAudioNotificationKind: i32 {
+RT_ENUM! { enum GuidanceAudioNotificationKind: i32 ["Windows.Services.Maps.Guidance.GuidanceAudioNotificationKind"] {
     Maneuver (GuidanceAudioNotificationKind_Maneuver) = 0, Route (GuidanceAudioNotificationKind_Route) = 1, Gps (GuidanceAudioNotificationKind_Gps) = 2, SpeedLimit (GuidanceAudioNotificationKind_SpeedLimit) = 3, Traffic (GuidanceAudioNotificationKind_Traffic) = 4, TrafficCamera (GuidanceAudioNotificationKind_TrafficCamera) = 5,
 }}
 DEFINE_IID!(IID_IGuidanceAudioNotificationRequestedEventArgs, 3391791690, 51138, 19788, 157, 124, 73, 149, 118, 188, 237, 219);
@@ -1275,8 +1275,8 @@ impl IGuidanceAudioNotificationRequestedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceAudioNotificationRequestedEventArgs: IGuidanceAudioNotificationRequestedEventArgs}
-RT_ENUM! { enum GuidanceAudioNotifications: u32 {
+RT_CLASS!{class GuidanceAudioNotificationRequestedEventArgs: IGuidanceAudioNotificationRequestedEventArgs ["Windows.Services.Maps.Guidance.GuidanceAudioNotificationRequestedEventArgs"]}
+RT_ENUM! { enum GuidanceAudioNotifications: u32 ["Windows.Services.Maps.Guidance.GuidanceAudioNotifications"] {
     None (GuidanceAudioNotifications_None) = 0, Maneuver (GuidanceAudioNotifications_Maneuver) = 1, Route (GuidanceAudioNotifications_Route) = 2, Gps (GuidanceAudioNotifications_Gps) = 4, SpeedLimit (GuidanceAudioNotifications_SpeedLimit) = 8, Traffic (GuidanceAudioNotifications_Traffic) = 16, TrafficCamera (GuidanceAudioNotifications_TrafficCamera) = 32,
 }}
 DEFINE_IID!(IID_IGuidanceLaneInfo, 2214908180, 25985, 17335, 172, 21, 201, 7, 155, 249, 13, 241);
@@ -1296,8 +1296,8 @@ impl IGuidanceLaneInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceLaneInfo: IGuidanceLaneInfo}
-RT_ENUM! { enum GuidanceLaneMarkers: u32 {
+RT_CLASS!{class GuidanceLaneInfo: IGuidanceLaneInfo ["Windows.Services.Maps.Guidance.GuidanceLaneInfo"]}
+RT_ENUM! { enum GuidanceLaneMarkers: u32 ["Windows.Services.Maps.Guidance.GuidanceLaneMarkers"] {
     None (GuidanceLaneMarkers_None) = 0, LightRight (GuidanceLaneMarkers_LightRight) = 1, Right (GuidanceLaneMarkers_Right) = 2, HardRight (GuidanceLaneMarkers_HardRight) = 4, Straight (GuidanceLaneMarkers_Straight) = 8, UTurnLeft (GuidanceLaneMarkers_UTurnLeft) = 16, HardLeft (GuidanceLaneMarkers_HardLeft) = 32, Left (GuidanceLaneMarkers_Left) = 64, LightLeft (GuidanceLaneMarkers_LightLeft) = 128, UTurnRight (GuidanceLaneMarkers_UTurnRight) = 256, Unknown (GuidanceLaneMarkers_Unknown) = 4294967295,
 }}
 DEFINE_IID!(IID_IGuidanceManeuver, 4228461164, 60617, 18728, 162, 161, 114, 50, 185, 155, 148, 161);
@@ -1378,8 +1378,8 @@ impl IGuidanceManeuver {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceManeuver: IGuidanceManeuver}
-RT_ENUM! { enum GuidanceManeuverKind: i32 {
+RT_CLASS!{class GuidanceManeuver: IGuidanceManeuver ["Windows.Services.Maps.Guidance.GuidanceManeuver"]}
+RT_ENUM! { enum GuidanceManeuverKind: i32 ["Windows.Services.Maps.Guidance.GuidanceManeuverKind"] {
     None (GuidanceManeuverKind_None) = 0, GoStraight (GuidanceManeuverKind_GoStraight) = 1, UTurnRight (GuidanceManeuverKind_UTurnRight) = 2, UTurnLeft (GuidanceManeuverKind_UTurnLeft) = 3, TurnKeepRight (GuidanceManeuverKind_TurnKeepRight) = 4, TurnLightRight (GuidanceManeuverKind_TurnLightRight) = 5, TurnRight (GuidanceManeuverKind_TurnRight) = 6, TurnHardRight (GuidanceManeuverKind_TurnHardRight) = 7, KeepMiddle (GuidanceManeuverKind_KeepMiddle) = 8, TurnKeepLeft (GuidanceManeuverKind_TurnKeepLeft) = 9, TurnLightLeft (GuidanceManeuverKind_TurnLightLeft) = 10, TurnLeft (GuidanceManeuverKind_TurnLeft) = 11, TurnHardLeft (GuidanceManeuverKind_TurnHardLeft) = 12, FreewayEnterRight (GuidanceManeuverKind_FreewayEnterRight) = 13, FreewayEnterLeft (GuidanceManeuverKind_FreewayEnterLeft) = 14, FreewayLeaveRight (GuidanceManeuverKind_FreewayLeaveRight) = 15, FreewayLeaveLeft (GuidanceManeuverKind_FreewayLeaveLeft) = 16, FreewayKeepRight (GuidanceManeuverKind_FreewayKeepRight) = 17, FreewayKeepLeft (GuidanceManeuverKind_FreewayKeepLeft) = 18, TrafficCircleRight1 (GuidanceManeuverKind_TrafficCircleRight1) = 19, TrafficCircleRight2 (GuidanceManeuverKind_TrafficCircleRight2) = 20, TrafficCircleRight3 (GuidanceManeuverKind_TrafficCircleRight3) = 21, TrafficCircleRight4 (GuidanceManeuverKind_TrafficCircleRight4) = 22, TrafficCircleRight5 (GuidanceManeuverKind_TrafficCircleRight5) = 23, TrafficCircleRight6 (GuidanceManeuverKind_TrafficCircleRight6) = 24, TrafficCircleRight7 (GuidanceManeuverKind_TrafficCircleRight7) = 25, TrafficCircleRight8 (GuidanceManeuverKind_TrafficCircleRight8) = 26, TrafficCircleRight9 (GuidanceManeuverKind_TrafficCircleRight9) = 27, TrafficCircleRight10 (GuidanceManeuverKind_TrafficCircleRight10) = 28, TrafficCircleRight11 (GuidanceManeuverKind_TrafficCircleRight11) = 29, TrafficCircleRight12 (GuidanceManeuverKind_TrafficCircleRight12) = 30, TrafficCircleLeft1 (GuidanceManeuverKind_TrafficCircleLeft1) = 31, TrafficCircleLeft2 (GuidanceManeuverKind_TrafficCircleLeft2) = 32, TrafficCircleLeft3 (GuidanceManeuverKind_TrafficCircleLeft3) = 33, TrafficCircleLeft4 (GuidanceManeuverKind_TrafficCircleLeft4) = 34, TrafficCircleLeft5 (GuidanceManeuverKind_TrafficCircleLeft5) = 35, TrafficCircleLeft6 (GuidanceManeuverKind_TrafficCircleLeft6) = 36, TrafficCircleLeft7 (GuidanceManeuverKind_TrafficCircleLeft7) = 37, TrafficCircleLeft8 (GuidanceManeuverKind_TrafficCircleLeft8) = 38, TrafficCircleLeft9 (GuidanceManeuverKind_TrafficCircleLeft9) = 39, TrafficCircleLeft10 (GuidanceManeuverKind_TrafficCircleLeft10) = 40, TrafficCircleLeft11 (GuidanceManeuverKind_TrafficCircleLeft11) = 41, TrafficCircleLeft12 (GuidanceManeuverKind_TrafficCircleLeft12) = 42, Start (GuidanceManeuverKind_Start) = 43, End (GuidanceManeuverKind_End) = 44, TakeFerry (GuidanceManeuverKind_TakeFerry) = 45, PassTransitStation (GuidanceManeuverKind_PassTransitStation) = 46, LeaveTransitStation (GuidanceManeuverKind_LeaveTransitStation) = 47,
 }}
 DEFINE_IID!(IID_IGuidanceMapMatchedCoordinate, 3081548136, 10514, 19097, 175, 241, 121, 134, 9, 185, 129, 254);
@@ -1418,8 +1418,8 @@ impl IGuidanceMapMatchedCoordinate {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceMapMatchedCoordinate: IGuidanceMapMatchedCoordinate}
-RT_ENUM! { enum GuidanceMode: i32 {
+RT_CLASS!{class GuidanceMapMatchedCoordinate: IGuidanceMapMatchedCoordinate ["Windows.Services.Maps.Guidance.GuidanceMapMatchedCoordinate"]}
+RT_ENUM! { enum GuidanceMode: i32 ["Windows.Services.Maps.Guidance.GuidanceMode"] {
     None (GuidanceMode_None) = 0, Simulation (GuidanceMode_Simulation) = 1, Navigation (GuidanceMode_Navigation) = 2, Tracking (GuidanceMode_Tracking) = 3,
 }}
 DEFINE_IID!(IID_IGuidanceNavigator, 150044407, 36415, 19866, 190, 138, 16, 143, 154, 1, 44, 103);
@@ -1576,7 +1576,7 @@ impl IGuidanceNavigator {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceNavigator: IGuidanceNavigator}
+RT_CLASS!{class GuidanceNavigator: IGuidanceNavigator ["Windows.Services.Maps.Guidance.GuidanceNavigator"]}
 impl RtActivatable<IGuidanceNavigatorStatics> for GuidanceNavigator {}
 impl RtActivatable<IGuidanceNavigatorStatics2> for GuidanceNavigator {}
 impl GuidanceNavigator {
@@ -1648,7 +1648,7 @@ impl IGuidanceReroutedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceReroutedEventArgs: IGuidanceReroutedEventArgs}
+RT_CLASS!{class GuidanceReroutedEventArgs: IGuidanceReroutedEventArgs ["Windows.Services.Maps.Guidance.GuidanceReroutedEventArgs"]}
 DEFINE_IID!(IID_IGuidanceRoadSegment, 3005700262, 48760, 19555, 175, 231, 108, 41, 87, 71, 155, 62);
 RT_INTERFACE!{interface IGuidanceRoadSegment(IGuidanceRoadSegmentVtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceRoadSegment] {
     fn get_RoadName(&self, out: *mut HSTRING) -> HRESULT,
@@ -1709,7 +1709,7 @@ impl IGuidanceRoadSegment {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceRoadSegment: IGuidanceRoadSegment}
+RT_CLASS!{class GuidanceRoadSegment: IGuidanceRoadSegment ["Windows.Services.Maps.Guidance.GuidanceRoadSegment"]}
 DEFINE_IID!(IID_IGuidanceRoadSegment2, 611624477, 5923, 18929, 137, 91, 71, 162, 196, 170, 156, 85);
 RT_INTERFACE!{interface IGuidanceRoadSegment2(IGuidanceRoadSegment2Vtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceRoadSegment2] {
     fn get_IsScenic(&self, out: *mut bool) -> HRESULT
@@ -1758,7 +1758,7 @@ impl IGuidanceRoadSignpost {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceRoadSignpost: IGuidanceRoadSignpost}
+RT_CLASS!{class GuidanceRoadSignpost: IGuidanceRoadSignpost ["Windows.Services.Maps.Guidance.GuidanceRoadSignpost"]}
 DEFINE_IID!(IID_IGuidanceRoute, 974410845, 32794, 16573, 162, 134, 175, 178, 1, 12, 206, 108);
 RT_INTERFACE!{interface IGuidanceRoute(IGuidanceRouteVtbl): IInspectable(IInspectableVtbl) [IID_IGuidanceRoute] {
     fn get_Duration(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -1808,7 +1808,7 @@ impl IGuidanceRoute {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceRoute: IGuidanceRoute}
+RT_CLASS!{class GuidanceRoute: IGuidanceRoute ["Windows.Services.Maps.Guidance.GuidanceRoute"]}
 impl RtActivatable<IGuidanceRouteStatics> for GuidanceRoute {}
 impl GuidanceRoute {
     #[inline] pub fn can_create_from_map_route(mapRoute: &super::MapRoute) -> Result<bool> {
@@ -1879,7 +1879,7 @@ impl IGuidanceTelemetryCollector {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceTelemetryCollector: IGuidanceTelemetryCollector}
+RT_CLASS!{class GuidanceTelemetryCollector: IGuidanceTelemetryCollector ["Windows.Services.Maps.Guidance.GuidanceTelemetryCollector"]}
 impl RtActivatable<IGuidanceTelemetryCollectorStatics> for GuidanceTelemetryCollector {}
 impl GuidanceTelemetryCollector {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<GuidanceTelemetryCollector>>> {
@@ -1987,7 +1987,7 @@ impl IGuidanceUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GuidanceUpdatedEventArgs: IGuidanceUpdatedEventArgs}
+RT_CLASS!{class GuidanceUpdatedEventArgs: IGuidanceUpdatedEventArgs ["Windows.Services.Maps.Guidance.GuidanceUpdatedEventArgs"]}
 } // Windows.Services.Maps.Guidance
 pub mod localsearch { // Windows.Services.Maps.LocalSearch
 use ::prelude::*;
@@ -2121,7 +2121,7 @@ impl ILocalLocation {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LocalLocation: ILocalLocation}
+RT_CLASS!{class LocalLocation: ILocalLocation ["Windows.Services.Maps.LocalSearch.LocalLocation"]}
 DEFINE_IID!(IID_ILocalLocation2, 1855860860, 60597, 20476, 187, 140, 186, 80, 186, 140, 45, 198);
 RT_INTERFACE!{interface ILocalLocation2(ILocalLocation2Vtbl): IInspectable(IInspectableVtbl) [IID_ILocalLocation2] {
     fn get_Category(&self, out: *mut HSTRING) -> HRESULT,
@@ -2170,7 +2170,7 @@ impl ILocalLocationFinderResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LocalLocationFinderResult: ILocalLocationFinderResult}
+RT_CLASS!{class LocalLocationFinderResult: ILocalLocationFinderResult ["Windows.Services.Maps.LocalSearch.LocalLocationFinderResult"]}
 DEFINE_IID!(IID_ILocalLocationFinderStatics, 3538907972, 41182, 18634, 129, 168, 7, 199, 220, 253, 55, 171);
 RT_INTERFACE!{static interface ILocalLocationFinderStatics(ILocalLocationFinderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ILocalLocationFinderStatics] {
     #[cfg(feature="windows-devices")] fn FindLocalLocationsAsync(&self, searchTerm: HSTRING, searchArea: *mut ::rt::gen::windows::devices::geolocation::Geocircle, localCategory: HSTRING, maxResults: u32, out: *mut *mut foundation::IAsyncOperation<LocalLocationFinderResult>) -> HRESULT
@@ -2182,7 +2182,7 @@ impl ILocalLocationFinderStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LocalLocationFinderStatus: i32 {
+RT_ENUM! { enum LocalLocationFinderStatus: i32 ["Windows.Services.Maps.LocalSearch.LocalLocationFinderStatus"] {
     Success (LocalLocationFinderStatus_Success) = 0, UnknownError (LocalLocationFinderStatus_UnknownError) = 1, InvalidCredentials (LocalLocationFinderStatus_InvalidCredentials) = 2, InvalidCategory (LocalLocationFinderStatus_InvalidCategory) = 3, InvalidSearchTerm (LocalLocationFinderStatus_InvalidSearchTerm) = 4, InvalidSearchArea (LocalLocationFinderStatus_InvalidSearchArea) = 5, NetworkFailure (LocalLocationFinderStatus_NetworkFailure) = 6, NotSupported (LocalLocationFinderStatus_NotSupported) = 7,
 }}
 DEFINE_IID!(IID_ILocalLocationHoursOfOperationItem, 592743538, 41415, 17393, 164, 240, 16, 145, 195, 158, 198, 64);
@@ -2209,7 +2209,7 @@ impl ILocalLocationHoursOfOperationItem {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LocalLocationHoursOfOperationItem: ILocalLocationHoursOfOperationItem}
+RT_CLASS!{class LocalLocationHoursOfOperationItem: ILocalLocationHoursOfOperationItem ["Windows.Services.Maps.LocalSearch.LocalLocationHoursOfOperationItem"]}
 DEFINE_IID!(IID_ILocalLocationRatingInfo, 3407719254, 13140, 17169, 139, 192, 162, 212, 213, 235, 128, 110);
 RT_INTERFACE!{interface ILocalLocationRatingInfo(ILocalLocationRatingInfoVtbl): IInspectable(IInspectableVtbl) [IID_ILocalLocationRatingInfo] {
     fn get_AggregateRating(&self, out: *mut *mut foundation::IReference<f64>) -> HRESULT,
@@ -2233,7 +2233,7 @@ impl ILocalLocationRatingInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LocalLocationRatingInfo: ILocalLocationRatingInfo}
+RT_CLASS!{class LocalLocationRatingInfo: ILocalLocationRatingInfo ["Windows.Services.Maps.LocalSearch.LocalLocationRatingInfo"]}
 RT_CLASS!{static class PlaceInfoHelper}
 impl RtActivatable<IPlaceInfoHelperStatics> for PlaceInfoHelper {}
 impl PlaceInfoHelper {
@@ -2302,7 +2302,7 @@ impl IOfflineMapPackage {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OfflineMapPackage: IOfflineMapPackage}
+RT_CLASS!{class OfflineMapPackage: IOfflineMapPackage ["Windows.Services.Maps.OfflineMaps.OfflineMapPackage"]}
 impl RtActivatable<IOfflineMapPackageStatics> for OfflineMapPackage {}
 impl OfflineMapPackage {
     #[cfg(feature="windows-devices")] #[inline] pub fn find_packages_async(queryPoint: &::rt::gen::windows::devices::geolocation::Geopoint) -> Result<ComPtr<foundation::IAsyncOperation<OfflineMapPackageQueryResult>>> {
@@ -2333,8 +2333,8 @@ impl IOfflineMapPackageQueryResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OfflineMapPackageQueryResult: IOfflineMapPackageQueryResult}
-RT_ENUM! { enum OfflineMapPackageQueryStatus: i32 {
+RT_CLASS!{class OfflineMapPackageQueryResult: IOfflineMapPackageQueryResult ["Windows.Services.Maps.OfflineMaps.OfflineMapPackageQueryResult"]}
+RT_ENUM! { enum OfflineMapPackageQueryStatus: i32 ["Windows.Services.Maps.OfflineMaps.OfflineMapPackageQueryStatus"] {
     Success (OfflineMapPackageQueryStatus_Success) = 0, UnknownError (OfflineMapPackageQueryStatus_UnknownError) = 1, InvalidCredentials (OfflineMapPackageQueryStatus_InvalidCredentials) = 2, NetworkFailure (OfflineMapPackageQueryStatus_NetworkFailure) = 3,
 }}
 DEFINE_IID!(IID_IOfflineMapPackageStartDownloadResult, 3647322392, 54486, 19198, 147, 120, 62, 199, 30, 241, 28, 61);
@@ -2348,8 +2348,8 @@ impl IOfflineMapPackageStartDownloadResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OfflineMapPackageStartDownloadResult: IOfflineMapPackageStartDownloadResult}
-RT_ENUM! { enum OfflineMapPackageStartDownloadStatus: i32 {
+RT_CLASS!{class OfflineMapPackageStartDownloadResult: IOfflineMapPackageStartDownloadResult ["Windows.Services.Maps.OfflineMaps.OfflineMapPackageStartDownloadResult"]}
+RT_ENUM! { enum OfflineMapPackageStartDownloadStatus: i32 ["Windows.Services.Maps.OfflineMaps.OfflineMapPackageStartDownloadStatus"] {
     Success (OfflineMapPackageStartDownloadStatus_Success) = 0, UnknownError (OfflineMapPackageStartDownloadStatus_UnknownError) = 1, InvalidCredentials (OfflineMapPackageStartDownloadStatus_InvalidCredentials) = 2, DeniedWithoutCapability (OfflineMapPackageStartDownloadStatus_DeniedWithoutCapability) = 3,
 }}
 DEFINE_IID!(IID_IOfflineMapPackageStatics, 408844578, 43057, 19120, 148, 31, 105, 152, 250, 146, 146, 133);
@@ -2375,7 +2375,7 @@ impl IOfflineMapPackageStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum OfflineMapPackageStatus: i32 {
+RT_ENUM! { enum OfflineMapPackageStatus: i32 ["Windows.Services.Maps.OfflineMaps.OfflineMapPackageStatus"] {
     NotDownloaded (OfflineMapPackageStatus_NotDownloaded) = 0, Downloading (OfflineMapPackageStatus_Downloading) = 1, Downloaded (OfflineMapPackageStatus_Downloaded) = 2, Deleting (OfflineMapPackageStatus_Deleting) = 3,
 }}
 } // Windows.Services.Maps.OfflineMaps
@@ -2399,7 +2399,7 @@ impl IStoreAcquireLicenseResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreAcquireLicenseResult: IStoreAcquireLicenseResult}
+RT_CLASS!{class StoreAcquireLicenseResult: IStoreAcquireLicenseResult ["Windows.Services.Store.StoreAcquireLicenseResult"]}
 DEFINE_IID!(IID_IStoreAppLicense, 4085905886, 29632, 17870, 155, 171, 178, 254, 62, 94, 175, 211);
 RT_INTERFACE!{interface IStoreAppLicense(IStoreAppLicenseVtbl): IInspectable(IInspectableVtbl) [IID_IStoreAppLicense] {
     fn get_SkuStoreId(&self, out: *mut HSTRING) -> HRESULT,
@@ -2459,7 +2459,7 @@ impl IStoreAppLicense {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreAppLicense: IStoreAppLicense}
+RT_CLASS!{class StoreAppLicense: IStoreAppLicense ["Windows.Services.Store.StoreAppLicense"]}
 DEFINE_IID!(IID_IStoreAppLicense2, 3026611857, 17475, 16563, 153, 63, 40, 144, 68, 53, 189, 198);
 RT_INTERFACE!{interface IStoreAppLicense2(IStoreAppLicense2Vtbl): IInspectable(IInspectableVtbl) [IID_IStoreAppLicense2] {
     fn get_IsDiscLicense(&self, out: *mut bool) -> HRESULT
@@ -2512,7 +2512,7 @@ impl IStoreAvailability {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreAvailability: IStoreAvailability}
+RT_CLASS!{class StoreAvailability: IStoreAvailability ["Windows.Services.Store.StoreAvailability"]}
 DEFINE_IID!(IID_IStoreCanAcquireLicenseResult, 979975603, 136, 18479, 134, 213, 189, 70, 82, 38, 99, 173);
 RT_INTERFACE!{interface IStoreCanAcquireLicenseResult(IStoreCanAcquireLicenseResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreCanAcquireLicenseResult] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT,
@@ -2536,8 +2536,8 @@ impl IStoreCanAcquireLicenseResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreCanAcquireLicenseResult: IStoreCanAcquireLicenseResult}
-RT_ENUM! { enum StoreCanLicenseStatus: i32 {
+RT_CLASS!{class StoreCanAcquireLicenseResult: IStoreCanAcquireLicenseResult ["Windows.Services.Store.StoreCanAcquireLicenseResult"]}
+RT_ENUM! { enum StoreCanLicenseStatus: i32 ["Windows.Services.Store.StoreCanLicenseStatus"] {
     NotLicensableToUser (StoreCanLicenseStatus_NotLicensableToUser) = 0, Licensable (StoreCanLicenseStatus_Licensable) = 1, LicenseActionNotApplicableToProduct (StoreCanLicenseStatus_LicenseActionNotApplicableToProduct) = 2, NetworkError (StoreCanLicenseStatus_NetworkError) = 3, ServerError (StoreCanLicenseStatus_ServerError) = 4,
 }}
 DEFINE_IID!(IID_IStoreCollectionData, 2326053811, 23475, 17434, 42, 180, 77, 171, 115, 213, 206, 103);
@@ -2593,7 +2593,7 @@ impl IStoreCollectionData {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreCollectionData: IStoreCollectionData}
+RT_CLASS!{class StoreCollectionData: IStoreCollectionData ["Windows.Services.Store.StoreCollectionData"]}
 DEFINE_IID!(IID_IStoreConsumableResult, 3932007282, 27136, 16466, 190, 91, 191, 218, 180, 67, 51, 82);
 RT_INTERFACE!{interface IStoreConsumableResult(IStoreConsumableResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreConsumableResult] {
     fn get_Status(&self, out: *mut StoreConsumableStatus) -> HRESULT,
@@ -2623,8 +2623,8 @@ impl IStoreConsumableResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreConsumableResult: IStoreConsumableResult}
-RT_ENUM! { enum StoreConsumableStatus: i32 {
+RT_CLASS!{class StoreConsumableResult: IStoreConsumableResult ["Windows.Services.Store.StoreConsumableResult"]}
+RT_ENUM! { enum StoreConsumableStatus: i32 ["Windows.Services.Store.StoreConsumableStatus"] {
     Succeeded (StoreConsumableStatus_Succeeded) = 0, InsufficentQuantity (StoreConsumableStatus_InsufficentQuantity) = 1, NetworkError (StoreConsumableStatus_NetworkError) = 2, ServerError (StoreConsumableStatus_ServerError) = 3,
 }}
 DEFINE_IID!(IID_IStoreContext, 2895689406, 62717, 18706, 186, 189, 80, 53, 229, 232, 188, 171);
@@ -2759,7 +2759,7 @@ impl IStoreContext {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreContext: IStoreContext}
+RT_CLASS!{class StoreContext: IStoreContext ["Windows.Services.Store.StoreContext"]}
 impl RtActivatable<IStoreContextStatics> for StoreContext {}
 impl StoreContext {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<StoreContext>>> {
@@ -2907,7 +2907,7 @@ impl IStoreContextStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StoreDurationUnit: i32 {
+RT_ENUM! { enum StoreDurationUnit: i32 ["Windows.Services.Store.StoreDurationUnit"] {
     Minute (StoreDurationUnit_Minute) = 0, Hour (StoreDurationUnit_Hour) = 1, Day (StoreDurationUnit_Day) = 2, Week (StoreDurationUnit_Week) = 3, Month (StoreDurationUnit_Month) = 4, Year (StoreDurationUnit_Year) = 5,
 }}
 DEFINE_IID!(IID_IStoreImage, 136303176, 44468, 19300, 169, 147, 120, 71, 137, 146, 110, 213);
@@ -2945,7 +2945,7 @@ impl IStoreImage {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreImage: IStoreImage}
+RT_CLASS!{class StoreImage: IStoreImage ["Windows.Services.Store.StoreImage"]}
 DEFINE_IID!(IID_IStoreLicense, 651990393, 19535, 20272, 188, 137, 100, 159, 96, 227, 96, 85);
 RT_INTERFACE!{interface IStoreLicense(IStoreLicenseVtbl): IInspectable(IInspectableVtbl) [IID_IStoreLicense] {
     fn get_SkuStoreId(&self, out: *mut HSTRING) -> HRESULT,
@@ -2981,7 +2981,7 @@ impl IStoreLicense {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreLicense: IStoreLicense}
+RT_CLASS!{class StoreLicense: IStoreLicense ["Windows.Services.Store.StoreLicense"]}
 DEFINE_IID!(IID_IStorePackageInstallOptions, 490562316, 3277, 17629, 140, 89, 128, 129, 10, 114, 153, 115);
 RT_INTERFACE!{interface IStorePackageInstallOptions(IStorePackageInstallOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IStorePackageInstallOptions] {
     fn get_AllowForcedAppRestart(&self, out: *mut bool) -> HRESULT,
@@ -2998,7 +2998,7 @@ impl IStorePackageInstallOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePackageInstallOptions: IStorePackageInstallOptions}
+RT_CLASS!{class StorePackageInstallOptions: IStorePackageInstallOptions ["Windows.Services.Store.StorePackageInstallOptions"]}
 impl RtActivatable<IActivationFactory> for StorePackageInstallOptions {}
 DEFINE_CLSID!(StorePackageInstallOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,83,116,111,114,101,46,83,116,111,114,101,80,97,99,107,97,103,101,73,110,115,116,97,108,108,79,112,116,105,111,110,115,0]) [CLSID_StorePackageInstallOptions]);
 DEFINE_IID!(IID_IStorePackageLicense, 205936404, 5345, 18803, 189, 20, 247, 119, 36, 39, 30, 153);
@@ -3035,7 +3035,7 @@ impl IStorePackageLicense {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePackageLicense: IStorePackageLicense}
+RT_CLASS!{class StorePackageLicense: IStorePackageLicense ["Windows.Services.Store.StorePackageLicense"]}
 DEFINE_IID!(IID_IStorePackageUpdate, 336568656, 15551, 18997, 185, 31, 72, 39, 28, 49, 176, 114);
 RT_INTERFACE!{interface IStorePackageUpdate(IStorePackageUpdateVtbl): IInspectable(IInspectableVtbl) [IID_IStorePackageUpdate] {
     #[cfg(not(feature="windows-applicationmodel"))] fn __Dummy0(&self) -> (),
@@ -3054,7 +3054,7 @@ impl IStorePackageUpdate {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePackageUpdate: IStorePackageUpdate}
+RT_CLASS!{class StorePackageUpdate: IStorePackageUpdate ["Windows.Services.Store.StorePackageUpdate"]}
 DEFINE_IID!(IID_IStorePackageUpdateResult, 3885056749, 25081, 18579, 180, 254, 207, 25, 22, 3, 175, 123);
 RT_INTERFACE!{interface IStorePackageUpdateResult(IStorePackageUpdateResultVtbl): IInspectable(IInspectableVtbl) [IID_IStorePackageUpdateResult] {
     fn get_OverallState(&self, out: *mut StorePackageUpdateState) -> HRESULT,
@@ -3072,7 +3072,7 @@ impl IStorePackageUpdateResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePackageUpdateResult: IStorePackageUpdateResult}
+RT_CLASS!{class StorePackageUpdateResult: IStorePackageUpdateResult ["Windows.Services.Store.StorePackageUpdateResult"]}
 DEFINE_IID!(IID_IStorePackageUpdateResult2, 119341358, 48226, 20270, 135, 234, 153, 216, 1, 174, 175, 152);
 RT_INTERFACE!{interface IStorePackageUpdateResult2(IStorePackageUpdateResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorePackageUpdateResult2] {
     fn get_StoreQueueItems(&self, out: *mut *mut foundation::collections::IVectorView<StoreQueueItem>) -> HRESULT
@@ -3084,10 +3084,10 @@ impl IStorePackageUpdateResult2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StorePackageUpdateState: i32 {
+RT_ENUM! { enum StorePackageUpdateState: i32 ["Windows.Services.Store.StorePackageUpdateState"] {
     Pending (StorePackageUpdateState_Pending) = 0, Downloading (StorePackageUpdateState_Downloading) = 1, Deploying (StorePackageUpdateState_Deploying) = 2, Completed (StorePackageUpdateState_Completed) = 3, Canceled (StorePackageUpdateState_Canceled) = 4, OtherError (StorePackageUpdateState_OtherError) = 5, ErrorLowBattery (StorePackageUpdateState_ErrorLowBattery) = 6, ErrorWiFiRecommended (StorePackageUpdateState_ErrorWiFiRecommended) = 7, ErrorWiFiRequired (StorePackageUpdateState_ErrorWiFiRequired) = 8,
 }}
-RT_STRUCT! { struct StorePackageUpdateStatus {
+RT_STRUCT! { struct StorePackageUpdateStatus ["Windows.Services.Store.StorePackageUpdateStatus"] {
     PackageFamilyName: HSTRING, PackageDownloadSizeInBytes: u64, PackageBytesDownloaded: u64, PackageDownloadProgress: f64, TotalDownloadProgress: f64, PackageUpdateState: StorePackageUpdateState,
 }}
 DEFINE_IID!(IID_IStorePrice, 1438291140, 5617, 16508, 143, 6, 0, 99, 128, 244, 223, 11);
@@ -3131,7 +3131,7 @@ impl IStorePrice {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePrice: IStorePrice}
+RT_CLASS!{class StorePrice: IStorePrice ["Windows.Services.Store.StorePrice"]}
 DEFINE_IID!(IID_IStoreProduct, 839789650, 55136, 17674, 164, 43, 103, 209, 233, 1, 172, 144);
 RT_INTERFACE!{interface IStoreProduct(IStoreProductVtbl): IInspectable(IInspectableVtbl) [IID_IStoreProduct] {
     fn get_StoreId(&self, out: *mut HSTRING) -> HRESULT,
@@ -3245,7 +3245,7 @@ impl IStoreProduct {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreProduct: IStoreProduct}
+RT_CLASS!{class StoreProduct: IStoreProduct ["Windows.Services.Store.StoreProduct"]}
 DEFINE_IID!(IID_IStoreProductOptions, 1530175737, 41235, 18449, 131, 38, 22, 25, 156, 146, 127, 49);
 RT_INTERFACE!{interface IStoreProductOptions(IStoreProductOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IStoreProductOptions] {
     fn get_ActionFilters(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT
@@ -3257,7 +3257,7 @@ impl IStoreProductOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreProductOptions: IStoreProductOptions}
+RT_CLASS!{class StoreProductOptions: IStoreProductOptions ["Windows.Services.Store.StoreProductOptions"]}
 impl RtActivatable<IActivationFactory> for StoreProductOptions {}
 DEFINE_CLSID!(StoreProductOptions(&[87,105,110,100,111,119,115,46,83,101,114,118,105,99,101,115,46,83,116,111,114,101,46,83,116,111,114,101,80,114,111,100,117,99,116,79,112,116,105,111,110,115,0]) [CLSID_StoreProductOptions]);
 DEFINE_IID!(IID_IStoreProductPagedQueryResult, 3374782661, 19925, 18537, 164, 98, 236, 198, 135, 46, 67, 197);
@@ -3289,7 +3289,7 @@ impl IStoreProductPagedQueryResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreProductPagedQueryResult: IStoreProductPagedQueryResult}
+RT_CLASS!{class StoreProductPagedQueryResult: IStoreProductPagedQueryResult ["Windows.Services.Store.StoreProductPagedQueryResult"]}
 DEFINE_IID!(IID_IStoreProductQueryResult, 3624265413, 54358, 20470, 128, 73, 144, 118, 213, 22, 95, 115);
 RT_INTERFACE!{interface IStoreProductQueryResult(IStoreProductQueryResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreProductQueryResult] {
     fn get_Products(&self, out: *mut *mut foundation::collections::IMapView<HString, StoreProduct>) -> HRESULT,
@@ -3307,7 +3307,7 @@ impl IStoreProductQueryResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreProductQueryResult: IStoreProductQueryResult}
+RT_CLASS!{class StoreProductQueryResult: IStoreProductQueryResult ["Windows.Services.Store.StoreProductQueryResult"]}
 DEFINE_IID!(IID_IStoreProductResult, 3077001075, 15495, 20193, 130, 1, 244, 40, 53, 155, 211, 175);
 RT_INTERFACE!{interface IStoreProductResult(IStoreProductResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreProductResult] {
     fn get_Product(&self, out: *mut *mut StoreProduct) -> HRESULT,
@@ -3325,7 +3325,7 @@ impl IStoreProductResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreProductResult: IStoreProductResult}
+RT_CLASS!{class StoreProductResult: IStoreProductResult ["Windows.Services.Store.StoreProductResult"]}
 DEFINE_IID!(IID_IStorePurchaseProperties, 2204268787, 65415, 17252, 165, 180, 253, 33, 83, 235, 228, 59);
 RT_INTERFACE!{interface IStorePurchaseProperties(IStorePurchasePropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IStorePurchaseProperties] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -3353,7 +3353,7 @@ impl IStorePurchaseProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePurchaseProperties: IStorePurchaseProperties}
+RT_CLASS!{class StorePurchaseProperties: IStorePurchaseProperties ["Windows.Services.Store.StorePurchaseProperties"]}
 impl RtActivatable<IStorePurchasePropertiesFactory> for StorePurchaseProperties {}
 impl RtActivatable<IActivationFactory> for StorePurchaseProperties {}
 impl StorePurchaseProperties {
@@ -3390,8 +3390,8 @@ impl IStorePurchaseResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorePurchaseResult: IStorePurchaseResult}
-RT_ENUM! { enum StorePurchaseStatus: i32 {
+RT_CLASS!{class StorePurchaseResult: IStorePurchaseResult ["Windows.Services.Store.StorePurchaseResult"]}
+RT_ENUM! { enum StorePurchaseStatus: i32 ["Windows.Services.Store.StorePurchaseStatus"] {
     Succeeded (StorePurchaseStatus_Succeeded) = 0, AlreadyPurchased (StorePurchaseStatus_AlreadyPurchased) = 1, NotPurchased (StorePurchaseStatus_NotPurchased) = 2, NetworkError (StorePurchaseStatus_NetworkError) = 3, ServerError (StorePurchaseStatus_ServerError) = 4,
 }}
 DEFINE_IID!(IID_IStoreQueueItem, 1456849707, 63536, 17043, 145, 136, 202, 210, 220, 222, 115, 87);
@@ -3445,7 +3445,7 @@ impl IStoreQueueItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreQueueItem: IStoreQueueItem}
+RT_CLASS!{class StoreQueueItem: IStoreQueueItem ["Windows.Services.Store.StoreQueueItem"]}
 DEFINE_IID!(IID_IStoreQueueItem2, 1766399144, 6868, 17532, 173, 140, 169, 80, 53, 246, 77, 130);
 RT_INTERFACE!{interface IStoreQueueItem2(IStoreQueueItem2Vtbl): IInspectable(IInspectableVtbl) [IID_IStoreQueueItem2] {
     fn CancelInstallAsync(&self, out: *mut *mut foundation::IAsyncAction) -> HRESULT,
@@ -3480,14 +3480,14 @@ impl IStoreQueueItemCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreQueueItemCompletedEventArgs: IStoreQueueItemCompletedEventArgs}
-RT_ENUM! { enum StoreQueueItemExtendedState: i32 {
+RT_CLASS!{class StoreQueueItemCompletedEventArgs: IStoreQueueItemCompletedEventArgs ["Windows.Services.Store.StoreQueueItemCompletedEventArgs"]}
+RT_ENUM! { enum StoreQueueItemExtendedState: i32 ["Windows.Services.Store.StoreQueueItemExtendedState"] {
     ActivePending (StoreQueueItemExtendedState_ActivePending) = 0, ActiveStarting (StoreQueueItemExtendedState_ActiveStarting) = 1, ActiveAcquiringLicense (StoreQueueItemExtendedState_ActiveAcquiringLicense) = 2, ActiveDownloading (StoreQueueItemExtendedState_ActiveDownloading) = 3, ActiveRestoringData (StoreQueueItemExtendedState_ActiveRestoringData) = 4, ActiveInstalling (StoreQueueItemExtendedState_ActiveInstalling) = 5, Completed (StoreQueueItemExtendedState_Completed) = 6, Canceled (StoreQueueItemExtendedState_Canceled) = 7, Paused (StoreQueueItemExtendedState_Paused) = 8, Error (StoreQueueItemExtendedState_Error) = 9, PausedPackagesInUse (StoreQueueItemExtendedState_PausedPackagesInUse) = 10, PausedLowBattery (StoreQueueItemExtendedState_PausedLowBattery) = 11, PausedWiFiRecommended (StoreQueueItemExtendedState_PausedWiFiRecommended) = 12, PausedWiFiRequired (StoreQueueItemExtendedState_PausedWiFiRequired) = 13, PausedReadyToInstall (StoreQueueItemExtendedState_PausedReadyToInstall) = 14,
 }}
-RT_ENUM! { enum StoreQueueItemKind: i32 {
+RT_ENUM! { enum StoreQueueItemKind: i32 ["Windows.Services.Store.StoreQueueItemKind"] {
     Install (StoreQueueItemKind_Install) = 0, Update (StoreQueueItemKind_Update) = 1, Repair (StoreQueueItemKind_Repair) = 2,
 }}
-RT_ENUM! { enum StoreQueueItemState: i32 {
+RT_ENUM! { enum StoreQueueItemState: i32 ["Windows.Services.Store.StoreQueueItemState"] {
     Active (StoreQueueItemState_Active) = 0, Completed (StoreQueueItemState_Completed) = 1, Canceled (StoreQueueItemState_Canceled) = 2, Error (StoreQueueItemState_Error) = 3, Paused (StoreQueueItemState_Paused) = 4,
 }}
 DEFINE_IID!(IID_IStoreQueueItemStatus, 2614524271, 40131, 20163, 178, 239, 123, 228, 51, 179, 1, 116);
@@ -3519,7 +3519,7 @@ impl IStoreQueueItemStatus {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreQueueItemStatus: IStoreQueueItemStatus}
+RT_CLASS!{class StoreQueueItemStatus: IStoreQueueItemStatus ["Windows.Services.Store.StoreQueueItemStatus"]}
 DEFINE_IID!(IID_IStoreRateAndReviewResult, 2636160342, 42677, 16673, 155, 97, 238, 109, 15, 189, 189, 187);
 RT_INTERFACE!{interface IStoreRateAndReviewResult(IStoreRateAndReviewResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreRateAndReviewResult] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT,
@@ -3549,8 +3549,8 @@ impl IStoreRateAndReviewResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreRateAndReviewResult: IStoreRateAndReviewResult}
-RT_ENUM! { enum StoreRateAndReviewStatus: i32 {
+RT_CLASS!{class StoreRateAndReviewResult: IStoreRateAndReviewResult ["Windows.Services.Store.StoreRateAndReviewResult"]}
+RT_ENUM! { enum StoreRateAndReviewStatus: i32 ["Windows.Services.Store.StoreRateAndReviewStatus"] {
     Succeeded (StoreRateAndReviewStatus_Succeeded) = 0, CanceledByUser (StoreRateAndReviewStatus_CanceledByUser) = 1, NetworkError (StoreRateAndReviewStatus_NetworkError) = 2, Error (StoreRateAndReviewStatus_Error) = 3,
 }}
 RT_CLASS!{static class StoreRequestHelper}
@@ -3589,7 +3589,7 @@ impl IStoreSendRequestResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreSendRequestResult: IStoreSendRequestResult}
+RT_CLASS!{class StoreSendRequestResult: IStoreSendRequestResult ["Windows.Services.Store.StoreSendRequestResult"]}
 DEFINE_IID!(IID_IStoreSendRequestResult2, 687941999, 49328, 18896, 142, 141, 170, 148, 10, 249, 193, 11);
 RT_INTERFACE!{interface IStoreSendRequestResult2(IStoreSendRequestResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IStoreSendRequestResult2] {
     #[cfg(feature="windows-web")] fn get_HttpStatusCode(&self, out: *mut super::super::web::http::HttpStatusCode) -> HRESULT
@@ -3720,7 +3720,7 @@ impl IStoreSku {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreSku: IStoreSku}
+RT_CLASS!{class StoreSku: IStoreSku ["Windows.Services.Store.StoreSku"]}
 DEFINE_IID!(IID_IStoreSubscriptionInfo, 1099528042, 1369, 17324, 169, 198, 58, 176, 1, 31, 184, 235);
 RT_INTERFACE!{interface IStoreSubscriptionInfo(IStoreSubscriptionInfoVtbl): IInspectable(IInspectableVtbl) [IID_IStoreSubscriptionInfo] {
     fn get_BillingPeriod(&self, out: *mut u32) -> HRESULT,
@@ -3756,7 +3756,7 @@ impl IStoreSubscriptionInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreSubscriptionInfo: IStoreSubscriptionInfo}
+RT_CLASS!{class StoreSubscriptionInfo: IStoreSubscriptionInfo ["Windows.Services.Store.StoreSubscriptionInfo"]}
 DEFINE_IID!(IID_IStoreUninstallStorePackageResult, 2680830461, 4719, 19674, 184, 1, 19, 70, 184, 208, 162, 96);
 RT_INTERFACE!{interface IStoreUninstallStorePackageResult(IStoreUninstallStorePackageResultVtbl): IInspectable(IInspectableVtbl) [IID_IStoreUninstallStorePackageResult] {
     fn get_ExtendedError(&self, out: *mut foundation::HResult) -> HRESULT,
@@ -3774,8 +3774,8 @@ impl IStoreUninstallStorePackageResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreUninstallStorePackageResult: IStoreUninstallStorePackageResult}
-RT_ENUM! { enum StoreUninstallStorePackageStatus: i32 {
+RT_CLASS!{class StoreUninstallStorePackageResult: IStoreUninstallStorePackageResult ["Windows.Services.Store.StoreUninstallStorePackageResult"]}
+RT_ENUM! { enum StoreUninstallStorePackageStatus: i32 ["Windows.Services.Store.StoreUninstallStorePackageStatus"] {
     Succeeded (StoreUninstallStorePackageStatus_Succeeded) = 0, CanceledByUser (StoreUninstallStorePackageStatus_CanceledByUser) = 1, NetworkError (StoreUninstallStorePackageStatus_NetworkError) = 2, UninstallNotApplicable (StoreUninstallStorePackageStatus_UninstallNotApplicable) = 3, Error (StoreUninstallStorePackageStatus_Error) = 4,
 }}
 DEFINE_IID!(IID_IStoreVideo, 4067209604, 28510, 19906, 136, 108, 60, 99, 8, 60, 47, 148);
@@ -3819,7 +3819,7 @@ impl IStoreVideo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StoreVideo: IStoreVideo}
+RT_CLASS!{class StoreVideo: IStoreVideo ["Windows.Services.Store.StoreVideo"]}
 } // Windows.Services.Store
 pub mod targetedcontent { // Windows.Services.TargetedContent
 use ::prelude::*;
@@ -3834,11 +3834,11 @@ impl ITargetedContentAction {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentAction: ITargetedContentAction}
-RT_ENUM! { enum TargetedContentAppInstallationState: i32 {
+RT_CLASS!{class TargetedContentAction: ITargetedContentAction ["Windows.Services.TargetedContent.TargetedContentAction"]}
+RT_ENUM! { enum TargetedContentAppInstallationState: i32 ["Windows.Services.TargetedContent.TargetedContentAppInstallationState"] {
     NotApplicable (TargetedContentAppInstallationState_NotApplicable) = 0, NotInstalled (TargetedContentAppInstallationState_NotInstalled) = 1, Installed (TargetedContentAppInstallationState_Installed) = 2,
 }}
-RT_ENUM! { enum TargetedContentAvailability: i32 {
+RT_ENUM! { enum TargetedContentAvailability: i32 ["Windows.Services.TargetedContent.TargetedContentAvailability"] {
     None (TargetedContentAvailability_None) = 0, Partial (TargetedContentAvailability_Partial) = 1, All (TargetedContentAvailability_All) = 2,
 }}
 DEFINE_IID!(IID_ITargetedContentAvailabilityChangedEventArgs, 3774192934, 22823, 17488, 150, 92, 28, 235, 123, 236, 222, 101);
@@ -3852,7 +3852,7 @@ impl ITargetedContentAvailabilityChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentAvailabilityChangedEventArgs: ITargetedContentAvailabilityChangedEventArgs}
+RT_CLASS!{class TargetedContentAvailabilityChangedEventArgs: ITargetedContentAvailabilityChangedEventArgs ["Windows.Services.TargetedContent.TargetedContentAvailabilityChangedEventArgs"]}
 DEFINE_IID!(IID_ITargetedContentChangedEventArgs, 2580842697, 22654, 17798, 142, 247, 181, 76, 169, 69, 58, 22);
 RT_INTERFACE!{interface ITargetedContentChangedEventArgs(ITargetedContentChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentChangedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut foundation::Deferral) -> HRESULT,
@@ -3870,7 +3870,7 @@ impl ITargetedContentChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentChangedEventArgs: ITargetedContentChangedEventArgs}
+RT_CLASS!{class TargetedContentChangedEventArgs: ITargetedContentChangedEventArgs ["Windows.Services.TargetedContent.TargetedContentChangedEventArgs"]}
 DEFINE_IID!(IID_ITargetedContentCollection, 759916229, 61795, 17594, 159, 110, 225, 164, 194, 187, 85, 157);
 RT_INTERFACE!{interface ITargetedContentCollection(ITargetedContentCollectionVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentCollection] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -3916,7 +3916,7 @@ impl ITargetedContentCollection {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentCollection: ITargetedContentCollection}
+RT_CLASS!{class TargetedContentCollection: ITargetedContentCollection ["Windows.Services.TargetedContent.TargetedContentCollection"]}
 DEFINE_IID!(IID_ITargetedContentContainer, 3156513993, 34871, 18370, 133, 15, 215, 157, 100, 89, 89, 38);
 RT_INTERFACE!{interface ITargetedContentContainer(ITargetedContentContainerVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentContainer] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -3952,7 +3952,7 @@ impl ITargetedContentContainer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentContainer: ITargetedContentContainer}
+RT_CLASS!{class TargetedContentContainer: ITargetedContentContainer ["Windows.Services.TargetedContent.TargetedContentContainer"]}
 impl RtActivatable<ITargetedContentContainerStatics> for TargetedContentContainer {}
 impl TargetedContentContainer {
     #[inline] pub fn get_async(contentId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<TargetedContentContainer>>> {
@@ -3971,8 +3971,8 @@ impl ITargetedContentContainerStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-storage")] RT_CLASS!{class TargetedContentFile: super::super::storage::streams::IRandomAccessStreamReference}
-#[cfg(not(feature="windows-storage"))] RT_CLASS!{class TargetedContentFile: IInspectable}
+#[cfg(feature="windows-storage")] RT_CLASS!{class TargetedContentFile: super::super::storage::streams::IRandomAccessStreamReference ["Windows.Services.TargetedContent.TargetedContentFile"]}
+#[cfg(not(feature="windows-storage"))] RT_CLASS!{class TargetedContentFile: IInspectable ["Windows.Services.TargetedContent.TargetedContentFile"]}
 DEFINE_IID!(IID_ITargetedContentImage, 2812642777, 30623, 19230, 187, 177, 142, 175, 83, 251, 234, 178);
 RT_INTERFACE!{interface ITargetedContentImage(ITargetedContentImageVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentImage] {
     fn get_Height(&self, out: *mut u32) -> HRESULT,
@@ -3990,8 +3990,8 @@ impl ITargetedContentImage {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentImage: ITargetedContentImage}
-RT_ENUM! { enum TargetedContentInteraction: i32 {
+RT_CLASS!{class TargetedContentImage: ITargetedContentImage ["Windows.Services.TargetedContent.TargetedContentImage"]}
+RT_ENUM! { enum TargetedContentInteraction: i32 ["Windows.Services.TargetedContent.TargetedContentInteraction"] {
     Impression (TargetedContentInteraction_Impression) = 0, ClickThrough (TargetedContentInteraction_ClickThrough) = 1, Hover (TargetedContentInteraction_Hover) = 2, Like (TargetedContentInteraction_Like) = 3, Dislike (TargetedContentInteraction_Dislike) = 4, Dismiss (TargetedContentInteraction_Dismiss) = 5, Ineligible (TargetedContentInteraction_Ineligible) = 6, Accept (TargetedContentInteraction_Accept) = 7, Decline (TargetedContentInteraction_Decline) = 8, Defer (TargetedContentInteraction_Defer) = 9, Canceled (TargetedContentInteraction_Canceled) = 10, Conversion (TargetedContentInteraction_Conversion) = 11, Opportunity (TargetedContentInteraction_Opportunity) = 12,
 }}
 DEFINE_IID!(IID_ITargetedContentItem, 941002180, 10092, 19506, 150, 186, 86, 92, 110, 64, 110, 116);
@@ -4033,7 +4033,7 @@ impl ITargetedContentItem {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentItem: ITargetedContentItem}
+RT_CLASS!{class TargetedContentItem: ITargetedContentItem ["Windows.Services.TargetedContent.TargetedContentItem"]}
 DEFINE_IID!(IID_ITargetedContentItemState, 1939035220, 19557, 19271, 164, 65, 71, 45, 229, 60, 121, 182);
 RT_INTERFACE!{interface ITargetedContentItemState(ITargetedContentItemStateVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentItemState] {
     fn get_ShouldDisplay(&self, out: *mut bool) -> HRESULT,
@@ -4051,7 +4051,7 @@ impl ITargetedContentItemState {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentItemState: ITargetedContentItemState}
+RT_CLASS!{class TargetedContentItemState: ITargetedContentItemState ["Windows.Services.TargetedContent.TargetedContentItemState"]}
 DEFINE_IID!(IID_ITargetedContentObject, 69040489, 8722, 17105, 157, 250, 136, 168, 227, 3, 58, 163);
 RT_INTERFACE!{interface ITargetedContentObject(ITargetedContentObjectVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentObject] {
     fn get_ObjectKind(&self, out: *mut TargetedContentObjectKind) -> HRESULT,
@@ -4081,8 +4081,8 @@ impl ITargetedContentObject {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentObject: ITargetedContentObject}
-RT_ENUM! { enum TargetedContentObjectKind: i32 {
+RT_CLASS!{class TargetedContentObject: ITargetedContentObject ["Windows.Services.TargetedContent.TargetedContentObject"]}
+RT_ENUM! { enum TargetedContentObjectKind: i32 ["Windows.Services.TargetedContent.TargetedContentObjectKind"] {
     Collection (TargetedContentObjectKind_Collection) = 0, Item (TargetedContentObjectKind_Item) = 1, Value (TargetedContentObjectKind_Value) = 2,
 }}
 DEFINE_IID!(IID_ITargetedContentStateChangedEventArgs, 2585587517, 32883, 17430, 141, 242, 84, 104, 53, 166, 65, 79);
@@ -4096,7 +4096,7 @@ impl ITargetedContentStateChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentStateChangedEventArgs: ITargetedContentStateChangedEventArgs}
+RT_CLASS!{class TargetedContentStateChangedEventArgs: ITargetedContentStateChangedEventArgs ["Windows.Services.TargetedContent.TargetedContentStateChangedEventArgs"]}
 DEFINE_IID!(IID_ITargetedContentSubscription, 2284596297, 50770, 19578, 172, 173, 31, 127, 162, 152, 108, 115);
 RT_INTERFACE!{interface ITargetedContentSubscription(ITargetedContentSubscriptionVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentSubscription] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -4147,7 +4147,7 @@ impl ITargetedContentSubscription {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentSubscription: ITargetedContentSubscription}
+RT_CLASS!{class TargetedContentSubscription: ITargetedContentSubscription ["Windows.Services.TargetedContent.TargetedContentSubscription"]}
 impl RtActivatable<ITargetedContentSubscriptionStatics> for TargetedContentSubscription {}
 impl TargetedContentSubscription {
     #[inline] pub fn get_async(subscriptionId: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<TargetedContentSubscription>>> {
@@ -4197,7 +4197,7 @@ impl ITargetedContentSubscriptionOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentSubscriptionOptions: ITargetedContentSubscriptionOptions}
+RT_CLASS!{class TargetedContentSubscriptionOptions: ITargetedContentSubscriptionOptions ["Windows.Services.TargetedContent.TargetedContentSubscriptionOptions"]}
 DEFINE_IID!(IID_ITargetedContentSubscriptionStatics, 4208852608, 13837, 18710, 181, 60, 126, 162, 112, 144, 208, 42);
 RT_INTERFACE!{static interface ITargetedContentSubscriptionStatics(ITargetedContentSubscriptionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITargetedContentSubscriptionStatics] {
     fn GetAsync(&self, subscriptionId: HSTRING, out: *mut *mut foundation::IAsyncOperation<TargetedContentSubscription>) -> HRESULT,
@@ -4316,8 +4316,8 @@ impl ITargetedContentValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetedContentValue: ITargetedContentValue}
-RT_ENUM! { enum TargetedContentValueKind: i32 {
+RT_CLASS!{class TargetedContentValue: ITargetedContentValue ["Windows.Services.TargetedContent.TargetedContentValue"]}
+RT_ENUM! { enum TargetedContentValueKind: i32 ["Windows.Services.TargetedContent.TargetedContentValueKind"] {
     String (TargetedContentValueKind_String) = 0, Uri (TargetedContentValueKind_Uri) = 1, Number (TargetedContentValueKind_Number) = 2, Boolean (TargetedContentValueKind_Boolean) = 3, File (TargetedContentValueKind_File) = 4, ImageFile (TargetedContentValueKind_ImageFile) = 5, Action (TargetedContentValueKind_Action) = 6, Strings (TargetedContentValueKind_Strings) = 7, Uris (TargetedContentValueKind_Uris) = 8, Numbers (TargetedContentValueKind_Numbers) = 9, Booleans (TargetedContentValueKind_Booleans) = 10, Files (TargetedContentValueKind_Files) = 11, ImageFiles (TargetedContentValueKind_ImageFiles) = 12, Actions (TargetedContentValueKind_Actions) = 13,
 }}
 } // Windows.Services.TargetedContent

--- a/src/rt/gen/windows/storage.rs
+++ b/src/rt/gen/windows/storage.rs
@@ -58,7 +58,7 @@ impl IAppDataPaths {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppDataPaths: IAppDataPaths}
+RT_CLASS!{class AppDataPaths: IAppDataPaths ["Windows.Storage.AppDataPaths"]}
 impl RtActivatable<IAppDataPathsStatics> for AppDataPaths {}
 impl AppDataPaths {
     #[cfg(feature="windows-system")] #[inline] pub fn get_for_user(user: &super::system::User) -> Result<Option<ComPtr<AppDataPaths>>> {
@@ -168,7 +168,7 @@ impl IApplicationData {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationData: IApplicationData}
+RT_CLASS!{class ApplicationData: IApplicationData ["Windows.Storage.ApplicationData"]}
 impl RtActivatable<IApplicationDataStatics> for ApplicationData {}
 impl RtActivatable<IApplicationDataStatics2> for ApplicationData {}
 impl ApplicationData {
@@ -214,7 +214,7 @@ impl IApplicationData3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationDataCompositeValue: foundation::collections::IPropertySet}
+RT_CLASS!{class ApplicationDataCompositeValue: foundation::collections::IPropertySet ["Windows.Storage.ApplicationDataCompositeValue"]}
 impl RtActivatable<IActivationFactory> for ApplicationDataCompositeValue {}
 DEFINE_CLSID!(ApplicationDataCompositeValue(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,65,112,112,108,105,99,97,116,105,111,110,68,97,116,97,67,111,109,112,111,115,105,116,101,86,97,108,117,101,0]) [CLSID_ApplicationDataCompositeValue]);
 DEFINE_IID!(IID_IApplicationDataContainer, 3316579614, 62567, 16570, 133, 102, 171, 100, 10, 68, 30, 29);
@@ -257,12 +257,12 @@ impl IApplicationDataContainer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationDataContainer: IApplicationDataContainer}
-RT_CLASS!{class ApplicationDataContainerSettings: foundation::collections::IPropertySet}
-RT_ENUM! { enum ApplicationDataCreateDisposition: i32 {
+RT_CLASS!{class ApplicationDataContainer: IApplicationDataContainer ["Windows.Storage.ApplicationDataContainer"]}
+RT_CLASS!{class ApplicationDataContainerSettings: foundation::collections::IPropertySet ["Windows.Storage.ApplicationDataContainerSettings"]}
+RT_ENUM! { enum ApplicationDataCreateDisposition: i32 ["Windows.Storage.ApplicationDataCreateDisposition"] {
     Always (ApplicationDataCreateDisposition_Always) = 0, Existing (ApplicationDataCreateDisposition_Existing) = 1,
 }}
-RT_ENUM! { enum ApplicationDataLocality: i32 {
+RT_ENUM! { enum ApplicationDataLocality: i32 ["Windows.Storage.ApplicationDataLocality"] {
     Local (ApplicationDataLocality_Local) = 0, Roaming (ApplicationDataLocality_Roaming) = 1, Temporary (ApplicationDataLocality_Temporary) = 2, LocalCache (ApplicationDataLocality_LocalCache) = 3,
 }}
 DEFINE_IID!(IID_ApplicationDataSetVersionHandler, 2690093542, 52383, 18055, 172, 171, 163, 100, 253, 120, 84, 99);
@@ -324,7 +324,7 @@ impl ICachedFileManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CreationCollisionOption: i32 {
+RT_ENUM! { enum CreationCollisionOption: i32 ["Windows.Storage.CreationCollisionOption"] {
     GenerateUniqueName (CreationCollisionOption_GenerateUniqueName) = 0, ReplaceExisting (CreationCollisionOption_ReplaceExisting) = 1, FailIfExists (CreationCollisionOption_FailIfExists) = 2, OpenIfExists (CreationCollisionOption_OpenIfExists) = 3,
 }}
 RT_CLASS!{static class DownloadsFolder}
@@ -415,10 +415,10 @@ impl IDownloadsFolderStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum FileAccessMode: i32 {
+RT_ENUM! { enum FileAccessMode: i32 ["Windows.Storage.FileAccessMode"] {
     Read (FileAccessMode_Read) = 0, ReadWrite (FileAccessMode_ReadWrite) = 1,
 }}
-RT_ENUM! { enum FileAttributes: u32 {
+RT_ENUM! { enum FileAttributes: u32 ["Windows.Storage.FileAttributes"] {
     Normal (FileAttributes_Normal) = 0, ReadOnly (FileAttributes_ReadOnly) = 1, Directory (FileAttributes_Directory) = 16, Archive (FileAttributes_Archive) = 32, Temporary (FileAttributes_Temporary) = 256, LocallyIncomplete (FileAttributes_LocallyIncomplete) = 512,
 }}
 RT_CLASS!{static class FileIO}
@@ -566,7 +566,7 @@ impl IFileIOStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum KnownFolderId: i32 {
+RT_ENUM! { enum KnownFolderId: i32 ["Windows.Storage.KnownFolderId"] {
     AppCaptures (KnownFolderId_AppCaptures) = 0, CameraRoll (KnownFolderId_CameraRoll) = 1, DocumentsLibrary (KnownFolderId_DocumentsLibrary) = 2, HomeGroup (KnownFolderId_HomeGroup) = 3, MediaServerDevices (KnownFolderId_MediaServerDevices) = 4, MusicLibrary (KnownFolderId_MusicLibrary) = 5, Objects3D (KnownFolderId_Objects3D) = 6, PicturesLibrary (KnownFolderId_PicturesLibrary) = 7, Playlists (KnownFolderId_Playlists) = 8, RecordedCalls (KnownFolderId_RecordedCalls) = 9, RemovableDevices (KnownFolderId_RemovableDevices) = 10, SavedPictures (KnownFolderId_SavedPictures) = 11, Screenshots (KnownFolderId_Screenshots) = 12, VideosLibrary (KnownFolderId_VideosLibrary) = 13, AllAppMods (KnownFolderId_AllAppMods) = 14, CurrentAppMods (KnownFolderId_CurrentAppMods) = 15,
 }}
 RT_CLASS!{static class KnownFolders}
@@ -735,10 +735,10 @@ impl IKnownFoldersStatics3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum KnownLibraryId: i32 {
+RT_ENUM! { enum KnownLibraryId: i32 ["Windows.Storage.KnownLibraryId"] {
     Music (KnownLibraryId_Music) = 0, Pictures (KnownLibraryId_Pictures) = 1, Videos (KnownLibraryId_Videos) = 2, Documents (KnownLibraryId_Documents) = 3,
 }}
-RT_ENUM! { enum NameCollisionOption: i32 {
+RT_ENUM! { enum NameCollisionOption: i32 ["Windows.Storage.NameCollisionOption"] {
     GenerateUniqueName (NameCollisionOption_GenerateUniqueName) = 0, ReplaceExisting (NameCollisionOption_ReplaceExisting) = 1, FailIfExists (NameCollisionOption_FailIfExists) = 2,
 }}
 RT_CLASS!{static class PathIO}
@@ -896,7 +896,7 @@ impl ISetVersionDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SetVersionDeferral: ISetVersionDeferral}
+RT_CLASS!{class SetVersionDeferral: ISetVersionDeferral ["Windows.Storage.SetVersionDeferral"]}
 DEFINE_IID!(IID_ISetVersionRequest, 3116854171, 4182, 20073, 131, 48, 22, 38, 25, 149, 111, 155);
 RT_INTERFACE!{interface ISetVersionRequest(ISetVersionRequestVtbl): IInspectable(IInspectableVtbl) [IID_ISetVersionRequest] {
     fn get_CurrentVersion(&self, out: *mut u32) -> HRESULT,
@@ -920,8 +920,8 @@ impl ISetVersionRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SetVersionRequest: ISetVersionRequest}
-RT_ENUM! { enum StorageDeleteOption: i32 {
+RT_CLASS!{class SetVersionRequest: ISetVersionRequest ["Windows.Storage.SetVersionRequest"]}
+RT_ENUM! { enum StorageDeleteOption: i32 ["Windows.Storage.StorageDeleteOption"] {
     Default (StorageDeleteOption_Default) = 0, PermanentDelete (StorageDeleteOption_PermanentDelete) = 1,
 }}
 DEFINE_IID!(IID_IStorageFile, 4198457734, 16916, 17036, 166, 76, 20, 201, 172, 115, 21, 234);
@@ -1001,7 +1001,7 @@ impl IStorageFile {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageFile: IStorageFile}
+RT_CLASS!{class StorageFile: IStorageFile ["Windows.Storage.StorageFile"]}
 impl RtActivatable<IStorageFileStatics> for StorageFile {}
 impl StorageFile {
     #[inline] pub fn get_file_from_path_async(path: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<StorageFile>>> {
@@ -1158,7 +1158,7 @@ impl IStorageFolder {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageFolder: IStorageFolder}
+RT_CLASS!{class StorageFolder: IStorageFolder ["Windows.Storage.StorageFolder"]}
 impl RtActivatable<IStorageFolderStatics> for StorageFolder {}
 impl StorageFolder {
     #[inline] pub fn get_folder_from_path_async(path: &HStringArg) -> Result<ComPtr<foundation::IAsyncOperation<StorageFolder>>> {
@@ -1362,7 +1362,7 @@ impl IStorageItemPropertiesWithProvider {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StorageItemTypes: u32 {
+RT_ENUM! { enum StorageItemTypes: u32 ["Windows.Storage.StorageItemTypes"] {
     None (StorageItemTypes_None) = 0, File (StorageItemTypes_File) = 1, Folder (StorageItemTypes_Folder) = 2,
 }}
 DEFINE_IID!(IID_IStorageLibrary, 517828867, 3678, 19820, 181, 232, 147, 24, 152, 61, 106, 3);
@@ -1405,7 +1405,7 @@ impl IStorageLibrary {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageLibrary: IStorageLibrary}
+RT_CLASS!{class StorageLibrary: IStorageLibrary ["Windows.Storage.StorageLibrary"]}
 impl RtActivatable<IStorageLibraryStatics> for StorageLibrary {}
 impl RtActivatable<IStorageLibraryStatics2> for StorageLibrary {}
 impl StorageLibrary {
@@ -1474,7 +1474,7 @@ impl IStorageLibraryChange {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageLibraryChange: IStorageLibraryChange}
+RT_CLASS!{class StorageLibraryChange: IStorageLibraryChange ["Windows.Storage.StorageLibraryChange"]}
 DEFINE_IID!(IID_IStorageLibraryChangeReader, 4060462211, 64674, 16889, 137, 84, 238, 46, 153, 30, 185, 111);
 RT_INTERFACE!{interface IStorageLibraryChangeReader(IStorageLibraryChangeReaderVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryChangeReader] {
     fn ReadBatchAsync(&self, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<StorageLibraryChange>>) -> HRESULT,
@@ -1492,7 +1492,7 @@ impl IStorageLibraryChangeReader {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageLibraryChangeReader: IStorageLibraryChangeReader}
+RT_CLASS!{class StorageLibraryChangeReader: IStorageLibraryChangeReader ["Windows.Storage.StorageLibraryChangeReader"]}
 DEFINE_IID!(IID_IStorageLibraryChangeTracker, 2652205846, 24691, 17654, 150, 129, 116, 146, 209, 40, 108, 144);
 RT_INTERFACE!{interface IStorageLibraryChangeTracker(IStorageLibraryChangeTrackerVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryChangeTracker] {
     fn GetChangeReader(&self, out: *mut *mut StorageLibraryChangeReader) -> HRESULT,
@@ -1514,8 +1514,8 @@ impl IStorageLibraryChangeTracker {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageLibraryChangeTracker: IStorageLibraryChangeTracker}
-RT_ENUM! { enum StorageLibraryChangeType: i32 {
+RT_CLASS!{class StorageLibraryChangeTracker: IStorageLibraryChangeTracker ["Windows.Storage.StorageLibraryChangeTracker"]}
+RT_ENUM! { enum StorageLibraryChangeType: i32 ["Windows.Storage.StorageLibraryChangeType"] {
     Created (StorageLibraryChangeType_Created) = 0, Deleted (StorageLibraryChangeType_Deleted) = 1, MovedOrRenamed (StorageLibraryChangeType_MovedOrRenamed) = 2, ContentsChanged (StorageLibraryChangeType_ContentsChanged) = 3, MovedOutOfLibrary (StorageLibraryChangeType_MovedOutOfLibrary) = 4, MovedIntoLibrary (StorageLibraryChangeType_MovedIntoLibrary) = 5, ContentsReplaced (StorageLibraryChangeType_ContentsReplaced) = 6, IndexingStatusChanged (StorageLibraryChangeType_IndexingStatusChanged) = 7, EncryptionChanged (StorageLibraryChangeType_EncryptionChanged) = 8, ChangeTrackingLost (StorageLibraryChangeType_ChangeTrackingLost) = 9,
 }}
 DEFINE_IID!(IID_IStorageLibraryStatics, 1107863259, 26698, 18886, 158, 89, 144, 18, 30, 224, 80, 214);
@@ -1540,7 +1540,7 @@ impl IStorageLibraryStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StorageOpenOptions: u32 {
+RT_ENUM! { enum StorageOpenOptions: u32 ["Windows.Storage.StorageOpenOptions"] {
     None (StorageOpenOptions_None) = 0, AllowOnlyReaders (StorageOpenOptions_AllowOnlyReaders) = 1, AllowReadersAndWriters (StorageOpenOptions_AllowReadersAndWriters) = 2,
 }}
 DEFINE_IID!(IID_IStorageProvider, 3875925716, 54392, 18390, 186, 70, 26, 142, 190, 17, 74, 32);
@@ -1560,7 +1560,7 @@ impl IStorageProvider {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageProvider: IStorageProvider}
+RT_CLASS!{class StorageProvider: IStorageProvider ["Windows.Storage.StorageProvider"]}
 DEFINE_IID!(IID_IStorageProvider2, 17635607, 13316, 16715, 159, 215, 205, 68, 71, 46, 170, 57);
 RT_INTERFACE!{interface IStorageProvider2(IStorageProvider2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorageProvider2] {
     fn IsPropertySupportedForPartialFileAsync(&self, propertyCanonicalName: HSTRING, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT
@@ -1589,7 +1589,7 @@ impl IStorageStreamTransaction {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageStreamTransaction: IStorageStreamTransaction}
+RT_CLASS!{class StorageStreamTransaction: IStorageStreamTransaction ["Windows.Storage.StorageStreamTransaction"]}
 DEFINE_IID!(IID_IStreamedFileDataRequest, 376700110, 55997, 19792, 190, 238, 24, 11, 138, 129, 145, 182);
 RT_INTERFACE!{interface IStreamedFileDataRequest(IStreamedFileDataRequestVtbl): IInspectable(IInspectableVtbl) [IID_IStreamedFileDataRequest] {
     fn FailAndClose(&self, failureMode: StreamedFileFailureMode) -> HRESULT
@@ -1600,7 +1600,7 @@ impl IStreamedFileDataRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StreamedFileDataRequest: streams::IOutputStream}
+RT_CLASS!{class StreamedFileDataRequest: streams::IOutputStream ["Windows.Storage.StreamedFileDataRequest"]}
 DEFINE_IID!(IID_StreamedFileDataRequestedHandler, 4277577764, 12257, 19719, 163, 91, 183, 124, 80, 181, 244, 204);
 RT_DELEGATE!{delegate StreamedFileDataRequestedHandler(StreamedFileDataRequestedHandlerVtbl, StreamedFileDataRequestedHandlerImpl) [IID_StreamedFileDataRequestedHandler] {
     fn Invoke(&self, stream: *mut StreamedFileDataRequest) -> HRESULT
@@ -1611,7 +1611,7 @@ impl StreamedFileDataRequestedHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StreamedFileFailureMode: i32 {
+RT_ENUM! { enum StreamedFileFailureMode: i32 ["Windows.Storage.StreamedFileFailureMode"] {
     Failed (StreamedFileFailureMode_Failed) = 0, CurrentlyUnavailable (StreamedFileFailureMode_CurrentlyUnavailable) = 1, Incomplete (StreamedFileFailureMode_Incomplete) = 2,
 }}
 DEFINE_IID!(IID_ISystemAudioProperties, 1066350775, 12428, 18401, 146, 77, 134, 69, 52, 142, 93, 183);
@@ -1625,7 +1625,7 @@ impl ISystemAudioProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemAudioProperties: ISystemAudioProperties}
+RT_CLASS!{class SystemAudioProperties: ISystemAudioProperties ["Windows.Storage.SystemAudioProperties"]}
 DEFINE_IID!(IID_ISystemDataPaths, 3811229552, 55546, 17900, 169, 66, 210, 226, 111, 182, 11, 165);
 RT_INTERFACE!{interface ISystemDataPaths(ISystemDataPathsVtbl): IInspectable(IInspectableVtbl) [IID_ISystemDataPaths] {
     fn get_Fonts(&self, out: *mut HSTRING) -> HRESULT,
@@ -1727,7 +1727,7 @@ impl ISystemDataPaths {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemDataPaths: ISystemDataPaths}
+RT_CLASS!{class SystemDataPaths: ISystemDataPaths ["Windows.Storage.SystemDataPaths"]}
 impl RtActivatable<ISystemDataPathsStatics> for SystemDataPaths {}
 impl SystemDataPaths {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<SystemDataPaths>>> {
@@ -1763,7 +1763,7 @@ impl ISystemGPSProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemGPSProperties: ISystemGPSProperties}
+RT_CLASS!{class SystemGPSProperties: ISystemGPSProperties ["Windows.Storage.SystemGPSProperties"]}
 DEFINE_IID!(IID_ISystemImageProperties, 18558512, 35641, 17160, 190, 161, 232, 170, 97, 228, 120, 38);
 RT_INTERFACE!{interface ISystemImageProperties(ISystemImagePropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISystemImageProperties] {
     fn get_HorizontalSize(&self, out: *mut HSTRING) -> HRESULT,
@@ -1781,7 +1781,7 @@ impl ISystemImageProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemImageProperties: ISystemImageProperties}
+RT_CLASS!{class SystemImageProperties: ISystemImageProperties ["Windows.Storage.SystemImageProperties"]}
 DEFINE_IID!(IID_ISystemMediaProperties, 2754294550, 33813, 16604, 140, 68, 152, 54, 29, 35, 84, 48);
 RT_INTERFACE!{interface ISystemMediaProperties(ISystemMediaPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISystemMediaProperties] {
     fn get_Duration(&self, out: *mut HSTRING) -> HRESULT,
@@ -1823,7 +1823,7 @@ impl ISystemMediaProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMediaProperties: ISystemMediaProperties}
+RT_CLASS!{class SystemMediaProperties: ISystemMediaProperties ["Windows.Storage.SystemMediaProperties"]}
 DEFINE_IID!(IID_ISystemMusicProperties, 3027863765, 26543, 19395, 141, 57, 91, 137, 2, 32, 38, 161);
 RT_INTERFACE!{interface ISystemMusicProperties(ISystemMusicPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISystemMusicProperties] {
     fn get_AlbumArtist(&self, out: *mut HSTRING) -> HRESULT,
@@ -1877,7 +1877,7 @@ impl ISystemMusicProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMusicProperties: ISystemMusicProperties}
+RT_CLASS!{class SystemMusicProperties: ISystemMusicProperties ["Windows.Storage.SystemMusicProperties"]}
 DEFINE_IID!(IID_ISystemPhotoProperties, 1194654781, 43809, 17444, 183, 53, 244, 53, 58, 86, 200, 252);
 RT_INTERFACE!{interface ISystemPhotoProperties(ISystemPhotoPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISystemPhotoProperties] {
     fn get_CameraManufacturer(&self, out: *mut HSTRING) -> HRESULT,
@@ -1913,7 +1913,7 @@ impl ISystemPhotoProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemPhotoProperties: ISystemPhotoProperties}
+RT_CLASS!{class SystemPhotoProperties: ISystemPhotoProperties ["Windows.Storage.SystemPhotoProperties"]}
 DEFINE_IID!(IID_ISystemProperties, 2440720833, 34291, 19921, 176, 1, 165, 11, 253, 33, 200, 210);
 RT_INTERFACE!{static interface ISystemProperties(ISystemPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_ISystemProperties] {
     fn get_Author(&self, out: *mut HSTRING) -> HRESULT,
@@ -2076,7 +2076,7 @@ impl ISystemVideoProperties {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemVideoProperties: ISystemVideoProperties}
+RT_CLASS!{class SystemVideoProperties: ISystemVideoProperties ["Windows.Storage.SystemVideoProperties"]}
 DEFINE_IID!(IID_IUserDataPaths, 4190451986, 43972, 18175, 138, 43, 220, 157, 127, 166, 229, 47);
 RT_INTERFACE!{interface IUserDataPaths(IUserDataPathsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDataPaths] {
     fn get_CameraRoll(&self, out: *mut HSTRING) -> HRESULT,
@@ -2196,7 +2196,7 @@ impl IUserDataPaths {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDataPaths: IUserDataPaths}
+RT_CLASS!{class UserDataPaths: IUserDataPaths ["Windows.Storage.UserDataPaths"]}
 impl RtActivatable<IUserDataPathsStatics> for UserDataPaths {}
 impl UserDataPaths {
     #[cfg(feature="windows-system")] #[inline] pub fn get_for_user(user: &super::system::User) -> Result<Option<ComPtr<UserDataPaths>>> {
@@ -2227,13 +2227,13 @@ impl IUserDataPathsStatics {
 }
 pub mod accesscache { // Windows.Storage.AccessCache
 use ::prelude::*;
-RT_ENUM! { enum AccessCacheOptions: u32 {
+RT_ENUM! { enum AccessCacheOptions: u32 ["Windows.Storage.AccessCache.AccessCacheOptions"] {
     None (AccessCacheOptions_None) = 0, DisallowUserInput (AccessCacheOptions_DisallowUserInput) = 1, FastLocationsOnly (AccessCacheOptions_FastLocationsOnly) = 2, UseReadOnlyCachedCopy (AccessCacheOptions_UseReadOnlyCachedCopy) = 4, SuppressAccessTimeUpdate (AccessCacheOptions_SuppressAccessTimeUpdate) = 8,
 }}
-RT_STRUCT! { struct AccessListEntry {
+RT_STRUCT! { struct AccessListEntry ["Windows.Storage.AccessCache.AccessListEntry"] {
     Token: HSTRING, Metadata: HSTRING,
 }}
-RT_CLASS!{class AccessListEntryView: foundation::collections::IVectorView<AccessListEntry>}
+RT_CLASS!{class AccessListEntryView: foundation::collections::IVectorView<AccessListEntry> ["Windows.Storage.AccessCache.AccessListEntryView"]}
 DEFINE_IID!(IID_IItemRemovedEventArgs, 1499954780, 21950, 19558, 186, 102, 94, 174, 167, 157, 38, 49);
 RT_INTERFACE!{interface IItemRemovedEventArgs(IItemRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IItemRemovedEventArgs] {
     fn get_RemovedEntry(&self, out: *mut AccessListEntry) -> HRESULT
@@ -2245,8 +2245,8 @@ impl IItemRemovedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ItemRemovedEventArgs: IItemRemovedEventArgs}
-RT_ENUM! { enum RecentStorageItemVisibility: i32 {
+RT_CLASS!{class ItemRemovedEventArgs: IItemRemovedEventArgs ["Windows.Storage.AccessCache.ItemRemovedEventArgs"]}
+RT_ENUM! { enum RecentStorageItemVisibility: i32 ["Windows.Storage.AccessCache.RecentStorageItemVisibility"] {
     AppOnly (RecentStorageItemVisibility_AppOnly) = 0, AppAndSystem (RecentStorageItemVisibility_AppAndSystem) = 1,
 }}
 RT_CLASS!{static class StorageApplicationPermissions}
@@ -2374,7 +2374,7 @@ impl IStorageItemAccessList {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageItemAccessList: IStorageItemAccessList}
+RT_CLASS!{class StorageItemAccessList: IStorageItemAccessList ["Windows.Storage.AccessCache.StorageItemAccessList"]}
 DEFINE_IID!(IID_IStorageItemMostRecentlyUsedList, 23214549, 20749, 16670, 140, 241, 195, 209, 239, 250, 76, 51);
 RT_INTERFACE!{interface IStorageItemMostRecentlyUsedList(IStorageItemMostRecentlyUsedListVtbl): IInspectable(IInspectableVtbl) [IID_IStorageItemMostRecentlyUsedList] {
     fn add_ItemRemoved(&self, handler: *mut foundation::TypedEventHandler<StorageItemMostRecentlyUsedList, ItemRemovedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -2391,7 +2391,7 @@ impl IStorageItemMostRecentlyUsedList {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageItemMostRecentlyUsedList: IStorageItemMostRecentlyUsedList}
+RT_CLASS!{class StorageItemMostRecentlyUsedList: IStorageItemMostRecentlyUsedList ["Windows.Storage.AccessCache.StorageItemMostRecentlyUsedList"]}
 DEFINE_IID!(IID_IStorageItemMostRecentlyUsedList2, 3662159520, 60813, 18225, 161, 219, 228, 78, 226, 32, 64, 147);
 RT_INTERFACE!{interface IStorageItemMostRecentlyUsedList2(IStorageItemMostRecentlyUsedList2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorageItemMostRecentlyUsedList2] {
     fn AddWithMetadataAndVisibility(&self, file: *mut super::IStorageItem, metadata: HSTRING, visibility: RecentStorageItemVisibility, out: *mut HSTRING) -> HRESULT,
@@ -2411,7 +2411,7 @@ impl IStorageItemMostRecentlyUsedList2 {
 } // Windows.Storage.AccessCache
 pub mod bulkaccess { // Windows.Storage.BulkAccess
 use ::prelude::*;
-RT_CLASS!{class FileInformation: IStorageItemInformation}
+RT_CLASS!{class FileInformation: IStorageItemInformation ["Windows.Storage.BulkAccess.FileInformation"]}
 DEFINE_IID!(IID_IFileInformationFactory, 1075677374, 38415, 19821, 167, 208, 26, 56, 97, 231, 108, 131);
 RT_INTERFACE!{interface IFileInformationFactory(IFileInformationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IFileInformationFactory] {
     fn GetItemsAsync(&self, startIndex: u32, maxItemsToRetrieve: u32, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<IStorageItemInformation>>) -> HRESULT,
@@ -2471,7 +2471,7 @@ impl IFileInformationFactory {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileInformationFactory: IFileInformationFactory}
+RT_CLASS!{class FileInformationFactory: IFileInformationFactory ["Windows.Storage.BulkAccess.FileInformationFactory"]}
 impl RtActivatable<IFileInformationFactoryFactory> for FileInformationFactory {}
 impl FileInformationFactory {
     #[inline] pub fn create_with_mode(queryResult: &super::search::IStorageQueryResultBase, mode: super::fileproperties::ThumbnailMode) -> Result<ComPtr<FileInformationFactory>> {
@@ -2517,7 +2517,7 @@ impl IFileInformationFactoryFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FolderInformation: IStorageItemInformation}
+RT_CLASS!{class FolderInformation: IStorageItemInformation ["Windows.Storage.BulkAccess.FolderInformation"]}
 DEFINE_IID!(IID_IStorageItemInformation, 2275789707, 35186, 20288, 141, 224, 216, 111, 177, 121, 216, 250);
 RT_INTERFACE!{interface IStorageItemInformation(IStorageItemInformationVtbl): IInspectable(IInspectableVtbl) [IID_IStorageItemInformation] {
     fn get_MusicProperties(&self, out: *mut *mut super::fileproperties::MusicProperties) -> HRESULT,
@@ -2584,7 +2584,7 @@ impl IStorageItemInformation {
 } // Windows.Storage.BulkAccess
 pub mod compression { // Windows.Storage.Compression
 use ::prelude::*;
-RT_ENUM! { enum CompressAlgorithm: i32 {
+RT_ENUM! { enum CompressAlgorithm: i32 ["Windows.Storage.Compression.CompressAlgorithm"] {
     InvalidAlgorithm (CompressAlgorithm_InvalidAlgorithm) = 0, NullAlgorithm (CompressAlgorithm_NullAlgorithm) = 1, Mszip (CompressAlgorithm_Mszip) = 2, Xpress (CompressAlgorithm_Xpress) = 3, XpressHuff (CompressAlgorithm_XpressHuff) = 4, Lzms (CompressAlgorithm_Lzms) = 5,
 }}
 DEFINE_IID!(IID_ICompressor, 180577370, 22444, 20193, 183, 2, 132, 211, 157, 84, 36, 224);
@@ -2604,7 +2604,7 @@ impl ICompressor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Compressor: ICompressor}
+RT_CLASS!{class Compressor: ICompressor ["Windows.Storage.Compression.Compressor"]}
 impl RtActivatable<ICompressorFactory> for Compressor {}
 impl Compressor {
     #[inline] pub fn create_compressor(underlyingStream: &super::streams::IOutputStream) -> Result<ComPtr<Compressor>> {
@@ -2643,7 +2643,7 @@ impl IDecompressor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Decompressor: IDecompressor}
+RT_CLASS!{class Decompressor: IDecompressor ["Windows.Storage.Compression.Decompressor"]}
 impl RtActivatable<IDecompressorFactory> for Decompressor {}
 impl Decompressor {
     #[inline] pub fn create_decompressor(underlyingStream: &super::streams::IInputStream) -> Result<ComPtr<Decompressor>> {
@@ -2688,7 +2688,7 @@ impl IBasicProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BasicProperties: IBasicProperties}
+RT_CLASS!{class BasicProperties: IBasicProperties ["Windows.Storage.FileProperties.BasicProperties"]}
 DEFINE_IID!(IID_IDocumentProperties, 2125142460, 6177, 18723, 180, 169, 10, 234, 64, 77, 0, 112);
 RT_INTERFACE!{interface IDocumentProperties(IDocumentPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IDocumentProperties] {
     fn get_Author(&self, out: *mut *mut foundation::collections::IVector<HString>) -> HRESULT,
@@ -2728,7 +2728,7 @@ impl IDocumentProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DocumentProperties: IDocumentProperties}
+RT_CLASS!{class DocumentProperties: IDocumentProperties ["Windows.Storage.FileProperties.DocumentProperties"]}
 RT_CLASS!{static class GeotagHelper}
 impl RtActivatable<IGeotagHelperStatics> for GeotagHelper {}
 impl GeotagHelper {
@@ -2868,7 +2868,7 @@ impl IImageProperties {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ImageProperties: IImageProperties}
+RT_CLASS!{class ImageProperties: IImageProperties ["Windows.Storage.FileProperties.ImageProperties"]}
 DEFINE_IID!(IID_IMusicProperties, 3163204450, 26348, 16794, 188, 93, 202, 101, 164, 203, 70, 218);
 RT_INTERFACE!{interface IMusicProperties(IMusicPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IMusicProperties] {
     fn get_Album(&self, out: *mut HSTRING) -> HRESULT,
@@ -3015,11 +3015,11 @@ impl IMusicProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MusicProperties: IMusicProperties}
-RT_ENUM! { enum PhotoOrientation: i32 {
+RT_CLASS!{class MusicProperties: IMusicProperties ["Windows.Storage.FileProperties.MusicProperties"]}
+RT_ENUM! { enum PhotoOrientation: i32 ["Windows.Storage.FileProperties.PhotoOrientation"] {
     Unspecified (PhotoOrientation_Unspecified) = 0, Normal (PhotoOrientation_Normal) = 1, FlipHorizontal (PhotoOrientation_FlipHorizontal) = 2, Rotate180 (PhotoOrientation_Rotate180) = 3, FlipVertical (PhotoOrientation_FlipVertical) = 4, Transpose (PhotoOrientation_Transpose) = 5, Rotate270 (PhotoOrientation_Rotate270) = 6, Transverse (PhotoOrientation_Transverse) = 7, Rotate90 (PhotoOrientation_Rotate90) = 8,
 }}
-RT_ENUM! { enum PropertyPrefetchOptions: u32 {
+RT_ENUM! { enum PropertyPrefetchOptions: u32 ["Windows.Storage.FileProperties.PropertyPrefetchOptions"] {
     None (PropertyPrefetchOptions_None) = 0, MusicProperties (PropertyPrefetchOptions_MusicProperties) = 1, VideoProperties (PropertyPrefetchOptions_VideoProperties) = 2, ImageProperties (PropertyPrefetchOptions_ImageProperties) = 4, DocumentProperties (PropertyPrefetchOptions_DocumentProperties) = 8, BasicProperties (PropertyPrefetchOptions_BasicProperties) = 16,
 }}
 DEFINE_IID!(IID_IStorageItemContentProperties, 86592429, 48184, 18623, 133, 215, 119, 14, 14, 42, 224, 186);
@@ -3051,7 +3051,7 @@ impl IStorageItemContentProperties {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageItemContentProperties: IStorageItemContentProperties}
+RT_CLASS!{class StorageItemContentProperties: IStorageItemContentProperties ["Windows.Storage.FileProperties.StorageItemContentProperties"]}
 DEFINE_IID!(IID_IStorageItemExtraProperties, 3309527474, 21709, 17195, 189, 188, 75, 25, 196, 180, 112, 215);
 RT_INTERFACE!{interface IStorageItemExtraProperties(IStorageItemExtraPropertiesVtbl): IInspectable(IInspectableVtbl) [IID_IStorageItemExtraProperties] {
     fn RetrievePropertiesAsync(&self, propertiesToRetrieve: *mut foundation::collections::IIterable<HString>, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IMap<HString, IInspectable>>) -> HRESULT,
@@ -3075,11 +3075,11 @@ impl IStorageItemExtraProperties {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageItemThumbnail: super::streams::IRandomAccessStreamWithContentType}
-RT_ENUM! { enum ThumbnailMode: i32 {
+RT_CLASS!{class StorageItemThumbnail: super::streams::IRandomAccessStreamWithContentType ["Windows.Storage.FileProperties.StorageItemThumbnail"]}
+RT_ENUM! { enum ThumbnailMode: i32 ["Windows.Storage.FileProperties.ThumbnailMode"] {
     PicturesView (ThumbnailMode_PicturesView) = 0, VideosView (ThumbnailMode_VideosView) = 1, MusicView (ThumbnailMode_MusicView) = 2, DocumentsView (ThumbnailMode_DocumentsView) = 3, ListView (ThumbnailMode_ListView) = 4, SingleItem (ThumbnailMode_SingleItem) = 5,
 }}
-RT_ENUM! { enum ThumbnailOptions: u32 {
+RT_ENUM! { enum ThumbnailOptions: u32 ["Windows.Storage.FileProperties.ThumbnailOptions"] {
     None (ThumbnailOptions_None) = 0, ReturnOnlyIfCached (ThumbnailOptions_ReturnOnlyIfCached) = 1, ResizeThumbnail (ThumbnailOptions_ResizeThumbnail) = 2, UseCurrentScale (ThumbnailOptions_UseCurrentScale) = 4,
 }}
 DEFINE_IID!(IID_IThumbnailProperties, 1765659695, 56295, 18869, 179, 179, 40, 147, 172, 93, 52, 35);
@@ -3111,10 +3111,10 @@ impl IThumbnailProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ThumbnailType: i32 {
+RT_ENUM! { enum ThumbnailType: i32 ["Windows.Storage.FileProperties.ThumbnailType"] {
     Image (ThumbnailType_Image) = 0, Icon (ThumbnailType_Icon) = 1,
 }}
-RT_ENUM! { enum VideoOrientation: i32 {
+RT_ENUM! { enum VideoOrientation: i32 ["Windows.Storage.FileProperties.VideoOrientation"] {
     Normal (VideoOrientation_Normal) = 0, Rotate90 (VideoOrientation_Rotate90) = 90, Rotate180 (VideoOrientation_Rotate180) = 180, Rotate270 (VideoOrientation_Rotate270) = 270,
 }}
 DEFINE_IID!(IID_IVideoProperties, 1905976583, 26846, 19896, 151, 222, 73, 153, 140, 5, 159, 47);
@@ -3243,11 +3243,11 @@ impl IVideoProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VideoProperties: IVideoProperties}
+RT_CLASS!{class VideoProperties: IVideoProperties ["Windows.Storage.FileProperties.VideoProperties"]}
 } // Windows.Storage.FileProperties
 pub mod pickers { // Windows.Storage.Pickers
 use ::prelude::*;
-RT_CLASS!{class FileExtensionVector: foundation::collections::IVector<HString>}
+RT_CLASS!{class FileExtensionVector: foundation::collections::IVector<HString> ["Windows.Storage.Pickers.FileExtensionVector"]}
 DEFINE_IID!(IID_IFileOpenPicker, 749217674, 4805, 19551, 137, 119, 148, 84, 119, 147, 194, 65);
 RT_INTERFACE!{interface IFileOpenPicker(IFileOpenPickerVtbl): IInspectable(IInspectableVtbl) [IID_IFileOpenPicker] {
     fn get_ViewMode(&self, out: *mut PickerViewMode) -> HRESULT,
@@ -3315,7 +3315,7 @@ impl IFileOpenPicker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileOpenPicker: IFileOpenPicker}
+RT_CLASS!{class FileOpenPicker: IFileOpenPicker ["Windows.Storage.Pickers.FileOpenPicker"]}
 impl RtActivatable<IFileOpenPickerStatics> for FileOpenPicker {}
 impl RtActivatable<IActivationFactory> for FileOpenPicker {}
 impl FileOpenPicker {
@@ -3367,8 +3367,8 @@ impl IFileOpenPickerWithOperationId {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FilePickerFileTypesOrderedMap: foundation::collections::IMap<HString, foundation::collections::IVector<HString>>}
-RT_CLASS!{class FilePickerSelectedFilesArray: foundation::collections::IVectorView<super::StorageFile>}
+RT_CLASS!{class FilePickerFileTypesOrderedMap: foundation::collections::IMap<HString, foundation::collections::IVector<HString>> ["Windows.Storage.Pickers.FilePickerFileTypesOrderedMap"]}
+RT_CLASS!{class FilePickerSelectedFilesArray: foundation::collections::IVectorView<super::StorageFile> ["Windows.Storage.Pickers.FilePickerSelectedFilesArray"]}
 DEFINE_IID!(IID_IFileSavePicker, 847708107, 24959, 19653, 175, 106, 179, 253, 242, 154, 209, 69);
 RT_INTERFACE!{interface IFileSavePicker(IFileSavePickerVtbl): IInspectable(IInspectableVtbl) [IID_IFileSavePicker] {
     fn get_SettingsIdentifier(&self, out: *mut HSTRING) -> HRESULT,
@@ -3452,7 +3452,7 @@ impl IFileSavePicker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileSavePicker: IFileSavePicker}
+RT_CLASS!{class FileSavePicker: IFileSavePicker ["Windows.Storage.Pickers.FileSavePicker"]}
 impl RtActivatable<IActivationFactory> for FileSavePicker {}
 DEFINE_CLSID!(FileSavePicker(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,105,99,107,101,114,115,46,70,105,108,101,83,97,118,101,80,105,99,107,101,114,0]) [CLSID_FileSavePicker]);
 DEFINE_IID!(IID_IFileSavePicker2, 247665570, 53835, 17562, 129, 151, 232, 145, 4, 253, 66, 204);
@@ -3548,7 +3548,7 @@ impl IFolderPicker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FolderPicker: IFolderPicker}
+RT_CLASS!{class FolderPicker: IFolderPicker ["Windows.Storage.Pickers.FolderPicker"]}
 impl RtActivatable<IActivationFactory> for FolderPicker {}
 DEFINE_CLSID!(FolderPicker(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,105,99,107,101,114,115,46,70,111,108,100,101,114,80,105,99,107,101,114,0]) [CLSID_FolderPicker]);
 DEFINE_IID!(IID_IFolderPicker2, 2394143383, 56453, 17942, 190, 148, 150, 96, 136, 31, 47, 93);
@@ -3567,15 +3567,15 @@ impl IFolderPicker2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PickerLocationId: i32 {
+RT_ENUM! { enum PickerLocationId: i32 ["Windows.Storage.Pickers.PickerLocationId"] {
     DocumentsLibrary (PickerLocationId_DocumentsLibrary) = 0, ComputerFolder (PickerLocationId_ComputerFolder) = 1, Desktop (PickerLocationId_Desktop) = 2, Downloads (PickerLocationId_Downloads) = 3, HomeGroup (PickerLocationId_HomeGroup) = 4, MusicLibrary (PickerLocationId_MusicLibrary) = 5, PicturesLibrary (PickerLocationId_PicturesLibrary) = 6, VideosLibrary (PickerLocationId_VideosLibrary) = 7, Objects3D (PickerLocationId_Objects3D) = 8, Unspecified (PickerLocationId_Unspecified) = 9,
 }}
-RT_ENUM! { enum PickerViewMode: i32 {
+RT_ENUM! { enum PickerViewMode: i32 ["Windows.Storage.Pickers.PickerViewMode"] {
     List (PickerViewMode_List) = 0, Thumbnail (PickerViewMode_Thumbnail) = 1,
 }}
 pub mod provider { // Windows.Storage.Pickers.Provider
 use ::prelude::*;
-RT_ENUM! { enum AddFileResult: i32 {
+RT_ENUM! { enum AddFileResult: i32 ["Windows.Storage.Pickers.Provider.AddFileResult"] {
     Added (AddFileResult_Added) = 0, AlreadyAdded (AddFileResult_AlreadyAdded) = 1, NotAllowed (AddFileResult_NotAllowed) = 2, Unavailable (AddFileResult_Unavailable) = 3,
 }}
 DEFINE_IID!(IID_IFileOpenPickerUI, 3718535696, 63956, 16580, 138, 245, 197, 182, 181, 166, 29, 29);
@@ -3657,7 +3657,7 @@ impl IFileOpenPickerUI {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileOpenPickerUI: IFileOpenPickerUI}
+RT_CLASS!{class FileOpenPickerUI: IFileOpenPickerUI ["Windows.Storage.Pickers.Provider.FileOpenPickerUI"]}
 DEFINE_IID!(IID_IFileRemovedEventArgs, 319045031, 32714, 19499, 158, 202, 104, 144, 249, 240, 1, 133);
 RT_INTERFACE!{interface IFileRemovedEventArgs(IFileRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IFileRemovedEventArgs] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT
@@ -3669,7 +3669,7 @@ impl IFileRemovedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileRemovedEventArgs: IFileRemovedEventArgs}
+RT_CLASS!{class FileRemovedEventArgs: IFileRemovedEventArgs ["Windows.Storage.Pickers.Provider.FileRemovedEventArgs"]}
 DEFINE_IID!(IID_IFileSavePickerUI, 2522268135, 15958, 17356, 138, 57, 51, 199, 61, 157, 84, 43);
 RT_INTERFACE!{interface IFileSavePickerUI(IFileSavePickerUIVtbl): IInspectable(IInspectableVtbl) [IID_IFileSavePickerUI] {
     fn get_Title(&self, out: *mut HSTRING) -> HRESULT,
@@ -3732,8 +3732,8 @@ impl IFileSavePickerUI {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileSavePickerUI: IFileSavePickerUI}
-RT_ENUM! { enum FileSelectionMode: i32 {
+RT_CLASS!{class FileSavePickerUI: IFileSavePickerUI ["Windows.Storage.Pickers.Provider.FileSavePickerUI"]}
+RT_ENUM! { enum FileSelectionMode: i32 ["Windows.Storage.Pickers.Provider.FileSelectionMode"] {
     Single (FileSelectionMode_Single) = 0, Multiple (FileSelectionMode_Multiple) = 1,
 }}
 DEFINE_IID!(IID_IPickerClosingDeferral, 2063071006, 6759, 18993, 174, 128, 233, 7, 112, 138, 97, 155);
@@ -3746,7 +3746,7 @@ impl IPickerClosingDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PickerClosingDeferral: IPickerClosingDeferral}
+RT_CLASS!{class PickerClosingDeferral: IPickerClosingDeferral ["Windows.Storage.Pickers.Provider.PickerClosingDeferral"]}
 DEFINE_IID!(IID_IPickerClosingEventArgs, 2119823908, 45874, 20242, 139, 159, 168, 194, 240, 107, 50, 205);
 RT_INTERFACE!{interface IPickerClosingEventArgs(IPickerClosingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IPickerClosingEventArgs] {
     fn get_ClosingOperation(&self, out: *mut *mut PickerClosingOperation) -> HRESULT,
@@ -3764,7 +3764,7 @@ impl IPickerClosingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PickerClosingEventArgs: IPickerClosingEventArgs}
+RT_CLASS!{class PickerClosingEventArgs: IPickerClosingEventArgs ["Windows.Storage.Pickers.Provider.PickerClosingEventArgs"]}
 DEFINE_IID!(IID_IPickerClosingOperation, 1290402692, 48878, 20025, 167, 115, 252, 95, 14, 174, 50, 141);
 RT_INTERFACE!{interface IPickerClosingOperation(IPickerClosingOperationVtbl): IInspectable(IInspectableVtbl) [IID_IPickerClosingOperation] {
     fn GetDeferral(&self, out: *mut *mut PickerClosingDeferral) -> HRESULT,
@@ -3782,8 +3782,8 @@ impl IPickerClosingOperation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PickerClosingOperation: IPickerClosingOperation}
-RT_ENUM! { enum SetFileNameResult: i32 {
+RT_CLASS!{class PickerClosingOperation: IPickerClosingOperation ["Windows.Storage.Pickers.Provider.PickerClosingOperation"]}
+RT_ENUM! { enum SetFileNameResult: i32 ["Windows.Storage.Pickers.Provider.SetFileNameResult"] {
     Succeeded (SetFileNameResult_Succeeded) = 0, NotAllowed (SetFileNameResult_NotAllowed) = 1, Unavailable (SetFileNameResult_Unavailable) = 2,
 }}
 DEFINE_IID!(IID_ITargetFileRequest, 1119695701, 32648, 18315, 142, 129, 105, 11, 32, 52, 6, 120);
@@ -3808,7 +3808,7 @@ impl ITargetFileRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetFileRequest: ITargetFileRequest}
+RT_CLASS!{class TargetFileRequest: ITargetFileRequest ["Windows.Storage.Pickers.Provider.TargetFileRequest"]}
 DEFINE_IID!(IID_ITargetFileRequestDeferral, 1257151889, 48917, 19881, 149, 246, 246, 183, 213, 88, 34, 91);
 RT_INTERFACE!{interface ITargetFileRequestDeferral(ITargetFileRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_ITargetFileRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -3819,7 +3819,7 @@ impl ITargetFileRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetFileRequestDeferral: ITargetFileRequestDeferral}
+RT_CLASS!{class TargetFileRequestDeferral: ITargetFileRequestDeferral ["Windows.Storage.Pickers.Provider.TargetFileRequestDeferral"]}
 DEFINE_IID!(IID_ITargetFileRequestedEventArgs, 2976111553, 6993, 19593, 165, 145, 15, 212, 11, 60, 87, 201);
 RT_INTERFACE!{interface ITargetFileRequestedEventArgs(ITargetFileRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITargetFileRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut TargetFileRequest) -> HRESULT
@@ -3831,15 +3831,15 @@ impl ITargetFileRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TargetFileRequestedEventArgs: ITargetFileRequestedEventArgs}
+RT_CLASS!{class TargetFileRequestedEventArgs: ITargetFileRequestedEventArgs ["Windows.Storage.Pickers.Provider.TargetFileRequestedEventArgs"]}
 } // Windows.Storage.Pickers.Provider
 } // Windows.Storage.Pickers
 pub mod provider { // Windows.Storage.Provider
 use ::prelude::*;
-RT_ENUM! { enum CachedFileOptions: u32 {
+RT_ENUM! { enum CachedFileOptions: u32 ["Windows.Storage.Provider.CachedFileOptions"] {
     None (CachedFileOptions_None) = 0, RequireUpdateOnAccess (CachedFileOptions_RequireUpdateOnAccess) = 1, UseCachedFileWhenOffline (CachedFileOptions_UseCachedFileWhenOffline) = 2, DenyAccessWhenOffline (CachedFileOptions_DenyAccessWhenOffline) = 4,
 }}
-RT_ENUM! { enum CachedFileTarget: i32 {
+RT_ENUM! { enum CachedFileTarget: i32 ["Windows.Storage.Provider.CachedFileTarget"] {
     Local (CachedFileTarget_Local) = 0, Remote (CachedFileTarget_Remote) = 1,
 }}
 RT_CLASS!{static class CachedFileUpdater}
@@ -3910,7 +3910,7 @@ impl ICachedFileUpdaterUI {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CachedFileUpdaterUI: ICachedFileUpdaterUI}
+RT_CLASS!{class CachedFileUpdaterUI: ICachedFileUpdaterUI ["Windows.Storage.Provider.CachedFileUpdaterUI"]}
 DEFINE_IID!(IID_ICachedFileUpdaterUI2, 2287378972, 34457, 17216, 159, 73, 247, 202, 215, 254, 137, 145);
 RT_INTERFACE!{interface ICachedFileUpdaterUI2(ICachedFileUpdaterUI2Vtbl): IInspectable(IInspectableVtbl) [IID_ICachedFileUpdaterUI2] {
     fn get_UpdateRequest(&self, out: *mut *mut FileUpdateRequest) -> HRESULT,
@@ -3967,7 +3967,7 @@ impl IFileUpdateRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileUpdateRequest: IFileUpdateRequest}
+RT_CLASS!{class FileUpdateRequest: IFileUpdateRequest ["Windows.Storage.Provider.FileUpdateRequest"]}
 DEFINE_IID!(IID_IFileUpdateRequest2, 2185774664, 48574, 17531, 162, 238, 122, 254, 106, 3, 42, 148);
 RT_INTERFACE!{interface IFileUpdateRequest2(IFileUpdateRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_IFileUpdateRequest2] {
     fn get_UserInputNeededMessage(&self, out: *mut HSTRING) -> HRESULT,
@@ -3994,7 +3994,7 @@ impl IFileUpdateRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileUpdateRequestDeferral: IFileUpdateRequestDeferral}
+RT_CLASS!{class FileUpdateRequestDeferral: IFileUpdateRequestDeferral ["Windows.Storage.Provider.FileUpdateRequestDeferral"]}
 DEFINE_IID!(IID_IFileUpdateRequestedEventArgs, 2064290626, 14597, 17293, 170, 239, 120, 174, 38, 95, 141, 210);
 RT_INTERFACE!{interface IFileUpdateRequestedEventArgs(IFileUpdateRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IFileUpdateRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut FileUpdateRequest) -> HRESULT
@@ -4006,11 +4006,11 @@ impl IFileUpdateRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FileUpdateRequestedEventArgs: IFileUpdateRequestedEventArgs}
-RT_ENUM! { enum FileUpdateStatus: i32 {
+RT_CLASS!{class FileUpdateRequestedEventArgs: IFileUpdateRequestedEventArgs ["Windows.Storage.Provider.FileUpdateRequestedEventArgs"]}
+RT_ENUM! { enum FileUpdateStatus: i32 ["Windows.Storage.Provider.FileUpdateStatus"] {
     Incomplete (FileUpdateStatus_Incomplete) = 0, Complete (FileUpdateStatus_Complete) = 1, UserInputNeeded (FileUpdateStatus_UserInputNeeded) = 2, CurrentlyUnavailable (FileUpdateStatus_CurrentlyUnavailable) = 3, Failed (FileUpdateStatus_Failed) = 4, CompleteAndRenamed (FileUpdateStatus_CompleteAndRenamed) = 5,
 }}
-RT_ENUM! { enum ReadActivationMode: i32 {
+RT_ENUM! { enum ReadActivationMode: i32 ["Windows.Storage.Provider.ReadActivationMode"] {
     NotNeeded (ReadActivationMode_NotNeeded) = 0, BeforeAccess (ReadActivationMode_BeforeAccess) = 1,
 }}
 DEFINE_IID!(IID_IStorageProviderGetContentInfoForPathResult, 627339549, 43657, 19730, 130, 227, 247, 42, 146, 227, 57, 102);
@@ -4051,7 +4051,7 @@ impl IStorageProviderGetContentInfoForPathResult {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageProviderGetContentInfoForPathResult: IStorageProviderGetContentInfoForPathResult}
+RT_CLASS!{class StorageProviderGetContentInfoForPathResult: IStorageProviderGetContentInfoForPathResult ["Windows.Storage.Provider.StorageProviderGetContentInfoForPathResult"]}
 impl RtActivatable<IActivationFactory> for StorageProviderGetContentInfoForPathResult {}
 DEFINE_CLSID!(StorageProviderGetContentInfoForPathResult(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,71,101,116,67,111,110,116,101,110,116,73,110,102,111,70,111,114,80,97,116,104,82,101,115,117,108,116,0]) [CLSID_StorageProviderGetContentInfoForPathResult]);
 DEFINE_IID!(IID_IStorageProviderGetPathForContentUriResult, 1668356765, 16664, 17830, 172, 182, 34, 196, 157, 1, 159, 64);
@@ -4081,19 +4081,19 @@ impl IStorageProviderGetPathForContentUriResult {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageProviderGetPathForContentUriResult: IStorageProviderGetPathForContentUriResult}
+RT_CLASS!{class StorageProviderGetPathForContentUriResult: IStorageProviderGetPathForContentUriResult ["Windows.Storage.Provider.StorageProviderGetPathForContentUriResult"]}
 impl RtActivatable<IActivationFactory> for StorageProviderGetPathForContentUriResult {}
 DEFINE_CLSID!(StorageProviderGetPathForContentUriResult(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,71,101,116,80,97,116,104,70,111,114,67,111,110,116,101,110,116,85,114,105,82,101,115,117,108,116,0]) [CLSID_StorageProviderGetPathForContentUriResult]);
-RT_ENUM! { enum StorageProviderHardlinkPolicy: u32 {
+RT_ENUM! { enum StorageProviderHardlinkPolicy: u32 ["Windows.Storage.Provider.StorageProviderHardlinkPolicy"] {
     None (StorageProviderHardlinkPolicy_None) = 0, Allowed (StorageProviderHardlinkPolicy_Allowed) = 1,
 }}
-RT_ENUM! { enum StorageProviderHydrationPolicy: i32 {
+RT_ENUM! { enum StorageProviderHydrationPolicy: i32 ["Windows.Storage.Provider.StorageProviderHydrationPolicy"] {
     Partial (StorageProviderHydrationPolicy_Partial) = 0, Progressive (StorageProviderHydrationPolicy_Progressive) = 1, Full (StorageProviderHydrationPolicy_Full) = 2, AlwaysFull (StorageProviderHydrationPolicy_AlwaysFull) = 3,
 }}
-RT_ENUM! { enum StorageProviderHydrationPolicyModifier: u32 {
+RT_ENUM! { enum StorageProviderHydrationPolicyModifier: u32 ["Windows.Storage.Provider.StorageProviderHydrationPolicyModifier"] {
     None (StorageProviderHydrationPolicyModifier_None) = 0, ValidationRequired (StorageProviderHydrationPolicyModifier_ValidationRequired) = 1, StreamingAllowed (StorageProviderHydrationPolicyModifier_StreamingAllowed) = 2, AutoDehydrationAllowed (StorageProviderHydrationPolicyModifier_AutoDehydrationAllowed) = 4,
 }}
-RT_ENUM! { enum StorageProviderInSyncPolicy: u32 {
+RT_ENUM! { enum StorageProviderInSyncPolicy: u32 ["Windows.Storage.Provider.StorageProviderInSyncPolicy"] {
     Default (StorageProviderInSyncPolicy_Default) = 0, FileCreationTime (StorageProviderInSyncPolicy_FileCreationTime) = 1, FileReadOnlyAttribute (StorageProviderInSyncPolicy_FileReadOnlyAttribute) = 2, FileHiddenAttribute (StorageProviderInSyncPolicy_FileHiddenAttribute) = 4, FileSystemAttribute (StorageProviderInSyncPolicy_FileSystemAttribute) = 8, DirectoryCreationTime (StorageProviderInSyncPolicy_DirectoryCreationTime) = 16, DirectoryReadOnlyAttribute (StorageProviderInSyncPolicy_DirectoryReadOnlyAttribute) = 32, DirectoryHiddenAttribute (StorageProviderInSyncPolicy_DirectoryHiddenAttribute) = 64, DirectorySystemAttribute (StorageProviderInSyncPolicy_DirectorySystemAttribute) = 128, FileLastWriteTime (StorageProviderInSyncPolicy_FileLastWriteTime) = 256, DirectoryLastWriteTime (StorageProviderInSyncPolicy_DirectoryLastWriteTime) = 512, PreserveInsyncForSyncEngine (StorageProviderInSyncPolicy_PreserveInsyncForSyncEngine) = 2147483648,
 }}
 RT_CLASS!{static class StorageProviderItemProperties}
@@ -4153,7 +4153,7 @@ impl IStorageProviderItemProperty {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageProviderItemProperty: IStorageProviderItemProperty}
+RT_CLASS!{class StorageProviderItemProperty: IStorageProviderItemProperty ["Windows.Storage.Provider.StorageProviderItemProperty"]}
 impl RtActivatable<IActivationFactory> for StorageProviderItemProperty {}
 DEFINE_CLSID!(StorageProviderItemProperty(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,73,116,101,109,80,114,111,112,101,114,116,121,0]) [CLSID_StorageProviderItemProperty]);
 DEFINE_IID!(IID_IStorageProviderItemPropertyDefinition, 3316876219, 65311, 17048, 131, 30, 255, 28, 8, 8, 150, 144);
@@ -4183,7 +4183,7 @@ impl IStorageProviderItemPropertyDefinition {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageProviderItemPropertyDefinition: IStorageProviderItemPropertyDefinition}
+RT_CLASS!{class StorageProviderItemPropertyDefinition: IStorageProviderItemPropertyDefinition ["Windows.Storage.Provider.StorageProviderItemPropertyDefinition"]}
 impl RtActivatable<IActivationFactory> for StorageProviderItemPropertyDefinition {}
 DEFINE_CLSID!(StorageProviderItemPropertyDefinition(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,73,116,101,109,80,114,111,112,101,114,116,121,68,101,102,105,110,105,116,105,111,110,0]) [CLSID_StorageProviderItemPropertyDefinition]);
 DEFINE_IID!(IID_IStorageProviderItemPropertySource, 2406456382, 63026, 19099, 141, 153, 210, 215, 161, 29, 245, 106);
@@ -4197,7 +4197,7 @@ impl IStorageProviderItemPropertySource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StorageProviderPopulationPolicy: i32 {
+RT_ENUM! { enum StorageProviderPopulationPolicy: i32 ["Windows.Storage.Provider.StorageProviderPopulationPolicy"] {
     Full (StorageProviderPopulationPolicy_Full) = 1, AlwaysFull (StorageProviderPopulationPolicy_AlwaysFull) = 2,
 }}
 DEFINE_IID!(IID_IStorageProviderPropertyCapabilities, 1703751438, 25527, 17767, 172, 249, 81, 171, 227, 1, 221, 165);
@@ -4211,7 +4211,7 @@ impl IStorageProviderPropertyCapabilities {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StorageProviderProtectionMode: i32 {
+RT_ENUM! { enum StorageProviderProtectionMode: i32 ["Windows.Storage.Provider.StorageProviderProtectionMode"] {
     Unknown (StorageProviderProtectionMode_Unknown) = 0, Personal (StorageProviderProtectionMode_Personal) = 1,
 }}
 DEFINE_IID!(IID_IStorageProviderSyncRootInfo, 2081621444, 39417, 16812, 137, 4, 171, 5, 93, 101, 73, 38);
@@ -4390,7 +4390,7 @@ impl IStorageProviderSyncRootInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageProviderSyncRootInfo: IStorageProviderSyncRootInfo}
+RT_CLASS!{class StorageProviderSyncRootInfo: IStorageProviderSyncRootInfo ["Windows.Storage.Provider.StorageProviderSyncRootInfo"]}
 impl RtActivatable<IActivationFactory> for StorageProviderSyncRootInfo {}
 DEFINE_CLSID!(StorageProviderSyncRootInfo(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,80,114,111,118,105,100,101,114,46,83,116,111,114,97,103,101,80,114,111,118,105,100,101,114,83,121,110,99,82,111,111,116,73,110,102,111,0]) [CLSID_StorageProviderSyncRootInfo]);
 DEFINE_IID!(IID_IStorageProviderSyncRootInfo2, 3478237219, 31985, 20838, 189, 186, 239, 217, 95, 82, 158, 49);
@@ -4477,22 +4477,22 @@ impl IStorageProviderUriSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum StorageProviderUriSourceStatus: i32 {
+RT_ENUM! { enum StorageProviderUriSourceStatus: i32 ["Windows.Storage.Provider.StorageProviderUriSourceStatus"] {
     Success (StorageProviderUriSourceStatus_Success) = 0, NoSyncRoot (StorageProviderUriSourceStatus_NoSyncRoot) = 1, FileNotFound (StorageProviderUriSourceStatus_FileNotFound) = 2,
 }}
-RT_ENUM! { enum UIStatus: i32 {
+RT_ENUM! { enum UIStatus: i32 ["Windows.Storage.Provider.UIStatus"] {
     Unavailable (UIStatus_Unavailable) = 0, Hidden (UIStatus_Hidden) = 1, Visible (UIStatus_Visible) = 2, Complete (UIStatus_Complete) = 3,
 }}
-RT_ENUM! { enum WriteActivationMode: i32 {
+RT_ENUM! { enum WriteActivationMode: i32 ["Windows.Storage.Provider.WriteActivationMode"] {
     ReadOnly (WriteActivationMode_ReadOnly) = 0, NotNeeded (WriteActivationMode_NotNeeded) = 1, AfterWrite (WriteActivationMode_AfterWrite) = 2,
 }}
 } // Windows.Storage.Provider
 pub mod search { // Windows.Storage.Search
 use ::prelude::*;
-RT_ENUM! { enum CommonFileQuery: i32 {
+RT_ENUM! { enum CommonFileQuery: i32 ["Windows.Storage.Search.CommonFileQuery"] {
     DefaultQuery (CommonFileQuery_DefaultQuery) = 0, OrderByName (CommonFileQuery_OrderByName) = 1, OrderByTitle (CommonFileQuery_OrderByTitle) = 2, OrderByMusicProperties (CommonFileQuery_OrderByMusicProperties) = 3, OrderBySearchRank (CommonFileQuery_OrderBySearchRank) = 4, OrderByDate (CommonFileQuery_OrderByDate) = 5,
 }}
-RT_ENUM! { enum CommonFolderQuery: i32 {
+RT_ENUM! { enum CommonFolderQuery: i32 ["Windows.Storage.Search.CommonFolderQuery"] {
     DefaultQuery (CommonFolderQuery_DefaultQuery) = 0, GroupByYear (CommonFolderQuery_GroupByYear) = 100, GroupByMonth (CommonFolderQuery_GroupByMonth) = 101, GroupByArtist (CommonFolderQuery_GroupByArtist) = 102, GroupByAlbum (CommonFolderQuery_GroupByAlbum) = 103, GroupByAlbumArtist (CommonFolderQuery_GroupByAlbumArtist) = 104, GroupByComposer (CommonFolderQuery_GroupByComposer) = 105, GroupByGenre (CommonFolderQuery_GroupByGenre) = 106, GroupByPublishedYear (CommonFolderQuery_GroupByPublishedYear) = 107, GroupByRating (CommonFolderQuery_GroupByRating) = 108, GroupByTag (CommonFolderQuery_GroupByTag) = 109, GroupByAuthor (CommonFolderQuery_GroupByAuthor) = 110, GroupByType (CommonFolderQuery_GroupByType) = 111,
 }}
 DEFINE_IID!(IID_IContentIndexer, 2977333133, 63128, 18818, 176, 95, 58, 110, 140, 171, 1, 162);
@@ -4542,7 +4542,7 @@ impl IContentIndexer {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContentIndexer: IContentIndexer}
+RT_CLASS!{class ContentIndexer: IContentIndexer ["Windows.Storage.Search.ContentIndexer"]}
 impl RtActivatable<IContentIndexerStatics> for ContentIndexer {}
 impl ContentIndexer {
     #[inline] pub fn get_indexer_with_name(indexName: &HStringArg) -> Result<Option<ComPtr<ContentIndexer>>> {
@@ -4594,7 +4594,7 @@ impl IContentIndexerQuery {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContentIndexerQuery: IContentIndexerQuery}
+RT_CLASS!{class ContentIndexerQuery: IContentIndexerQuery ["Windows.Storage.Search.ContentIndexerQuery"]}
 DEFINE_IID!(IID_IContentIndexerQueryOperations, 679624208, 18310, 17137, 151, 48, 121, 43, 53, 102, 177, 80);
 RT_INTERFACE!{interface IContentIndexerQueryOperations(IContentIndexerQueryOperationsVtbl): IInspectable(IInspectableVtbl) [IID_IContentIndexerQueryOperations] {
     fn CreateQueryWithSortOrderAndLanguage(&self, searchFilter: HSTRING, propertiesToRetrieve: *mut foundation::collections::IIterable<HString>, sortOrder: *mut foundation::collections::IIterable<SortEntry>, searchFilterLanguage: HSTRING, out: *mut *mut ContentIndexerQuery) -> HRESULT,
@@ -4635,10 +4635,10 @@ impl IContentIndexerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DateStackOption: i32 {
+RT_ENUM! { enum DateStackOption: i32 ["Windows.Storage.Search.DateStackOption"] {
     None (DateStackOption_None) = 0, Year (DateStackOption_Year) = 1, Month (DateStackOption_Month) = 2,
 }}
-RT_ENUM! { enum FolderDepth: i32 {
+RT_ENUM! { enum FolderDepth: i32 ["Windows.Storage.Search.FolderDepth"] {
     Shallow (FolderDepth_Shallow) = 0, Deep (FolderDepth_Deep) = 1,
 }}
 DEFINE_IID!(IID_IIndexableContent, 3438387295, 54453, 18490, 176, 110, 224, 219, 30, 196, 32, 228);
@@ -4685,13 +4685,13 @@ impl IIndexableContent {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class IndexableContent: IIndexableContent}
+RT_CLASS!{class IndexableContent: IIndexableContent ["Windows.Storage.Search.IndexableContent"]}
 impl RtActivatable<IActivationFactory> for IndexableContent {}
 DEFINE_CLSID!(IndexableContent(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,73,110,100,101,120,97,98,108,101,67,111,110,116,101,110,116,0]) [CLSID_IndexableContent]);
-RT_ENUM! { enum IndexedState: i32 {
+RT_ENUM! { enum IndexedState: i32 ["Windows.Storage.Search.IndexedState"] {
     Unknown (IndexedState_Unknown) = 0, NotIndexed (IndexedState_NotIndexed) = 1, PartiallyIndexed (IndexedState_PartiallyIndexed) = 2, FullyIndexed (IndexedState_FullyIndexed) = 3,
 }}
-RT_ENUM! { enum IndexerOption: i32 {
+RT_ENUM! { enum IndexerOption: i32 ["Windows.Storage.Search.IndexerOption"] {
     UseIndexerWhenAvailable (IndexerOption_UseIndexerWhenAvailable) = 0, OnlyUseIndexer (IndexerOption_OnlyUseIndexer) = 1, DoNotUseIndexer (IndexerOption_DoNotUseIndexer) = 2, OnlyUseIndexerAndOptimizeForIndexedProperties (IndexerOption_OnlyUseIndexerAndOptimizeForIndexedProperties) = 3,
 }}
 DEFINE_IID!(IID_IQueryOptions, 509495022, 3909, 18488, 168, 233, 208, 71, 157, 68, 108, 48);
@@ -4799,7 +4799,7 @@ impl IQueryOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class QueryOptions: IQueryOptions}
+RT_CLASS!{class QueryOptions: IQueryOptions ["Windows.Storage.Search.QueryOptions"]}
 impl RtActivatable<IQueryOptionsFactory> for QueryOptions {}
 impl RtActivatable<IActivationFactory> for QueryOptions {}
 impl QueryOptions {
@@ -4839,10 +4839,10 @@ impl IQueryOptionsWithProviderFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct SortEntry {
+RT_STRUCT! { struct SortEntry ["Windows.Storage.Search.SortEntry"] {
     PropertyName: HSTRING, AscendingOrder: bool,
 }}
-RT_CLASS!{class SortEntryVector: foundation::collections::IVector<SortEntry>}
+RT_CLASS!{class SortEntryVector: foundation::collections::IVector<SortEntry> ["Windows.Storage.Search.SortEntryVector"]}
 DEFINE_IID!(IID_IStorageFileQueryResult, 1392354375, 11178, 16684, 178, 159, 212, 177, 119, 142, 250, 30);
 RT_INTERFACE!{interface IStorageFileQueryResult(IStorageFileQueryResultVtbl): IInspectable(IInspectableVtbl) [IID_IStorageFileQueryResult] {
     fn GetFilesAsync(&self, startIndex: u32, maxNumberOfItems: u32, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::StorageFile>>) -> HRESULT,
@@ -4860,7 +4860,7 @@ impl IStorageFileQueryResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageFileQueryResult: IStorageFileQueryResult}
+RT_CLASS!{class StorageFileQueryResult: IStorageFileQueryResult ["Windows.Storage.Search.StorageFileQueryResult"]}
 DEFINE_IID!(IID_IStorageFileQueryResult2, 1314765277, 28993, 18116, 139, 227, 233, 220, 158, 39, 39, 92);
 RT_INTERFACE!{interface IStorageFileQueryResult2(IStorageFileQueryResult2Vtbl): IInspectable(IInspectableVtbl) [IID_IStorageFileQueryResult2] {
     #[cfg(feature="windows-data")] fn GetMatchingPropertiesWithRanges(&self, file: *mut super::StorageFile, out: *mut *mut foundation::collections::IMap<HString, foundation::collections::IVectorView<super::super::data::text::TextSegment>>) -> HRESULT
@@ -4996,7 +4996,7 @@ impl IStorageFolderQueryResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageFolderQueryResult: IStorageFolderQueryResult}
+RT_CLASS!{class StorageFolderQueryResult: IStorageFolderQueryResult ["Windows.Storage.Search.StorageFolderQueryResult"]}
 DEFINE_IID!(IID_IStorageItemQueryResult, 3902046329, 40280, 18360, 178, 178, 65, 176, 127, 71, 149, 249);
 RT_INTERFACE!{interface IStorageItemQueryResult(IStorageItemQueryResultVtbl): IInspectable(IInspectableVtbl) [IID_IStorageItemQueryResult] {
     fn GetItemsAsync(&self, startIndex: u32, maxNumberOfItems: u32, out: *mut *mut foundation::IAsyncOperation<foundation::collections::IVectorView<super::IStorageItem>>) -> HRESULT,
@@ -5014,7 +5014,7 @@ impl IStorageItemQueryResult {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageItemQueryResult: IStorageItemQueryResult}
+RT_CLASS!{class StorageItemQueryResult: IStorageItemQueryResult ["Windows.Storage.Search.StorageItemQueryResult"]}
 DEFINE_IID!(IID_IStorageLibraryChangeTrackerTriggerDetails, 499622761, 47011, 19954, 157, 97, 235, 168, 90, 3, 67, 210);
 RT_INTERFACE!{interface IStorageLibraryChangeTrackerTriggerDetails(IStorageLibraryChangeTrackerTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryChangeTrackerTriggerDetails] {
     fn get_Folder(&self, out: *mut *mut super::StorageFolder) -> HRESULT,
@@ -5032,7 +5032,7 @@ impl IStorageLibraryChangeTrackerTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageLibraryChangeTrackerTriggerDetails: IStorageLibraryChangeTrackerTriggerDetails}
+RT_CLASS!{class StorageLibraryChangeTrackerTriggerDetails: IStorageLibraryChangeTrackerTriggerDetails ["Windows.Storage.Search.StorageLibraryChangeTrackerTriggerDetails"]}
 DEFINE_IID!(IID_IStorageLibraryContentChangedTriggerDetails, 708254071, 43967, 19997, 138, 165, 99, 133, 216, 136, 71, 153);
 RT_INTERFACE!{interface IStorageLibraryContentChangedTriggerDetails(IStorageLibraryContentChangedTriggerDetailsVtbl): IInspectable(IInspectableVtbl) [IID_IStorageLibraryContentChangedTriggerDetails] {
     fn get_Folder(&self, out: *mut *mut super::StorageFolder) -> HRESULT,
@@ -5050,7 +5050,7 @@ impl IStorageLibraryContentChangedTriggerDetails {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StorageLibraryContentChangedTriggerDetails: IStorageLibraryContentChangedTriggerDetails}
+RT_CLASS!{class StorageLibraryContentChangedTriggerDetails: IStorageLibraryContentChangedTriggerDetails ["Windows.Storage.Search.StorageLibraryContentChangedTriggerDetails"]}
 DEFINE_IID!(IID_IStorageQueryResultBase, 3264730893, 29523, 18347, 186, 88, 140, 97, 66, 93, 197, 75);
 RT_INTERFACE!{interface IStorageQueryResultBase(IStorageQueryResultBaseVtbl): IInspectable(IInspectableVtbl) [IID_IStorageQueryResultBase] {
     fn GetItemCountAsync(&self, out: *mut *mut foundation::IAsyncOperation<u32>) -> HRESULT,
@@ -5134,7 +5134,7 @@ impl IValueAndLanguage {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ValueAndLanguage: IValueAndLanguage}
+RT_CLASS!{class ValueAndLanguage: IValueAndLanguage ["Windows.Storage.Search.ValueAndLanguage"]}
 impl RtActivatable<IActivationFactory> for ValueAndLanguage {}
 DEFINE_CLSID!(ValueAndLanguage(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,101,97,114,99,104,46,86,97,108,117,101,65,110,100,76,97,110,103,117,97,103,101,0]) [CLSID_ValueAndLanguage]);
 } // Windows.Storage.Search
@@ -5162,7 +5162,7 @@ impl IBuffer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Buffer: IBuffer}
+RT_CLASS!{class Buffer: IBuffer ["Windows.Storage.Streams.Buffer"]}
 impl RtActivatable<IBufferFactory> for Buffer {}
 impl RtActivatable<IBufferStatics> for Buffer {}
 impl Buffer {
@@ -5205,7 +5205,7 @@ impl IBufferStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ByteOrder: i32 {
+RT_ENUM! { enum ByteOrder: i32 ["Windows.Storage.Streams.ByteOrder"] {
     LittleEndian (ByteOrder_LittleEndian) = 0, BigEndian (ByteOrder_BigEndian) = 1,
 }}
 DEFINE_IID!(IID_IContentTypeProvider, 2547030181, 15257, 19945, 136, 165, 225, 29, 47, 80, 199, 149);
@@ -5376,7 +5376,7 @@ impl IDataReader {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataReader: IDataReader}
+RT_CLASS!{class DataReader: IDataReader ["Windows.Storage.Streams.DataReader"]}
 impl RtActivatable<IDataReaderFactory> for DataReader {}
 impl RtActivatable<IDataReaderStatics> for DataReader {}
 impl DataReader {
@@ -5399,7 +5399,7 @@ impl IDataReaderFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataReaderLoadOperation: foundation::IAsyncOperation<u32>}
+RT_CLASS!{class DataReaderLoadOperation: foundation::IAsyncOperation<u32> ["Windows.Storage.Streams.DataReaderLoadOperation"]}
 DEFINE_IID!(IID_IDataReaderStatics, 301776840, 63802, 18203, 177, 33, 243, 121, 227, 73, 49, 60);
 RT_INTERFACE!{static interface IDataReaderStatics(IDataReaderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDataReaderStatics] {
     fn FromBuffer(&self, buffer: *mut IBuffer, out: *mut *mut DataReader) -> HRESULT
@@ -5560,7 +5560,7 @@ impl IDataWriter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataWriter: IDataWriter}
+RT_CLASS!{class DataWriter: IDataWriter ["Windows.Storage.Streams.DataWriter"]}
 impl RtActivatable<IDataWriterFactory> for DataWriter {}
 impl RtActivatable<IActivationFactory> for DataWriter {}
 impl DataWriter {
@@ -5580,13 +5580,13 @@ impl IDataWriterFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DataWriterStoreOperation: foundation::IAsyncOperation<u32>}
-RT_CLASS!{class FileInputStream: IInputStream}
-RT_ENUM! { enum FileOpenDisposition: i32 {
+RT_CLASS!{class DataWriterStoreOperation: foundation::IAsyncOperation<u32> ["Windows.Storage.Streams.DataWriterStoreOperation"]}
+RT_CLASS!{class FileInputStream: IInputStream ["Windows.Storage.Streams.FileInputStream"]}
+RT_ENUM! { enum FileOpenDisposition: i32 ["Windows.Storage.Streams.FileOpenDisposition"] {
     OpenExisting (FileOpenDisposition_OpenExisting) = 0, OpenAlways (FileOpenDisposition_OpenAlways) = 1, CreateNew (FileOpenDisposition_CreateNew) = 2, CreateAlways (FileOpenDisposition_CreateAlways) = 3, TruncateExisting (FileOpenDisposition_TruncateExisting) = 4,
 }}
-RT_CLASS!{class FileOutputStream: IOutputStream}
-RT_CLASS!{class FileRandomAccessStream: IRandomAccessStream}
+RT_CLASS!{class FileOutputStream: IOutputStream ["Windows.Storage.Streams.FileOutputStream"]}
+RT_CLASS!{class FileRandomAccessStream: IRandomAccessStream ["Windows.Storage.Streams.FileRandomAccessStream"]}
 impl RtActivatable<IFileRandomAccessStreamStatics> for FileRandomAccessStream {}
 impl FileRandomAccessStream {
     #[inline] pub fn open_async(filePath: &HStringArg, accessMode: super::FileAccessMode) -> Result<ComPtr<foundation::IAsyncOperation<IRandomAccessStream>>> {
@@ -5668,7 +5668,7 @@ impl IFileRandomAccessStreamStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InMemoryRandomAccessStream: IRandomAccessStream}
+RT_CLASS!{class InMemoryRandomAccessStream: IRandomAccessStream ["Windows.Storage.Streams.InMemoryRandomAccessStream"]}
 impl RtActivatable<IActivationFactory> for InMemoryRandomAccessStream {}
 DEFINE_CLSID!(InMemoryRandomAccessStream(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,73,110,77,101,109,111,114,121,82,97,110,100,111,109,65,99,99,101,115,115,83,116,114,101,97,109,0]) [CLSID_InMemoryRandomAccessStream]);
 DEFINE_IID!(IID_IInputStream, 2421821410, 48211, 4575, 140, 73, 0, 30, 79, 198, 134, 218);
@@ -5682,10 +5682,10 @@ impl IInputStream {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum InputStreamOptions: u32 {
+RT_ENUM! { enum InputStreamOptions: u32 ["Windows.Storage.Streams.InputStreamOptions"] {
     None (InputStreamOptions_None) = 0, Partial (InputStreamOptions_Partial) = 1, ReadAhead (InputStreamOptions_ReadAhead) = 2,
 }}
-RT_CLASS!{class InputStreamOverStream: IInputStream}
+RT_CLASS!{class InputStreamOverStream: IInputStream ["Windows.Storage.Streams.InputStreamOverStream"]}
 DEFINE_IID!(IID_IInputStreamReference, 1133681944, 24265, 19290, 145, 156, 66, 5, 176, 200, 4, 182);
 RT_INTERFACE!{interface IInputStreamReference(IInputStreamReferenceVtbl): IInspectable(IInspectableVtbl) [IID_IInputStreamReference] {
     fn OpenSequentialReadAsync(&self, out: *mut *mut foundation::IAsyncOperation<IInputStream>) -> HRESULT
@@ -5714,7 +5714,7 @@ impl IOutputStream {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OutputStreamOverStream: IOutputStream}
+RT_CLASS!{class OutputStreamOverStream: IOutputStream ["Windows.Storage.Streams.OutputStreamOverStream"]}
 DEFINE_IID!(IID_IRandomAccessStream, 2421821409, 48211, 4575, 140, 73, 0, 30, 79, 198, 134, 218);
 RT_INTERFACE!{interface IRandomAccessStream(IRandomAccessStreamVtbl): IInspectable(IInspectableVtbl) [IID_IRandomAccessStream] {
     fn get_Size(&self, out: *mut u64) -> HRESULT,
@@ -5786,7 +5786,7 @@ impl RandomAccessStream {
     }
 }
 DEFINE_CLSID!(RandomAccessStream(&[87,105,110,100,111,119,115,46,83,116,111,114,97,103,101,46,83,116,114,101,97,109,115,46,82,97,110,100,111,109,65,99,99,101,115,115,83,116,114,101,97,109,0]) [CLSID_RandomAccessStream]);
-RT_CLASS!{class RandomAccessStreamOverStream: IRandomAccessStream}
+RT_CLASS!{class RandomAccessStreamOverStream: IRandomAccessStream ["Windows.Storage.Streams.RandomAccessStreamOverStream"]}
 DEFINE_IID!(IID_IRandomAccessStreamReference, 871248180, 7638, 20026, 128, 103, 209, 193, 98, 232, 100, 43);
 RT_INTERFACE!{interface IRandomAccessStreamReference(IRandomAccessStreamReferenceVtbl): IInspectable(IInspectableVtbl) [IID_IRandomAccessStreamReference] {
     fn OpenReadAsync(&self, out: *mut *mut foundation::IAsyncOperation<IRandomAccessStreamWithContentType>) -> HRESULT
@@ -5798,7 +5798,7 @@ impl IRandomAccessStreamReference {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RandomAccessStreamReference: IRandomAccessStreamReference}
+RT_CLASS!{class RandomAccessStreamReference: IRandomAccessStreamReference ["Windows.Storage.Streams.RandomAccessStreamReference"]}
 impl RtActivatable<IRandomAccessStreamReferenceStatics> for RandomAccessStreamReference {}
 impl RandomAccessStreamReference {
     #[inline] pub fn create_from_file(file: &super::IStorageFile) -> Result<Option<ComPtr<RandomAccessStreamReference>>> {
@@ -5862,7 +5862,7 @@ DEFINE_IID!(IID_IRandomAccessStreamWithContentType, 3424995367, 19261, 17295, 14
 RT_INTERFACE!{interface IRandomAccessStreamWithContentType(IRandomAccessStreamWithContentTypeVtbl): IInspectable(IInspectableVtbl) [IID_IRandomAccessStreamWithContentType] {
     
 }}
-RT_ENUM! { enum UnicodeEncoding: i32 {
+RT_ENUM! { enum UnicodeEncoding: i32 ["Windows.Storage.Streams.UnicodeEncoding"] {
     Utf8 (UnicodeEncoding_Utf8) = 0, Utf16LE (UnicodeEncoding_Utf16LE) = 1, Utf16BE (UnicodeEncoding_Utf16BE) = 2,
 }}
 } // Windows.Storage.Streams

--- a/src/rt/gen/windows/system.rs
+++ b/src/rt/gen/windows/system.rs
@@ -16,7 +16,7 @@ impl IAppActivationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppActivationResult: IAppActivationResult}
+RT_CLASS!{class AppActivationResult: IAppActivationResult ["Windows.System.AppActivationResult"]}
 DEFINE_IID!(IID_IAppDiagnosticInfo, 3813189274, 34953, 19619, 190, 7, 213, 255, 255, 95, 8, 4);
 RT_INTERFACE!{interface IAppDiagnosticInfo(IAppDiagnosticInfoVtbl): IInspectable(IInspectableVtbl) [IID_IAppDiagnosticInfo] {
     #[cfg(feature="windows-applicationmodel")] fn get_AppInfo(&self, out: *mut *mut super::applicationmodel::AppInfo) -> HRESULT
@@ -28,7 +28,7 @@ impl IAppDiagnosticInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppDiagnosticInfo: IAppDiagnosticInfo}
+RT_CLASS!{class AppDiagnosticInfo: IAppDiagnosticInfo ["Windows.System.AppDiagnosticInfo"]}
 impl RtActivatable<IAppDiagnosticInfoStatics> for AppDiagnosticInfo {}
 impl RtActivatable<IAppDiagnosticInfoStatics2> for AppDiagnosticInfo {}
 impl AppDiagnosticInfo {
@@ -191,7 +191,7 @@ impl IAppDiagnosticInfoWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppDiagnosticInfoWatcher: IAppDiagnosticInfoWatcher}
+RT_CLASS!{class AppDiagnosticInfoWatcher: IAppDiagnosticInfoWatcher ["Windows.System.AppDiagnosticInfoWatcher"]}
 DEFINE_IID!(IID_IAppDiagnosticInfoWatcherEventArgs, 1880606486, 57818, 19557, 153, 223, 4, 109, 255, 91, 231, 26);
 RT_INTERFACE!{interface IAppDiagnosticInfoWatcherEventArgs(IAppDiagnosticInfoWatcherEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppDiagnosticInfoWatcherEventArgs] {
     fn get_AppDiagnosticInfo(&self, out: *mut *mut AppDiagnosticInfo) -> HRESULT
@@ -203,8 +203,8 @@ impl IAppDiagnosticInfoWatcherEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppDiagnosticInfoWatcherEventArgs: IAppDiagnosticInfoWatcherEventArgs}
-RT_ENUM! { enum AppDiagnosticInfoWatcherStatus: i32 {
+RT_CLASS!{class AppDiagnosticInfoWatcherEventArgs: IAppDiagnosticInfoWatcherEventArgs ["Windows.System.AppDiagnosticInfoWatcherEventArgs"]}
+RT_ENUM! { enum AppDiagnosticInfoWatcherStatus: i32 ["Windows.System.AppDiagnosticInfoWatcherStatus"] {
     Created (AppDiagnosticInfoWatcherStatus_Created) = 0, Started (AppDiagnosticInfoWatcherStatus_Started) = 1, EnumerationCompleted (AppDiagnosticInfoWatcherStatus_EnumerationCompleted) = 2, Stopping (AppDiagnosticInfoWatcherStatus_Stopping) = 3, Stopped (AppDiagnosticInfoWatcherStatus_Stopped) = 4, Aborted (AppDiagnosticInfoWatcherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IAppExecutionStateChangeResult, 1862507504, 63771, 19960, 174, 119, 48, 51, 204, 182, 145, 20);
@@ -218,7 +218,7 @@ impl IAppExecutionStateChangeResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppExecutionStateChangeResult: IAppExecutionStateChangeResult}
+RT_CLASS!{class AppExecutionStateChangeResult: IAppExecutionStateChangeResult ["Windows.System.AppExecutionStateChangeResult"]}
 DEFINE_IID!(IID_IAppMemoryReport, 1835348891, 19823, 17852, 156, 94, 228, 155, 63, 242, 117, 141);
 RT_INTERFACE!{interface IAppMemoryReport(IAppMemoryReportVtbl): IInspectable(IInspectableVtbl) [IID_IAppMemoryReport] {
     fn get_PrivateCommitUsage(&self, out: *mut u64) -> HRESULT,
@@ -248,7 +248,7 @@ impl IAppMemoryReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppMemoryReport: IAppMemoryReport}
+RT_CLASS!{class AppMemoryReport: IAppMemoryReport ["Windows.System.AppMemoryReport"]}
 DEFINE_IID!(IID_IAppMemoryReport2, 1602172728, 20919, 17116, 183, 237, 121, 186, 70, 210, 136, 87);
 RT_INTERFACE!{interface IAppMemoryReport2(IAppMemoryReport2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppMemoryReport2] {
     fn get_ExpectedTotalCommitLimit(&self, out: *mut u64) -> HRESULT
@@ -260,7 +260,7 @@ impl IAppMemoryReport2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppMemoryUsageLevel: i32 {
+RT_ENUM! { enum AppMemoryUsageLevel: i32 ["Windows.System.AppMemoryUsageLevel"] {
     Low (AppMemoryUsageLevel_Low) = 0, Medium (AppMemoryUsageLevel_Medium) = 1, High (AppMemoryUsageLevel_High) = 2, OverLimit (AppMemoryUsageLevel_OverLimit) = 3,
 }}
 DEFINE_IID!(IID_IAppMemoryUsageLimitChangingEventArgs, 2046322276, 65226, 19877, 158, 64, 43, 198, 62, 253, 201, 121);
@@ -280,7 +280,7 @@ impl IAppMemoryUsageLimitChangingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppMemoryUsageLimitChangingEventArgs: IAppMemoryUsageLimitChangingEventArgs}
+RT_CLASS!{class AppMemoryUsageLimitChangingEventArgs: IAppMemoryUsageLimitChangingEventArgs ["Windows.System.AppMemoryUsageLimitChangingEventArgs"]}
 DEFINE_IID!(IID_IAppResourceGroupBackgroundTaskReport, 627500878, 45149, 16578, 157, 193, 26, 79, 3, 158, 161, 32);
 RT_INTERFACE!{interface IAppResourceGroupBackgroundTaskReport(IAppResourceGroupBackgroundTaskReportVtbl): IInspectable(IInspectableVtbl) [IID_IAppResourceGroupBackgroundTaskReport] {
     fn get_TaskId(&self, out: *mut Guid) -> HRESULT,
@@ -310,11 +310,11 @@ impl IAppResourceGroupBackgroundTaskReport {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupBackgroundTaskReport: IAppResourceGroupBackgroundTaskReport}
-RT_ENUM! { enum AppResourceGroupEnergyQuotaState: i32 {
+RT_CLASS!{class AppResourceGroupBackgroundTaskReport: IAppResourceGroupBackgroundTaskReport ["Windows.System.AppResourceGroupBackgroundTaskReport"]}
+RT_ENUM! { enum AppResourceGroupEnergyQuotaState: i32 ["Windows.System.AppResourceGroupEnergyQuotaState"] {
     Unknown (AppResourceGroupEnergyQuotaState_Unknown) = 0, Over (AppResourceGroupEnergyQuotaState_Over) = 1, Under (AppResourceGroupEnergyQuotaState_Under) = 2,
 }}
-RT_ENUM! { enum AppResourceGroupExecutionState: i32 {
+RT_ENUM! { enum AppResourceGroupExecutionState: i32 ["Windows.System.AppResourceGroupExecutionState"] {
     Unknown (AppResourceGroupExecutionState_Unknown) = 0, Running (AppResourceGroupExecutionState_Running) = 1, Suspending (AppResourceGroupExecutionState_Suspending) = 2, Suspended (AppResourceGroupExecutionState_Suspended) = 3, NotRunning (AppResourceGroupExecutionState_NotRunning) = 4,
 }}
 DEFINE_IID!(IID_IAppResourceGroupInfo, 3105093498, 59399, 18932, 132, 94, 123, 139, 220, 254, 142, 231);
@@ -358,7 +358,7 @@ impl IAppResourceGroupInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupInfo: IAppResourceGroupInfo}
+RT_CLASS!{class AppResourceGroupInfo: IAppResourceGroupInfo ["Windows.System.AppResourceGroupInfo"]}
 DEFINE_IID!(IID_IAppResourceGroupInfo2, 4003144557, 54021, 19819, 146, 247, 106, 253, 173, 114, 222, 220);
 RT_INTERFACE!{interface IAppResourceGroupInfo2(IAppResourceGroupInfo2Vtbl): IInspectable(IInspectableVtbl) [IID_IAppResourceGroupInfo2] {
     fn StartSuspendAsync(&self, out: *mut *mut foundation::IAsyncOperation<AppExecutionStateChangeResult>) -> HRESULT,
@@ -458,7 +458,7 @@ impl IAppResourceGroupInfoWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupInfoWatcher: IAppResourceGroupInfoWatcher}
+RT_CLASS!{class AppResourceGroupInfoWatcher: IAppResourceGroupInfoWatcher ["Windows.System.AppResourceGroupInfoWatcher"]}
 DEFINE_IID!(IID_IAppResourceGroupInfoWatcherEventArgs, 2054714935, 25346, 19759, 191, 137, 28, 18, 208, 178, 166, 185);
 RT_INTERFACE!{interface IAppResourceGroupInfoWatcherEventArgs(IAppResourceGroupInfoWatcherEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppResourceGroupInfoWatcherEventArgs] {
     fn get_AppDiagnosticInfos(&self, out: *mut *mut foundation::collections::IVectorView<AppDiagnosticInfo>) -> HRESULT,
@@ -476,7 +476,7 @@ impl IAppResourceGroupInfoWatcherEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupInfoWatcherEventArgs: IAppResourceGroupInfoWatcherEventArgs}
+RT_CLASS!{class AppResourceGroupInfoWatcherEventArgs: IAppResourceGroupInfoWatcherEventArgs ["Windows.System.AppResourceGroupInfoWatcherEventArgs"]}
 DEFINE_IID!(IID_IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs, 467398103, 65254, 20436, 152, 221, 233, 42, 44, 194, 153, 243);
 RT_INTERFACE!{interface IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs(IAppResourceGroupInfoWatcherExecutionStateChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs] {
     fn get_AppDiagnosticInfos(&self, out: *mut *mut foundation::collections::IVectorView<AppDiagnosticInfo>) -> HRESULT,
@@ -494,8 +494,8 @@ impl IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupInfoWatcherExecutionStateChangedEventArgs: IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs}
-RT_ENUM! { enum AppResourceGroupInfoWatcherStatus: i32 {
+RT_CLASS!{class AppResourceGroupInfoWatcherExecutionStateChangedEventArgs: IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs ["Windows.System.AppResourceGroupInfoWatcherExecutionStateChangedEventArgs"]}
+RT_ENUM! { enum AppResourceGroupInfoWatcherStatus: i32 ["Windows.System.AppResourceGroupInfoWatcherStatus"] {
     Created (AppResourceGroupInfoWatcherStatus_Created) = 0, Started (AppResourceGroupInfoWatcherStatus_Started) = 1, EnumerationCompleted (AppResourceGroupInfoWatcherStatus_EnumerationCompleted) = 2, Stopping (AppResourceGroupInfoWatcherStatus_Stopping) = 3, Stopped (AppResourceGroupInfoWatcherStatus_Stopped) = 4, Aborted (AppResourceGroupInfoWatcherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IAppResourceGroupMemoryReport, 747374257, 32177, 19537, 162, 37, 127, 174, 45, 73, 228, 49);
@@ -527,7 +527,7 @@ impl IAppResourceGroupMemoryReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupMemoryReport: IAppResourceGroupMemoryReport}
+RT_CLASS!{class AppResourceGroupMemoryReport: IAppResourceGroupMemoryReport ["Windows.System.AppResourceGroupMemoryReport"]}
 DEFINE_IID!(IID_IAppResourceGroupStateReport, 1384423192, 12144, 16950, 171, 64, 208, 77, 176, 199, 185, 49);
 RT_INTERFACE!{interface IAppResourceGroupStateReport(IAppResourceGroupStateReportVtbl): IInspectable(IInspectableVtbl) [IID_IAppResourceGroupStateReport] {
     fn get_ExecutionState(&self, out: *mut AppResourceGroupExecutionState) -> HRESULT,
@@ -545,7 +545,7 @@ impl IAppResourceGroupStateReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppResourceGroupStateReport: IAppResourceGroupStateReport}
+RT_CLASS!{class AppResourceGroupStateReport: IAppResourceGroupStateReport ["Windows.System.AppResourceGroupStateReport"]}
 DEFINE_IID!(IID_IAppUriHandlerHost, 1565575877, 37586, 21513, 181, 111, 127, 115, 225, 14, 164, 195);
 RT_INTERFACE!{interface IAppUriHandlerHost(IAppUriHandlerHostVtbl): IInspectable(IInspectableVtbl) [IID_IAppUriHandlerHost] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -562,7 +562,7 @@ impl IAppUriHandlerHost {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppUriHandlerHost: IAppUriHandlerHost}
+RT_CLASS!{class AppUriHandlerHost: IAppUriHandlerHost ["Windows.System.AppUriHandlerHost"]}
 impl RtActivatable<IAppUriHandlerHostFactory> for AppUriHandlerHost {}
 impl RtActivatable<IActivationFactory> for AppUriHandlerHost {}
 impl AppUriHandlerHost {
@@ -611,7 +611,7 @@ impl IAppUriHandlerRegistration {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppUriHandlerRegistration: IAppUriHandlerRegistration}
+RT_CLASS!{class AppUriHandlerRegistration: IAppUriHandlerRegistration ["Windows.System.AppUriHandlerRegistration"]}
 DEFINE_IID!(IID_IAppUriHandlerRegistrationManager, 3861682770, 44180, 22352, 172, 27, 108, 251, 111, 37, 2, 99);
 RT_INTERFACE!{interface IAppUriHandlerRegistrationManager(IAppUriHandlerRegistrationManagerVtbl): IInspectable(IInspectableVtbl) [IID_IAppUriHandlerRegistrationManager] {
     fn get_User(&self, out: *mut *mut User) -> HRESULT,
@@ -629,7 +629,7 @@ impl IAppUriHandlerRegistrationManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AppUriHandlerRegistrationManager: IAppUriHandlerRegistrationManager}
+RT_CLASS!{class AppUriHandlerRegistrationManager: IAppUriHandlerRegistrationManager ["Windows.System.AppUriHandlerRegistrationManager"]}
 impl RtActivatable<IAppUriHandlerRegistrationManagerStatics> for AppUriHandlerRegistrationManager {}
 impl AppUriHandlerRegistrationManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<AppUriHandlerRegistrationManager>>> {
@@ -657,7 +657,7 @@ impl IAppUriHandlerRegistrationManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AutoUpdateTimeZoneStatus: i32 {
+RT_ENUM! { enum AutoUpdateTimeZoneStatus: i32 ["Windows.System.AutoUpdateTimeZoneStatus"] {
     Attempted (AutoUpdateTimeZoneStatus_Attempted) = 0, TimedOut (AutoUpdateTimeZoneStatus_TimedOut) = 1, Failed (AutoUpdateTimeZoneStatus_Failed) = 2,
 }}
 RT_CLASS!{static class DateTimeSettings}
@@ -678,7 +678,7 @@ impl IDateTimeSettingsStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DiagnosticAccessStatus: i32 {
+RT_ENUM! { enum DiagnosticAccessStatus: i32 ["Windows.System.DiagnosticAccessStatus"] {
     Unspecified (DiagnosticAccessStatus_Unspecified) = 0, Denied (DiagnosticAccessStatus_Denied) = 1, Limited (DiagnosticAccessStatus_Limited) = 2, Allowed (DiagnosticAccessStatus_Allowed) = 3,
 }}
 DEFINE_IID!(IID_IDispatcherQueue, 1614711012, 41784, 20478, 164, 87, 165, 207, 185, 206, 184, 153);
@@ -726,7 +726,7 @@ impl IDispatcherQueue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DispatcherQueue: IDispatcherQueue}
+RT_CLASS!{class DispatcherQueue: IDispatcherQueue ["Windows.System.DispatcherQueue"]}
 impl RtActivatable<IDispatcherQueueStatics> for DispatcherQueue {}
 impl DispatcherQueue {
     #[inline] pub fn get_for_current_thread() -> Result<Option<ComPtr<DispatcherQueue>>> {
@@ -751,7 +751,7 @@ impl IDispatcherQueueController {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DispatcherQueueController: IDispatcherQueueController}
+RT_CLASS!{class DispatcherQueueController: IDispatcherQueueController ["Windows.System.DispatcherQueueController"]}
 impl RtActivatable<IDispatcherQueueControllerStatics> for DispatcherQueueController {}
 impl DispatcherQueueController {
     #[inline] pub fn create_on_dedicated_thread() -> Result<Option<ComPtr<DispatcherQueueController>>> {
@@ -780,7 +780,7 @@ impl DispatcherQueueHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum DispatcherQueuePriority: i32 {
+RT_ENUM! { enum DispatcherQueuePriority: i32 ["Windows.System.DispatcherQueuePriority"] {
     Low (DispatcherQueuePriority_Low) = -10, Normal (DispatcherQueuePriority_Normal) = 0, High (DispatcherQueuePriority_High) = 10,
 }}
 DEFINE_IID!(IID_IDispatcherQueueShutdownStartingEventArgs, 3295824972, 65431, 16576, 162, 38, 204, 10, 170, 84, 94, 137);
@@ -794,7 +794,7 @@ impl IDispatcherQueueShutdownStartingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DispatcherQueueShutdownStartingEventArgs: IDispatcherQueueShutdownStartingEventArgs}
+RT_CLASS!{class DispatcherQueueShutdownStartingEventArgs: IDispatcherQueueShutdownStartingEventArgs ["Windows.System.DispatcherQueueShutdownStartingEventArgs"]}
 DEFINE_IID!(IID_IDispatcherQueueStatics, 2842526679, 37745, 17687, 146, 69, 208, 130, 74, 193, 44, 116);
 RT_INTERFACE!{static interface IDispatcherQueueStatics(IDispatcherQueueStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDispatcherQueueStatics] {
     fn GetForCurrentThread(&self, out: *mut *mut DispatcherQueue) -> HRESULT
@@ -860,7 +860,7 @@ impl IDispatcherQueueTimer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DispatcherQueueTimer: IDispatcherQueueTimer}
+RT_CLASS!{class DispatcherQueueTimer: IDispatcherQueueTimer ["Windows.System.DispatcherQueueTimer"]}
 DEFINE_IID!(IID_IFolderLauncherOptions, 3146891901, 27527, 17194, 189, 4, 119, 108, 111, 95, 178, 171);
 RT_INTERFACE!{interface IFolderLauncherOptions(IFolderLauncherOptionsVtbl): IInspectable(IInspectableVtbl) [IID_IFolderLauncherOptions] {
     #[cfg(feature="windows-storage")] fn get_ItemsToSelect(&self, out: *mut *mut foundation::collections::IVector<super::storage::IStorageItem>) -> HRESULT
@@ -872,7 +872,7 @@ impl IFolderLauncherOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class FolderLauncherOptions: IFolderLauncherOptions}
+RT_CLASS!{class FolderLauncherOptions: IFolderLauncherOptions ["Windows.System.FolderLauncherOptions"]}
 impl RtActivatable<IActivationFactory> for FolderLauncherOptions {}
 DEFINE_CLSID!(FolderLauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,70,111,108,100,101,114,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_FolderLauncherOptions]);
 RT_CLASS!{static class KnownUserProperties}
@@ -1136,7 +1136,7 @@ impl ILauncherOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LauncherOptions: ILauncherOptions}
+RT_CLASS!{class LauncherOptions: ILauncherOptions ["Windows.System.LauncherOptions"]}
 impl RtActivatable<IActivationFactory> for LauncherOptions {}
 DEFINE_CLSID!(LauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_LauncherOptions]);
 DEFINE_IID!(IID_ILauncherOptions2, 1000378036, 28224, 19918, 161, 163, 47, 83, 149, 10, 251, 73);
@@ -1434,7 +1434,7 @@ impl ILauncherUIOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LauncherUIOptions: ILauncherUIOptions}
+RT_CLASS!{class LauncherUIOptions: ILauncherUIOptions ["Windows.System.LauncherUIOptions"]}
 DEFINE_IID!(IID_ILauncherViewOptions, 2325424625, 31911, 18910, 155, 211, 60, 91, 113, 132, 246, 22);
 RT_INTERFACE!{interface ILauncherViewOptions(ILauncherViewOptionsVtbl): IInspectable(IInspectableVtbl) [IID_ILauncherViewOptions] {
     #[cfg(feature="windows-ui")] fn get_DesiredRemainingView(&self, out: *mut super::ui::viewmanagement::ViewSizePreference) -> HRESULT,
@@ -1451,13 +1451,13 @@ impl ILauncherViewOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum LaunchFileStatus: i32 {
+RT_ENUM! { enum LaunchFileStatus: i32 ["Windows.System.LaunchFileStatus"] {
     Success (LaunchFileStatus_Success) = 0, AppUnavailable (LaunchFileStatus_AppUnavailable) = 1, DeniedByPolicy (LaunchFileStatus_DeniedByPolicy) = 2, FileTypeNotSupported (LaunchFileStatus_FileTypeNotSupported) = 3, Unknown (LaunchFileStatus_Unknown) = 4,
 }}
-RT_ENUM! { enum LaunchQuerySupportStatus: i32 {
+RT_ENUM! { enum LaunchQuerySupportStatus: i32 ["Windows.System.LaunchQuerySupportStatus"] {
     Available (LaunchQuerySupportStatus_Available) = 0, AppNotInstalled (LaunchQuerySupportStatus_AppNotInstalled) = 1, AppUnavailable (LaunchQuerySupportStatus_AppUnavailable) = 2, NotSupported (LaunchQuerySupportStatus_NotSupported) = 3, Unknown (LaunchQuerySupportStatus_Unknown) = 4,
 }}
-RT_ENUM! { enum LaunchQuerySupportType: i32 {
+RT_ENUM! { enum LaunchQuerySupportType: i32 ["Windows.System.LaunchQuerySupportType"] {
     Uri (LaunchQuerySupportType_Uri) = 0, UriForResults (LaunchQuerySupportType_UriForResults) = 1,
 }}
 DEFINE_IID!(IID_ILaunchUriResult, 3962022111, 63189, 17866, 145, 58, 112, 164, 12, 92, 130, 33);
@@ -1477,8 +1477,8 @@ impl ILaunchUriResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LaunchUriResult: ILaunchUriResult}
-RT_ENUM! { enum LaunchUriStatus: i32 {
+RT_CLASS!{class LaunchUriResult: ILaunchUriResult ["Windows.System.LaunchUriResult"]}
+RT_ENUM! { enum LaunchUriStatus: i32 ["Windows.System.LaunchUriStatus"] {
     Success (LaunchUriStatus_Success) = 0, AppUnavailable (LaunchUriStatus_AppUnavailable) = 1, ProtocolUnavailable (LaunchUriStatus_ProtocolUnavailable) = 2, Unknown (LaunchUriStatus_Unknown) = 3,
 }}
 RT_CLASS!{static class MemoryManager}
@@ -1623,7 +1623,7 @@ impl IMemoryManagerStatics4 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PowerState: i32 {
+RT_ENUM! { enum PowerState: i32 ["Windows.System.PowerState"] {
     ConnectedStandby (PowerState_ConnectedStandby) = 0, SleepS3 (PowerState_SleepS3) = 1,
 }}
 RT_CLASS!{static class ProcessLauncher}
@@ -1692,7 +1692,7 @@ impl IProcessLauncherOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessLauncherOptions: IProcessLauncherOptions}
+RT_CLASS!{class ProcessLauncherOptions: IProcessLauncherOptions ["Windows.System.ProcessLauncherOptions"]}
 impl RtActivatable<IActivationFactory> for ProcessLauncherOptions {}
 DEFINE_CLSID!(ProcessLauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,80,114,111,99,101,115,115,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_ProcessLauncherOptions]);
 DEFINE_IID!(IID_IProcessLauncherResult, 1414302004, 34520, 18833, 142, 117, 236, 232, 164, 59, 107, 109);
@@ -1706,7 +1706,7 @@ impl IProcessLauncherResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessLauncherResult: IProcessLauncherResult}
+RT_CLASS!{class ProcessLauncherResult: IProcessLauncherResult ["Windows.System.ProcessLauncherResult"]}
 DEFINE_IID!(IID_IProcessLauncherStatics, 866871015, 11534, 17547, 166, 160, 193, 60, 56, 54, 208, 156);
 RT_INTERFACE!{static interface IProcessLauncherStatics(IProcessLauncherStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IProcessLauncherStatics] {
     fn RunToCompletionAsync(&self, fileName: HSTRING, args: HSTRING, out: *mut *mut foundation::IAsyncOperation<ProcessLauncherResult>) -> HRESULT,
@@ -1741,8 +1741,8 @@ impl IProcessMemoryReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessMemoryReport: IProcessMemoryReport}
-RT_ENUM! { enum ProcessorArchitecture: i32 {
+RT_CLASS!{class ProcessMemoryReport: IProcessMemoryReport ["Windows.System.ProcessMemoryReport"]}
+RT_ENUM! { enum ProcessorArchitecture: i32 ["Windows.System.ProcessorArchitecture"] {
     X86 (ProcessorArchitecture_X86) = 0, Arm (ProcessorArchitecture_Arm) = 5, X64 (ProcessorArchitecture_X64) = 9, Neutral (ProcessorArchitecture_Neutral) = 11, Unknown (ProcessorArchitecture_Unknown) = 65535,
 }}
 DEFINE_IID!(IID_IProtocolForResultsOperation, 3582011706, 28137, 19752, 147, 120, 248, 103, 130, 225, 130, 187);
@@ -1755,7 +1755,7 @@ impl IProtocolForResultsOperation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProtocolForResultsOperation: IProtocolForResultsOperation}
+RT_CLASS!{class ProtocolForResultsOperation: IProtocolForResultsOperation ["Windows.System.ProtocolForResultsOperation"]}
 RT_CLASS!{static class RemoteLauncher}
 impl RtActivatable<IRemoteLauncherStatics> for RemoteLauncher {}
 impl RemoteLauncher {
@@ -1792,7 +1792,7 @@ impl IRemoteLauncherOptions {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteLauncherOptions: IRemoteLauncherOptions}
+RT_CLASS!{class RemoteLauncherOptions: IRemoteLauncherOptions ["Windows.System.RemoteLauncherOptions"]}
 impl RtActivatable<IActivationFactory> for RemoteLauncherOptions {}
 DEFINE_CLSID!(RemoteLauncherOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,76,97,117,110,99,104,101,114,79,112,116,105,111,110,115,0]) [CLSID_RemoteLauncherOptions]);
 DEFINE_IID!(IID_IRemoteLauncherStatics, 3621485203, 41740, 18615, 159, 33, 5, 16, 38, 164, 229, 23);
@@ -1818,10 +1818,10 @@ impl IRemoteLauncherStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteLaunchUriStatus: i32 {
+RT_ENUM! { enum RemoteLaunchUriStatus: i32 ["Windows.System.RemoteLaunchUriStatus"] {
     Unknown (RemoteLaunchUriStatus_Unknown) = 0, Success (RemoteLaunchUriStatus_Success) = 1, AppUnavailable (RemoteLaunchUriStatus_AppUnavailable) = 2, ProtocolUnavailable (RemoteLaunchUriStatus_ProtocolUnavailable) = 3, RemoteSystemUnavailable (RemoteLaunchUriStatus_RemoteSystemUnavailable) = 4, ValueSetTooLarge (RemoteLaunchUriStatus_ValueSetTooLarge) = 5, DeniedByLocalSystem (RemoteLaunchUriStatus_DeniedByLocalSystem) = 6, DeniedByRemoteSystem (RemoteLaunchUriStatus_DeniedByRemoteSystem) = 7,
 }}
-RT_ENUM! { enum ShutdownKind: i32 {
+RT_ENUM! { enum ShutdownKind: i32 ["Windows.System.ShutdownKind"] {
     Shutdown (ShutdownKind_Shutdown) = 0, Restart (ShutdownKind_Restart) = 1,
 }}
 RT_CLASS!{static class ShutdownManager}
@@ -1982,7 +1982,7 @@ impl IUser {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class User: IUser}
+RT_CLASS!{class User: IUser ["Windows.System.User"]}
 impl RtActivatable<IUserStatics> for User {}
 impl User {
     #[inline] pub fn create_watcher() -> Result<Option<ComPtr<UserWatcher>>> {
@@ -2002,7 +2002,7 @@ impl User {
     }
 }
 DEFINE_CLSID!(User(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,115,101,114,0]) [CLSID_User]);
-RT_ENUM! { enum UserAuthenticationStatus: i32 {
+RT_ENUM! { enum UserAuthenticationStatus: i32 ["Windows.System.UserAuthenticationStatus"] {
     Unauthenticated (UserAuthenticationStatus_Unauthenticated) = 0, LocallyAuthenticated (UserAuthenticationStatus_LocallyAuthenticated) = 1, RemotelyAuthenticated (UserAuthenticationStatus_RemotelyAuthenticated) = 2,
 }}
 DEFINE_IID!(IID_IUserAuthenticationStatusChangeDeferral, 2293601640, 47920, 17147, 162, 112, 233, 144, 46, 64, 239, 167);
@@ -2015,7 +2015,7 @@ impl IUserAuthenticationStatusChangeDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserAuthenticationStatusChangeDeferral: IUserAuthenticationStatusChangeDeferral}
+RT_CLASS!{class UserAuthenticationStatusChangeDeferral: IUserAuthenticationStatusChangeDeferral ["Windows.System.UserAuthenticationStatusChangeDeferral"]}
 DEFINE_IID!(IID_IUserAuthenticationStatusChangingEventArgs, 2349010728, 42769, 19486, 171, 72, 4, 23, 156, 21, 147, 143);
 RT_INTERFACE!{interface IUserAuthenticationStatusChangingEventArgs(IUserAuthenticationStatusChangingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserAuthenticationStatusChangingEventArgs] {
     fn GetDeferral(&self, out: *mut *mut UserAuthenticationStatusChangeDeferral) -> HRESULT,
@@ -2045,7 +2045,7 @@ impl IUserAuthenticationStatusChangingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserAuthenticationStatusChangingEventArgs: IUserAuthenticationStatusChangingEventArgs}
+RT_CLASS!{class UserAuthenticationStatusChangingEventArgs: IUserAuthenticationStatusChangingEventArgs ["Windows.System.UserAuthenticationStatusChangingEventArgs"]}
 DEFINE_IID!(IID_IUserChangedEventArgs, 140794332, 6342, 18651, 188, 153, 114, 79, 185, 32, 60, 204);
 RT_INTERFACE!{interface IUserChangedEventArgs(IUserChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserChangedEventArgs] {
     fn get_User(&self, out: *mut *mut User) -> HRESULT
@@ -2057,7 +2057,7 @@ impl IUserChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserChangedEventArgs: IUserChangedEventArgs}
+RT_CLASS!{class UserChangedEventArgs: IUserChangedEventArgs ["Windows.System.UserChangedEventArgs"]}
 RT_CLASS!{static class UserDeviceAssociation}
 impl RtActivatable<IUserDeviceAssociationStatics> for UserDeviceAssociation {}
 impl UserDeviceAssociation {
@@ -2095,7 +2095,7 @@ impl IUserDeviceAssociationChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserDeviceAssociationChangedEventArgs: IUserDeviceAssociationChangedEventArgs}
+RT_CLASS!{class UserDeviceAssociationChangedEventArgs: IUserDeviceAssociationChangedEventArgs ["Windows.System.UserDeviceAssociationChangedEventArgs"]}
 DEFINE_IID!(IID_IUserDeviceAssociationStatics, 2118721044, 63578, 19463, 141, 169, 127, 227, 208, 84, 35, 67);
 RT_INTERFACE!{static interface IUserDeviceAssociationStatics(IUserDeviceAssociationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IUserDeviceAssociationStatics] {
     fn FindUserFromDeviceId(&self, deviceId: HSTRING, out: *mut *mut User) -> HRESULT,
@@ -2151,7 +2151,7 @@ impl IUserPicker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserPicker: IUserPicker}
+RT_CLASS!{class UserPicker: IUserPicker ["Windows.System.UserPicker"]}
 impl RtActivatable<IUserPickerStatics> for UserPicker {}
 impl RtActivatable<IActivationFactory> for UserPicker {}
 impl UserPicker {
@@ -2171,7 +2171,7 @@ impl IUserPickerStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserPictureSize: i32 {
+RT_ENUM! { enum UserPictureSize: i32 ["Windows.System.UserPictureSize"] {
     Size64x64 (UserPictureSize_Size64x64) = 0, Size208x208 (UserPictureSize_Size208x208) = 1, Size424x424 (UserPictureSize_Size424x424) = 2, Size1080x1080 (UserPictureSize_Size1080x1080) = 3,
 }}
 DEFINE_IID!(IID_IUserStatics, 358527547, 9258, 17888, 162, 233, 49, 113, 252, 106, 127, 221);
@@ -2209,7 +2209,7 @@ impl IUserStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserType: i32 {
+RT_ENUM! { enum UserType: i32 ["Windows.System.UserType"] {
     LocalUser (UserType_LocalUser) = 0, RemoteUser (UserType_RemoteUser) = 1, LocalGuest (UserType_LocalGuest) = 2, RemoteGuest (UserType_RemoteGuest) = 3,
 }}
 DEFINE_IID!(IID_IUserWatcher, 358527547, 9258, 17888, 162, 233, 49, 113, 252, 106, 127, 187);
@@ -2310,14 +2310,14 @@ impl IUserWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserWatcher: IUserWatcher}
-RT_ENUM! { enum UserWatcherStatus: i32 {
+RT_CLASS!{class UserWatcher: IUserWatcher ["Windows.System.UserWatcher"]}
+RT_ENUM! { enum UserWatcherStatus: i32 ["Windows.System.UserWatcherStatus"] {
     Created (UserWatcherStatus_Created) = 0, Started (UserWatcherStatus_Started) = 1, EnumerationCompleted (UserWatcherStatus_EnumerationCompleted) = 2, Stopping (UserWatcherStatus_Stopping) = 3, Stopped (UserWatcherStatus_Stopped) = 4, Aborted (UserWatcherStatus_Aborted) = 5,
 }}
-RT_ENUM! { enum VirtualKey: i32 {
+RT_ENUM! { enum VirtualKey: i32 ["Windows.System.VirtualKey"] {
     None (VirtualKey_None) = 0, LeftButton (VirtualKey_LeftButton) = 1, RightButton (VirtualKey_RightButton) = 2, Cancel (VirtualKey_Cancel) = 3, MiddleButton (VirtualKey_MiddleButton) = 4, XButton1 (VirtualKey_XButton1) = 5, XButton2 (VirtualKey_XButton2) = 6, Back (VirtualKey_Back) = 8, Tab (VirtualKey_Tab) = 9, Clear (VirtualKey_Clear) = 12, Enter (VirtualKey_Enter) = 13, Shift (VirtualKey_Shift) = 16, Control (VirtualKey_Control) = 17, Menu (VirtualKey_Menu) = 18, Pause (VirtualKey_Pause) = 19, CapitalLock (VirtualKey_CapitalLock) = 20, Kana (VirtualKey_Kana) = 21, Hangul (VirtualKey_Hangul) = 21, Junja (VirtualKey_Junja) = 23, Final (VirtualKey_Final) = 24, Hanja (VirtualKey_Hanja) = 25, Kanji (VirtualKey_Kanji) = 25, Escape (VirtualKey_Escape) = 27, Convert (VirtualKey_Convert) = 28, NonConvert (VirtualKey_NonConvert) = 29, Accept (VirtualKey_Accept) = 30, ModeChange (VirtualKey_ModeChange) = 31, Space (VirtualKey_Space) = 32, PageUp (VirtualKey_PageUp) = 33, PageDown (VirtualKey_PageDown) = 34, End (VirtualKey_End) = 35, Home (VirtualKey_Home) = 36, Left (VirtualKey_Left) = 37, Up (VirtualKey_Up) = 38, Right (VirtualKey_Right) = 39, Down (VirtualKey_Down) = 40, Select (VirtualKey_Select) = 41, Print (VirtualKey_Print) = 42, Execute (VirtualKey_Execute) = 43, Snapshot (VirtualKey_Snapshot) = 44, Insert (VirtualKey_Insert) = 45, Delete (VirtualKey_Delete) = 46, Help (VirtualKey_Help) = 47, Number0 (VirtualKey_Number0) = 48, Number1 (VirtualKey_Number1) = 49, Number2 (VirtualKey_Number2) = 50, Number3 (VirtualKey_Number3) = 51, Number4 (VirtualKey_Number4) = 52, Number5 (VirtualKey_Number5) = 53, Number6 (VirtualKey_Number6) = 54, Number7 (VirtualKey_Number7) = 55, Number8 (VirtualKey_Number8) = 56, Number9 (VirtualKey_Number9) = 57, A (VirtualKey_A) = 65, B (VirtualKey_B) = 66, C (VirtualKey_C) = 67, D (VirtualKey_D) = 68, E (VirtualKey_E) = 69, F (VirtualKey_F) = 70, G (VirtualKey_G) = 71, H (VirtualKey_H) = 72, I (VirtualKey_I) = 73, J (VirtualKey_J) = 74, K (VirtualKey_K) = 75, L (VirtualKey_L) = 76, M (VirtualKey_M) = 77, N (VirtualKey_N) = 78, O (VirtualKey_O) = 79, P (VirtualKey_P) = 80, Q (VirtualKey_Q) = 81, R (VirtualKey_R) = 82, S (VirtualKey_S) = 83, T (VirtualKey_T) = 84, U (VirtualKey_U) = 85, V (VirtualKey_V) = 86, W (VirtualKey_W) = 87, X (VirtualKey_X) = 88, Y (VirtualKey_Y) = 89, Z (VirtualKey_Z) = 90, LeftWindows (VirtualKey_LeftWindows) = 91, RightWindows (VirtualKey_RightWindows) = 92, Application (VirtualKey_Application) = 93, Sleep (VirtualKey_Sleep) = 95, NumberPad0 (VirtualKey_NumberPad0) = 96, NumberPad1 (VirtualKey_NumberPad1) = 97, NumberPad2 (VirtualKey_NumberPad2) = 98, NumberPad3 (VirtualKey_NumberPad3) = 99, NumberPad4 (VirtualKey_NumberPad4) = 100, NumberPad5 (VirtualKey_NumberPad5) = 101, NumberPad6 (VirtualKey_NumberPad6) = 102, NumberPad7 (VirtualKey_NumberPad7) = 103, NumberPad8 (VirtualKey_NumberPad8) = 104, NumberPad9 (VirtualKey_NumberPad9) = 105, Multiply (VirtualKey_Multiply) = 106, Add (VirtualKey_Add) = 107, Separator (VirtualKey_Separator) = 108, Subtract (VirtualKey_Subtract) = 109, Decimal (VirtualKey_Decimal) = 110, Divide (VirtualKey_Divide) = 111, F1 (VirtualKey_F1) = 112, F2 (VirtualKey_F2) = 113, F3 (VirtualKey_F3) = 114, F4 (VirtualKey_F4) = 115, F5 (VirtualKey_F5) = 116, F6 (VirtualKey_F6) = 117, F7 (VirtualKey_F7) = 118, F8 (VirtualKey_F8) = 119, F9 (VirtualKey_F9) = 120, F10 (VirtualKey_F10) = 121, F11 (VirtualKey_F11) = 122, F12 (VirtualKey_F12) = 123, F13 (VirtualKey_F13) = 124, F14 (VirtualKey_F14) = 125, F15 (VirtualKey_F15) = 126, F16 (VirtualKey_F16) = 127, F17 (VirtualKey_F17) = 128, F18 (VirtualKey_F18) = 129, F19 (VirtualKey_F19) = 130, F20 (VirtualKey_F20) = 131, F21 (VirtualKey_F21) = 132, F22 (VirtualKey_F22) = 133, F23 (VirtualKey_F23) = 134, F24 (VirtualKey_F24) = 135, NavigationView (VirtualKey_NavigationView) = 136, NavigationMenu (VirtualKey_NavigationMenu) = 137, NavigationUp (VirtualKey_NavigationUp) = 138, NavigationDown (VirtualKey_NavigationDown) = 139, NavigationLeft (VirtualKey_NavigationLeft) = 140, NavigationRight (VirtualKey_NavigationRight) = 141, NavigationAccept (VirtualKey_NavigationAccept) = 142, NavigationCancel (VirtualKey_NavigationCancel) = 143, NumberKeyLock (VirtualKey_NumberKeyLock) = 144, Scroll (VirtualKey_Scroll) = 145, LeftShift (VirtualKey_LeftShift) = 160, RightShift (VirtualKey_RightShift) = 161, LeftControl (VirtualKey_LeftControl) = 162, RightControl (VirtualKey_RightControl) = 163, LeftMenu (VirtualKey_LeftMenu) = 164, RightMenu (VirtualKey_RightMenu) = 165, GoBack (VirtualKey_GoBack) = 166, GoForward (VirtualKey_GoForward) = 167, Refresh (VirtualKey_Refresh) = 168, Stop (VirtualKey_Stop) = 169, Search (VirtualKey_Search) = 170, Favorites (VirtualKey_Favorites) = 171, GoHome (VirtualKey_GoHome) = 172, GamepadA (VirtualKey_GamepadA) = 195, GamepadB (VirtualKey_GamepadB) = 196, GamepadX (VirtualKey_GamepadX) = 197, GamepadY (VirtualKey_GamepadY) = 198, GamepadRightShoulder (VirtualKey_GamepadRightShoulder) = 199, GamepadLeftShoulder (VirtualKey_GamepadLeftShoulder) = 200, GamepadLeftTrigger (VirtualKey_GamepadLeftTrigger) = 201, GamepadRightTrigger (VirtualKey_GamepadRightTrigger) = 202, GamepadDPadUp (VirtualKey_GamepadDPadUp) = 203, GamepadDPadDown (VirtualKey_GamepadDPadDown) = 204, GamepadDPadLeft (VirtualKey_GamepadDPadLeft) = 205, GamepadDPadRight (VirtualKey_GamepadDPadRight) = 206, GamepadMenu (VirtualKey_GamepadMenu) = 207, GamepadView (VirtualKey_GamepadView) = 208, GamepadLeftThumbstickButton (VirtualKey_GamepadLeftThumbstickButton) = 209, GamepadRightThumbstickButton (VirtualKey_GamepadRightThumbstickButton) = 210, GamepadLeftThumbstickUp (VirtualKey_GamepadLeftThumbstickUp) = 211, GamepadLeftThumbstickDown (VirtualKey_GamepadLeftThumbstickDown) = 212, GamepadLeftThumbstickRight (VirtualKey_GamepadLeftThumbstickRight) = 213, GamepadLeftThumbstickLeft (VirtualKey_GamepadLeftThumbstickLeft) = 214, GamepadRightThumbstickUp (VirtualKey_GamepadRightThumbstickUp) = 215, GamepadRightThumbstickDown (VirtualKey_GamepadRightThumbstickDown) = 216, GamepadRightThumbstickRight (VirtualKey_GamepadRightThumbstickRight) = 217, GamepadRightThumbstickLeft (VirtualKey_GamepadRightThumbstickLeft) = 218,
 }}
-RT_ENUM! { enum VirtualKeyModifiers: u32 {
+RT_ENUM! { enum VirtualKeyModifiers: u32 ["Windows.System.VirtualKeyModifiers"] {
     None (VirtualKeyModifiers_None) = 0, Control (VirtualKeyModifiers_Control) = 1, Menu (VirtualKeyModifiers_Menu) = 2, Shift (VirtualKeyModifiers_Shift) = 4, Windows (VirtualKeyModifiers_Windows) = 8,
 }}
 pub mod diagnostics { // Windows.System.Diagnostics
@@ -2339,8 +2339,8 @@ impl IDiagnosticActionResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DiagnosticActionResult: IDiagnosticActionResult}
-RT_ENUM! { enum DiagnosticActionState: i32 {
+RT_CLASS!{class DiagnosticActionResult: IDiagnosticActionResult ["Windows.System.Diagnostics.DiagnosticActionResult"]}
+RT_ENUM! { enum DiagnosticActionState: i32 ["Windows.System.Diagnostics.DiagnosticActionState"] {
     Initializing (DiagnosticActionState_Initializing) = 0, Downloading (DiagnosticActionState_Downloading) = 1, VerifyingTrust (DiagnosticActionState_VerifyingTrust) = 2, Detecting (DiagnosticActionState_Detecting) = 3, Resolving (DiagnosticActionState_Resolving) = 4, VerifyingResolution (DiagnosticActionState_VerifyingResolution) = 5,
 }}
 DEFINE_IID!(IID_IDiagnosticInvoker, 410724106, 739, 20358, 132, 252, 253, 216, 146, 181, 148, 15);
@@ -2354,7 +2354,7 @@ impl IDiagnosticInvoker {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DiagnosticInvoker: IDiagnosticInvoker}
+RT_CLASS!{class DiagnosticInvoker: IDiagnosticInvoker ["Windows.System.Diagnostics.DiagnosticInvoker"]}
 impl RtActivatable<IDiagnosticInvokerStatics> for DiagnosticInvoker {}
 impl DiagnosticInvoker {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<DiagnosticInvoker>>> {
@@ -2413,7 +2413,7 @@ impl IProcessCpuUsage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessCpuUsage: IProcessCpuUsage}
+RT_CLASS!{class ProcessCpuUsage: IProcessCpuUsage ["Windows.System.Diagnostics.ProcessCpuUsage"]}
 DEFINE_IID!(IID_IProcessCpuUsageReport, 2322439340, 14727, 20015, 161, 25, 107, 95, 162, 20, 241, 180);
 RT_INTERFACE!{interface IProcessCpuUsageReport(IProcessCpuUsageReportVtbl): IInspectable(IInspectableVtbl) [IID_IProcessCpuUsageReport] {
     fn get_KernelTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -2431,7 +2431,7 @@ impl IProcessCpuUsageReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessCpuUsageReport: IProcessCpuUsageReport}
+RT_CLASS!{class ProcessCpuUsageReport: IProcessCpuUsageReport ["Windows.System.Diagnostics.ProcessCpuUsageReport"]}
 DEFINE_IID!(IID_IProcessDiagnosticInfo, 3895504971, 12302, 20198, 160, 171, 91, 95, 82, 49, 180, 52);
 RT_INTERFACE!{interface IProcessDiagnosticInfo(IProcessDiagnosticInfoVtbl): IInspectable(IInspectableVtbl) [IID_IProcessDiagnosticInfo] {
     fn get_ProcessId(&self, out: *mut u32) -> HRESULT,
@@ -2479,7 +2479,7 @@ impl IProcessDiagnosticInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessDiagnosticInfo: IProcessDiagnosticInfo}
+RT_CLASS!{class ProcessDiagnosticInfo: IProcessDiagnosticInfo ["Windows.System.Diagnostics.ProcessDiagnosticInfo"]}
 impl RtActivatable<IProcessDiagnosticInfoStatics> for ProcessDiagnosticInfo {}
 impl RtActivatable<IProcessDiagnosticInfoStatics2> for ProcessDiagnosticInfo {}
 impl ProcessDiagnosticInfo {
@@ -2550,7 +2550,7 @@ impl IProcessDiskUsage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessDiskUsage: IProcessDiskUsage}
+RT_CLASS!{class ProcessDiskUsage: IProcessDiskUsage ["Windows.System.Diagnostics.ProcessDiskUsage"]}
 DEFINE_IID!(IID_IProcessDiskUsageReport, 1075193853, 21341, 19487, 129, 184, 218, 84, 225, 190, 99, 94);
 RT_INTERFACE!{interface IProcessDiskUsageReport(IProcessDiskUsageReportVtbl): IInspectable(IInspectableVtbl) [IID_IProcessDiskUsageReport] {
     fn get_ReadOperationCount(&self, out: *mut i64) -> HRESULT,
@@ -2592,7 +2592,7 @@ impl IProcessDiskUsageReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessDiskUsageReport: IProcessDiskUsageReport}
+RT_CLASS!{class ProcessDiskUsageReport: IProcessDiskUsageReport ["Windows.System.Diagnostics.ProcessDiskUsageReport"]}
 DEFINE_IID!(IID_IProcessMemoryUsage, 4111147675, 33404, 17079, 176, 124, 14, 50, 98, 126, 107, 62);
 RT_INTERFACE!{interface IProcessMemoryUsage(IProcessMemoryUsageVtbl): IInspectable(IInspectableVtbl) [IID_IProcessMemoryUsage] {
     fn GetReport(&self, out: *mut *mut ProcessMemoryUsageReport) -> HRESULT
@@ -2604,7 +2604,7 @@ impl IProcessMemoryUsage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessMemoryUsage: IProcessMemoryUsage}
+RT_CLASS!{class ProcessMemoryUsage: IProcessMemoryUsage ["Windows.System.Diagnostics.ProcessMemoryUsage"]}
 DEFINE_IID!(IID_IProcessMemoryUsageReport, 3267853498, 6481, 18053, 133, 50, 126, 116, 158, 207, 142, 235);
 RT_INTERFACE!{interface IProcessMemoryUsageReport(IProcessMemoryUsageReportVtbl): IInspectable(IInspectableVtbl) [IID_IProcessMemoryUsageReport] {
     fn get_NonPagedPoolSizeInBytes(&self, out: *mut u64) -> HRESULT,
@@ -2682,7 +2682,7 @@ impl IProcessMemoryUsageReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ProcessMemoryUsageReport: IProcessMemoryUsageReport}
+RT_CLASS!{class ProcessMemoryUsageReport: IProcessMemoryUsageReport ["Windows.System.Diagnostics.ProcessMemoryUsageReport"]}
 DEFINE_IID!(IID_ISystemCpuUsage, 1614263212, 726, 16948, 131, 98, 127, 227, 173, 200, 31, 95);
 RT_INTERFACE!{interface ISystemCpuUsage(ISystemCpuUsageVtbl): IInspectable(IInspectableVtbl) [IID_ISystemCpuUsage] {
     fn GetReport(&self, out: *mut *mut SystemCpuUsageReport) -> HRESULT
@@ -2694,7 +2694,7 @@ impl ISystemCpuUsage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemCpuUsage: ISystemCpuUsage}
+RT_CLASS!{class SystemCpuUsage: ISystemCpuUsage ["Windows.System.Diagnostics.SystemCpuUsage"]}
 DEFINE_IID!(IID_ISystemCpuUsageReport, 740741298, 38019, 20322, 171, 87, 130, 178, 157, 151, 25, 184);
 RT_INTERFACE!{interface ISystemCpuUsageReport(ISystemCpuUsageReportVtbl): IInspectable(IInspectableVtbl) [IID_ISystemCpuUsageReport] {
     fn get_KernelTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -2718,7 +2718,7 @@ impl ISystemCpuUsageReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemCpuUsageReport: ISystemCpuUsageReport}
+RT_CLASS!{class SystemCpuUsageReport: ISystemCpuUsageReport ["Windows.System.Diagnostics.SystemCpuUsageReport"]}
 DEFINE_IID!(IID_ISystemDiagnosticInfo, 2727411205, 57331, 16511, 154, 27, 11, 43, 49, 124, 168, 0);
 RT_INTERFACE!{interface ISystemDiagnosticInfo(ISystemDiagnosticInfoVtbl): IInspectable(IInspectableVtbl) [IID_ISystemDiagnosticInfo] {
     fn get_MemoryUsage(&self, out: *mut *mut SystemMemoryUsage) -> HRESULT,
@@ -2736,7 +2736,7 @@ impl ISystemDiagnosticInfo {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemDiagnosticInfo: ISystemDiagnosticInfo}
+RT_CLASS!{class SystemDiagnosticInfo: ISystemDiagnosticInfo ["Windows.System.Diagnostics.SystemDiagnosticInfo"]}
 impl RtActivatable<ISystemDiagnosticInfoStatics> for SystemDiagnosticInfo {}
 impl SystemDiagnosticInfo {
     #[inline] pub fn get_for_current_system() -> Result<Option<ComPtr<SystemDiagnosticInfo>>> {
@@ -2766,7 +2766,7 @@ impl ISystemMemoryUsage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMemoryUsage: ISystemMemoryUsage}
+RT_CLASS!{class SystemMemoryUsage: ISystemMemoryUsage ["Windows.System.Diagnostics.SystemMemoryUsage"]}
 DEFINE_IID!(IID_ISystemMemoryUsageReport, 946224263, 10911, 16442, 189, 25, 44, 243, 232, 22, 149, 0);
 RT_INTERFACE!{interface ISystemMemoryUsageReport(ISystemMemoryUsageReportVtbl): IInspectable(IInspectableVtbl) [IID_ISystemMemoryUsageReport] {
     fn get_TotalPhysicalSizeInBytes(&self, out: *mut u64) -> HRESULT,
@@ -2790,7 +2790,7 @@ impl ISystemMemoryUsageReport {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemMemoryUsageReport: ISystemMemoryUsageReport}
+RT_CLASS!{class SystemMemoryUsageReport: ISystemMemoryUsageReport ["Windows.System.Diagnostics.SystemMemoryUsageReport"]}
 pub mod deviceportal { // Windows.System.Diagnostics.DevicePortal
 use ::prelude::*;
 DEFINE_IID!(IID_IDevicePortalConnection, 256147281, 4504, 19873, 141, 84, 189, 239, 57, 62, 9, 182);
@@ -2820,7 +2820,7 @@ impl IDevicePortalConnection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePortalConnection: IDevicePortalConnection}
+RT_CLASS!{class DevicePortalConnection: IDevicePortalConnection ["Windows.System.Diagnostics.DevicePortal.DevicePortalConnection"]}
 impl RtActivatable<IDevicePortalConnectionStatics> for DevicePortalConnection {}
 impl DevicePortalConnection {
     #[cfg(feature="windows-applicationmodel")] #[inline] pub fn get_for_app_service_connection(appServiceConnection: &::rt::gen::windows::applicationmodel::appservice::AppServiceConnection) -> Result<Option<ComPtr<DevicePortalConnection>>> {
@@ -2839,8 +2839,8 @@ impl IDevicePortalConnectionClosedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePortalConnectionClosedEventArgs: IDevicePortalConnectionClosedEventArgs}
-RT_ENUM! { enum DevicePortalConnectionClosedReason: i32 {
+RT_CLASS!{class DevicePortalConnectionClosedEventArgs: IDevicePortalConnectionClosedEventArgs ["Windows.System.Diagnostics.DevicePortal.DevicePortalConnectionClosedEventArgs"]}
+RT_ENUM! { enum DevicePortalConnectionClosedReason: i32 ["Windows.System.Diagnostics.DevicePortal.DevicePortalConnectionClosedReason"] {
     Unknown (DevicePortalConnectionClosedReason_Unknown) = 0, ResourceLimitsExceeded (DevicePortalConnectionClosedReason_ResourceLimitsExceeded) = 1, ProtocolError (DevicePortalConnectionClosedReason_ProtocolError) = 2, NotAuthorized (DevicePortalConnectionClosedReason_NotAuthorized) = 3, UserNotPresent (DevicePortalConnectionClosedReason_UserNotPresent) = 4, ServiceTerminated (DevicePortalConnectionClosedReason_ServiceTerminated) = 5,
 }}
 DEFINE_IID!(IID_IDevicePortalConnectionRequestReceivedEventArgs, 1692065861, 28634, 17497, 158, 189, 236, 206, 34, 227, 133, 89);
@@ -2860,7 +2860,7 @@ impl IDevicePortalConnectionRequestReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DevicePortalConnectionRequestReceivedEventArgs: IDevicePortalConnectionRequestReceivedEventArgs}
+RT_CLASS!{class DevicePortalConnectionRequestReceivedEventArgs: IDevicePortalConnectionRequestReceivedEventArgs ["Windows.System.Diagnostics.DevicePortal.DevicePortalConnectionRequestReceivedEventArgs"]}
 DEFINE_IID!(IID_IDevicePortalConnectionStatics, 1270755815, 59833, 17989, 143, 237, 165, 62, 234, 14, 219, 214);
 RT_INTERFACE!{static interface IDevicePortalConnectionStatics(IDevicePortalConnectionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IDevicePortalConnectionStatics] {
     #[cfg(feature="windows-applicationmodel")] fn GetForAppServiceConnection(&self, appServiceConnection: *mut ::rt::gen::windows::applicationmodel::appservice::AppServiceConnection, out: *mut *mut DevicePortalConnection) -> HRESULT
@@ -2972,7 +2972,7 @@ impl IPlatformTelemetryRegistrationResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlatformTelemetryRegistrationResult: IPlatformTelemetryRegistrationResult}
+RT_CLASS!{class PlatformTelemetryRegistrationResult: IPlatformTelemetryRegistrationResult ["Windows.System.Diagnostics.Telemetry.PlatformTelemetryRegistrationResult"]}
 DEFINE_IID!(IID_IPlatformTelemetryRegistrationSettings, 2174387586, 51737, 16734, 187, 121, 156, 34, 75, 250, 58, 115);
 RT_INTERFACE!{interface IPlatformTelemetryRegistrationSettings(IPlatformTelemetryRegistrationSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IPlatformTelemetryRegistrationSettings] {
     fn get_StorageSize(&self, out: *mut u32) -> HRESULT,
@@ -3000,10 +3000,10 @@ impl IPlatformTelemetryRegistrationSettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlatformTelemetryRegistrationSettings: IPlatformTelemetryRegistrationSettings}
+RT_CLASS!{class PlatformTelemetryRegistrationSettings: IPlatformTelemetryRegistrationSettings ["Windows.System.Diagnostics.Telemetry.PlatformTelemetryRegistrationSettings"]}
 impl RtActivatable<IActivationFactory> for PlatformTelemetryRegistrationSettings {}
 DEFINE_CLSID!(PlatformTelemetryRegistrationSettings(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,97,103,110,111,115,116,105,99,115,46,84,101,108,101,109,101,116,114,121,46,80,108,97,116,102,111,114,109,84,101,108,101,109,101,116,114,121,82,101,103,105,115,116,114,97,116,105,111,110,83,101,116,116,105,110,103,115,0]) [CLSID_PlatformTelemetryRegistrationSettings]);
-RT_ENUM! { enum PlatformTelemetryRegistrationStatus: i32 {
+RT_ENUM! { enum PlatformTelemetryRegistrationStatus: i32 ["Windows.System.Diagnostics.Telemetry.PlatformTelemetryRegistrationStatus"] {
     Success (PlatformTelemetryRegistrationStatus_Success) = 0, SettingsOutOfRange (PlatformTelemetryRegistrationStatus_SettingsOutOfRange) = 1, UnknownFailure (PlatformTelemetryRegistrationStatus_UnknownFailure) = 2,
 }}
 } // Windows.System.Diagnostics.Telemetry
@@ -3091,13 +3091,13 @@ impl IPlatformDiagnosticActionsStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PlatformDiagnosticActionState: i32 {
+RT_ENUM! { enum PlatformDiagnosticActionState: i32 ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticActionState"] {
     Success (PlatformDiagnosticActionState_Success) = 0, FreeNetworkNotAvailable (PlatformDiagnosticActionState_FreeNetworkNotAvailable) = 1, ACPowerNotAvailable (PlatformDiagnosticActionState_ACPowerNotAvailable) = 2,
 }}
-RT_ENUM! { enum PlatformDiagnosticEscalationType: i32 {
+RT_ENUM! { enum PlatformDiagnosticEscalationType: i32 ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticEscalationType"] {
     OnCompletion (PlatformDiagnosticEscalationType_OnCompletion) = 0, OnFailure (PlatformDiagnosticEscalationType_OnFailure) = 1,
 }}
-RT_ENUM! { enum PlatformDiagnosticEventBufferLatencies: u32 {
+RT_ENUM! { enum PlatformDiagnosticEventBufferLatencies: u32 ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticEventBufferLatencies"] {
     Normal (PlatformDiagnosticEventBufferLatencies_Normal) = 1, CostDeferred (PlatformDiagnosticEventBufferLatencies_CostDeferred) = 2, Realtime (PlatformDiagnosticEventBufferLatencies_Realtime) = 4,
 }}
 DEFINE_IID!(IID_IPlatformDiagnosticTraceInfo, 4168150423, 54679, 19447, 136, 220, 207, 92, 125, 194, 161, 210);
@@ -3141,8 +3141,8 @@ impl IPlatformDiagnosticTraceInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlatformDiagnosticTraceInfo: IPlatformDiagnosticTraceInfo}
-RT_ENUM! { enum PlatformDiagnosticTracePriority: i32 {
+RT_CLASS!{class PlatformDiagnosticTraceInfo: IPlatformDiagnosticTraceInfo ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTraceInfo"]}
+RT_ENUM! { enum PlatformDiagnosticTracePriority: i32 ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTracePriority"] {
     Normal (PlatformDiagnosticTracePriority_Normal) = 0, UserElevated (PlatformDiagnosticTracePriority_UserElevated) = 1,
 }}
 DEFINE_IID!(IID_IPlatformDiagnosticTraceRuntimeInfo, 1028480557, 472, 18280, 133, 84, 30, 177, 202, 97, 9, 134);
@@ -3162,11 +3162,11 @@ impl IPlatformDiagnosticTraceRuntimeInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PlatformDiagnosticTraceRuntimeInfo: IPlatformDiagnosticTraceRuntimeInfo}
-RT_ENUM! { enum PlatformDiagnosticTraceSlotState: i32 {
+RT_CLASS!{class PlatformDiagnosticTraceRuntimeInfo: IPlatformDiagnosticTraceRuntimeInfo ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTraceRuntimeInfo"]}
+RT_ENUM! { enum PlatformDiagnosticTraceSlotState: i32 ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTraceSlotState"] {
     NotRunning (PlatformDiagnosticTraceSlotState_NotRunning) = 0, Running (PlatformDiagnosticTraceSlotState_Running) = 1, Throttled (PlatformDiagnosticTraceSlotState_Throttled) = 2,
 }}
-RT_ENUM! { enum PlatformDiagnosticTraceSlotType: i32 {
+RT_ENUM! { enum PlatformDiagnosticTraceSlotType: i32 ["Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTraceSlotType"] {
     Alternative (PlatformDiagnosticTraceSlotType_Alternative) = 0, AlwaysOn (PlatformDiagnosticTraceSlotType_AlwaysOn) = 1, Mini (PlatformDiagnosticTraceSlotType_Mini) = 2,
 }}
 } // Windows.System.Diagnostics.TraceReporting
@@ -3188,7 +3188,7 @@ impl IDisplayRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DisplayRequest: IDisplayRequest}
+RT_CLASS!{class DisplayRequest: IDisplayRequest ["Windows.System.Display.DisplayRequest"]}
 impl RtActivatable<IActivationFactory> for DisplayRequest {}
 DEFINE_CLSID!(DisplayRequest(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,68,105,115,112,108,97,121,46,68,105,115,112,108,97,121,82,101,113,117,101,115,116,0]) [CLSID_DisplayRequest]);
 } // Windows.System.Display
@@ -3223,7 +3223,7 @@ impl IInstalledDesktopApp {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InstalledDesktopApp: IInstalledDesktopApp}
+RT_CLASS!{class InstalledDesktopApp: IInstalledDesktopApp ["Windows.System.Inventory.InstalledDesktopApp"]}
 impl RtActivatable<IInstalledDesktopAppStatics> for InstalledDesktopApp {}
 impl InstalledDesktopApp {
     #[inline] pub fn get_inventory_async() -> Result<ComPtr<foundation::IAsyncOperation<foundation::collections::IVectorView<InstalledDesktopApp>>>> {
@@ -3361,10 +3361,10 @@ impl IBackgroundEnergyManagerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BatteryStatus: i32 {
+RT_ENUM! { enum BatteryStatus: i32 ["Windows.System.Power.BatteryStatus"] {
     NotPresent (BatteryStatus_NotPresent) = 0, Discharging (BatteryStatus_Discharging) = 1, Idle (BatteryStatus_Idle) = 2, Charging (BatteryStatus_Charging) = 3,
 }}
-RT_ENUM! { enum EnergySaverStatus: i32 {
+RT_ENUM! { enum EnergySaverStatus: i32 ["Windows.System.Power.EnergySaverStatus"] {
     Disabled (EnergySaverStatus_Disabled) = 0, Off (EnergySaverStatus_Off) = 1, On (EnergySaverStatus_On) = 2,
 }}
 RT_CLASS!{static class ForegroundEnergyManager}
@@ -3605,7 +3605,7 @@ impl IPowerManagerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PowerSupplyStatus: i32 {
+RT_ENUM! { enum PowerSupplyStatus: i32 ["Windows.System.Power.PowerSupplyStatus"] {
     NotPresent (PowerSupplyStatus_NotPresent) = 0, Inadequate (PowerSupplyStatus_Inadequate) = 1, Adequate (PowerSupplyStatus_Adequate) = 2,
 }}
 pub mod diagnostics { // Windows.System.Power.Diagnostics
@@ -3686,7 +3686,7 @@ impl IForegroundEnergyDiagnosticsStatics {
 } // Windows.System.Power
 pub mod preview { // Windows.System.Preview
 use ::prelude::*;
-RT_ENUM! { enum HingeState: i32 {
+RT_ENUM! { enum HingeState: i32 ["Windows.System.Preview.HingeState"] {
     Unknown (HingeState_Unknown) = 0, Closed (HingeState_Closed) = 1, Concave (HingeState_Concave) = 2, Flat (HingeState_Flat) = 3, Convex (HingeState_Convex) = 4, Full (HingeState_Full) = 5,
 }}
 DEFINE_IID!(IID_ITwoPanelHingedDevicePosturePreview, 1914985521, 19257, 17062, 142, 115, 114, 53, 173, 225, 104, 83);
@@ -3711,7 +3711,7 @@ impl ITwoPanelHingedDevicePosturePreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TwoPanelHingedDevicePosturePreview: ITwoPanelHingedDevicePosturePreview}
+RT_CLASS!{class TwoPanelHingedDevicePosturePreview: ITwoPanelHingedDevicePosturePreview ["Windows.System.Preview.TwoPanelHingedDevicePosturePreview"]}
 impl RtActivatable<ITwoPanelHingedDevicePosturePreviewStatics> for TwoPanelHingedDevicePosturePreview {}
 impl TwoPanelHingedDevicePosturePreview {
     #[inline] pub fn get_default_async() -> Result<ComPtr<foundation::IAsyncOperation<TwoPanelHingedDevicePosturePreview>>> {
@@ -3762,7 +3762,7 @@ impl ITwoPanelHingedDevicePosturePreviewReading {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TwoPanelHingedDevicePosturePreviewReading: ITwoPanelHingedDevicePosturePreviewReading}
+RT_CLASS!{class TwoPanelHingedDevicePosturePreviewReading: ITwoPanelHingedDevicePosturePreviewReading ["Windows.System.Preview.TwoPanelHingedDevicePosturePreviewReading"]}
 DEFINE_IID!(IID_ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgs, 757930950, 718, 18250, 165, 86, 167, 91, 28, 249, 58, 3);
 RT_INTERFACE!{interface ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgs(ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgs] {
     fn get_Reading(&self, out: *mut *mut TwoPanelHingedDevicePosturePreviewReading) -> HRESULT
@@ -3774,7 +3774,7 @@ impl ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs: ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgs}
+RT_CLASS!{class TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs: ITwoPanelHingedDevicePosturePreviewReadingChangedEventArgs ["Windows.System.Preview.TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs"]}
 DEFINE_IID!(IID_ITwoPanelHingedDevicePosturePreviewStatics, 205992914, 22496, 16768, 189, 94, 243, 26, 33, 56, 66, 62);
 RT_INTERFACE!{static interface ITwoPanelHingedDevicePosturePreviewStatics(ITwoPanelHingedDevicePosturePreviewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITwoPanelHingedDevicePosturePreviewStatics] {
     fn GetDefaultAsync(&self, out: *mut *mut foundation::IAsyncOperation<TwoPanelHingedDevicePosturePreview>) -> HRESULT
@@ -3849,7 +3849,7 @@ impl IAnalyticsVersionInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AnalyticsVersionInfo: IAnalyticsVersionInfo}
+RT_CLASS!{class AnalyticsVersionInfo: IAnalyticsVersionInfo ["Windows.System.Profile.AnalyticsVersionInfo"]}
 RT_CLASS!{static class EducationSettings}
 impl RtActivatable<IEducationSettingsStatics> for EducationSettings {}
 impl EducationSettings {
@@ -3911,7 +3911,7 @@ impl IHardwareToken {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HardwareToken: IHardwareToken}
+RT_CLASS!{class HardwareToken: IHardwareToken ["Windows.System.Profile.HardwareToken"]}
 RT_CLASS!{static class KnownRetailInfoProperties}
 impl RtActivatable<IKnownRetailInfoPropertiesStatics> for KnownRetailInfoProperties {}
 impl KnownRetailInfoProperties {
@@ -4120,7 +4120,7 @@ impl IKnownRetailInfoPropertiesStatics {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PlatformDataCollectionLevel: i32 {
+RT_ENUM! { enum PlatformDataCollectionLevel: i32 ["Windows.System.Profile.PlatformDataCollectionLevel"] {
     Security (PlatformDataCollectionLevel_Security) = 0, Basic (PlatformDataCollectionLevel_Basic) = 1, Enhanced (PlatformDataCollectionLevel_Enhanced) = 2, Full (PlatformDataCollectionLevel_Full) = 3,
 }}
 RT_CLASS!{static class PlatformDiagnosticsAndUsageDataSettings}
@@ -4259,8 +4259,8 @@ impl ISystemIdentificationInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemIdentificationInfo: ISystemIdentificationInfo}
-RT_ENUM! { enum SystemIdentificationSource: i32 {
+RT_CLASS!{class SystemIdentificationInfo: ISystemIdentificationInfo ["Windows.System.Profile.SystemIdentificationInfo"]}
+RT_ENUM! { enum SystemIdentificationSource: i32 ["Windows.System.Profile.SystemIdentificationSource"] {
     None (SystemIdentificationSource_None) = 0, Tpm (SystemIdentificationSource_Tpm) = 1, Uefi (SystemIdentificationSource_Uefi) = 2, Registry (SystemIdentificationSource_Registry) = 3,
 }}
 DEFINE_IID!(IID_ISystemIdentificationStatics, 1434580010, 54239, 19859, 163, 125, 196, 26, 97, 108, 109, 1);
@@ -4280,7 +4280,7 @@ impl ISystemIdentificationStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SystemOutOfBoxExperienceState: i32 {
+RT_ENUM! { enum SystemOutOfBoxExperienceState: i32 ["Windows.System.Profile.SystemOutOfBoxExperienceState"] {
     NotStarted (SystemOutOfBoxExperienceState_NotStarted) = 0, InProgress (SystemOutOfBoxExperienceState_InProgress) = 1, Completed (SystemOutOfBoxExperienceState_Completed) = 2,
 }}
 RT_CLASS!{static class SystemSetupInfo}
@@ -4407,7 +4407,7 @@ impl IOemSupportInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OemSupportInfo: IOemSupportInfo}
+RT_CLASS!{class OemSupportInfo: IOemSupportInfo ["Windows.System.Profile.SystemManufacturers.OemSupportInfo"]}
 RT_CLASS!{static class SmbiosInformation}
 impl RtActivatable<ISmbiosInformationStatics> for SmbiosInformation {}
 impl SmbiosInformation {
@@ -4474,7 +4474,7 @@ impl ISystemSupportDeviceInfo {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemSupportDeviceInfo: ISystemSupportDeviceInfo}
+RT_CLASS!{class SystemSupportDeviceInfo: ISystemSupportDeviceInfo ["Windows.System.Profile.SystemManufacturers.SystemSupportDeviceInfo"]}
 RT_CLASS!{static class SystemSupportInfo}
 impl RtActivatable<ISystemSupportInfoStatics> for SystemSupportInfo {}
 impl RtActivatable<ISystemSupportInfoStatics2> for SystemSupportInfo {}
@@ -4625,7 +4625,7 @@ impl IRemoteSystem {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystem: IRemoteSystem}
+RT_CLASS!{class RemoteSystem: IRemoteSystem ["Windows.System.RemoteSystems.RemoteSystem"]}
 impl RtActivatable<IRemoteSystemStatics> for RemoteSystem {}
 impl RtActivatable<IRemoteSystemStatics2> for RemoteSystem {}
 impl RemoteSystem {
@@ -4702,7 +4702,7 @@ impl IRemoteSystem5 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemAccessStatus: i32 {
+RT_ENUM! { enum RemoteSystemAccessStatus: i32 ["Windows.System.RemoteSystems.RemoteSystemAccessStatus"] {
     Unspecified (RemoteSystemAccessStatus_Unspecified) = 0, Allowed (RemoteSystemAccessStatus_Allowed) = 1, DeniedByUser (RemoteSystemAccessStatus_DeniedByUser) = 2, DeniedBySystem (RemoteSystemAccessStatus_DeniedBySystem) = 3,
 }}
 DEFINE_IID!(IID_IRemoteSystemAddedEventArgs, 2402899471, 58676, 18071, 136, 54, 122, 190, 161, 81, 81, 110);
@@ -4716,7 +4716,7 @@ impl IRemoteSystemAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemAddedEventArgs: IRemoteSystemAddedEventArgs}
+RT_CLASS!{class RemoteSystemAddedEventArgs: IRemoteSystemAddedEventArgs ["Windows.System.RemoteSystems.RemoteSystemAddedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemApp, 2162539709, 54605, 16817, 155, 22, 104, 16, 168, 113, 237, 79);
 RT_INTERFACE!{interface IRemoteSystemApp(IRemoteSystemAppVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemApp] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -4752,7 +4752,7 @@ impl IRemoteSystemApp {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemApp: IRemoteSystemApp}
+RT_CLASS!{class RemoteSystemApp: IRemoteSystemApp ["Windows.System.RemoteSystems.RemoteSystemApp"]}
 DEFINE_IID!(IID_IRemoteSystemAppRegistration, 3027847093, 28725, 19034, 184, 223, 150, 45, 143, 132, 49, 244);
 RT_INTERFACE!{interface IRemoteSystemAppRegistration(IRemoteSystemAppRegistrationVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemAppRegistration] {
     fn get_User(&self, out: *mut *mut super::User) -> HRESULT,
@@ -4776,7 +4776,7 @@ impl IRemoteSystemAppRegistration {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemAppRegistration: IRemoteSystemAppRegistration}
+RT_CLASS!{class RemoteSystemAppRegistration: IRemoteSystemAppRegistration ["Windows.System.RemoteSystems.RemoteSystemAppRegistration"]}
 impl RtActivatable<IRemoteSystemAppRegistrationStatics> for RemoteSystemAppRegistration {}
 impl RemoteSystemAppRegistration {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<RemoteSystemAppRegistration>>> {
@@ -4804,7 +4804,7 @@ impl IRemoteSystemAppRegistrationStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemAuthorizationKind: i32 {
+RT_ENUM! { enum RemoteSystemAuthorizationKind: i32 ["Windows.System.RemoteSystems.RemoteSystemAuthorizationKind"] {
     SameUser (RemoteSystemAuthorizationKind_SameUser) = 0, Anonymous (RemoteSystemAuthorizationKind_Anonymous) = 1,
 }}
 DEFINE_IID!(IID_IRemoteSystemAuthorizationKindFilter, 1796071054, 1232, 16628, 162, 127, 194, 172, 187, 214, 183, 52);
@@ -4818,7 +4818,7 @@ impl IRemoteSystemAuthorizationKindFilter {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemAuthorizationKindFilter: IRemoteSystemAuthorizationKindFilter}
+RT_CLASS!{class RemoteSystemAuthorizationKindFilter: IRemoteSystemAuthorizationKindFilter ["Windows.System.RemoteSystems.RemoteSystemAuthorizationKindFilter"]}
 impl RtActivatable<IRemoteSystemAuthorizationKindFilterFactory> for RemoteSystemAuthorizationKindFilter {}
 impl RemoteSystemAuthorizationKindFilter {
     #[inline] pub fn create(remoteSystemAuthorizationKind: RemoteSystemAuthorizationKind) -> Result<ComPtr<RemoteSystemAuthorizationKindFilter>> {
@@ -4848,7 +4848,7 @@ impl IRemoteSystemConnectionInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemConnectionInfo: IRemoteSystemConnectionInfo}
+RT_CLASS!{class RemoteSystemConnectionInfo: IRemoteSystemConnectionInfo ["Windows.System.RemoteSystems.RemoteSystemConnectionInfo"]}
 impl RtActivatable<IRemoteSystemConnectionInfoStatics> for RemoteSystemConnectionInfo {}
 impl RemoteSystemConnectionInfo {
     #[cfg(feature="windows-applicationmodel")] #[inline] pub fn try_create_from_app_service_connection(connection: &super::super::applicationmodel::appservice::AppServiceConnection) -> Result<Option<ComPtr<RemoteSystemConnectionInfo>>> {
@@ -4878,7 +4878,7 @@ impl IRemoteSystemConnectionRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemConnectionRequest: IRemoteSystemConnectionRequest}
+RT_CLASS!{class RemoteSystemConnectionRequest: IRemoteSystemConnectionRequest ["Windows.System.RemoteSystems.RemoteSystemConnectionRequest"]}
 impl RtActivatable<IRemoteSystemConnectionRequestFactory> for RemoteSystemConnectionRequest {}
 impl RtActivatable<IRemoteSystemConnectionRequestStatics> for RemoteSystemConnectionRequest {}
 impl RemoteSystemConnectionRequest {
@@ -4923,7 +4923,7 @@ impl IRemoteSystemConnectionRequestStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemDiscoveryType: i32 {
+RT_ENUM! { enum RemoteSystemDiscoveryType: i32 ["Windows.System.RemoteSystems.RemoteSystemDiscoveryType"] {
     Any (RemoteSystemDiscoveryType_Any) = 0, Proximal (RemoteSystemDiscoveryType_Proximal) = 1, Cloud (RemoteSystemDiscoveryType_Cloud) = 2, SpatiallyProximal (RemoteSystemDiscoveryType_SpatiallyProximal) = 3,
 }}
 DEFINE_IID!(IID_IRemoteSystemDiscoveryTypeFilter, 1121518623, 61018, 17370, 172, 106, 111, 238, 37, 70, 7, 65);
@@ -4937,7 +4937,7 @@ impl IRemoteSystemDiscoveryTypeFilter {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemDiscoveryTypeFilter: IRemoteSystemDiscoveryTypeFilter}
+RT_CLASS!{class RemoteSystemDiscoveryTypeFilter: IRemoteSystemDiscoveryTypeFilter ["Windows.System.RemoteSystems.RemoteSystemDiscoveryTypeFilter"]}
 impl RtActivatable<IRemoteSystemDiscoveryTypeFilterFactory> for RemoteSystemDiscoveryTypeFilter {}
 impl RemoteSystemDiscoveryTypeFilter {
     #[inline] pub fn create(discoveryType: RemoteSystemDiscoveryType) -> Result<ComPtr<RemoteSystemDiscoveryTypeFilter>> {
@@ -4960,7 +4960,7 @@ DEFINE_IID!(IID_IRemoteSystemEnumerationCompletedEventArgs, 3337108831, 16432, 1
 RT_INTERFACE!{interface IRemoteSystemEnumerationCompletedEventArgs(IRemoteSystemEnumerationCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemEnumerationCompletedEventArgs] {
     
 }}
-RT_CLASS!{class RemoteSystemEnumerationCompletedEventArgs: IRemoteSystemEnumerationCompletedEventArgs}
+RT_CLASS!{class RemoteSystemEnumerationCompletedEventArgs: IRemoteSystemEnumerationCompletedEventArgs ["Windows.System.RemoteSystems.RemoteSystemEnumerationCompletedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemFilter, 1245424100, 39403, 17899, 186, 22, 3, 103, 114, 143, 243, 116);
 RT_INTERFACE!{interface IRemoteSystemFilter(IRemoteSystemFilterVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemFilter] {
     
@@ -4976,7 +4976,7 @@ impl IRemoteSystemKindFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemKindFilter: IRemoteSystemKindFilter}
+RT_CLASS!{class RemoteSystemKindFilter: IRemoteSystemKindFilter ["Windows.System.RemoteSystems.RemoteSystemKindFilter"]}
 impl RtActivatable<IRemoteSystemKindFilterFactory> for RemoteSystemKindFilter {}
 impl RemoteSystemKindFilter {
     #[inline] pub fn create(remoteSystemKinds: &foundation::collections::IIterable<HString>) -> Result<ComPtr<RemoteSystemKindFilter>> {
@@ -5083,7 +5083,7 @@ impl IRemoteSystemKindStatics2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemPlatform: i32 {
+RT_ENUM! { enum RemoteSystemPlatform: i32 ["Windows.System.RemoteSystems.RemoteSystemPlatform"] {
     Unknown (RemoteSystemPlatform_Unknown) = 0, Windows (RemoteSystemPlatform_Windows) = 1, Android (RemoteSystemPlatform_Android) = 2, Ios (RemoteSystemPlatform_Ios) = 3, Linux (RemoteSystemPlatform_Linux) = 4,
 }}
 DEFINE_IID!(IID_IRemoteSystemRemovedEventArgs, 2336036539, 29446, 18922, 183, 223, 103, 213, 113, 76, 176, 19);
@@ -5097,7 +5097,7 @@ impl IRemoteSystemRemovedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemRemovedEventArgs: IRemoteSystemRemovedEventArgs}
+RT_CLASS!{class RemoteSystemRemovedEventArgs: IRemoteSystemRemovedEventArgs ["Windows.System.RemoteSystems.RemoteSystemRemovedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSession, 1766287873, 39642, 18703, 149, 73, 211, 28, 177, 76, 158, 149);
 RT_INTERFACE!{interface IRemoteSystemSession(IRemoteSystemSessionVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSession] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -5144,7 +5144,7 @@ impl IRemoteSystemSession {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSession: IRemoteSystemSession}
+RT_CLASS!{class RemoteSystemSession: IRemoteSystemSession ["Windows.System.RemoteSystems.RemoteSystemSession"]}
 impl RtActivatable<IRemoteSystemSessionStatics> for RemoteSystemSession {}
 impl RemoteSystemSession {
     #[inline] pub fn create_watcher() -> Result<Option<ComPtr<RemoteSystemSessionWatcher>>> {
@@ -5163,7 +5163,7 @@ impl IRemoteSystemSessionAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionAddedEventArgs: IRemoteSystemSessionAddedEventArgs}
+RT_CLASS!{class RemoteSystemSessionAddedEventArgs: IRemoteSystemSessionAddedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionAddedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionController, 3834326482, 26656, 18535, 180, 37, 216, 156, 10, 62, 247, 186);
 RT_INTERFACE!{interface IRemoteSystemSessionController(IRemoteSystemSessionControllerVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionController] {
     fn add_JoinRequested(&self, handler: *mut foundation::TypedEventHandler<RemoteSystemSessionController, RemoteSystemSessionJoinRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5192,7 +5192,7 @@ impl IRemoteSystemSessionController {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionController: IRemoteSystemSessionController}
+RT_CLASS!{class RemoteSystemSessionController: IRemoteSystemSessionController ["Windows.System.RemoteSystems.RemoteSystemSessionController"]}
 impl RtActivatable<IRemoteSystemSessionControllerFactory> for RemoteSystemSessionController {}
 impl RemoteSystemSessionController {
     #[inline] pub fn create_controller(displayName: &HStringArg) -> Result<ComPtr<RemoteSystemSessionController>> {
@@ -5237,8 +5237,8 @@ impl IRemoteSystemSessionCreationResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionCreationResult: IRemoteSystemSessionCreationResult}
-RT_ENUM! { enum RemoteSystemSessionCreationStatus: i32 {
+RT_CLASS!{class RemoteSystemSessionCreationResult: IRemoteSystemSessionCreationResult ["Windows.System.RemoteSystems.RemoteSystemSessionCreationResult"]}
+RT_ENUM! { enum RemoteSystemSessionCreationStatus: i32 ["Windows.System.RemoteSystems.RemoteSystemSessionCreationStatus"] {
     Success (RemoteSystemSessionCreationStatus_Success) = 0, SessionLimitsExceeded (RemoteSystemSessionCreationStatus_SessionLimitsExceeded) = 1, OperationAborted (RemoteSystemSessionCreationStatus_OperationAborted) = 2,
 }}
 DEFINE_IID!(IID_IRemoteSystemSessionDisconnectedEventArgs, 3725313691, 30661, 17948, 130, 9, 124, 108, 93, 49, 17, 171);
@@ -5252,8 +5252,8 @@ impl IRemoteSystemSessionDisconnectedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionDisconnectedEventArgs: IRemoteSystemSessionDisconnectedEventArgs}
-RT_ENUM! { enum RemoteSystemSessionDisconnectedReason: i32 {
+RT_CLASS!{class RemoteSystemSessionDisconnectedEventArgs: IRemoteSystemSessionDisconnectedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionDisconnectedEventArgs"]}
+RT_ENUM! { enum RemoteSystemSessionDisconnectedReason: i32 ["Windows.System.RemoteSystems.RemoteSystemSessionDisconnectedReason"] {
     SessionUnavailable (RemoteSystemSessionDisconnectedReason_SessionUnavailable) = 0, RemovedByController (RemoteSystemSessionDisconnectedReason_RemovedByController) = 1, SessionClosed (RemoteSystemSessionDisconnectedReason_SessionClosed) = 2,
 }}
 DEFINE_IID!(IID_IRemoteSystemSessionInfo, 4283299400, 35594, 20122, 153, 5, 105, 228, 184, 65, 197, 136);
@@ -5279,7 +5279,7 @@ impl IRemoteSystemSessionInfo {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionInfo: IRemoteSystemSessionInfo}
+RT_CLASS!{class RemoteSystemSessionInfo: IRemoteSystemSessionInfo ["Windows.System.RemoteSystems.RemoteSystemSessionInfo"]}
 DEFINE_IID!(IID_IRemoteSystemSessionInvitation, 1043516561, 20951, 18278, 161, 33, 37, 81, 108, 59, 130, 148);
 RT_INTERFACE!{interface IRemoteSystemSessionInvitation(IRemoteSystemSessionInvitationVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionInvitation] {
     fn get_Sender(&self, out: *mut *mut RemoteSystem) -> HRESULT,
@@ -5297,7 +5297,7 @@ impl IRemoteSystemSessionInvitation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionInvitation: IRemoteSystemSessionInvitation}
+RT_CLASS!{class RemoteSystemSessionInvitation: IRemoteSystemSessionInvitation ["Windows.System.RemoteSystems.RemoteSystemSessionInvitation"]}
 DEFINE_IID!(IID_IRemoteSystemSessionInvitationListener, 150208575, 48241, 18913, 135, 74, 49, 221, 255, 154, 39, 185);
 RT_INTERFACE!{interface IRemoteSystemSessionInvitationListener(IRemoteSystemSessionInvitationListenerVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionInvitationListener] {
     fn add_InvitationReceived(&self, handler: *mut foundation::TypedEventHandler<RemoteSystemSessionInvitationListener, RemoteSystemSessionInvitationReceivedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5314,7 +5314,7 @@ impl IRemoteSystemSessionInvitationListener {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionInvitationListener: IRemoteSystemSessionInvitationListener}
+RT_CLASS!{class RemoteSystemSessionInvitationListener: IRemoteSystemSessionInvitationListener ["Windows.System.RemoteSystems.RemoteSystemSessionInvitationListener"]}
 impl RtActivatable<IActivationFactory> for RemoteSystemSessionInvitationListener {}
 DEFINE_CLSID!(RemoteSystemSessionInvitationListener(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,73,110,118,105,116,97,116,105,111,110,76,105,115,116,101,110,101,114,0]) [CLSID_RemoteSystemSessionInvitationListener]);
 DEFINE_IID!(IID_IRemoteSystemSessionInvitationReceivedEventArgs, 1586907693, 41229, 20187, 141, 234, 84, 210, 10, 193, 149, 67);
@@ -5328,7 +5328,7 @@ impl IRemoteSystemSessionInvitationReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionInvitationReceivedEventArgs: IRemoteSystemSessionInvitationReceivedEventArgs}
+RT_CLASS!{class RemoteSystemSessionInvitationReceivedEventArgs: IRemoteSystemSessionInvitationReceivedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionInvitationReceivedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionJoinRequest, 543162472, 31124, 17201, 134, 209, 216, 157, 136, 37, 133, 238);
 RT_INTERFACE!{interface IRemoteSystemSessionJoinRequest(IRemoteSystemSessionJoinRequestVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionJoinRequest] {
     fn get_Participant(&self, out: *mut *mut RemoteSystemSessionParticipant) -> HRESULT,
@@ -5345,7 +5345,7 @@ impl IRemoteSystemSessionJoinRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionJoinRequest: IRemoteSystemSessionJoinRequest}
+RT_CLASS!{class RemoteSystemSessionJoinRequest: IRemoteSystemSessionJoinRequest ["Windows.System.RemoteSystems.RemoteSystemSessionJoinRequest"]}
 DEFINE_IID!(IID_IRemoteSystemSessionJoinRequestedEventArgs, 3687468995, 33465, 18454, 156, 36, 228, 14, 97, 119, 75, 216);
 RT_INTERFACE!{interface IRemoteSystemSessionJoinRequestedEventArgs(IRemoteSystemSessionJoinRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionJoinRequestedEventArgs] {
     fn get_JoinRequest(&self, out: *mut *mut RemoteSystemSessionJoinRequest) -> HRESULT,
@@ -5363,7 +5363,7 @@ impl IRemoteSystemSessionJoinRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionJoinRequestedEventArgs: IRemoteSystemSessionJoinRequestedEventArgs}
+RT_CLASS!{class RemoteSystemSessionJoinRequestedEventArgs: IRemoteSystemSessionJoinRequestedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionJoinRequestedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionJoinResult, 3464175364, 41022, 16804, 144, 11, 30, 121, 50, 140, 18, 103);
 RT_INTERFACE!{interface IRemoteSystemSessionJoinResult(IRemoteSystemSessionJoinResultVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionJoinResult] {
     fn get_Status(&self, out: *mut RemoteSystemSessionJoinStatus) -> HRESULT,
@@ -5381,8 +5381,8 @@ impl IRemoteSystemSessionJoinResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionJoinResult: IRemoteSystemSessionJoinResult}
-RT_ENUM! { enum RemoteSystemSessionJoinStatus: i32 {
+RT_CLASS!{class RemoteSystemSessionJoinResult: IRemoteSystemSessionJoinResult ["Windows.System.RemoteSystems.RemoteSystemSessionJoinResult"]}
+RT_ENUM! { enum RemoteSystemSessionJoinStatus: i32 ["Windows.System.RemoteSystems.RemoteSystemSessionJoinStatus"] {
     Success (RemoteSystemSessionJoinStatus_Success) = 0, SessionLimitsExceeded (RemoteSystemSessionJoinStatus_SessionLimitsExceeded) = 1, OperationAborted (RemoteSystemSessionJoinStatus_OperationAborted) = 2, SessionUnavailable (RemoteSystemSessionJoinStatus_SessionUnavailable) = 3, RejectedByController (RemoteSystemSessionJoinStatus_RejectedByController) = 4,
 }}
 DEFINE_IID!(IID_IRemoteSystemSessionMessageChannel, 2502218026, 29657, 19472, 183, 81, 194, 103, 132, 67, 113, 39);
@@ -5425,7 +5425,7 @@ impl IRemoteSystemSessionMessageChannel {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionMessageChannel: IRemoteSystemSessionMessageChannel}
+RT_CLASS!{class RemoteSystemSessionMessageChannel: IRemoteSystemSessionMessageChannel ["Windows.System.RemoteSystems.RemoteSystemSessionMessageChannel"]}
 impl RtActivatable<IRemoteSystemSessionMessageChannelFactory> for RemoteSystemSessionMessageChannel {}
 impl RemoteSystemSessionMessageChannel {
     #[inline] pub fn create(session: &RemoteSystemSession, channelName: &HStringArg) -> Result<ComPtr<RemoteSystemSessionMessageChannel>> {
@@ -5453,7 +5453,7 @@ impl IRemoteSystemSessionMessageChannelFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemSessionMessageChannelReliability: i32 {
+RT_ENUM! { enum RemoteSystemSessionMessageChannelReliability: i32 ["Windows.System.RemoteSystems.RemoteSystemSessionMessageChannelReliability"] {
     Reliable (RemoteSystemSessionMessageChannelReliability_Reliable) = 0, Unreliable (RemoteSystemSessionMessageChannelReliability_Unreliable) = 1,
 }}
 DEFINE_IID!(IID_IRemoteSystemSessionOptions, 1947129685, 33816, 20225, 147, 83, 226, 28, 158, 204, 108, 252);
@@ -5472,7 +5472,7 @@ impl IRemoteSystemSessionOptions {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionOptions: IRemoteSystemSessionOptions}
+RT_CLASS!{class RemoteSystemSessionOptions: IRemoteSystemSessionOptions ["Windows.System.RemoteSystems.RemoteSystemSessionOptions"]}
 impl RtActivatable<IActivationFactory> for RemoteSystemSessionOptions {}
 DEFINE_CLSID!(RemoteSystemSessionOptions(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,82,101,109,111,116,101,83,121,115,116,101,109,115,46,82,101,109,111,116,101,83,121,115,116,101,109,83,101,115,115,105,111,110,79,112,116,105,111,110,115,0]) [CLSID_RemoteSystemSessionOptions]);
 DEFINE_IID!(IID_IRemoteSystemSessionParticipant, 2123367820, 44281, 18217, 138, 23, 68, 231, 186, 237, 93, 204);
@@ -5492,7 +5492,7 @@ impl IRemoteSystemSessionParticipant {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionParticipant: IRemoteSystemSessionParticipant}
+RT_CLASS!{class RemoteSystemSessionParticipant: IRemoteSystemSessionParticipant ["Windows.System.RemoteSystems.RemoteSystemSessionParticipant"]}
 DEFINE_IID!(IID_IRemoteSystemSessionParticipantAddedEventArgs, 3545913304, 51617, 19383, 182, 176, 121, 187, 145, 173, 249, 61);
 RT_INTERFACE!{interface IRemoteSystemSessionParticipantAddedEventArgs(IRemoteSystemSessionParticipantAddedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionParticipantAddedEventArgs] {
     fn get_Participant(&self, out: *mut *mut RemoteSystemSessionParticipant) -> HRESULT
@@ -5504,7 +5504,7 @@ impl IRemoteSystemSessionParticipantAddedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionParticipantAddedEventArgs: IRemoteSystemSessionParticipantAddedEventArgs}
+RT_CLASS!{class RemoteSystemSessionParticipantAddedEventArgs: IRemoteSystemSessionParticipantAddedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionParticipantAddedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionParticipantRemovedEventArgs, 2255417480, 56936, 19135, 136, 161, 249, 13, 22, 39, 65, 146);
 RT_INTERFACE!{interface IRemoteSystemSessionParticipantRemovedEventArgs(IRemoteSystemSessionParticipantRemovedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionParticipantRemovedEventArgs] {
     fn get_Participant(&self, out: *mut *mut RemoteSystemSessionParticipant) -> HRESULT
@@ -5516,7 +5516,7 @@ impl IRemoteSystemSessionParticipantRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionParticipantRemovedEventArgs: IRemoteSystemSessionParticipantRemovedEventArgs}
+RT_CLASS!{class RemoteSystemSessionParticipantRemovedEventArgs: IRemoteSystemSessionParticipantRemovedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionParticipantRemovedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionParticipantWatcher, 3705471692, 43655, 19833, 182, 204, 68, 89, 179, 233, 32, 117);
 RT_INTERFACE!{interface IRemoteSystemSessionParticipantWatcher(IRemoteSystemSessionParticipantWatcherVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionParticipantWatcher] {
     fn Start(&self) -> HRESULT,
@@ -5571,8 +5571,8 @@ impl IRemoteSystemSessionParticipantWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionParticipantWatcher: IRemoteSystemSessionParticipantWatcher}
-RT_ENUM! { enum RemoteSystemSessionParticipantWatcherStatus: i32 {
+RT_CLASS!{class RemoteSystemSessionParticipantWatcher: IRemoteSystemSessionParticipantWatcher ["Windows.System.RemoteSystems.RemoteSystemSessionParticipantWatcher"]}
+RT_ENUM! { enum RemoteSystemSessionParticipantWatcherStatus: i32 ["Windows.System.RemoteSystems.RemoteSystemSessionParticipantWatcherStatus"] {
     Created (RemoteSystemSessionParticipantWatcherStatus_Created) = 0, Started (RemoteSystemSessionParticipantWatcherStatus_Started) = 1, EnumerationCompleted (RemoteSystemSessionParticipantWatcherStatus_EnumerationCompleted) = 2, Stopping (RemoteSystemSessionParticipantWatcherStatus_Stopping) = 3, Stopped (RemoteSystemSessionParticipantWatcherStatus_Stopped) = 4, Aborted (RemoteSystemSessionParticipantWatcherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IRemoteSystemSessionRemovedEventArgs, 2944569678, 14753, 19946, 157, 99, 67, 121, 141, 91, 187, 208);
@@ -5586,7 +5586,7 @@ impl IRemoteSystemSessionRemovedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionRemovedEventArgs: IRemoteSystemSessionRemovedEventArgs}
+RT_CLASS!{class RemoteSystemSessionRemovedEventArgs: IRemoteSystemSessionRemovedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionRemovedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionStatics, 2233764255, 64800, 17635, 149, 101, 231, 90, 59, 20, 198, 110);
 RT_INTERFACE!{static interface IRemoteSystemSessionStatics(IRemoteSystemSessionStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionStatics] {
     fn CreateWatcher(&self, out: *mut *mut RemoteSystemSessionWatcher) -> HRESULT
@@ -5609,7 +5609,7 @@ impl IRemoteSystemSessionUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionUpdatedEventArgs: IRemoteSystemSessionUpdatedEventArgs}
+RT_CLASS!{class RemoteSystemSessionUpdatedEventArgs: IRemoteSystemSessionUpdatedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionUpdatedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionValueSetReceivedEventArgs, 116594565, 11685, 20056, 167, 143, 158, 141, 7, 132, 238, 37);
 RT_INTERFACE!{interface IRemoteSystemSessionValueSetReceivedEventArgs(IRemoteSystemSessionValueSetReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionValueSetReceivedEventArgs] {
     fn get_Sender(&self, out: *mut *mut RemoteSystemSessionParticipant) -> HRESULT,
@@ -5627,7 +5627,7 @@ impl IRemoteSystemSessionValueSetReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionValueSetReceivedEventArgs: IRemoteSystemSessionValueSetReceivedEventArgs}
+RT_CLASS!{class RemoteSystemSessionValueSetReceivedEventArgs: IRemoteSystemSessionValueSetReceivedEventArgs ["Windows.System.RemoteSystems.RemoteSystemSessionValueSetReceivedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemSessionWatcher, 2147738432, 3137, 19042, 182, 215, 189, 190, 43, 25, 190, 45);
 RT_INTERFACE!{interface IRemoteSystemSessionWatcher(IRemoteSystemSessionWatcherVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemSessionWatcher] {
     fn Start(&self) -> HRESULT,
@@ -5682,8 +5682,8 @@ impl IRemoteSystemSessionWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemSessionWatcher: IRemoteSystemSessionWatcher}
-RT_ENUM! { enum RemoteSystemSessionWatcherStatus: i32 {
+RT_CLASS!{class RemoteSystemSessionWatcher: IRemoteSystemSessionWatcher ["Windows.System.RemoteSystems.RemoteSystemSessionWatcher"]}
+RT_ENUM! { enum RemoteSystemSessionWatcherStatus: i32 ["Windows.System.RemoteSystems.RemoteSystemSessionWatcherStatus"] {
     Created (RemoteSystemSessionWatcherStatus_Created) = 0, Started (RemoteSystemSessionWatcherStatus_Started) = 1, EnumerationCompleted (RemoteSystemSessionWatcherStatus_EnumerationCompleted) = 2, Stopping (RemoteSystemSessionWatcherStatus_Stopping) = 3, Stopped (RemoteSystemSessionWatcherStatus_Stopped) = 4, Aborted (RemoteSystemSessionWatcherStatus_Aborted) = 5,
 }}
 DEFINE_IID!(IID_IRemoteSystemStatics, 2760225682, 65323, 19271, 190, 98, 116, 63, 47, 20, 15, 48);
@@ -5727,10 +5727,10 @@ impl IRemoteSystemStatics2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemStatus: i32 {
+RT_ENUM! { enum RemoteSystemStatus: i32 ["Windows.System.RemoteSystems.RemoteSystemStatus"] {
     Unavailable (RemoteSystemStatus_Unavailable) = 0, DiscoveringAvailability (RemoteSystemStatus_DiscoveringAvailability) = 1, Available (RemoteSystemStatus_Available) = 2, Unknown (RemoteSystemStatus_Unknown) = 3,
 }}
-RT_ENUM! { enum RemoteSystemStatusType: i32 {
+RT_ENUM! { enum RemoteSystemStatusType: i32 ["Windows.System.RemoteSystems.RemoteSystemStatusType"] {
     Any (RemoteSystemStatusType_Any) = 0, Available (RemoteSystemStatusType_Available) = 1,
 }}
 DEFINE_IID!(IID_IRemoteSystemStatusTypeFilter, 205082958, 52150, 18295, 133, 52, 46, 12, 82, 26, 255, 162);
@@ -5744,7 +5744,7 @@ impl IRemoteSystemStatusTypeFilter {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemStatusTypeFilter: IRemoteSystemStatusTypeFilter}
+RT_CLASS!{class RemoteSystemStatusTypeFilter: IRemoteSystemStatusTypeFilter ["Windows.System.RemoteSystems.RemoteSystemStatusTypeFilter"]}
 impl RtActivatable<IRemoteSystemStatusTypeFilterFactory> for RemoteSystemStatusTypeFilter {}
 impl RemoteSystemStatusTypeFilter {
     #[inline] pub fn create(remoteSystemStatusType: RemoteSystemStatusType) -> Result<ComPtr<RemoteSystemStatusTypeFilter>> {
@@ -5774,7 +5774,7 @@ impl IRemoteSystemUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemUpdatedEventArgs: IRemoteSystemUpdatedEventArgs}
+RT_CLASS!{class RemoteSystemUpdatedEventArgs: IRemoteSystemUpdatedEventArgs ["Windows.System.RemoteSystems.RemoteSystemUpdatedEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemWatcher, 1566575742, 11271, 18629, 136, 156, 69, 93, 43, 9, 151, 113);
 RT_INTERFACE!{interface IRemoteSystemWatcher(IRemoteSystemWatcherVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemWatcher] {
     fn Start(&self) -> HRESULT,
@@ -5823,7 +5823,7 @@ impl IRemoteSystemWatcher {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemWatcher: IRemoteSystemWatcher}
+RT_CLASS!{class RemoteSystemWatcher: IRemoteSystemWatcher ["Windows.System.RemoteSystems.RemoteSystemWatcher"]}
 DEFINE_IID!(IID_IRemoteSystemWatcher2, 1933797120, 6602, 18681, 164, 205, 120, 15, 122, 213, 140, 113);
 RT_INTERFACE!{interface IRemoteSystemWatcher2(IRemoteSystemWatcher2Vtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemWatcher2] {
     fn add_EnumerationCompleted(&self, handler: *mut foundation::TypedEventHandler<RemoteSystemWatcher, RemoteSystemEnumerationCompletedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -5851,7 +5851,7 @@ impl IRemoteSystemWatcher2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RemoteSystemWatcherError: i32 {
+RT_ENUM! { enum RemoteSystemWatcherError: i32 ["Windows.System.RemoteSystems.RemoteSystemWatcherError"] {
     Unknown (RemoteSystemWatcherError_Unknown) = 0, InternetNotAvailable (RemoteSystemWatcherError_InternetNotAvailable) = 1, AuthenticationError (RemoteSystemWatcherError_AuthenticationError) = 2,
 }}
 DEFINE_IID!(IID_IRemoteSystemWatcherErrorOccurredEventArgs, 1959118511, 20756, 17446, 146, 22, 32, 216, 31, 133, 25, 174);
@@ -5865,7 +5865,7 @@ impl IRemoteSystemWatcherErrorOccurredEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemWatcherErrorOccurredEventArgs: IRemoteSystemWatcherErrorOccurredEventArgs}
+RT_CLASS!{class RemoteSystemWatcherErrorOccurredEventArgs: IRemoteSystemWatcherErrorOccurredEventArgs ["Windows.System.RemoteSystems.RemoteSystemWatcherErrorOccurredEventArgs"]}
 DEFINE_IID!(IID_IRemoteSystemWebAccountFilter, 1068980339, 34760, 23951, 151, 126, 246, 159, 150, 214, 114, 56);
 RT_INTERFACE!{interface IRemoteSystemWebAccountFilter(IRemoteSystemWebAccountFilterVtbl): IInspectable(IInspectableVtbl) [IID_IRemoteSystemWebAccountFilter] {
     #[cfg(feature="windows-security")] fn get_Account(&self, out: *mut *mut super::super::security::credentials::WebAccount) -> HRESULT
@@ -5877,7 +5877,7 @@ impl IRemoteSystemWebAccountFilter {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RemoteSystemWebAccountFilter: IRemoteSystemWebAccountFilter}
+RT_CLASS!{class RemoteSystemWebAccountFilter: IRemoteSystemWebAccountFilter ["Windows.System.RemoteSystems.RemoteSystemWebAccountFilter"]}
 impl RtActivatable<IRemoteSystemWebAccountFilterFactory> for RemoteSystemWebAccountFilter {}
 impl RemoteSystemWebAccountFilter {
     #[cfg(feature="windows-security")] #[inline] pub fn create(account: &super::super::security::credentials::WebAccount) -> Result<ComPtr<RemoteSystemWebAccountFilter>> {
@@ -5958,7 +5958,7 @@ impl IThreadPoolTimer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ThreadPoolTimer: IThreadPoolTimer}
+RT_CLASS!{class ThreadPoolTimer: IThreadPoolTimer ["Windows.System.Threading.ThreadPoolTimer"]}
 impl RtActivatable<IThreadPoolTimerStatics> for ThreadPoolTimer {}
 impl ThreadPoolTimer {
     #[inline] pub fn create_periodic_timer(handler: &TimerElapsedHandler, period: foundation::TimeSpan) -> Result<Option<ComPtr<ThreadPoolTimer>>> {
@@ -6034,10 +6034,10 @@ impl WorkItemHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WorkItemOptions: u32 {
+RT_ENUM! { enum WorkItemOptions: u32 ["Windows.System.Threading.WorkItemOptions"] {
     None (WorkItemOptions_None) = 0, TimeSliced (WorkItemOptions_TimeSliced) = 1,
 }}
-RT_ENUM! { enum WorkItemPriority: i32 {
+RT_ENUM! { enum WorkItemPriority: i32 ["Windows.System.Threading.WorkItemPriority"] {
     Low (WorkItemPriority_Low) = -1, Normal (WorkItemPriority_Normal) = 0, High (WorkItemPriority_High) = 1,
 }}
 pub mod core { // Windows.System.Threading.Core
@@ -6053,7 +6053,7 @@ impl IPreallocatedWorkItem {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PreallocatedWorkItem: IPreallocatedWorkItem}
+RT_CLASS!{class PreallocatedWorkItem: IPreallocatedWorkItem ["Windows.System.Threading.Core.PreallocatedWorkItem"]}
 impl RtActivatable<IPreallocatedWorkItemFactory> for PreallocatedWorkItem {}
 impl PreallocatedWorkItem {
     #[inline] pub fn create_work_item(handler: &super::WorkItemHandler) -> Result<ComPtr<PreallocatedWorkItem>> {
@@ -6115,7 +6115,7 @@ impl ISignalNotifier {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SignalNotifier: ISignalNotifier}
+RT_CLASS!{class SignalNotifier: ISignalNotifier ["Windows.System.Threading.Core.SignalNotifier"]}
 impl RtActivatable<ISignalNotifierStatics> for SignalNotifier {}
 impl SignalNotifier {
     #[inline] pub fn attach_to_event(name: &HStringArg, handler: &SignalHandler) -> Result<Option<ComPtr<SignalNotifier>>> {
@@ -6165,7 +6165,7 @@ impl ISignalNotifierStatics {
 } // Windows.System.Threading
 pub mod update { // Windows.System.Update
 use ::prelude::*;
-RT_ENUM! { enum SystemUpdateAttentionRequiredReason: i32 {
+RT_ENUM! { enum SystemUpdateAttentionRequiredReason: i32 ["Windows.System.Update.SystemUpdateAttentionRequiredReason"] {
     None (SystemUpdateAttentionRequiredReason_None) = 0, NetworkRequired (SystemUpdateAttentionRequiredReason_NetworkRequired) = 1, InsufficientDiskSpace (SystemUpdateAttentionRequiredReason_InsufficientDiskSpace) = 2, InsufficientBattery (SystemUpdateAttentionRequiredReason_InsufficientBattery) = 3, UpdateBlocked (SystemUpdateAttentionRequiredReason_UpdateBlocked) = 4,
 }}
 DEFINE_IID!(IID_ISystemUpdateItem, 2006401259, 22052, 20894, 168, 226, 9, 233, 23, 59, 63, 183);
@@ -6221,8 +6221,8 @@ impl ISystemUpdateItem {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemUpdateItem: ISystemUpdateItem}
-RT_ENUM! { enum SystemUpdateItemState: i32 {
+RT_CLASS!{class SystemUpdateItem: ISystemUpdateItem ["Windows.System.Update.SystemUpdateItem"]}
+RT_ENUM! { enum SystemUpdateItemState: i32 ["Windows.System.Update.SystemUpdateItemState"] {
     NotStarted (SystemUpdateItemState_NotStarted) = 0, Initializing (SystemUpdateItemState_Initializing) = 1, Preparing (SystemUpdateItemState_Preparing) = 2, Calculating (SystemUpdateItemState_Calculating) = 3, Downloading (SystemUpdateItemState_Downloading) = 4, Installing (SystemUpdateItemState_Installing) = 5, Completed (SystemUpdateItemState_Completed) = 6, RebootRequired (SystemUpdateItemState_RebootRequired) = 7, Error (SystemUpdateItemState_Error) = 8,
 }}
 DEFINE_IID!(IID_ISystemUpdateLastErrorInfo, 2129168375, 35396, 23406, 189, 7, 122, 236, 228, 17, 110, 169);
@@ -6248,7 +6248,7 @@ impl ISystemUpdateLastErrorInfo {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemUpdateLastErrorInfo: ISystemUpdateLastErrorInfo}
+RT_CLASS!{class SystemUpdateLastErrorInfo: ISystemUpdateLastErrorInfo ["Windows.System.Update.SystemUpdateLastErrorInfo"]}
 RT_CLASS!{static class SystemUpdateManager}
 impl RtActivatable<ISystemUpdateManagerStatics> for SystemUpdateManager {}
 impl SystemUpdateManager {
@@ -6326,7 +6326,7 @@ impl SystemUpdateManager {
     }
 }
 DEFINE_CLSID!(SystemUpdateManager(&[87,105,110,100,111,119,115,46,83,121,115,116,101,109,46,85,112,100,97,116,101,46,83,121,115,116,101,109,85,112,100,97,116,101,77,97,110,97,103,101,114,0]) [CLSID_SystemUpdateManager]);
-RT_ENUM! { enum SystemUpdateManagerState: i32 {
+RT_ENUM! { enum SystemUpdateManagerState: i32 ["Windows.System.Update.SystemUpdateManagerState"] {
     Idle (SystemUpdateManagerState_Idle) = 0, Detecting (SystemUpdateManagerState_Detecting) = 1, ReadyToDownload (SystemUpdateManagerState_ReadyToDownload) = 2, Downloading (SystemUpdateManagerState_Downloading) = 3, ReadyToInstall (SystemUpdateManagerState_ReadyToInstall) = 4, Installing (SystemUpdateManagerState_Installing) = 5, RebootRequired (SystemUpdateManagerState_RebootRequired) = 6, ReadyToFinalize (SystemUpdateManagerState_ReadyToFinalize) = 7, Finalizing (SystemUpdateManagerState_Finalizing) = 8, Completed (SystemUpdateManagerState_Completed) = 9, AttentionRequired (SystemUpdateManagerState_AttentionRequired) = 10, Error (SystemUpdateManagerState_Error) = 11,
 }}
 DEFINE_IID!(IID_ISystemUpdateManagerStatics, 3000237295, 10609, 20926, 180, 26, 139, 215, 3, 187, 112, 26);
@@ -6474,13 +6474,13 @@ impl ISystemUpdateManagerStatics {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SystemUpdateStartInstallAction: i32 {
+RT_ENUM! { enum SystemUpdateStartInstallAction: i32 ["Windows.System.Update.SystemUpdateStartInstallAction"] {
     UpToReboot (SystemUpdateStartInstallAction_UpToReboot) = 0, AllowReboot (SystemUpdateStartInstallAction_AllowReboot) = 1,
 }}
 } // Windows.System.Update
 pub mod userprofile { // Windows.System.UserProfile
 use ::prelude::*;
-RT_ENUM! { enum AccountPictureKind: i32 {
+RT_ENUM! { enum AccountPictureKind: i32 ["Windows.System.UserProfile.AccountPictureKind"] {
     SmallImage (AccountPictureKind_SmallImage) = 0, LargeImage (AccountPictureKind_LargeImage) = 1, Video (AccountPictureKind_Video) = 2,
 }}
 RT_CLASS!{static class AdvertisingManager}
@@ -6512,7 +6512,7 @@ impl IAdvertisingManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdvertisingManagerForUser: IAdvertisingManagerForUser}
+RT_CLASS!{class AdvertisingManagerForUser: IAdvertisingManagerForUser ["Windows.System.UserProfile.AdvertisingManagerForUser"]}
 DEFINE_IID!(IID_IAdvertisingManagerStatics, 2916304524, 41587, 18635, 179, 70, 53, 68, 82, 45, 85, 129);
 RT_INTERFACE!{static interface IAdvertisingManagerStatics(IAdvertisingManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAdvertisingManagerStatics] {
     fn get_AdvertisingId(&self, out: *mut HSTRING) -> HRESULT
@@ -6558,7 +6558,7 @@ impl IAssignedAccessSettings {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AssignedAccessSettings: IAssignedAccessSettings}
+RT_CLASS!{class AssignedAccessSettings: IAssignedAccessSettings ["Windows.System.UserProfile.AssignedAccessSettings"]}
 impl RtActivatable<IAssignedAccessSettingsStatics> for AssignedAccessSettings {}
 impl AssignedAccessSettings {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<AssignedAccessSettings>>> {
@@ -6603,7 +6603,7 @@ impl IDiagnosticsSettings {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DiagnosticsSettings: IDiagnosticsSettings}
+RT_CLASS!{class DiagnosticsSettings: IDiagnosticsSettings ["Windows.System.UserProfile.DiagnosticsSettings"]}
 impl RtActivatable<IDiagnosticsSettingsStatics> for DiagnosticsSettings {}
 impl DiagnosticsSettings {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<DiagnosticsSettings>>> {
@@ -6635,7 +6635,7 @@ DEFINE_IID!(IID_IFirstSignInSettings, 1049907539, 14942, 17710, 166, 1, 245, 186
 RT_INTERFACE!{interface IFirstSignInSettings(IFirstSignInSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IFirstSignInSettings] {
     
 }}
-RT_CLASS!{class FirstSignInSettings: IFirstSignInSettings}
+RT_CLASS!{class FirstSignInSettings: IFirstSignInSettings ["Windows.System.UserProfile.FirstSignInSettings"]}
 impl RtActivatable<IFirstSignInSettingsStatics> for FirstSignInSettings {}
 impl FirstSignInSettings {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<FirstSignInSettings>>> {
@@ -6735,7 +6735,7 @@ impl IGlobalizationPreferencesForUser {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GlobalizationPreferencesForUser: IGlobalizationPreferencesForUser}
+RT_CLASS!{class GlobalizationPreferencesForUser: IGlobalizationPreferencesForUser ["Windows.System.UserProfile.GlobalizationPreferencesForUser"]}
 DEFINE_IID!(IID_IGlobalizationPreferencesStatics, 29311782, 60727, 20118, 176, 233, 193, 52, 13, 30, 161, 88);
 RT_INTERFACE!{static interface IGlobalizationPreferencesStatics(IGlobalizationPreferencesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IGlobalizationPreferencesStatics] {
     fn get_Calendars(&self, out: *mut *mut foundation::collections::IVectorView<HString>) -> HRESULT,
@@ -6875,10 +6875,10 @@ impl ILockScreenStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SetAccountPictureResult: i32 {
+RT_ENUM! { enum SetAccountPictureResult: i32 ["Windows.System.UserProfile.SetAccountPictureResult"] {
     Success (SetAccountPictureResult_Success) = 0, ChangeDisabled (SetAccountPictureResult_ChangeDisabled) = 1, LargeOrDynamicError (SetAccountPictureResult_LargeOrDynamicError) = 2, VideoFrameSizeError (SetAccountPictureResult_VideoFrameSizeError) = 3, FileSizeError (SetAccountPictureResult_FileSizeError) = 4, Failure (SetAccountPictureResult_Failure) = 5,
 }}
-RT_ENUM! { enum SetImageFeedResult: i32 {
+RT_ENUM! { enum SetImageFeedResult: i32 ["Windows.System.UserProfile.SetImageFeedResult"] {
     Success (SetImageFeedResult_Success) = 0, ChangeDisabled (SetImageFeedResult_ChangeDisabled) = 1, UserCanceled (SetImageFeedResult_UserCanceled) = 2,
 }}
 RT_CLASS!{static class UserInformation}
@@ -7047,7 +7047,7 @@ impl IUserProfilePersonalizationSettings {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserProfilePersonalizationSettings: IUserProfilePersonalizationSettings}
+RT_CLASS!{class UserProfilePersonalizationSettings: IUserProfilePersonalizationSettings ["Windows.System.UserProfile.UserProfilePersonalizationSettings"]}
 impl RtActivatable<IUserProfilePersonalizationSettingsStatics> for UserProfilePersonalizationSettings {}
 impl UserProfilePersonalizationSettings {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<UserProfilePersonalizationSettings>>> {

--- a/src/rt/gen/windows/ui/mod.rs
+++ b/src/rt/gen/windows/ui/mod.rs
@@ -1,12 +1,12 @@
 use ::prelude::*;
-RT_STRUCT! { struct Color {
+RT_STRUCT! { struct Color ["Windows.UI.Color"] {
     A: u8, R: u8, G: u8, B: u8,
 }}
 DEFINE_IID!(IID_IColorHelper, 423427047, 26055, 17728, 173, 8, 98, 131, 186, 118, 135, 154);
 RT_INTERFACE!{interface IColorHelper(IColorHelperVtbl): IInspectable(IInspectableVtbl) [IID_IColorHelper] {
     
 }}
-RT_CLASS!{class ColorHelper: IColorHelper}
+RT_CLASS!{class ColorHelper: IColorHelper ["Windows.UI.ColorHelper"]}
 impl RtActivatable<IColorHelperStatics> for ColorHelper {}
 impl RtActivatable<IColorHelperStatics2> for ColorHelper {}
 impl ColorHelper {
@@ -44,7 +44,7 @@ DEFINE_IID!(IID_IColors, 2609681190, 19622, 19685, 137, 148, 158, 255, 101, 202,
 RT_INTERFACE!{interface IColors(IColorsVtbl): IInspectable(IInspectableVtbl) [IID_IColors] {
     
 }}
-RT_CLASS!{class Colors: IColors}
+RT_CLASS!{class Colors: IColors ["Windows.UI.Colors"]}
 impl RtActivatable<IColorsStatics> for Colors {}
 impl Colors {
     #[inline] pub fn get_alice_blue() -> Result<Color> {
@@ -1342,7 +1342,7 @@ impl IScreenReaderPositionChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScreenReaderPositionChangedEventArgs: IScreenReaderPositionChangedEventArgs}
+RT_CLASS!{class ScreenReaderPositionChangedEventArgs: IScreenReaderPositionChangedEventArgs ["Windows.UI.Accessibility.ScreenReaderPositionChangedEventArgs"]}
 DEFINE_IID!(IID_IScreenReaderService, 424104999, 60096, 20691, 189, 217, 155, 72, 122, 34, 98, 86);
 RT_INTERFACE!{interface IScreenReaderService(IScreenReaderServiceVtbl): IInspectable(IInspectableVtbl) [IID_IScreenReaderService] {
     fn get_CurrentScreenReaderPosition(&self, out: *mut *mut ScreenReaderPositionChangedEventArgs) -> HRESULT,
@@ -1365,7 +1365,7 @@ impl IScreenReaderService {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScreenReaderService: IScreenReaderService}
+RT_CLASS!{class ScreenReaderService: IScreenReaderService ["Windows.UI.Accessibility.ScreenReaderService"]}
 impl RtActivatable<IActivationFactory> for ScreenReaderService {}
 DEFINE_CLSID!(ScreenReaderService(&[87,105,110,100,111,119,115,46,85,73,46,65,99,99,101,115,115,105,98,105,108,105,116,121,46,83,99,114,101,101,110,82,101,97,100,101,114,83,101,114,118,105,99,101,0]) [CLSID_ScreenReaderService]);
 } // Windows.UI.Accessibility
@@ -1387,7 +1387,7 @@ impl IAccountsSettingsPane {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccountsSettingsPane: IAccountsSettingsPane}
+RT_CLASS!{class AccountsSettingsPane: IAccountsSettingsPane ["Windows.UI.ApplicationSettings.AccountsSettingsPane"]}
 impl RtActivatable<IAccountsSettingsPaneStatics> for AccountsSettingsPane {}
 impl RtActivatable<IAccountsSettingsPaneStatics2> for AccountsSettingsPane {}
 impl RtActivatable<IAccountsSettingsPaneStatics3> for AccountsSettingsPane {}
@@ -1458,7 +1458,7 @@ impl IAccountsSettingsPaneCommandsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccountsSettingsPaneCommandsRequestedEventArgs: IAccountsSettingsPaneCommandsRequestedEventArgs}
+RT_CLASS!{class AccountsSettingsPaneCommandsRequestedEventArgs: IAccountsSettingsPaneCommandsRequestedEventArgs ["Windows.UI.ApplicationSettings.AccountsSettingsPaneCommandsRequestedEventArgs"]}
 DEFINE_IID!(IID_IAccountsSettingsPaneCommandsRequestedEventArgs2, 909081517, 20023, 18791, 140, 64, 231, 142, 231, 161, 229, 187);
 RT_INTERFACE!{interface IAccountsSettingsPaneCommandsRequestedEventArgs2(IAccountsSettingsPaneCommandsRequestedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAccountsSettingsPaneCommandsRequestedEventArgs2] {
     #[cfg(feature="windows-system")] fn get_User(&self, out: *mut *mut super::super::system::User) -> HRESULT
@@ -1480,7 +1480,7 @@ impl IAccountsSettingsPaneEventDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccountsSettingsPaneEventDeferral: IAccountsSettingsPaneEventDeferral}
+RT_CLASS!{class AccountsSettingsPaneEventDeferral: IAccountsSettingsPaneEventDeferral ["Windows.UI.ApplicationSettings.AccountsSettingsPaneEventDeferral"]}
 DEFINE_IID!(IID_IAccountsSettingsPaneStatics, 1444907872, 45292, 16720, 168, 220, 32, 142, 228, 75, 6, 138);
 RT_INTERFACE!{static interface IAccountsSettingsPaneStatics(IAccountsSettingsPaneStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IAccountsSettingsPaneStatics] {
     fn GetForCurrentView(&self, out: *mut *mut AccountsSettingsPane) -> HRESULT,
@@ -1549,7 +1549,7 @@ impl ICredentialCommand {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CredentialCommand: ICredentialCommand}
+RT_CLASS!{class CredentialCommand: ICredentialCommand ["Windows.UI.ApplicationSettings.CredentialCommand"]}
 impl RtActivatable<ICredentialCommandFactory> for CredentialCommand {}
 impl CredentialCommand {
     #[cfg(feature="windows-security")] #[inline] pub fn create_credential_command(passwordCredential: &super::super::security::credentials::PasswordCredential) -> Result<ComPtr<CredentialCommand>> {
@@ -1587,7 +1587,7 @@ impl ICredentialCommandFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SettingsCommand: super::popups::IUICommand}
+RT_CLASS!{class SettingsCommand: super::popups::IUICommand ["Windows.UI.ApplicationSettings.SettingsCommand"]}
 impl RtActivatable<ISettingsCommandFactory> for SettingsCommand {}
 impl RtActivatable<ISettingsCommandStatics> for SettingsCommand {}
 impl SettingsCommand {
@@ -1621,7 +1621,7 @@ impl ISettingsCommandStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SettingsEdgeLocation: i32 {
+RT_ENUM! { enum SettingsEdgeLocation: i32 ["Windows.UI.ApplicationSettings.SettingsEdgeLocation"] {
     Right (SettingsEdgeLocation_Right) = 0, Left (SettingsEdgeLocation_Left) = 1,
 }}
 DEFINE_IID!(IID_ISettingsPane, 2983004466, 17776, 19561, 141, 56, 137, 68, 101, 97, 172, 224);
@@ -1640,7 +1640,7 @@ impl ISettingsPane {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SettingsPane: ISettingsPane}
+RT_CLASS!{class SettingsPane: ISettingsPane ["Windows.UI.ApplicationSettings.SettingsPane"]}
 impl RtActivatable<ISettingsPaneStatics> for SettingsPane {}
 impl SettingsPane {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<SettingsPane>>> {
@@ -1665,7 +1665,7 @@ impl ISettingsPaneCommandsRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SettingsPaneCommandsRequest: ISettingsPaneCommandsRequest}
+RT_CLASS!{class SettingsPaneCommandsRequest: ISettingsPaneCommandsRequest ["Windows.UI.ApplicationSettings.SettingsPaneCommandsRequest"]}
 DEFINE_IID!(IID_ISettingsPaneCommandsRequestedEventArgs, 543120676, 6984, 17961, 166, 202, 47, 223, 237, 175, 183, 93);
 RT_INTERFACE!{interface ISettingsPaneCommandsRequestedEventArgs(ISettingsPaneCommandsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISettingsPaneCommandsRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut SettingsPaneCommandsRequest) -> HRESULT
@@ -1677,7 +1677,7 @@ impl ISettingsPaneCommandsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SettingsPaneCommandsRequestedEventArgs: ISettingsPaneCommandsRequestedEventArgs}
+RT_CLASS!{class SettingsPaneCommandsRequestedEventArgs: ISettingsPaneCommandsRequestedEventArgs ["Windows.UI.ApplicationSettings.SettingsPaneCommandsRequestedEventArgs"]}
 DEFINE_IID!(IID_ISettingsPaneStatics, 476730053, 65305, 18203, 186, 107, 248, 243, 86, 148, 173, 154);
 RT_INTERFACE!{static interface ISettingsPaneStatics(ISettingsPaneStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ISettingsPaneStatics] {
     fn GetForCurrentView(&self, out: *mut *mut SettingsPane) -> HRESULT,
@@ -1700,10 +1700,10 @@ impl ISettingsPaneStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SupportedWebAccountActions: u32 {
+RT_ENUM! { enum SupportedWebAccountActions: u32 ["Windows.UI.ApplicationSettings.SupportedWebAccountActions"] {
     None (SupportedWebAccountActions_None) = 0, Reconnect (SupportedWebAccountActions_Reconnect) = 1, Remove (SupportedWebAccountActions_Remove) = 2, ViewDetails (SupportedWebAccountActions_ViewDetails) = 4, Manage (SupportedWebAccountActions_Manage) = 8, More (SupportedWebAccountActions_More) = 16,
 }}
-RT_ENUM! { enum WebAccountAction: i32 {
+RT_ENUM! { enum WebAccountAction: i32 ["Windows.UI.ApplicationSettings.WebAccountAction"] {
     Reconnect (WebAccountAction_Reconnect) = 0, Remove (WebAccountAction_Remove) = 1, ViewDetails (WebAccountAction_ViewDetails) = 2, Manage (WebAccountAction_Manage) = 3, More (WebAccountAction_More) = 4,
 }}
 DEFINE_IID!(IID_IWebAccountCommand, 3399717784, 40186, 16966, 176, 196, 169, 19, 163, 137, 101, 65);
@@ -1730,7 +1730,7 @@ impl IWebAccountCommand {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountCommand: IWebAccountCommand}
+RT_CLASS!{class WebAccountCommand: IWebAccountCommand ["Windows.UI.ApplicationSettings.WebAccountCommand"]}
 impl RtActivatable<IWebAccountCommandFactory> for WebAccountCommand {}
 impl WebAccountCommand {
     #[cfg(feature="windows-security")] #[inline] pub fn create_web_account_command(webAccount: &super::super::security::credentials::WebAccount, invoked: &WebAccountCommandInvokedHandler, actions: SupportedWebAccountActions) -> Result<ComPtr<WebAccountCommand>> {
@@ -1770,7 +1770,7 @@ impl IWebAccountInvokedArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountInvokedArgs: IWebAccountInvokedArgs}
+RT_CLASS!{class WebAccountInvokedArgs: IWebAccountInvokedArgs ["Windows.UI.ApplicationSettings.WebAccountInvokedArgs"]}
 DEFINE_IID!(IID_IWebAccountProviderCommand, 3600539034, 41126, 20123, 136, 220, 199, 30, 117, 122, 53, 1);
 RT_INTERFACE!{interface IWebAccountProviderCommand(IWebAccountProviderCommandVtbl): IInspectable(IInspectableVtbl) [IID_IWebAccountProviderCommand] {
     #[cfg(not(feature="windows-security"))] fn __Dummy0(&self) -> (),
@@ -1789,7 +1789,7 @@ impl IWebAccountProviderCommand {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebAccountProviderCommand: IWebAccountProviderCommand}
+RT_CLASS!{class WebAccountProviderCommand: IWebAccountProviderCommand ["Windows.UI.ApplicationSettings.WebAccountProviderCommand"]}
 impl RtActivatable<IWebAccountProviderCommandFactory> for WebAccountProviderCommand {}
 impl WebAccountProviderCommand {
     #[cfg(feature="windows-security")] #[inline] pub fn create_web_account_provider_command(webAccountProvider: &super::super::security::credentials::WebAccountProvider, invoked: &WebAccountProviderCommandInvokedHandler) -> Result<ComPtr<WebAccountProviderCommand>> {
@@ -1837,7 +1837,7 @@ impl IAmbientLight {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AmbientLight: IAmbientLight}
+RT_CLASS!{class AmbientLight: IAmbientLight ["Windows.UI.Composition.AmbientLight"]}
 DEFINE_IID!(IID_IAmbientLight2, 996452031, 24471, 19604, 134, 229, 4, 45, 211, 134, 178, 125);
 RT_INTERFACE!{interface IAmbientLight2(IAmbientLight2Vtbl): IInspectable(IInspectableVtbl) [IID_IAmbientLight2] {
     fn get_Intensity(&self, out: *mut f32) -> HRESULT,
@@ -1902,7 +1902,7 @@ impl IAnimationController {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AnimationController: IAnimationController}
+RT_CLASS!{class AnimationController: IAnimationController ["Windows.UI.Composition.AnimationController"]}
 impl RtActivatable<IAnimationControllerStatics> for AnimationController {}
 impl AnimationController {
     #[inline] pub fn get_max_playback_rate() -> Result<f32> {
@@ -1913,7 +1913,7 @@ impl AnimationController {
     }
 }
 DEFINE_CLSID!(AnimationController(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,65,110,105,109,97,116,105,111,110,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_AnimationController]);
-RT_ENUM! { enum AnimationControllerProgressBehavior: i32 {
+RT_ENUM! { enum AnimationControllerProgressBehavior: i32 ["Windows.UI.Composition.AnimationControllerProgressBehavior"] {
     Default (AnimationControllerProgressBehavior_Default) = 0, IncludesDelayTime (AnimationControllerProgressBehavior_IncludesDelayTime) = 1,
 }}
 DEFINE_IID!(IID_IAnimationControllerStatics, 3876676831, 25883, 18432, 185, 229, 106, 59, 207, 237, 51, 101);
@@ -1933,13 +1933,13 @@ impl IAnimationControllerStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AnimationDelayBehavior: i32 {
+RT_ENUM! { enum AnimationDelayBehavior: i32 ["Windows.UI.Composition.AnimationDelayBehavior"] {
     SetInitialValueAfterDelay (AnimationDelayBehavior_SetInitialValueAfterDelay) = 0, SetInitialValueBeforeDelay (AnimationDelayBehavior_SetInitialValueBeforeDelay) = 1,
 }}
-RT_ENUM! { enum AnimationDirection: i32 {
+RT_ENUM! { enum AnimationDirection: i32 ["Windows.UI.Composition.AnimationDirection"] {
     Normal (AnimationDirection_Normal) = 0, Reverse (AnimationDirection_Reverse) = 1, Alternate (AnimationDirection_Alternate) = 2, AlternateReverse (AnimationDirection_AlternateReverse) = 3,
 }}
-RT_ENUM! { enum AnimationIterationBehavior: i32 {
+RT_ENUM! { enum AnimationIterationBehavior: i32 ["Windows.UI.Composition.AnimationIterationBehavior"] {
     Count (AnimationIterationBehavior_Count) = 0, Forever (AnimationIterationBehavior_Forever) = 1,
 }}
 DEFINE_IID!(IID_IAnimationObject, 3876855306, 1208, 20421, 164, 220, 25, 83, 146, 229, 120, 7);
@@ -1952,7 +1952,7 @@ impl IAnimationObject {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AnimationPropertyAccessMode: i32 {
+RT_ENUM! { enum AnimationPropertyAccessMode: i32 ["Windows.UI.Composition.AnimationPropertyAccessMode"] {
     None (AnimationPropertyAccessMode_None) = 0, ReadOnly (AnimationPropertyAccessMode_ReadOnly) = 1, WriteOnly (AnimationPropertyAccessMode_WriteOnly) = 2, ReadWrite (AnimationPropertyAccessMode_ReadWrite) = 3,
 }}
 DEFINE_IID!(IID_IAnimationPropertyInfo, 4101074693, 60791, 20028, 179, 40, 92, 57, 133, 179, 115, 143);
@@ -1971,8 +1971,8 @@ impl IAnimationPropertyInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AnimationPropertyInfo: IAnimationPropertyInfo}
-RT_ENUM! { enum AnimationStopBehavior: i32 {
+RT_CLASS!{class AnimationPropertyInfo: IAnimationPropertyInfo ["Windows.UI.Composition.AnimationPropertyInfo"]}
+RT_ENUM! { enum AnimationStopBehavior: i32 ["Windows.UI.Composition.AnimationStopBehavior"] {
     LeaveCurrentValue (AnimationStopBehavior_LeaveCurrentValue) = 0, SetToInitialValue (AnimationStopBehavior_SetToInitialValue) = 1, SetToFinalValue (AnimationStopBehavior_SetToFinalValue) = 2,
 }}
 DEFINE_IID!(IID_IBooleanKeyFrameAnimation, 2514631176, 53748, 18802, 151, 112, 62, 254, 104, 216, 46, 20);
@@ -1985,7 +1985,7 @@ impl IBooleanKeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BooleanKeyFrameAnimation: IBooleanKeyFrameAnimation}
+RT_CLASS!{class BooleanKeyFrameAnimation: IBooleanKeyFrameAnimation ["Windows.UI.Composition.BooleanKeyFrameAnimation"]}
 DEFINE_IID!(IID_IBounceScalarNaturalMotionAnimation, 3131248076, 42547, 17944, 155, 6, 127, 124, 114, 200, 124, 255);
 RT_INTERFACE!{interface IBounceScalarNaturalMotionAnimation(IBounceScalarNaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IBounceScalarNaturalMotionAnimation] {
     fn get_Acceleration(&self, out: *mut f32) -> HRESULT,
@@ -2013,7 +2013,7 @@ impl IBounceScalarNaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BounceScalarNaturalMotionAnimation: IBounceScalarNaturalMotionAnimation}
+RT_CLASS!{class BounceScalarNaturalMotionAnimation: IBounceScalarNaturalMotionAnimation ["Windows.UI.Composition.BounceScalarNaturalMotionAnimation"]}
 DEFINE_IID!(IID_IBounceVector2NaturalMotionAnimation, 3660857750, 8532, 19260, 136, 170, 71, 54, 18, 4, 236, 205);
 RT_INTERFACE!{interface IBounceVector2NaturalMotionAnimation(IBounceVector2NaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IBounceVector2NaturalMotionAnimation] {
     fn get_Acceleration(&self, out: *mut f32) -> HRESULT,
@@ -2041,7 +2041,7 @@ impl IBounceVector2NaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BounceVector2NaturalMotionAnimation: IBounceVector2NaturalMotionAnimation}
+RT_CLASS!{class BounceVector2NaturalMotionAnimation: IBounceVector2NaturalMotionAnimation ["Windows.UI.Composition.BounceVector2NaturalMotionAnimation"]}
 DEFINE_IID!(IID_IBounceVector3NaturalMotionAnimation, 1205517361, 4307, 17688, 134, 241, 9, 202, 247, 66, 209, 19);
 RT_INTERFACE!{interface IBounceVector3NaturalMotionAnimation(IBounceVector3NaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IBounceVector3NaturalMotionAnimation] {
     fn get_Acceleration(&self, out: *mut f32) -> HRESULT,
@@ -2069,7 +2069,7 @@ impl IBounceVector3NaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BounceVector3NaturalMotionAnimation: IBounceVector3NaturalMotionAnimation}
+RT_CLASS!{class BounceVector3NaturalMotionAnimation: IBounceVector3NaturalMotionAnimation ["Windows.UI.Composition.BounceVector3NaturalMotionAnimation"]}
 DEFINE_IID!(IID_IColorKeyFrameAnimation, 2477635049, 36357, 17811, 132, 163, 220, 161, 82, 120, 30, 86);
 RT_INTERFACE!{interface IColorKeyFrameAnimation(IColorKeyFrameAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IColorKeyFrameAnimation] {
     fn get_InterpolationColorSpace(&self, out: *mut CompositionColorSpace) -> HRESULT,
@@ -2096,7 +2096,7 @@ impl IColorKeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ColorKeyFrameAnimation: IColorKeyFrameAnimation}
+RT_CLASS!{class ColorKeyFrameAnimation: IColorKeyFrameAnimation ["Windows.UI.Composition.ColorKeyFrameAnimation"]}
 DEFINE_IID!(IID_ICompositionAnimation, 1179405356, 7338, 16481, 155, 64, 225, 63, 222, 21, 3, 202);
 RT_INTERFACE!{interface ICompositionAnimation(ICompositionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionAnimation] {
     fn ClearAllParameters(&self) -> HRESULT,
@@ -2157,7 +2157,7 @@ impl ICompositionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionAnimation: ICompositionAnimation}
+RT_CLASS!{class CompositionAnimation: ICompositionAnimation ["Windows.UI.Composition.CompositionAnimation"]}
 DEFINE_IID!(IID_ICompositionAnimation2, 916152382, 43023, 18760, 147, 227, 237, 35, 251, 56, 198, 203);
 RT_INTERFACE!{interface ICompositionAnimation2(ICompositionAnimation2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionAnimation2] {
     fn SetBooleanParameter(&self, key: HSTRING, value: bool) -> HRESULT,
@@ -2234,34 +2234,34 @@ impl ICompositionAnimationGroup {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionAnimationGroup: ICompositionAnimationGroup}
+RT_CLASS!{class CompositionAnimationGroup: ICompositionAnimationGroup ["Windows.UI.Composition.CompositionAnimationGroup"]}
 DEFINE_IID!(IID_ICompositionBackdropBrush, 3316428376, 14488, 18846, 141, 127, 34, 78, 145, 40, 106, 93);
 RT_INTERFACE!{interface ICompositionBackdropBrush(ICompositionBackdropBrushVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionBackdropBrush] {
     
 }}
-RT_CLASS!{class CompositionBackdropBrush: ICompositionBackdropBrush}
-RT_ENUM! { enum CompositionBackfaceVisibility: i32 {
+RT_CLASS!{class CompositionBackdropBrush: ICompositionBackdropBrush ["Windows.UI.Composition.CompositionBackdropBrush"]}
+RT_ENUM! { enum CompositionBackfaceVisibility: i32 ["Windows.UI.Composition.CompositionBackfaceVisibility"] {
     Inherit (CompositionBackfaceVisibility_Inherit) = 0, Visible (CompositionBackfaceVisibility_Visible) = 1, Hidden (CompositionBackfaceVisibility_Hidden) = 2,
 }}
 DEFINE_IID!(IID_ICompositionBatchCompletedEventArgs, 218159824, 37988, 17674, 165, 98, 46, 38, 152, 176, 168, 18);
 RT_INTERFACE!{interface ICompositionBatchCompletedEventArgs(ICompositionBatchCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionBatchCompletedEventArgs] {
     
 }}
-RT_CLASS!{class CompositionBatchCompletedEventArgs: ICompositionBatchCompletedEventArgs}
-RT_ENUM! { enum CompositionBatchTypes: u32 {
+RT_CLASS!{class CompositionBatchCompletedEventArgs: ICompositionBatchCompletedEventArgs ["Windows.UI.Composition.CompositionBatchCompletedEventArgs"]}
+RT_ENUM! { enum CompositionBatchTypes: u32 ["Windows.UI.Composition.CompositionBatchTypes"] {
     None (CompositionBatchTypes_None) = 0, Animation (CompositionBatchTypes_Animation) = 1, Effect (CompositionBatchTypes_Effect) = 2, InfiniteAnimation (CompositionBatchTypes_InfiniteAnimation) = 4, AllAnimations (CompositionBatchTypes_AllAnimations) = 5,
 }}
-RT_ENUM! { enum CompositionBitmapInterpolationMode: i32 {
+RT_ENUM! { enum CompositionBitmapInterpolationMode: i32 ["Windows.UI.Composition.CompositionBitmapInterpolationMode"] {
     NearestNeighbor (CompositionBitmapInterpolationMode_NearestNeighbor) = 0, Linear (CompositionBitmapInterpolationMode_Linear) = 1,
 }}
-RT_ENUM! { enum CompositionBorderMode: i32 {
+RT_ENUM! { enum CompositionBorderMode: i32 ["Windows.UI.Composition.CompositionBorderMode"] {
     Inherit (CompositionBorderMode_Inherit) = 0, Soft (CompositionBorderMode_Soft) = 1, Hard (CompositionBorderMode_Hard) = 2,
 }}
 DEFINE_IID!(IID_ICompositionBrush, 2869786120, 12480, 16617, 181, 104, 182, 10, 107, 209, 251, 70);
 RT_INTERFACE!{interface ICompositionBrush(ICompositionBrushVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionBrush] {
     
 }}
-RT_CLASS!{class CompositionBrush: ICompositionBrush}
+RT_CLASS!{class CompositionBrush: ICompositionBrush ["Windows.UI.Composition.CompositionBrush"]}
 DEFINE_IID!(IID_ICompositionBrushFactory, 3662936908, 18000, 18372, 173, 118, 118, 83, 121, 96, 126, 214);
 RT_INTERFACE!{interface ICompositionBrushFactory(ICompositionBrushFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionBrushFactory] {
     
@@ -2294,7 +2294,7 @@ impl ICompositionCapabilities {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionCapabilities: ICompositionCapabilities}
+RT_CLASS!{class CompositionCapabilities: ICompositionCapabilities ["Windows.UI.Composition.CompositionCapabilities"]}
 impl RtActivatable<ICompositionCapabilitiesStatics> for CompositionCapabilities {}
 impl CompositionCapabilities {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<CompositionCapabilities>>> {
@@ -2317,7 +2317,7 @@ DEFINE_IID!(IID_ICompositionClip, 483207762, 53191, 19150, 153, 131, 20, 107, 18
 RT_INTERFACE!{interface ICompositionClip(ICompositionClipVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionClip] {
     
 }}
-RT_CLASS!{class CompositionClip: ICompositionClip}
+RT_CLASS!{class CompositionClip: ICompositionClip ["Windows.UI.Composition.CompositionClip"]}
 DEFINE_IID!(IID_ICompositionClip2, 1486086249, 13590, 16609, 137, 224, 91, 169, 36, 146, 114, 53);
 RT_INTERFACE!{interface ICompositionClip2(ICompositionClip2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionClip2] {
     fn get_AnchorPoint(&self, out: *mut foundation::numerics::Vector2) -> HRESULT,
@@ -2420,7 +2420,7 @@ impl ICompositionColorBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionColorBrush: ICompositionColorBrush}
+RT_CLASS!{class CompositionColorBrush: ICompositionColorBrush ["Windows.UI.Composition.CompositionColorBrush"]}
 DEFINE_IID!(IID_ICompositionColorGradientStop, 1862322834, 51201, 20033, 154, 143, 165, 62, 32, 245, 119, 120);
 RT_INTERFACE!{interface ICompositionColorGradientStop(ICompositionColorGradientStopVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionColorGradientStop] {
     fn get_Color(&self, out: *mut super::Color) -> HRESULT,
@@ -2448,13 +2448,13 @@ impl ICompositionColorGradientStop {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionColorGradientStop: ICompositionColorGradientStop}
+RT_CLASS!{class CompositionColorGradientStop: ICompositionColorGradientStop ["Windows.UI.Composition.CompositionColorGradientStop"]}
 DEFINE_IID!(IID_ICompositionColorGradientStopCollection, 2669486316, 31492, 19229, 144, 188, 159, 163, 44, 12, 253, 38);
 RT_INTERFACE!{interface ICompositionColorGradientStopCollection(ICompositionColorGradientStopCollectionVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionColorGradientStopCollection] {
     
 }}
-RT_CLASS!{class CompositionColorGradientStopCollection: ICompositionColorGradientStopCollection}
-RT_ENUM! { enum CompositionColorSpace: i32 {
+RT_CLASS!{class CompositionColorGradientStopCollection: ICompositionColorGradientStopCollection ["Windows.UI.Composition.CompositionColorGradientStopCollection"]}
+RT_ENUM! { enum CompositionColorSpace: i32 ["Windows.UI.Composition.CompositionColorSpace"] {
     Auto (CompositionColorSpace_Auto) = 0, Hsl (CompositionColorSpace_Hsl) = 1, Rgb (CompositionColorSpace_Rgb) = 2, HslLinear (CompositionColorSpace_HslLinear) = 3, RgbLinear (CompositionColorSpace_RgbLinear) = 4,
 }}
 DEFINE_IID!(IID_ICompositionCommitBatch, 218159824, 51719, 17408, 140, 142, 203, 93, 176, 133, 89, 204);
@@ -2485,8 +2485,8 @@ impl ICompositionCommitBatch {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionCommitBatch: ICompositionCommitBatch}
-RT_ENUM! { enum CompositionCompositeMode: i32 {
+RT_CLASS!{class CompositionCommitBatch: ICompositionCommitBatch ["Windows.UI.Composition.CompositionCommitBatch"]}
+RT_ENUM! { enum CompositionCompositeMode: i32 ["Windows.UI.Composition.CompositionCompositeMode"] {
     Inherit (CompositionCompositeMode_Inherit) = 0, SourceOver (CompositionCompositeMode_SourceOver) = 1, DestinationInvert (CompositionCompositeMode_DestinationInvert) = 2, MinBlend (CompositionCompositeMode_MinBlend) = 3,
 }}
 DEFINE_IID!(IID_ICompositionContainerShape, 1331594651, 11867, 17576, 152, 44, 170, 15, 105, 193, 96, 89);
@@ -2500,7 +2500,7 @@ impl ICompositionContainerShape {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionContainerShape: ICompositionContainerShape}
+RT_CLASS!{class CompositionContainerShape: ICompositionContainerShape ["Windows.UI.Composition.CompositionContainerShape"]}
 DEFINE_IID!(IID_ICompositionDrawingSurface, 2707866368, 64208, 19729, 158, 103, 228, 51, 22, 47, 244, 158);
 RT_INTERFACE!{interface ICompositionDrawingSurface(ICompositionDrawingSurfaceVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionDrawingSurface] {
     #[cfg(not(feature="windows-graphics"))] fn __Dummy0(&self) -> (),
@@ -2526,7 +2526,7 @@ impl ICompositionDrawingSurface {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionDrawingSurface: ICompositionDrawingSurface}
+RT_CLASS!{class CompositionDrawingSurface: ICompositionDrawingSurface ["Windows.UI.Composition.CompositionDrawingSurface"]}
 DEFINE_IID!(IID_ICompositionDrawingSurface2, 4207995019, 58196, 17640, 142, 61, 196, 136, 13, 90, 33, 63);
 RT_INTERFACE!{interface ICompositionDrawingSurface2(ICompositionDrawingSurface2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionDrawingSurface2] {
     #[cfg(feature="windows-graphics")] fn get_SizeInt32(&self, out: *mut super::super::graphics::SizeInt32) -> HRESULT,
@@ -2567,14 +2567,14 @@ DEFINE_IID!(IID_ICompositionDrawingSurfaceFactory, 2492968970, 12589, 18105, 157
 RT_INTERFACE!{interface ICompositionDrawingSurfaceFactory(ICompositionDrawingSurfaceFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionDrawingSurfaceFactory] {
     
 }}
-RT_ENUM! { enum CompositionDropShadowSourcePolicy: i32 {
+RT_ENUM! { enum CompositionDropShadowSourcePolicy: i32 ["Windows.UI.Composition.CompositionDropShadowSourcePolicy"] {
     Default (CompositionDropShadowSourcePolicy_Default) = 0, InheritFromVisualContent (CompositionDropShadowSourcePolicy_InheritFromVisualContent) = 1,
 }}
 DEFINE_IID!(IID_ICompositionEasingFunction, 1363534678, 49017, 20136, 140, 194, 107, 91, 71, 46, 108, 154);
 RT_INTERFACE!{interface ICompositionEasingFunction(ICompositionEasingFunctionVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionEasingFunction] {
     
 }}
-RT_CLASS!{class CompositionEasingFunction: ICompositionEasingFunction}
+RT_CLASS!{class CompositionEasingFunction: ICompositionEasingFunction ["Windows.UI.Composition.CompositionEasingFunction"]}
 DEFINE_IID!(IID_ICompositionEasingFunctionFactory, 1619265396, 15776, 18761, 130, 0, 114, 6, 192, 1, 144, 160);
 RT_INTERFACE!{interface ICompositionEasingFunctionFactory(ICompositionEasingFunctionFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionEasingFunctionFactory] {
     
@@ -2595,7 +2595,7 @@ impl ICompositionEffectBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionEffectBrush: ICompositionEffectBrush}
+RT_CLASS!{class CompositionEffectBrush: ICompositionEffectBrush ["Windows.UI.Composition.CompositionEffectBrush"]}
 DEFINE_IID!(IID_ICompositionEffectFactory, 3193316527, 47742, 17680, 152, 80, 65, 192, 180, 255, 116, 223);
 RT_INTERFACE!{interface ICompositionEffectFactory(ICompositionEffectFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionEffectFactory] {
     fn CreateBrush(&self, out: *mut *mut CompositionEffectBrush) -> HRESULT,
@@ -2619,8 +2619,8 @@ impl ICompositionEffectFactory {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionEffectFactory: ICompositionEffectFactory}
-RT_ENUM! { enum CompositionEffectFactoryLoadStatus: i32 {
+RT_CLASS!{class CompositionEffectFactory: ICompositionEffectFactory ["Windows.UI.Composition.CompositionEffectFactory"]}
+RT_ENUM! { enum CompositionEffectFactoryLoadStatus: i32 ["Windows.UI.Composition.CompositionEffectFactoryLoadStatus"] {
     Success (CompositionEffectFactoryLoadStatus_Success) = 0, EffectTooComplex (CompositionEffectFactoryLoadStatus_EffectTooComplex) = 1, Pending (CompositionEffectFactoryLoadStatus_Pending) = 2, Other (CompositionEffectFactoryLoadStatus_Other) = -1,
 }}
 DEFINE_IID!(IID_ICompositionEffectSourceParameter, 2240459066, 12946, 20046, 179, 187, 43, 108, 101, 68, 166, 238);
@@ -2634,7 +2634,7 @@ impl ICompositionEffectSourceParameter {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionEffectSourceParameter: ICompositionEffectSourceParameter}
+RT_CLASS!{class CompositionEffectSourceParameter: ICompositionEffectSourceParameter ["Windows.UI.Composition.CompositionEffectSourceParameter"]}
 impl RtActivatable<ICompositionEffectSourceParameterFactory> for CompositionEffectSourceParameter {}
 impl CompositionEffectSourceParameter {
     #[inline] pub fn create(name: &HStringArg) -> Result<ComPtr<CompositionEffectSourceParameter>> {
@@ -2680,7 +2680,7 @@ impl ICompositionEllipseGeometry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionEllipseGeometry: ICompositionEllipseGeometry}
+RT_CLASS!{class CompositionEllipseGeometry: ICompositionEllipseGeometry ["Windows.UI.Composition.CompositionEllipseGeometry"]}
 DEFINE_IID!(IID_ICompositionGeometricClip, 3359683969, 33225, 17476, 162, 193, 204, 174, 206, 58, 80, 229);
 RT_INTERFACE!{interface ICompositionGeometricClip(ICompositionGeometricClipVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionGeometricClip] {
     fn get_Geometry(&self, out: *mut *mut CompositionGeometry) -> HRESULT,
@@ -2708,7 +2708,7 @@ impl ICompositionGeometricClip {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionGeometricClip: ICompositionGeometricClip}
+RT_CLASS!{class CompositionGeometricClip: ICompositionGeometricClip ["Windows.UI.Composition.CompositionGeometricClip"]}
 DEFINE_IID!(IID_ICompositionGeometry, 3917816188, 27159, 16903, 171, 216, 95, 211, 221, 97, 42, 157);
 RT_INTERFACE!{interface ICompositionGeometry(ICompositionGeometryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionGeometry] {
     fn get_TrimEnd(&self, out: *mut f32) -> HRESULT,
@@ -2747,12 +2747,12 @@ impl ICompositionGeometry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionGeometry: ICompositionGeometry}
+RT_CLASS!{class CompositionGeometry: ICompositionGeometry ["Windows.UI.Composition.CompositionGeometry"]}
 DEFINE_IID!(IID_ICompositionGeometryFactory, 3221143521, 35877, 18443, 159, 86, 254, 214, 178, 136, 5, 93);
 RT_INTERFACE!{interface ICompositionGeometryFactory(ICompositionGeometryFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionGeometryFactory] {
     
 }}
-RT_ENUM! { enum CompositionGetValueStatus: i32 {
+RT_ENUM! { enum CompositionGetValueStatus: i32 ["Windows.UI.Composition.CompositionGetValueStatus"] {
     Succeeded (CompositionGetValueStatus_Succeeded) = 0, TypeMismatch (CompositionGetValueStatus_TypeMismatch) = 1, NotFound (CompositionGetValueStatus_NotFound) = 2,
 }}
 DEFINE_IID!(IID_ICompositionGradientBrush, 496437728, 65478, 19470, 169, 171, 52, 20, 77, 76, 144, 152);
@@ -2865,7 +2865,7 @@ impl ICompositionGradientBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionGradientBrush: ICompositionGradientBrush}
+RT_CLASS!{class CompositionGradientBrush: ICompositionGradientBrush ["Windows.UI.Composition.CompositionGradientBrush"]}
 DEFINE_IID!(IID_ICompositionGradientBrush2, 2308822433, 46279, 19251, 161, 182, 38, 74, 221, 194, 109, 16);
 RT_INTERFACE!{interface ICompositionGradientBrush2(ICompositionGradientBrush2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionGradientBrush2] {
     fn get_MappingMode(&self, out: *mut CompositionMappingMode) -> HRESULT,
@@ -2886,7 +2886,7 @@ DEFINE_IID!(IID_ICompositionGradientBrushFactory, 1456956887, 61833, 18633, 156,
 RT_INTERFACE!{interface ICompositionGradientBrushFactory(ICompositionGradientBrushFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionGradientBrushFactory] {
     
 }}
-RT_ENUM! { enum CompositionGradientExtendMode: i32 {
+RT_ENUM! { enum CompositionGradientExtendMode: i32 ["Windows.UI.Composition.CompositionGradientExtendMode"] {
     Clamp (CompositionGradientExtendMode_Clamp) = 0, Wrap (CompositionGradientExtendMode_Wrap) = 1, Mirror (CompositionGradientExtendMode_Mirror) = 2,
 }}
 DEFINE_IID!(IID_ICompositionGraphicsDevice, 4213360353, 32930, 18023, 153, 54, 219, 234, 246, 238, 254, 149);
@@ -2912,7 +2912,7 @@ impl ICompositionGraphicsDevice {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionGraphicsDevice: ICompositionGraphicsDevice}
+RT_CLASS!{class CompositionGraphicsDevice: ICompositionGraphicsDevice ["Windows.UI.Composition.CompositionGraphicsDevice"]}
 DEFINE_IID!(IID_ICompositionGraphicsDevice2, 263765494, 49392, 19404, 159, 184, 8, 73, 130, 73, 13, 125);
 RT_INTERFACE!{interface ICompositionGraphicsDevice2(ICompositionGraphicsDevice2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionGraphicsDevice2] {
     #[cfg(feature="windows-graphics")] fn CreateDrawingSurface2(&self, sizePixels: super::super::graphics::SizeInt32, pixelFormat: super::super::graphics::directx::DirectXPixelFormat, alphaMode: super::super::graphics::directx::DirectXAlphaMode, out: *mut *mut CompositionDrawingSurface) -> HRESULT,
@@ -2941,7 +2941,7 @@ impl ICompositionLight {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionLight: ICompositionLight}
+RT_CLASS!{class CompositionLight: ICompositionLight ["Windows.UI.Composition.CompositionLight"]}
 DEFINE_IID!(IID_ICompositionLight2, 2814171762, 62301, 16989, 155, 152, 35, 244, 32, 95, 102, 105);
 RT_INTERFACE!{interface ICompositionLight2(ICompositionLight2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionLight2] {
     fn get_ExclusionsFromTargets(&self, out: *mut *mut VisualUnorderedCollection) -> HRESULT
@@ -3000,7 +3000,7 @@ impl ICompositionLinearGradientBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionLinearGradientBrush: ICompositionLinearGradientBrush}
+RT_CLASS!{class CompositionLinearGradientBrush: ICompositionLinearGradientBrush ["Windows.UI.Composition.CompositionLinearGradientBrush"]}
 DEFINE_IID!(IID_ICompositionLineGeometry, 3715503524, 3226, 19303, 141, 206, 68, 10, 91, 249, 205, 236);
 RT_INTERFACE!{interface ICompositionLineGeometry(ICompositionLineGeometryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionLineGeometry] {
     fn get_Start(&self, out: *mut foundation::numerics::Vector2) -> HRESULT,
@@ -3028,8 +3028,8 @@ impl ICompositionLineGeometry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionLineGeometry: ICompositionLineGeometry}
-RT_ENUM! { enum CompositionMappingMode: i32 {
+RT_CLASS!{class CompositionLineGeometry: ICompositionLineGeometry ["Windows.UI.Composition.CompositionLineGeometry"]}
+RT_ENUM! { enum CompositionMappingMode: i32 ["Windows.UI.Composition.CompositionMappingMode"] {
     Absolute (CompositionMappingMode_Absolute) = 0, Relative (CompositionMappingMode_Relative) = 1,
 }}
 DEFINE_IID!(IID_ICompositionMaskBrush, 1378676894, 48747, 20289, 190, 73, 249, 34, 109, 71, 27, 74);
@@ -3059,7 +3059,7 @@ impl ICompositionMaskBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionMaskBrush: ICompositionMaskBrush}
+RT_CLASS!{class CompositionMaskBrush: ICompositionMaskBrush ["Windows.UI.Composition.CompositionMaskBrush"]}
 DEFINE_IID!(IID_ICompositionNineGridBrush, 4065416420, 48268, 19431, 184, 15, 134, 133, 184, 60, 1, 134);
 RT_INTERFACE!{interface ICompositionNineGridBrush(ICompositionNineGridBrushVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionNineGridBrush] {
     fn get_BottomInset(&self, out: *mut f32) -> HRESULT,
@@ -3195,7 +3195,7 @@ impl ICompositionNineGridBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionNineGridBrush: ICompositionNineGridBrush}
+RT_CLASS!{class CompositionNineGridBrush: ICompositionNineGridBrush ["Windows.UI.Composition.CompositionNineGridBrush"]}
 DEFINE_IID!(IID_ICompositionObject, 3165957445, 30217, 17744, 147, 79, 22, 0, 42, 104, 253, 237);
 RT_INTERFACE!{interface ICompositionObject(ICompositionObjectVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionObject] {
     fn get_Compositor(&self, out: *mut *mut Compositor) -> HRESULT,
@@ -3229,7 +3229,7 @@ impl ICompositionObject {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionObject: ICompositionObject}
+RT_CLASS!{class CompositionObject: ICompositionObject ["Windows.UI.Composition.CompositionObject"]}
 impl RtActivatable<ICompositionObjectStatics> for CompositionObject {}
 impl CompositionObject {
     #[inline] pub fn start_animation_with_ianimationobject(target: &IAnimationObject, propertyName: &HStringArg, animation: &CompositionAnimation) -> Result<()> {
@@ -3322,7 +3322,7 @@ DEFINE_IID!(IID_ICompositionPath, 1725570399, 11792, 20258, 138, 6, 10, 129, 81,
 RT_INTERFACE!{interface ICompositionPath(ICompositionPathVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionPath] {
     
 }}
-RT_CLASS!{class CompositionPath: ICompositionPath}
+RT_CLASS!{class CompositionPath: ICompositionPath ["Windows.UI.Composition.CompositionPath"]}
 impl RtActivatable<ICompositionPathFactory> for CompositionPath {}
 impl CompositionPath {
     #[cfg(feature="windows-graphics")] #[inline] pub fn create(source: &super::super::graphics::IGeometrySource2D) -> Result<ComPtr<CompositionPath>> {
@@ -3357,7 +3357,7 @@ impl ICompositionPathGeometry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionPathGeometry: ICompositionPathGeometry}
+RT_CLASS!{class CompositionPathGeometry: ICompositionPathGeometry ["Windows.UI.Composition.CompositionPathGeometry"]}
 DEFINE_IID!(IID_ICompositionPropertySet, 3386298882, 24423, 17491, 145, 23, 158, 173, 212, 48, 211, 194);
 RT_INTERFACE!{interface ICompositionPropertySet(ICompositionPropertySetVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionPropertySet] {
     fn InsertColor(&self, propertyName: HSTRING, value: super::Color) -> HRESULT,
@@ -3451,7 +3451,7 @@ impl ICompositionPropertySet {
         if hr == S_OK { Ok((value, out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionPropertySet: ICompositionPropertySet}
+RT_CLASS!{class CompositionPropertySet: ICompositionPropertySet ["Windows.UI.Composition.CompositionPropertySet"]}
 DEFINE_IID!(IID_ICompositionPropertySet2, 3732960030, 41489, 17493, 136, 128, 125, 15, 63, 106, 68, 253);
 RT_INTERFACE!{interface ICompositionPropertySet2(ICompositionPropertySet2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionPropertySet2] {
     fn InsertBoolean(&self, propertyName: HSTRING, value: bool) -> HRESULT,
@@ -3495,7 +3495,7 @@ impl ICompositionRectangleGeometry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionRectangleGeometry: ICompositionRectangleGeometry}
+RT_CLASS!{class CompositionRectangleGeometry: ICompositionRectangleGeometry ["Windows.UI.Composition.CompositionRectangleGeometry"]}
 DEFINE_IID!(IID_ICompositionRoundedRectangleGeometry, 2272315426, 7504, 19339, 176, 19, 124, 154, 14, 70, 147, 95);
 RT_INTERFACE!{interface ICompositionRoundedRectangleGeometry(ICompositionRoundedRectangleGeometryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionRoundedRectangleGeometry] {
     fn get_CornerRadius(&self, out: *mut foundation::numerics::Vector2) -> HRESULT,
@@ -3534,7 +3534,7 @@ impl ICompositionRoundedRectangleGeometry {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionRoundedRectangleGeometry: ICompositionRoundedRectangleGeometry}
+RT_CLASS!{class CompositionRoundedRectangleGeometry: ICompositionRoundedRectangleGeometry ["Windows.UI.Composition.CompositionRoundedRectangleGeometry"]}
 DEFINE_IID!(IID_ICompositionScopedBatch, 218159824, 64263, 18173, 140, 114, 98, 128, 209, 163, 209, 221);
 RT_INTERFACE!{interface ICompositionScopedBatch(ICompositionScopedBatchVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionScopedBatch] {
     fn get_IsActive(&self, out: *mut bool) -> HRESULT,
@@ -3578,12 +3578,12 @@ impl ICompositionScopedBatch {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionScopedBatch: ICompositionScopedBatch}
+RT_CLASS!{class CompositionScopedBatch: ICompositionScopedBatch ["Windows.UI.Composition.CompositionScopedBatch"]}
 DEFINE_IID!(IID_ICompositionShadow, 849236706, 17205, 18892, 177, 74, 55, 120, 45, 16, 240, 196);
 RT_INTERFACE!{interface ICompositionShadow(ICompositionShadowVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionShadow] {
     
 }}
-RT_CLASS!{class CompositionShadow: ICompositionShadow}
+RT_CLASS!{class CompositionShadow: ICompositionShadow ["Windows.UI.Composition.CompositionShadow"]}
 DEFINE_IID!(IID_ICompositionShadowFactory, 572475695, 56506, 19345, 153, 158, 29, 194, 23, 160, 21, 48);
 RT_INTERFACE!{interface ICompositionShadowFactory(ICompositionShadowFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionShadowFactory] {
     
@@ -3659,8 +3659,8 @@ impl ICompositionShape {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionShape: ICompositionShape}
-RT_CLASS!{class CompositionShapeCollection: foundation::collections::IVector<CompositionShape>}
+RT_CLASS!{class CompositionShape: ICompositionShape ["Windows.UI.Composition.CompositionShape"]}
+RT_CLASS!{class CompositionShapeCollection: foundation::collections::IVector<CompositionShape> ["Windows.UI.Composition.CompositionShapeCollection"]}
 DEFINE_IID!(IID_ICompositionShapeFactory, 503068368, 45146, 17647, 130, 176, 18, 17, 139, 205, 76, 208);
 RT_INTERFACE!{interface ICompositionShapeFactory(ICompositionShapeFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionShapeFactory] {
     
@@ -3797,15 +3797,15 @@ impl ICompositionSpriteShape {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionSpriteShape: ICompositionSpriteShape}
-RT_ENUM! { enum CompositionStretch: i32 {
+RT_CLASS!{class CompositionSpriteShape: ICompositionSpriteShape ["Windows.UI.Composition.CompositionSpriteShape"]}
+RT_ENUM! { enum CompositionStretch: i32 ["Windows.UI.Composition.CompositionStretch"] {
     None (CompositionStretch_None) = 0, Fill (CompositionStretch_Fill) = 1, Uniform (CompositionStretch_Uniform) = 2, UniformToFill (CompositionStretch_UniformToFill) = 3,
 }}
-RT_ENUM! { enum CompositionStrokeCap: i32 {
+RT_ENUM! { enum CompositionStrokeCap: i32 ["Windows.UI.Composition.CompositionStrokeCap"] {
     Flat (CompositionStrokeCap_Flat) = 0, Square (CompositionStrokeCap_Square) = 1, Round (CompositionStrokeCap_Round) = 2, Triangle (CompositionStrokeCap_Triangle) = 3,
 }}
-RT_CLASS!{class CompositionStrokeDashArray: foundation::collections::IVector<f32>}
-RT_ENUM! { enum CompositionStrokeLineJoin: i32 {
+RT_CLASS!{class CompositionStrokeDashArray: foundation::collections::IVector<f32> ["Windows.UI.Composition.CompositionStrokeDashArray"]}
+RT_ENUM! { enum CompositionStrokeLineJoin: i32 ["Windows.UI.Composition.CompositionStrokeLineJoin"] {
     Miter (CompositionStrokeLineJoin_Miter) = 0, Bevel (CompositionStrokeLineJoin_Bevel) = 1, Round (CompositionStrokeLineJoin_Round) = 2, MiterOrBevel (CompositionStrokeLineJoin_MiterOrBevel) = 3,
 }}
 DEFINE_IID!(IID_ICompositionSurface, 354898957, 17095, 18342, 164, 8, 102, 143, 121, 169, 13, 251);
@@ -3872,7 +3872,7 @@ impl ICompositionSurfaceBrush {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionSurfaceBrush: ICompositionSurfaceBrush}
+RT_CLASS!{class CompositionSurfaceBrush: ICompositionSurfaceBrush ["Windows.UI.Composition.CompositionSurfaceBrush"]}
 DEFINE_IID!(IID_ICompositionSurfaceBrush2, 3530650837, 25845, 18066, 157, 199, 113, 182, 29, 126, 88, 128);
 RT_INTERFACE!{interface ICompositionSurfaceBrush2(ICompositionSurfaceBrush2Vtbl): IInspectable(IInspectableVtbl) [IID_ICompositionSurfaceBrush2] {
     fn get_AnchorPoint(&self, out: *mut foundation::numerics::Vector2) -> HRESULT,
@@ -3971,7 +3971,7 @@ impl ICompositionTarget {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionTarget: ICompositionTarget}
+RT_CLASS!{class CompositionTarget: ICompositionTarget ["Windows.UI.Composition.CompositionTarget"]}
 DEFINE_IID!(IID_ICompositionTargetFactory, 2479725867, 34070, 19220, 168, 206, 244, 158, 33, 25, 236, 66);
 RT_INTERFACE!{interface ICompositionTargetFactory(ICompositionTargetFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionTargetFactory] {
     
@@ -4036,7 +4036,7 @@ impl ICompositionViewBox {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionViewBox: ICompositionViewBox}
+RT_CLASS!{class CompositionViewBox: ICompositionViewBox ["Windows.UI.Composition.CompositionViewBox"]}
 DEFINE_IID!(IID_ICompositionVirtualDrawingSurface, 2848163035, 34624, 20372, 139, 157, 182, 133, 33, 231, 134, 61);
 RT_INTERFACE!{interface ICompositionVirtualDrawingSurface(ICompositionVirtualDrawingSurfaceVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionVirtualDrawingSurface] {
     #[cfg(feature="windows-graphics")] fn Trim(&self, rectsSize: u32, rects: *mut super::super::graphics::RectInt32) -> HRESULT
@@ -4047,7 +4047,7 @@ impl ICompositionVirtualDrawingSurface {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionVirtualDrawingSurface: ICompositionVirtualDrawingSurface}
+RT_CLASS!{class CompositionVirtualDrawingSurface: ICompositionVirtualDrawingSurface ["Windows.UI.Composition.CompositionVirtualDrawingSurface"]}
 DEFINE_IID!(IID_ICompositionVirtualDrawingSurfaceFactory, 1734742124, 54635, 19017, 177, 223, 80, 118, 160, 98, 7, 104);
 RT_INTERFACE!{interface ICompositionVirtualDrawingSurfaceFactory(ICompositionVirtualDrawingSurfaceFactoryVtbl): IInspectable(IInspectableVtbl) [IID_ICompositionVirtualDrawingSurfaceFactory] {
     
@@ -4203,7 +4203,7 @@ impl ICompositor {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Compositor: ICompositor}
+RT_CLASS!{class Compositor: ICompositor ["Windows.UI.Composition.Compositor"]}
 impl RtActivatable<ICompositorStatics> for Compositor {}
 impl RtActivatable<IActivationFactory> for Compositor {}
 impl Compositor {
@@ -4536,7 +4536,7 @@ impl IContainerVisual {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContainerVisual: IContainerVisual}
+RT_CLASS!{class ContainerVisual: IContainerVisual ["Windows.UI.Composition.ContainerVisual"]}
 DEFINE_IID!(IID_IContainerVisualFactory, 56862299, 51162, 19866, 149, 244, 105, 181, 200, 223, 103, 11);
 RT_INTERFACE!{interface IContainerVisualFactory(IContainerVisualFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IContainerVisualFactory] {
     
@@ -4558,7 +4558,7 @@ impl ICubicBezierEasingFunction {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CubicBezierEasingFunction: ICubicBezierEasingFunction}
+RT_CLASS!{class CubicBezierEasingFunction: ICubicBezierEasingFunction ["Windows.UI.Composition.CubicBezierEasingFunction"]}
 DEFINE_IID!(IID_IDistantLight, 831322876, 23779, 19285, 171, 93, 7, 160, 3, 83, 172, 153);
 RT_INTERFACE!{interface IDistantLight(IDistantLightVtbl): IInspectable(IInspectableVtbl) [IID_IDistantLight] {
     fn get_Color(&self, out: *mut super::Color) -> HRESULT,
@@ -4597,7 +4597,7 @@ impl IDistantLight {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DistantLight: IDistantLight}
+RT_CLASS!{class DistantLight: IDistantLight ["Windows.UI.Composition.DistantLight"]}
 DEFINE_IID!(IID_IDistantLight2, 3687688732, 10571, 18647, 182, 14, 118, 223, 100, 170, 57, 43);
 RT_INTERFACE!{interface IDistantLight2(IDistantLight2Vtbl): IInspectable(IInspectableVtbl) [IID_IDistantLight2] {
     fn get_Intensity(&self, out: *mut f32) -> HRESULT,
@@ -4674,7 +4674,7 @@ impl IDropShadow {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DropShadow: IDropShadow}
+RT_CLASS!{class DropShadow: IDropShadow ["Windows.UI.Composition.DropShadow"]}
 DEFINE_IID!(IID_IDropShadow2, 1816271036, 5561, 19501, 141, 74, 7, 103, 223, 17, 151, 122);
 RT_INTERFACE!{interface IDropShadow2(IDropShadow2Vtbl): IInspectable(IInspectableVtbl) [IID_IDropShadow2] {
     fn get_SourcePolicy(&self, out: *mut CompositionDropShadowSourcePolicy) -> HRESULT,
@@ -4707,13 +4707,13 @@ impl IExpressionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ExpressionAnimation: IExpressionAnimation}
+RT_CLASS!{class ExpressionAnimation: IExpressionAnimation ["Windows.UI.Composition.ExpressionAnimation"]}
 DEFINE_IID!(IID_IImplicitAnimationCollection, 93889535, 2706, 19613, 164, 39, 178, 85, 25, 37, 13, 191);
 RT_INTERFACE!{interface IImplicitAnimationCollection(IImplicitAnimationCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IImplicitAnimationCollection] {
     
 }}
-RT_CLASS!{class ImplicitAnimationCollection: IImplicitAnimationCollection}
-RT_CLASS!{class InitialValueExpressionCollection: foundation::collections::IMap<HString, HString>}
+RT_CLASS!{class ImplicitAnimationCollection: IImplicitAnimationCollection ["Windows.UI.Composition.ImplicitAnimationCollection"]}
+RT_CLASS!{class InitialValueExpressionCollection: foundation::collections::IMap<HString, HString> ["Windows.UI.Composition.InitialValueExpressionCollection"]}
 DEFINE_IID!(IID_IInsetClip, 510912071, 33991, 18298, 180, 116, 88, 128, 224, 68, 46, 21);
 RT_INTERFACE!{interface IInsetClip(IInsetClipVtbl): IInspectable(IInspectableVtbl) [IID_IInsetClip] {
     fn get_BottomInset(&self, out: *mut f32) -> HRESULT,
@@ -4763,7 +4763,7 @@ impl IInsetClip {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InsetClip: IInsetClip}
+RT_CLASS!{class InsetClip: IInsetClip ["Windows.UI.Composition.InsetClip"]}
 DEFINE_IID!(IID_IKeyFrameAnimation, 309231394, 15081, 17728, 154, 138, 222, 174, 138, 74, 74, 132);
 RT_INTERFACE!{interface IKeyFrameAnimation(IKeyFrameAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IKeyFrameAnimation] {
     fn get_DelayTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -4840,7 +4840,7 @@ impl IKeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyFrameAnimation: IKeyFrameAnimation}
+RT_CLASS!{class KeyFrameAnimation: IKeyFrameAnimation ["Windows.UI.Composition.KeyFrameAnimation"]}
 DEFINE_IID!(IID_IKeyFrameAnimation2, 4105472187, 10560, 20160, 164, 26, 235, 109, 128, 26, 47, 24);
 RT_INTERFACE!{interface IKeyFrameAnimation2(IKeyFrameAnimation2Vtbl): IInspectable(IInspectableVtbl) [IID_IKeyFrameAnimation2] {
     fn get_Direction(&self, out: *mut AnimationDirection) -> HRESULT,
@@ -4893,7 +4893,7 @@ impl ILayerVisual {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class LayerVisual: ILayerVisual}
+RT_CLASS!{class LayerVisual: ILayerVisual ["Windows.UI.Composition.LayerVisual"]}
 DEFINE_IID!(IID_ILayerVisual2, 2566500075, 28451, 18929, 144, 177, 31, 89, 161, 79, 188, 227);
 RT_INTERFACE!{interface ILayerVisual2(ILayerVisual2Vtbl): IInspectable(IInspectableVtbl) [IID_ILayerVisual2] {
     fn get_Shadow(&self, out: *mut *mut CompositionShadow) -> HRESULT,
@@ -4914,7 +4914,7 @@ DEFINE_IID!(IID_ILinearEasingFunction, 2483066714, 51110, 18099, 172, 247, 26, 3
 RT_INTERFACE!{interface ILinearEasingFunction(ILinearEasingFunctionVtbl): IInspectable(IInspectableVtbl) [IID_ILinearEasingFunction] {
     
 }}
-RT_CLASS!{class LinearEasingFunction: ILinearEasingFunction}
+RT_CLASS!{class LinearEasingFunction: ILinearEasingFunction ["Windows.UI.Composition.LinearEasingFunction"]}
 DEFINE_IID!(IID_INaturalMotionAnimation, 1133371693, 30363, 18465, 169, 73, 40, 74, 101, 71, 232, 115);
 RT_INTERFACE!{interface INaturalMotionAnimation(INaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_INaturalMotionAnimation] {
     fn get_DelayBehavior(&self, out: *mut AnimationDelayBehavior) -> HRESULT,
@@ -4953,7 +4953,7 @@ impl INaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NaturalMotionAnimation: INaturalMotionAnimation}
+RT_CLASS!{class NaturalMotionAnimation: INaturalMotionAnimation ["Windows.UI.Composition.NaturalMotionAnimation"]}
 DEFINE_IID!(IID_INaturalMotionAnimationFactory, 4114270982, 53098, 17287, 163, 254, 82, 33, 243, 231, 224, 224);
 RT_INTERFACE!{interface INaturalMotionAnimationFactory(INaturalMotionAnimationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_INaturalMotionAnimationFactory] {
     
@@ -4973,7 +4973,7 @@ impl IPathKeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PathKeyFrameAnimation: IPathKeyFrameAnimation}
+RT_CLASS!{class PathKeyFrameAnimation: IPathKeyFrameAnimation ["Windows.UI.Composition.PathKeyFrameAnimation"]}
 DEFINE_IID!(IID_IPointLight, 2978301363, 3162, 19120, 190, 220, 79, 53, 70, 148, 130, 114);
 RT_INTERFACE!{interface IPointLight(IPointLightVtbl): IInspectable(IInspectableVtbl) [IID_IPointLight] {
     fn get_Color(&self, out: *mut super::Color) -> HRESULT,
@@ -5045,7 +5045,7 @@ impl IPointLight {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PointLight: IPointLight}
+RT_CLASS!{class PointLight: IPointLight ["Windows.UI.Composition.PointLight"]}
 DEFINE_IID!(IID_IPointLight2, 4025061164, 1656, 20329, 177, 100, 168, 16, 217, 149, 188, 183);
 RT_INTERFACE!{interface IPointLight2(IPointLight2Vtbl): IInspectable(IInspectableVtbl) [IID_IPointLight2] {
     fn get_Intensity(&self, out: *mut f32) -> HRESULT,
@@ -5104,7 +5104,7 @@ impl IQuaternionKeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class QuaternionKeyFrameAnimation: IQuaternionKeyFrameAnimation}
+RT_CLASS!{class QuaternionKeyFrameAnimation: IQuaternionKeyFrameAnimation ["Windows.UI.Composition.QuaternionKeyFrameAnimation"]}
 DEFINE_IID!(IID_IRedirectVisual, 2361844544, 35701, 21538, 176, 111, 9, 255, 233, 248, 97, 126);
 RT_INTERFACE!{interface IRedirectVisual(IRedirectVisualVtbl): IInspectable(IInspectableVtbl) [IID_IRedirectVisual] {
     fn get_Source(&self, out: *mut *mut Visual) -> HRESULT,
@@ -5121,7 +5121,7 @@ impl IRedirectVisual {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RedirectVisual: IRedirectVisual}
+RT_CLASS!{class RedirectVisual: IRedirectVisual ["Windows.UI.Composition.RedirectVisual"]}
 DEFINE_IID!(IID_IRenderingDeviceReplacedEventArgs, 976333949, 10431, 20090, 133, 36, 113, 103, 157, 72, 15, 56);
 RT_INTERFACE!{interface IRenderingDeviceReplacedEventArgs(IRenderingDeviceReplacedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRenderingDeviceReplacedEventArgs] {
     fn get_GraphicsDevice(&self, out: *mut *mut CompositionGraphicsDevice) -> HRESULT
@@ -5133,7 +5133,7 @@ impl IRenderingDeviceReplacedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RenderingDeviceReplacedEventArgs: IRenderingDeviceReplacedEventArgs}
+RT_CLASS!{class RenderingDeviceReplacedEventArgs: IRenderingDeviceReplacedEventArgs ["Windows.UI.Composition.RenderingDeviceReplacedEventArgs"]}
 DEFINE_IID!(IID_IScalarKeyFrameAnimation, 2921893801, 9516, 19349, 167, 37, 191, 133, 227, 128, 0, 161);
 RT_INTERFACE!{interface IScalarKeyFrameAnimation(IScalarKeyFrameAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IScalarKeyFrameAnimation] {
     fn InsertKeyFrame(&self, normalizedProgressKey: f32, value: f32) -> HRESULT,
@@ -5149,7 +5149,7 @@ impl IScalarKeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScalarKeyFrameAnimation: IScalarKeyFrameAnimation}
+RT_CLASS!{class ScalarKeyFrameAnimation: IScalarKeyFrameAnimation ["Windows.UI.Composition.ScalarKeyFrameAnimation"]}
 DEFINE_IID!(IID_IScalarNaturalMotionAnimation, 2494121345, 49042, 18779, 181, 189, 210, 198, 89, 67, 7, 55);
 RT_INTERFACE!{interface IScalarNaturalMotionAnimation(IScalarNaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IScalarNaturalMotionAnimation] {
     fn get_FinalValue(&self, out: *mut *mut foundation::IReference<f32>) -> HRESULT,
@@ -5188,7 +5188,7 @@ impl IScalarNaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScalarNaturalMotionAnimation: IScalarNaturalMotionAnimation}
+RT_CLASS!{class ScalarNaturalMotionAnimation: IScalarNaturalMotionAnimation ["Windows.UI.Composition.ScalarNaturalMotionAnimation"]}
 DEFINE_IID!(IID_IScalarNaturalMotionAnimationFactory, 2203755772, 26396, 16861, 175, 72, 174, 141, 239, 139, 21, 41);
 RT_INTERFACE!{interface IScalarNaturalMotionAnimationFactory(IScalarNaturalMotionAnimationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IScalarNaturalMotionAnimationFactory] {
     
@@ -5215,7 +5215,7 @@ impl IShapeVisual {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShapeVisual: IShapeVisual}
+RT_CLASS!{class ShapeVisual: IShapeVisual ["Windows.UI.Composition.ShapeVisual"]}
 DEFINE_IID!(IID_ISpotLight, 1520427635, 17569, 20373, 164, 34, 143, 165, 17, 107, 219, 68);
 RT_INTERFACE!{interface ISpotLight(ISpotLightVtbl): IInspectable(IInspectableVtbl) [IID_ISpotLight] {
     fn get_ConstantAttenuation(&self, out: *mut f32) -> HRESULT,
@@ -5353,7 +5353,7 @@ impl ISpotLight {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpotLight: ISpotLight}
+RT_CLASS!{class SpotLight: ISpotLight ["Windows.UI.Composition.SpotLight"]}
 DEFINE_IID!(IID_ISpotLight2, 1693344094, 1670, 19946, 169, 232, 188, 58, 140, 112, 20, 89);
 RT_INTERFACE!{interface ISpotLight2(ISpotLight2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpotLight2] {
     fn get_InnerConeIntensity(&self, out: *mut f32) -> HRESULT,
@@ -5435,7 +5435,7 @@ impl ISpringScalarNaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpringScalarNaturalMotionAnimation: ISpringScalarNaturalMotionAnimation}
+RT_CLASS!{class SpringScalarNaturalMotionAnimation: ISpringScalarNaturalMotionAnimation ["Windows.UI.Composition.SpringScalarNaturalMotionAnimation"]}
 DEFINE_IID!(IID_ISpringVector2NaturalMotionAnimation, 603231413, 61043, 20239, 164, 35, 64, 43, 148, 109, 244, 179);
 RT_INTERFACE!{interface ISpringVector2NaturalMotionAnimation(ISpringVector2NaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_ISpringVector2NaturalMotionAnimation] {
     fn get_DampingRatio(&self, out: *mut f32) -> HRESULT,
@@ -5463,7 +5463,7 @@ impl ISpringVector2NaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpringVector2NaturalMotionAnimation: ISpringVector2NaturalMotionAnimation}
+RT_CLASS!{class SpringVector2NaturalMotionAnimation: ISpringVector2NaturalMotionAnimation ["Windows.UI.Composition.SpringVector2NaturalMotionAnimation"]}
 DEFINE_IID!(IID_ISpringVector3NaturalMotionAnimation, 1820805599, 54651, 18324, 142, 45, 206, 203, 17, 225, 148, 229);
 RT_INTERFACE!{interface ISpringVector3NaturalMotionAnimation(ISpringVector3NaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_ISpringVector3NaturalMotionAnimation] {
     fn get_DampingRatio(&self, out: *mut f32) -> HRESULT,
@@ -5491,7 +5491,7 @@ impl ISpringVector3NaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpringVector3NaturalMotionAnimation: ISpringVector3NaturalMotionAnimation}
+RT_CLASS!{class SpringVector3NaturalMotionAnimation: ISpringVector3NaturalMotionAnimation ["Windows.UI.Composition.SpringVector3NaturalMotionAnimation"]}
 DEFINE_IID!(IID_ISpriteVisual, 148919681, 6865, 20375, 151, 87, 64, 45, 118, 228, 35, 59);
 RT_INTERFACE!{interface ISpriteVisual(ISpriteVisualVtbl): IInspectable(IInspectableVtbl) [IID_ISpriteVisual] {
     fn get_Brush(&self, out: *mut *mut CompositionBrush) -> HRESULT,
@@ -5508,7 +5508,7 @@ impl ISpriteVisual {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpriteVisual: ISpriteVisual}
+RT_CLASS!{class SpriteVisual: ISpriteVisual ["Windows.UI.Composition.SpriteVisual"]}
 DEFINE_IID!(IID_ISpriteVisual2, 1485608548, 39290, 18512, 145, 254, 83, 203, 88, 248, 28, 233);
 RT_INTERFACE!{interface ISpriteVisual2(ISpriteVisual2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpriteVisual2] {
     fn get_Shadow(&self, out: *mut *mut CompositionShadow) -> HRESULT,
@@ -5585,7 +5585,7 @@ impl IStepEasingFunction {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StepEasingFunction: IStepEasingFunction}
+RT_CLASS!{class StepEasingFunction: IStepEasingFunction ["Windows.UI.Composition.StepEasingFunction"]}
 DEFINE_IID!(IID_IVector2KeyFrameAnimation, 3745596693, 20009, 20241, 181, 94, 191, 42, 110, 179, 98, 148);
 RT_INTERFACE!{interface IVector2KeyFrameAnimation(IVector2KeyFrameAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IVector2KeyFrameAnimation] {
     fn InsertKeyFrame(&self, normalizedProgressKey: f32, value: foundation::numerics::Vector2) -> HRESULT,
@@ -5601,7 +5601,7 @@ impl IVector2KeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Vector2KeyFrameAnimation: IVector2KeyFrameAnimation}
+RT_CLASS!{class Vector2KeyFrameAnimation: IVector2KeyFrameAnimation ["Windows.UI.Composition.Vector2KeyFrameAnimation"]}
 DEFINE_IID!(IID_IVector2NaturalMotionAnimation, 255724413, 58642, 18333, 160, 12, 119, 201, 58, 48, 163, 149);
 RT_INTERFACE!{interface IVector2NaturalMotionAnimation(IVector2NaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IVector2NaturalMotionAnimation] {
     fn get_FinalValue(&self, out: *mut *mut foundation::IReference<foundation::numerics::Vector2>) -> HRESULT,
@@ -5640,7 +5640,7 @@ impl IVector2NaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Vector2NaturalMotionAnimation: IVector2NaturalMotionAnimation}
+RT_CLASS!{class Vector2NaturalMotionAnimation: IVector2NaturalMotionAnimation ["Windows.UI.Composition.Vector2NaturalMotionAnimation"]}
 DEFINE_IID!(IID_IVector2NaturalMotionAnimationFactory, 2356477793, 1889, 18594, 189, 219, 106, 252, 197, 43, 137, 216);
 RT_INTERFACE!{interface IVector2NaturalMotionAnimationFactory(IVector2NaturalMotionAnimationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVector2NaturalMotionAnimationFactory] {
     
@@ -5660,7 +5660,7 @@ impl IVector3KeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Vector3KeyFrameAnimation: IVector3KeyFrameAnimation}
+RT_CLASS!{class Vector3KeyFrameAnimation: IVector3KeyFrameAnimation ["Windows.UI.Composition.Vector3KeyFrameAnimation"]}
 DEFINE_IID!(IID_IVector3NaturalMotionAnimation, 2618754092, 58058, 17837, 150, 158, 78, 120, 183, 185, 173, 65);
 RT_INTERFACE!{interface IVector3NaturalMotionAnimation(IVector3NaturalMotionAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IVector3NaturalMotionAnimation] {
     fn get_FinalValue(&self, out: *mut *mut foundation::IReference<foundation::numerics::Vector3>) -> HRESULT,
@@ -5699,7 +5699,7 @@ impl IVector3NaturalMotionAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Vector3NaturalMotionAnimation: IVector3NaturalMotionAnimation}
+RT_CLASS!{class Vector3NaturalMotionAnimation: IVector3NaturalMotionAnimation ["Windows.UI.Composition.Vector3NaturalMotionAnimation"]}
 DEFINE_IID!(IID_IVector3NaturalMotionAnimationFactory, 564665647, 2176, 17787, 172, 135, 182, 9, 1, 140, 135, 109);
 RT_INTERFACE!{interface IVector3NaturalMotionAnimationFactory(IVector3NaturalMotionAnimationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVector3NaturalMotionAnimationFactory] {
     
@@ -5719,7 +5719,7 @@ impl IVector4KeyFrameAnimation {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Vector4KeyFrameAnimation: IVector4KeyFrameAnimation}
+RT_CLASS!{class Vector4KeyFrameAnimation: IVector4KeyFrameAnimation ["Windows.UI.Composition.Vector4KeyFrameAnimation"]}
 DEFINE_IID!(IID_IVisual, 293478445, 43097, 19593, 135, 59, 194, 170, 86, 103, 136, 227);
 RT_INTERFACE!{interface IVisual(IVisualVtbl): IInspectable(IInspectableVtbl) [IID_IVisual] {
     fn get_AnchorPoint(&self, out: *mut foundation::numerics::Vector2) -> HRESULT,
@@ -5907,7 +5907,7 @@ impl IVisual {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Visual: IVisual}
+RT_CLASS!{class Visual: IVisual ["Windows.UI.Composition.Visual"]}
 DEFINE_IID!(IID_IVisual2, 810726929, 22211, 19518, 139, 243, 246, 225, 173, 71, 63, 6);
 RT_INTERFACE!{interface IVisual2(IVisual2Vtbl): IInspectable(IInspectableVtbl) [IID_IVisual2] {
     fn get_ParentForTransform(&self, out: *mut *mut Visual) -> HRESULT,
@@ -5987,7 +5987,7 @@ impl IVisualCollection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisualCollection: IVisualCollection}
+RT_CLASS!{class VisualCollection: IVisualCollection ["Windows.UI.Composition.VisualCollection"]}
 DEFINE_IID!(IID_IVisualFactory, 2903505214, 46338, 20149, 135, 180, 154, 56, 167, 29, 1, 55);
 RT_INTERFACE!{interface IVisualFactory(IVisualFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVisualFactory] {
     
@@ -6018,7 +6018,7 @@ impl IVisualUnorderedCollection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisualUnorderedCollection: IVisualUnorderedCollection}
+RT_CLASS!{class VisualUnorderedCollection: IVisualUnorderedCollection ["Windows.UI.Composition.VisualUnorderedCollection"]}
 pub mod core { // Windows.UI.Composition.Core
 use ::prelude::*;
 DEFINE_IID!(IID_ICompositorController, 762704730, 28839, 17301, 186, 45, 206, 240, 177, 131, 153, 249);
@@ -6054,7 +6054,7 @@ impl ICompositorController {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositorController: ICompositorController}
+RT_CLASS!{class CompositorController: ICompositorController ["Windows.UI.Composition.Core.CompositorController"]}
 impl RtActivatable<IActivationFactory> for CompositorController {}
 DEFINE_CLSID!(CompositorController(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,67,111,114,101,46,67,111,109,112,111,115,105,116,111,114,67,111,110,116,114,111,108,108,101,114,0]) [CLSID_CompositorController]);
 } // Windows.UI.Composition.Core
@@ -6071,7 +6071,7 @@ impl IDesktopWindowTarget {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DesktopWindowTarget: IDesktopWindowTarget}
+RT_CLASS!{class DesktopWindowTarget: IDesktopWindowTarget ["Windows.UI.Composition.Desktop.DesktopWindowTarget"]}
 } // Windows.UI.Composition.Desktop
 pub mod diagnostics { // Windows.UI.Composition.Diagnostics
 use ::prelude::*;
@@ -6100,8 +6100,8 @@ impl ICompositionDebugHeatMaps {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionDebugHeatMaps: ICompositionDebugHeatMaps}
-RT_ENUM! { enum CompositionDebugOverdrawContentKinds: u32 {
+RT_CLASS!{class CompositionDebugHeatMaps: ICompositionDebugHeatMaps ["Windows.UI.Composition.Diagnostics.CompositionDebugHeatMaps"]}
+RT_ENUM! { enum CompositionDebugOverdrawContentKinds: u32 ["Windows.UI.Composition.Diagnostics.CompositionDebugOverdrawContentKinds"] {
     None (CompositionDebugOverdrawContentKinds_None) = 0, OffscreenRendered (CompositionDebugOverdrawContentKinds_OffscreenRendered) = 1, Colors (CompositionDebugOverdrawContentKinds_Colors) = 2, Effects (CompositionDebugOverdrawContentKinds_Effects) = 4, Shadows (CompositionDebugOverdrawContentKinds_Shadows) = 8, Lights (CompositionDebugOverdrawContentKinds_Lights) = 16, Surfaces (CompositionDebugOverdrawContentKinds_Surfaces) = 32, SwapChains (CompositionDebugOverdrawContentKinds_SwapChains) = 64, All (CompositionDebugOverdrawContentKinds_All) = 4294967295,
 }}
 DEFINE_IID!(IID_ICompositionDebugSettings, 674338942, 7554, 19768, 183, 183, 239, 209, 28, 123, 195, 209);
@@ -6115,7 +6115,7 @@ impl ICompositionDebugSettings {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionDebugSettings: ICompositionDebugSettings}
+RT_CLASS!{class CompositionDebugSettings: ICompositionDebugSettings ["Windows.UI.Composition.Diagnostics.CompositionDebugSettings"]}
 impl RtActivatable<ICompositionDebugSettingsStatics> for CompositionDebugSettings {}
 impl CompositionDebugSettings {
     #[inline] pub fn try_get_settings(compositor: &super::Compositor) -> Result<Option<ComPtr<CompositionDebugSettings>>> {
@@ -6199,7 +6199,7 @@ impl ISceneLightingEffect {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SceneLightingEffect: ISceneLightingEffect}
+RT_CLASS!{class SceneLightingEffect: ISceneLightingEffect ["Windows.UI.Composition.Effects.SceneLightingEffect"]}
 impl RtActivatable<IActivationFactory> for SceneLightingEffect {}
 DEFINE_CLSID!(SceneLightingEffect(&[87,105,110,100,111,119,115,46,85,73,46,67,111,109,112,111,115,105,116,105,111,110,46,69,102,102,101,99,116,115,46,83,99,101,110,101,76,105,103,104,116,105,110,103,69,102,102,101,99,116,0]) [CLSID_SceneLightingEffect]);
 DEFINE_IID!(IID_ISceneLightingEffect2, 2653359745, 29424, 19548, 149, 248, 138, 110, 0, 36, 244, 9);
@@ -6218,7 +6218,7 @@ impl ISceneLightingEffect2 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SceneLightingEffectReflectanceModel: i32 {
+RT_ENUM! { enum SceneLightingEffectReflectanceModel: i32 ["Windows.UI.Composition.Effects.SceneLightingEffectReflectanceModel"] {
     BlinnPhong (SceneLightingEffectReflectanceModel_BlinnPhong) = 0, PhysicallyBasedBlinnPhong (SceneLightingEffectReflectanceModel_PhysicallyBasedBlinnPhong) = 1,
 }}
 } // Windows.UI.Composition.Effects
@@ -6251,7 +6251,7 @@ impl ICompositionConditionalValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionConditionalValue: ICompositionConditionalValue}
+RT_CLASS!{class CompositionConditionalValue: ICompositionConditionalValue ["Windows.UI.Composition.Interactions.CompositionConditionalValue"]}
 impl RtActivatable<ICompositionConditionalValueStatics> for CompositionConditionalValue {}
 impl CompositionConditionalValue {
     #[inline] pub fn create(compositor: &super::Compositor) -> Result<Option<ComPtr<CompositionConditionalValue>>> {
@@ -6300,8 +6300,8 @@ impl ICompositionInteractionSourceCollection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CompositionInteractionSourceCollection: ICompositionInteractionSourceCollection}
-RT_ENUM! { enum InteractionChainingMode: i32 {
+RT_CLASS!{class CompositionInteractionSourceCollection: ICompositionInteractionSourceCollection ["Windows.UI.Composition.Interactions.CompositionInteractionSourceCollection"]}
+RT_ENUM! { enum InteractionChainingMode: i32 ["Windows.UI.Composition.Interactions.InteractionChainingMode"] {
     Auto (InteractionChainingMode_Auto) = 0, Always (InteractionChainingMode_Always) = 1, Never (InteractionChainingMode_Never) = 2,
 }}
 DEFINE_IID!(IID_IInteractionSourceConfiguration, 2810398693, 43473, 19714, 152, 94, 185, 48, 205, 11, 157, 164);
@@ -6342,11 +6342,11 @@ impl IInteractionSourceConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionSourceConfiguration: IInteractionSourceConfiguration}
-RT_ENUM! { enum InteractionSourceMode: i32 {
+RT_CLASS!{class InteractionSourceConfiguration: IInteractionSourceConfiguration ["Windows.UI.Composition.Interactions.InteractionSourceConfiguration"]}
+RT_ENUM! { enum InteractionSourceMode: i32 ["Windows.UI.Composition.Interactions.InteractionSourceMode"] {
     Disabled (InteractionSourceMode_Disabled) = 0, EnabledWithInertia (InteractionSourceMode_EnabledWithInertia) = 1, EnabledWithoutInertia (InteractionSourceMode_EnabledWithoutInertia) = 2,
 }}
-RT_ENUM! { enum InteractionSourceRedirectionMode: i32 {
+RT_ENUM! { enum InteractionSourceRedirectionMode: i32 ["Windows.UI.Composition.Interactions.InteractionSourceRedirectionMode"] {
     Disabled (InteractionSourceRedirectionMode_Disabled) = 0, Enabled (InteractionSourceRedirectionMode_Enabled) = 1,
 }}
 DEFINE_IID!(IID_IInteractionTracker, 713985201, 4096, 17430, 131, 99, 204, 39, 251, 135, 115, 8);
@@ -6541,7 +6541,7 @@ impl IInteractionTracker {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTracker: IInteractionTracker}
+RT_CLASS!{class InteractionTracker: IInteractionTracker ["Windows.UI.Composition.Interactions.InteractionTracker"]}
 impl RtActivatable<IInteractionTrackerStatics> for InteractionTracker {}
 impl InteractionTracker {
     #[inline] pub fn create(compositor: &super::Compositor) -> Result<Option<ComPtr<InteractionTracker>>> {
@@ -6600,7 +6600,7 @@ impl IInteractionTracker4 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum InteractionTrackerClampingOption: i32 {
+RT_ENUM! { enum InteractionTrackerClampingOption: i32 ["Windows.UI.Composition.Interactions.InteractionTrackerClampingOption"] {
     Auto (InteractionTrackerClampingOption_Auto) = 0, Disabled (InteractionTrackerClampingOption_Disabled) = 1,
 }}
 DEFINE_IID!(IID_IInteractionTrackerCustomAnimationStateEnteredArgs, 2367458545, 55216, 17228, 165, 210, 45, 118, 17, 134, 72, 52);
@@ -6614,7 +6614,7 @@ impl IInteractionTrackerCustomAnimationStateEnteredArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerCustomAnimationStateEnteredArgs: IInteractionTrackerCustomAnimationStateEnteredArgs}
+RT_CLASS!{class InteractionTrackerCustomAnimationStateEnteredArgs: IInteractionTrackerCustomAnimationStateEnteredArgs ["Windows.UI.Composition.Interactions.InteractionTrackerCustomAnimationStateEnteredArgs"]}
 DEFINE_IID!(IID_IInteractionTrackerIdleStateEnteredArgs, 1342255018, 5392, 16706, 161, 165, 1, 155, 9, 248, 133, 123);
 RT_INTERFACE!{interface IInteractionTrackerIdleStateEnteredArgs(IInteractionTrackerIdleStateEnteredArgsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerIdleStateEnteredArgs] {
     fn get_RequestId(&self, out: *mut i32) -> HRESULT
@@ -6626,12 +6626,12 @@ impl IInteractionTrackerIdleStateEnteredArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerIdleStateEnteredArgs: IInteractionTrackerIdleStateEnteredArgs}
+RT_CLASS!{class InteractionTrackerIdleStateEnteredArgs: IInteractionTrackerIdleStateEnteredArgs ["Windows.UI.Composition.Interactions.InteractionTrackerIdleStateEnteredArgs"]}
 DEFINE_IID!(IID_IInteractionTrackerInertiaModifier, 2699217184, 9908, 19874, 139, 97, 94, 104, 57, 121, 187, 226);
 RT_INTERFACE!{interface IInteractionTrackerInertiaModifier(IInteractionTrackerInertiaModifierVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerInertiaModifier] {
     
 }}
-RT_CLASS!{class InteractionTrackerInertiaModifier: IInteractionTrackerInertiaModifier}
+RT_CLASS!{class InteractionTrackerInertiaModifier: IInteractionTrackerInertiaModifier ["Windows.UI.Composition.Interactions.InteractionTrackerInertiaModifier"]}
 DEFINE_IID!(IID_IInteractionTrackerInertiaModifierFactory, 2570590462, 51534, 19334, 135, 243, 146, 38, 101, 186, 70, 185);
 RT_INTERFACE!{interface IInteractionTrackerInertiaModifierFactory(IInteractionTrackerInertiaModifierFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerInertiaModifierFactory] {
     
@@ -6663,7 +6663,7 @@ impl IInteractionTrackerInertiaMotion {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerInertiaMotion: IInteractionTrackerInertiaMotion}
+RT_CLASS!{class InteractionTrackerInertiaMotion: IInteractionTrackerInertiaMotion ["Windows.UI.Composition.Interactions.InteractionTrackerInertiaMotion"]}
 impl RtActivatable<IInteractionTrackerInertiaMotionStatics> for InteractionTrackerInertiaMotion {}
 impl InteractionTrackerInertiaMotion {
     #[inline] pub fn create(compositor: &super::Compositor) -> Result<Option<ComPtr<InteractionTrackerInertiaMotion>>> {
@@ -6709,7 +6709,7 @@ impl IInteractionTrackerInertiaNaturalMotion {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerInertiaNaturalMotion: IInteractionTrackerInertiaNaturalMotion}
+RT_CLASS!{class InteractionTrackerInertiaNaturalMotion: IInteractionTrackerInertiaNaturalMotion ["Windows.UI.Composition.Interactions.InteractionTrackerInertiaNaturalMotion"]}
 impl RtActivatable<IInteractionTrackerInertiaNaturalMotionStatics> for InteractionTrackerInertiaNaturalMotion {}
 impl InteractionTrackerInertiaNaturalMotion {
     #[inline] pub fn create(compositor: &super::Compositor) -> Result<Option<ComPtr<InteractionTrackerInertiaNaturalMotion>>> {
@@ -6755,7 +6755,7 @@ impl IInteractionTrackerInertiaRestingValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerInertiaRestingValue: IInteractionTrackerInertiaRestingValue}
+RT_CLASS!{class InteractionTrackerInertiaRestingValue: IInteractionTrackerInertiaRestingValue ["Windows.UI.Composition.Interactions.InteractionTrackerInertiaRestingValue"]}
 impl RtActivatable<IInteractionTrackerInertiaRestingValueStatics> for InteractionTrackerInertiaRestingValue {}
 impl InteractionTrackerInertiaRestingValue {
     #[inline] pub fn create(compositor: &super::Compositor) -> Result<Option<ComPtr<InteractionTrackerInertiaRestingValue>>> {
@@ -6821,7 +6821,7 @@ impl IInteractionTrackerInertiaStateEnteredArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerInertiaStateEnteredArgs: IInteractionTrackerInertiaStateEnteredArgs}
+RT_CLASS!{class InteractionTrackerInertiaStateEnteredArgs: IInteractionTrackerInertiaStateEnteredArgs ["Windows.UI.Composition.Interactions.InteractionTrackerInertiaStateEnteredArgs"]}
 DEFINE_IID!(IID_IInteractionTrackerInertiaStateEnteredArgs2, 2984981238, 49772, 16886, 161, 137, 250, 188, 34, 179, 35, 204);
 RT_INTERFACE!{interface IInteractionTrackerInertiaStateEnteredArgs2(IInteractionTrackerInertiaStateEnteredArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerInertiaStateEnteredArgs2] {
     fn get_IsInertiaFromImpulse(&self, out: *mut bool) -> HRESULT
@@ -6844,7 +6844,7 @@ impl IInteractionTrackerInteractingStateEnteredArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerInteractingStateEnteredArgs: IInteractionTrackerInteractingStateEnteredArgs}
+RT_CLASS!{class InteractionTrackerInteractingStateEnteredArgs: IInteractionTrackerInteractingStateEnteredArgs ["Windows.UI.Composition.Interactions.InteractionTrackerInteractingStateEnteredArgs"]}
 DEFINE_IID!(IID_IInteractionTrackerOwner, 3677260531, 19947, 20051, 178, 156, 176, 108, 159, 150, 214, 81);
 RT_INTERFACE!{interface IInteractionTrackerOwner(IInteractionTrackerOwnerVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerOwner] {
     fn CustomAnimationStateEntered(&self, sender: *mut InteractionTracker, args: *mut InteractionTrackerCustomAnimationStateEnteredArgs) -> HRESULT,
@@ -6891,7 +6891,7 @@ impl IInteractionTrackerRequestIgnoredArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerRequestIgnoredArgs: IInteractionTrackerRequestIgnoredArgs}
+RT_CLASS!{class InteractionTrackerRequestIgnoredArgs: IInteractionTrackerRequestIgnoredArgs ["Windows.UI.Composition.Interactions.InteractionTrackerRequestIgnoredArgs"]}
 DEFINE_IID!(IID_IInteractionTrackerStatics, 3148208055, 26000, 17560, 141, 108, 235, 98, 181, 20, 201, 42);
 RT_INTERFACE!{static interface IInteractionTrackerStatics(IInteractionTrackerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerStatics] {
     fn Create(&self, compositor: *mut super::Compositor, out: *mut *mut InteractionTracker) -> HRESULT,
@@ -6932,12 +6932,12 @@ impl IInteractionTrackerValuesChangedArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerValuesChangedArgs: IInteractionTrackerValuesChangedArgs}
+RT_CLASS!{class InteractionTrackerValuesChangedArgs: IInteractionTrackerValuesChangedArgs ["Windows.UI.Composition.Interactions.InteractionTrackerValuesChangedArgs"]}
 DEFINE_IID!(IID_IInteractionTrackerVector2InertiaModifier, 2279639728, 12422, 18515, 164, 183, 119, 136, 42, 213, 215, 227);
 RT_INTERFACE!{interface IInteractionTrackerVector2InertiaModifier(IInteractionTrackerVector2InertiaModifierVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerVector2InertiaModifier] {
     
 }}
-RT_CLASS!{class InteractionTrackerVector2InertiaModifier: IInteractionTrackerVector2InertiaModifier}
+RT_CLASS!{class InteractionTrackerVector2InertiaModifier: IInteractionTrackerVector2InertiaModifier ["Windows.UI.Composition.Interactions.InteractionTrackerVector2InertiaModifier"]}
 DEFINE_IID!(IID_IInteractionTrackerVector2InertiaModifierFactory, 1946277572, 27757, 18655, 188, 62, 23, 30, 34, 126, 125, 127);
 RT_INTERFACE!{interface IInteractionTrackerVector2InertiaModifierFactory(IInteractionTrackerVector2InertiaModifierFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IInteractionTrackerVector2InertiaModifierFactory] {
     
@@ -6969,7 +6969,7 @@ impl IInteractionTrackerVector2InertiaNaturalMotion {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InteractionTrackerVector2InertiaNaturalMotion: IInteractionTrackerVector2InertiaNaturalMotion}
+RT_CLASS!{class InteractionTrackerVector2InertiaNaturalMotion: IInteractionTrackerVector2InertiaNaturalMotion ["Windows.UI.Composition.Interactions.InteractionTrackerVector2InertiaNaturalMotion"]}
 impl RtActivatable<IInteractionTrackerVector2InertiaNaturalMotionStatics> for InteractionTrackerVector2InertiaNaturalMotion {}
 impl InteractionTrackerVector2InertiaNaturalMotion {
     #[inline] pub fn create(compositor: &super::Compositor) -> Result<Option<ComPtr<InteractionTrackerVector2InertiaNaturalMotion>>> {
@@ -7103,7 +7103,7 @@ impl IVisualInteractionSource {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisualInteractionSource: IVisualInteractionSource}
+RT_CLASS!{class VisualInteractionSource: IVisualInteractionSource ["Windows.UI.Composition.Interactions.VisualInteractionSource"]}
 impl RtActivatable<IVisualInteractionSourceStatics> for VisualInteractionSource {}
 impl VisualInteractionSource {
     #[inline] pub fn create(source: &super::Visual) -> Result<Option<ComPtr<VisualInteractionSource>>> {
@@ -7192,7 +7192,7 @@ DEFINE_IID!(IID_IVisualInteractionSourceObjectFactory, 2999619964, 59786, 16882,
 RT_INTERFACE!{interface IVisualInteractionSourceObjectFactory(IVisualInteractionSourceObjectFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IVisualInteractionSourceObjectFactory] {
     
 }}
-RT_ENUM! { enum VisualInteractionSourceRedirectionMode: i32 {
+RT_ENUM! { enum VisualInteractionSourceRedirectionMode: i32 ["Windows.UI.Composition.Interactions.VisualInteractionSourceRedirectionMode"] {
     Off (VisualInteractionSourceRedirectionMode_Off) = 0, CapableTouchpadOnly (VisualInteractionSourceRedirectionMode_CapableTouchpadOnly) = 1, PointerWheelOnly (VisualInteractionSourceRedirectionMode_PointerWheelOnly) = 2, CapableTouchpadAndPointerWheel (VisualInteractionSourceRedirectionMode_CapableTouchpadAndPointerWheel) = 3,
 }}
 DEFINE_IID!(IID_IVisualInteractionSourceStatics, 916022753, 34373, 20341, 186, 0, 100, 121, 205, 16, 200, 230);
@@ -7234,7 +7234,7 @@ impl IAcceleratorKeyEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AcceleratorKeyEventArgs: IAcceleratorKeyEventArgs}
+RT_CLASS!{class AcceleratorKeyEventArgs: IAcceleratorKeyEventArgs ["Windows.UI.Core.AcceleratorKeyEventArgs"]}
 DEFINE_IID!(IID_IAcceleratorKeyEventArgs2, 3540036086, 12158, 18547, 165, 85, 22, 110, 89, 110, 225, 197);
 RT_INTERFACE!{interface IAcceleratorKeyEventArgs2(IAcceleratorKeyEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IAcceleratorKeyEventArgs2] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT
@@ -7246,7 +7246,7 @@ impl IAcceleratorKeyEventArgs2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AppViewBackButtonVisibility: i32 {
+RT_ENUM! { enum AppViewBackButtonVisibility: i32 ["Windows.UI.Core.AppViewBackButtonVisibility"] {
     Visible (AppViewBackButtonVisibility_Visible) = 0, Collapsed (AppViewBackButtonVisibility_Collapsed) = 1, Disabled (AppViewBackButtonVisibility_Disabled) = 2,
 }}
 DEFINE_IID!(IID_IAutomationProviderRequestedEventArgs, 2518676056, 8639, 19266, 162, 152, 250, 71, 157, 76, 82, 226);
@@ -7265,7 +7265,7 @@ impl IAutomationProviderRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AutomationProviderRequestedEventArgs: IAutomationProviderRequestedEventArgs}
+RT_CLASS!{class AutomationProviderRequestedEventArgs: IAutomationProviderRequestedEventArgs ["Windows.UI.Core.AutomationProviderRequestedEventArgs"]}
 DEFINE_IID!(IID_IBackRequestedEventArgs, 3590574730, 58385, 19022, 186, 65, 106, 50, 122, 134, 117, 188);
 RT_INTERFACE!{interface IBackRequestedEventArgs(IBackRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IBackRequestedEventArgs] {
     fn get_Handled(&self, out: *mut bool) -> HRESULT,
@@ -7282,7 +7282,7 @@ impl IBackRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BackRequestedEventArgs: IBackRequestedEventArgs}
+RT_CLASS!{class BackRequestedEventArgs: IBackRequestedEventArgs ["Windows.UI.Core.BackRequestedEventArgs"]}
 DEFINE_IID!(IID_ICharacterReceivedEventArgs, 3313788319, 39346, 19404, 189, 51, 4, 230, 63, 66, 144, 46);
 RT_INTERFACE!{interface ICharacterReceivedEventArgs(ICharacterReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICharacterReceivedEventArgs] {
     fn get_KeyCode(&self, out: *mut u32) -> HRESULT,
@@ -7300,7 +7300,7 @@ impl ICharacterReceivedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CharacterReceivedEventArgs: ICharacterReceivedEventArgs}
+RT_CLASS!{class CharacterReceivedEventArgs: ICharacterReceivedEventArgs ["Windows.UI.Core.CharacterReceivedEventArgs"]}
 DEFINE_IID!(IID_IClosestInteractiveBoundsRequestedEventArgs, 880546263, 63224, 16611, 178, 159, 174, 80, 211, 232, 100, 134);
 RT_INTERFACE!{interface IClosestInteractiveBoundsRequestedEventArgs(IClosestInteractiveBoundsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IClosestInteractiveBoundsRequestedEventArgs] {
     fn get_PointerPosition(&self, out: *mut foundation::Point) -> HRESULT,
@@ -7329,8 +7329,8 @@ impl IClosestInteractiveBoundsRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ClosestInteractiveBoundsRequestedEventArgs: IClosestInteractiveBoundsRequestedEventArgs}
-RT_ENUM! { enum CoreAcceleratorKeyEventType: i32 {
+RT_CLASS!{class ClosestInteractiveBoundsRequestedEventArgs: IClosestInteractiveBoundsRequestedEventArgs ["Windows.UI.Core.ClosestInteractiveBoundsRequestedEventArgs"]}
+RT_ENUM! { enum CoreAcceleratorKeyEventType: i32 ["Windows.UI.Core.CoreAcceleratorKeyEventType"] {
     Character (CoreAcceleratorKeyEventType_Character) = 2, DeadCharacter (CoreAcceleratorKeyEventType_DeadCharacter) = 3, KeyDown (CoreAcceleratorKeyEventType_KeyDown) = 0, KeyUp (CoreAcceleratorKeyEventType_KeyUp) = 1, SystemCharacter (CoreAcceleratorKeyEventType_SystemCharacter) = 6, SystemDeadCharacter (CoreAcceleratorKeyEventType_SystemDeadCharacter) = 7, SystemKeyDown (CoreAcceleratorKeyEventType_SystemKeyDown) = 4, SystemKeyUp (CoreAcceleratorKeyEventType_SystemKeyUp) = 5, UnicodeCharacter (CoreAcceleratorKeyEventType_UnicodeCharacter) = 8,
 }}
 DEFINE_IID!(IID_ICoreAcceleratorKeys, 2684221429, 47305, 20208, 183, 210, 29, 230, 38, 86, 31, 200);
@@ -7349,7 +7349,7 @@ impl ICoreAcceleratorKeys {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreAcceleratorKeys: ICoreAcceleratorKeys}
+RT_CLASS!{class CoreAcceleratorKeys: ICoreAcceleratorKeys ["Windows.UI.Core.CoreAcceleratorKeys"]}
 DEFINE_IID!(IID_ICoreClosestInteractiveBoundsRequested, 4077061178, 59583, 20110, 174, 105, 201, 218, 221, 87, 161, 20);
 RT_INTERFACE!{interface ICoreClosestInteractiveBoundsRequested(ICoreClosestInteractiveBoundsRequestedVtbl): IInspectable(IInspectableVtbl) [IID_ICoreClosestInteractiveBoundsRequested] {
     fn add_ClosestInteractiveBoundsRequested(&self, handler: *mut foundation::TypedEventHandler<CoreComponentInputSource, ClosestInteractiveBoundsRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -7399,7 +7399,7 @@ impl ICoreComponentFocusable {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreComponentInputSource: ICoreInputSourceBase}
+RT_CLASS!{class CoreComponentInputSource: ICoreInputSourceBase ["Windows.UI.Core.CoreComponentInputSource"]}
 DEFINE_IID!(IID_ICoreCursor, 2525575887, 4381, 17452, 138, 119, 184, 121, 146, 248, 226, 214);
 RT_INTERFACE!{interface ICoreCursor(ICoreCursorVtbl): IInspectable(IInspectableVtbl) [IID_ICoreCursor] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -7417,7 +7417,7 @@ impl ICoreCursor {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreCursor: ICoreCursor}
+RT_CLASS!{class CoreCursor: ICoreCursor ["Windows.UI.Core.CoreCursor"]}
 impl RtActivatable<ICoreCursorFactory> for CoreCursor {}
 impl CoreCursor {
     #[inline] pub fn create_cursor(type_: CoreCursorType, id: u32) -> Result<ComPtr<CoreCursor>> {
@@ -7436,7 +7436,7 @@ impl ICoreCursorFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreCursorType: i32 {
+RT_ENUM! { enum CoreCursorType: i32 ["Windows.UI.Core.CoreCursorType"] {
     Arrow (CoreCursorType_Arrow) = 0, Cross (CoreCursorType_Cross) = 1, Custom (CoreCursorType_Custom) = 2, Hand (CoreCursorType_Hand) = 3, Help (CoreCursorType_Help) = 4, IBeam (CoreCursorType_IBeam) = 5, SizeAll (CoreCursorType_SizeAll) = 6, SizeNortheastSouthwest (CoreCursorType_SizeNortheastSouthwest) = 7, SizeNorthSouth (CoreCursorType_SizeNorthSouth) = 8, SizeNorthwestSoutheast (CoreCursorType_SizeNorthwestSoutheast) = 9, SizeWestEast (CoreCursorType_SizeWestEast) = 10, UniversalNo (CoreCursorType_UniversalNo) = 11, UpArrow (CoreCursorType_UpArrow) = 12, Wait (CoreCursorType_Wait) = 13, Pin (CoreCursorType_Pin) = 14, Person (CoreCursorType_Person) = 15,
 }}
 DEFINE_IID!(IID_ICoreDispatcher, 1624977320, 46853, 20446, 167, 214, 235, 187, 24, 145, 211, 158);
@@ -7467,7 +7467,7 @@ impl ICoreDispatcher {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreDispatcher: ICoreDispatcher}
+RT_CLASS!{class CoreDispatcher: ICoreDispatcher ["Windows.UI.Core.CoreDispatcher"]}
 DEFINE_IID!(IID_ICoreDispatcher2, 1868456903, 58282, 20142, 176, 224, 220, 243, 33, 202, 75, 47);
 RT_INTERFACE!{interface ICoreDispatcher2(ICoreDispatcher2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreDispatcher2] {
     fn TryRunAsync(&self, priority: CoreDispatcherPriority, agileCallback: *mut DispatchedHandler, out: *mut *mut foundation::IAsyncOperation<bool>) -> HRESULT,
@@ -7485,7 +7485,7 @@ impl ICoreDispatcher2 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreDispatcherPriority: i32 {
+RT_ENUM! { enum CoreDispatcherPriority: i32 ["Windows.UI.Core.CoreDispatcherPriority"] {
     Idle (CoreDispatcherPriority_Idle) = -2, Low (CoreDispatcherPriority_Low) = -1, Normal (CoreDispatcherPriority_Normal) = 0, High (CoreDispatcherPriority_High) = 1,
 }}
 DEFINE_IID!(IID_ICoreDispatcherWithTaskPriority, 3137006765, 18509, 16830, 186, 128, 29, 88, 198, 82, 99, 234);
@@ -7521,8 +7521,8 @@ impl ICoreDispatcherWithTaskPriority {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreIndependentInputSource: ICoreInputSourceBase}
-RT_ENUM! { enum CoreInputDeviceTypes: u32 {
+RT_CLASS!{class CoreIndependentInputSource: ICoreInputSourceBase ["Windows.UI.Core.CoreIndependentInputSource"]}
+RT_ENUM! { enum CoreInputDeviceTypes: u32 ["Windows.UI.Core.CoreInputDeviceTypes"] {
     None (CoreInputDeviceTypes_None) = 0, Touch (CoreInputDeviceTypes_Touch) = 1, Pen (CoreInputDeviceTypes_Pen) = 2, Mouse (CoreInputDeviceTypes_Mouse) = 4,
 }}
 DEFINE_IID!(IID_ICoreInputSourceBase, 2672330759, 17792, 19432, 190, 104, 146, 169, 49, 23, 19, 187);
@@ -7614,7 +7614,7 @@ impl ICoreKeyboardInputSource2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct CorePhysicalKeyStatus {
+RT_STRUCT! { struct CorePhysicalKeyStatus ["Windows.UI.Core.CorePhysicalKeyStatus"] {
     RepeatCount: u32, ScanCode: u32, IsExtendedKey: bool, IsMenuKeyDown: bool, WasKeyDown: bool, IsKeyReleased: bool,
 }}
 DEFINE_IID!(IID_ICorePointerInputSource, 3153181464, 58490, 18667, 136, 7, 248, 248, 211, 234, 69, 81);
@@ -7781,13 +7781,13 @@ impl ICorePointerRedirector {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreProcessEventsOption: i32 {
+RT_ENUM! { enum CoreProcessEventsOption: i32 ["Windows.UI.Core.CoreProcessEventsOption"] {
     ProcessOneAndAllPending (CoreProcessEventsOption_ProcessOneAndAllPending) = 0, ProcessOneIfPresent (CoreProcessEventsOption_ProcessOneIfPresent) = 1, ProcessUntilQuit (CoreProcessEventsOption_ProcessUntilQuit) = 2, ProcessAllIfPresent (CoreProcessEventsOption_ProcessAllIfPresent) = 3,
 }}
-RT_STRUCT! { struct CoreProximityEvaluation {
+RT_STRUCT! { struct CoreProximityEvaluation ["Windows.UI.Core.CoreProximityEvaluation"] {
     Score: i32, AdjustedPoint: foundation::Point,
 }}
-RT_ENUM! { enum CoreProximityEvaluationScore: i32 {
+RT_ENUM! { enum CoreProximityEvaluationScore: i32 ["Windows.UI.Core.CoreProximityEvaluationScore"] {
     Closest (CoreProximityEvaluationScore_Closest) = 0, Farthest (CoreProximityEvaluationScore_Farthest) = 2147483647,
 }}
 DEFINE_IID!(IID_ICoreTouchHitTesting, 2983764617, 15055, 16676, 159, 163, 234, 138, 186, 53, 60, 33);
@@ -7806,7 +7806,7 @@ impl ICoreTouchHitTesting {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreVirtualKeyStates: u32 {
+RT_ENUM! { enum CoreVirtualKeyStates: u32 ["Windows.UI.Core.CoreVirtualKeyStates"] {
     None (CoreVirtualKeyStates_None) = 0, Down (CoreVirtualKeyStates_Down) = 1, Locked (CoreVirtualKeyStates_Locked) = 2,
 }}
 DEFINE_IID!(IID_ICoreWindow, 2042222066, 34718, 19337, 183, 152, 121, 228, 117, 152, 3, 12);
@@ -8104,7 +8104,7 @@ impl ICoreWindow {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWindow: ICoreWindow}
+RT_CLASS!{class CoreWindow: ICoreWindow ["Windows.UI.Core.CoreWindow"]}
 impl RtActivatable<ICoreWindowStatic> for CoreWindow {}
 impl CoreWindow {
     #[inline] pub fn get_for_current_thread() -> Result<Option<ComPtr<CoreWindow>>> {
@@ -8189,10 +8189,10 @@ impl ICoreWindow5 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreWindowActivationMode: i32 {
+RT_ENUM! { enum CoreWindowActivationMode: i32 ["Windows.UI.Core.CoreWindowActivationMode"] {
     None (CoreWindowActivationMode_None) = 0, Deactivated (CoreWindowActivationMode_Deactivated) = 1, ActivatedNotForeground (CoreWindowActivationMode_ActivatedNotForeground) = 2, ActivatedInForeground (CoreWindowActivationMode_ActivatedInForeground) = 3,
 }}
-RT_ENUM! { enum CoreWindowActivationState: i32 {
+RT_ENUM! { enum CoreWindowActivationState: i32 ["Windows.UI.Core.CoreWindowActivationState"] {
     CodeActivated (CoreWindowActivationState_CodeActivated) = 0, Deactivated (CoreWindowActivationState_Deactivated) = 1, PointerActivated (CoreWindowActivationState_PointerActivated) = 2,
 }}
 DEFINE_IID!(IID_ICoreWindowDialog, 3879283936, 51085, 17022, 139, 44, 1, 255, 66, 12, 105, 213);
@@ -8290,7 +8290,7 @@ impl ICoreWindowDialog {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWindowDialog: ICoreWindowDialog}
+RT_CLASS!{class CoreWindowDialog: ICoreWindowDialog ["Windows.UI.Core.CoreWindowDialog"]}
 impl RtActivatable<ICoreWindowDialogFactory> for CoreWindowDialog {}
 impl RtActivatable<IActivationFactory> for CoreWindowDialog {}
 impl CoreWindowDialog {
@@ -8326,8 +8326,8 @@ impl ICoreWindowEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWindowEventArgs: ICoreWindowEventArgs}
-RT_ENUM! { enum CoreWindowFlowDirection: i32 {
+RT_CLASS!{class CoreWindowEventArgs: ICoreWindowEventArgs ["Windows.UI.Core.CoreWindowEventArgs"]}
+RT_ENUM! { enum CoreWindowFlowDirection: i32 ["Windows.UI.Core.CoreWindowFlowDirection"] {
     LeftToRight (CoreWindowFlowDirection_LeftToRight) = 0, RightToLeft (CoreWindowFlowDirection_RightToLeft) = 1,
 }}
 DEFINE_IID!(IID_ICoreWindowFlyout, 3902637389, 8272, 16571, 179, 68, 246, 243, 85, 238, 179, 20);
@@ -8414,7 +8414,7 @@ impl ICoreWindowFlyout {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWindowFlyout: ICoreWindowFlyout}
+RT_CLASS!{class CoreWindowFlyout: ICoreWindowFlyout ["Windows.UI.Core.CoreWindowFlyout"]}
 impl RtActivatable<ICoreWindowFlyoutFactory> for CoreWindowFlyout {}
 impl CoreWindowFlyout {
     #[inline] pub fn create(position: foundation::Point) -> Result<ComPtr<CoreWindowFlyout>> {
@@ -8452,7 +8452,7 @@ impl ICoreWindowPopupShowingEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWindowPopupShowingEventArgs: ICoreWindowPopupShowingEventArgs}
+RT_CLASS!{class CoreWindowPopupShowingEventArgs: ICoreWindowPopupShowingEventArgs ["Windows.UI.Core.CoreWindowPopupShowingEventArgs"]}
 DEFINE_IID!(IID_ICoreWindowResizeManager, 3102783781, 45904, 18611, 161, 152, 92, 26, 132, 112, 2, 67);
 RT_INTERFACE!{interface ICoreWindowResizeManager(ICoreWindowResizeManagerVtbl): IInspectable(IInspectableVtbl) [IID_ICoreWindowResizeManager] {
     fn NotifyLayoutCompleted(&self) -> HRESULT
@@ -8463,7 +8463,7 @@ impl ICoreWindowResizeManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWindowResizeManager: ICoreWindowResizeManager}
+RT_CLASS!{class CoreWindowResizeManager: ICoreWindowResizeManager ["Windows.UI.Core.CoreWindowResizeManager"]}
 impl RtActivatable<ICoreWindowResizeManagerStatics> for CoreWindowResizeManager {}
 impl CoreWindowResizeManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<CoreWindowResizeManager>>> {
@@ -8540,7 +8540,7 @@ impl IIdleDispatchedHandlerArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class IdleDispatchedHandlerArgs: IIdleDispatchedHandlerArgs}
+RT_CLASS!{class IdleDispatchedHandlerArgs: IIdleDispatchedHandlerArgs ["Windows.UI.Core.IdleDispatchedHandlerArgs"]}
 DEFINE_IID!(IID_IInitializeWithCoreWindow, 412033238, 39027, 17994, 172, 229, 87, 224, 16, 244, 101, 230);
 RT_INTERFACE!{interface IInitializeWithCoreWindow(IInitializeWithCoreWindowVtbl): IInspectable(IInspectableVtbl) [IID_IInitializeWithCoreWindow] {
     fn Initialize(&self, window: *mut CoreWindow) -> HRESULT
@@ -8562,7 +8562,7 @@ impl IInputEnabledEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InputEnabledEventArgs: IInputEnabledEventArgs}
+RT_CLASS!{class InputEnabledEventArgs: IInputEnabledEventArgs ["Windows.UI.Core.InputEnabledEventArgs"]}
 DEFINE_IID!(IID_IKeyEventArgs, 1609951536, 9540, 18967, 189, 120, 31, 47, 222, 187, 16, 107);
 RT_INTERFACE!{interface IKeyEventArgs(IKeyEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IKeyEventArgs] {
     #[cfg(not(feature="windows-system"))] fn __Dummy0(&self) -> (),
@@ -8581,7 +8581,7 @@ impl IKeyEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyEventArgs: IKeyEventArgs}
+RT_CLASS!{class KeyEventArgs: IKeyEventArgs ["Windows.UI.Core.KeyEventArgs"]}
 DEFINE_IID!(IID_IKeyEventArgs2, 1480252824, 1936, 17777, 155, 18, 100, 94, 249, 215, 158, 66);
 RT_INTERFACE!{interface IKeyEventArgs2(IKeyEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IKeyEventArgs2] {
     fn get_DeviceId(&self, out: *mut HSTRING) -> HRESULT
@@ -8617,7 +8617,7 @@ impl IPointerEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PointerEventArgs: IPointerEventArgs}
+RT_CLASS!{class PointerEventArgs: IPointerEventArgs ["Windows.UI.Core.PointerEventArgs"]}
 DEFINE_IID!(IID_ISystemNavigationManager, 2466394392, 53072, 17062, 151, 6, 105, 16, 127, 161, 34, 225);
 RT_INTERFACE!{interface ISystemNavigationManager(ISystemNavigationManagerVtbl): IInspectable(IInspectableVtbl) [IID_ISystemNavigationManager] {
     fn add_BackRequested(&self, handler: *mut foundation::EventHandler<BackRequestedEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -8634,7 +8634,7 @@ impl ISystemNavigationManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemNavigationManager: ISystemNavigationManager}
+RT_CLASS!{class SystemNavigationManager: ISystemNavigationManager ["Windows.UI.Core.SystemNavigationManager"]}
 impl RtActivatable<ISystemNavigationManagerStatics> for SystemNavigationManager {}
 impl SystemNavigationManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<SystemNavigationManager>>> {
@@ -8709,7 +8709,7 @@ impl ITouchHitTestingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TouchHitTestingEventArgs: ITouchHitTestingEventArgs}
+RT_CLASS!{class TouchHitTestingEventArgs: ITouchHitTestingEventArgs ["Windows.UI.Core.TouchHitTestingEventArgs"]}
 DEFINE_IID!(IID_IVisibilityChangedEventArgs, 3214481642, 55297, 17764, 164, 149, 177, 232, 79, 138, 208, 133);
 RT_INTERFACE!{interface IVisibilityChangedEventArgs(IVisibilityChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVisibilityChangedEventArgs] {
     fn get_Visible(&self, out: *mut bool) -> HRESULT
@@ -8721,7 +8721,7 @@ impl IVisibilityChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisibilityChangedEventArgs: IVisibilityChangedEventArgs}
+RT_CLASS!{class VisibilityChangedEventArgs: IVisibilityChangedEventArgs ["Windows.UI.Core.VisibilityChangedEventArgs"]}
 DEFINE_IID!(IID_IWindowActivatedEventArgs, 396191207, 18008, 19638, 170, 19, 65, 208, 148, 234, 37, 94);
 RT_INTERFACE!{interface IWindowActivatedEventArgs(IWindowActivatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWindowActivatedEventArgs] {
     fn get_WindowActivationState(&self, out: *mut CoreWindowActivationState) -> HRESULT
@@ -8733,7 +8733,7 @@ impl IWindowActivatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WindowActivatedEventArgs: IWindowActivatedEventArgs}
+RT_CLASS!{class WindowActivatedEventArgs: IWindowActivatedEventArgs ["Windows.UI.Core.WindowActivatedEventArgs"]}
 DEFINE_IID!(IID_IWindowSizeChangedEventArgs, 1512050375, 1062, 18396, 184, 108, 111, 71, 89, 21, 228, 81);
 RT_INTERFACE!{interface IWindowSizeChangedEventArgs(IWindowSizeChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWindowSizeChangedEventArgs] {
     fn get_Size(&self, out: *mut foundation::Size) -> HRESULT
@@ -8745,7 +8745,7 @@ impl IWindowSizeChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WindowSizeChangedEventArgs: IWindowSizeChangedEventArgs}
+RT_CLASS!{class WindowSizeChangedEventArgs: IWindowSizeChangedEventArgs ["Windows.UI.Core.WindowSizeChangedEventArgs"]}
 pub mod animationmetrics { // Windows.UI.Core.AnimationMetrics
 use ::prelude::*;
 DEFINE_IID!(IID_IAnimationDescription, 2098308425, 48701, 16862, 176, 129, 5, 193, 73, 150, 47, 155);
@@ -8783,7 +8783,7 @@ impl IAnimationDescription {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AnimationDescription: IAnimationDescription}
+RT_CLASS!{class AnimationDescription: IAnimationDescription ["Windows.UI.Core.AnimationMetrics.AnimationDescription"]}
 impl RtActivatable<IAnimationDescriptionFactory> for AnimationDescription {}
 impl AnimationDescription {
     #[inline] pub fn create_instance(effect: AnimationEffect, target: AnimationEffectTarget) -> Result<ComPtr<AnimationDescription>> {
@@ -8802,10 +8802,10 @@ impl IAnimationDescriptionFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AnimationEffect: i32 {
+RT_ENUM! { enum AnimationEffect: i32 ["Windows.UI.Core.AnimationMetrics.AnimationEffect"] {
     Expand (AnimationEffect_Expand) = 0, Collapse (AnimationEffect_Collapse) = 1, Reposition (AnimationEffect_Reposition) = 2, FadeIn (AnimationEffect_FadeIn) = 3, FadeOut (AnimationEffect_FadeOut) = 4, AddToList (AnimationEffect_AddToList) = 5, DeleteFromList (AnimationEffect_DeleteFromList) = 6, AddToGrid (AnimationEffect_AddToGrid) = 7, DeleteFromGrid (AnimationEffect_DeleteFromGrid) = 8, AddToSearchGrid (AnimationEffect_AddToSearchGrid) = 9, DeleteFromSearchGrid (AnimationEffect_DeleteFromSearchGrid) = 10, AddToSearchList (AnimationEffect_AddToSearchList) = 11, DeleteFromSearchList (AnimationEffect_DeleteFromSearchList) = 12, ShowEdgeUI (AnimationEffect_ShowEdgeUI) = 13, ShowPanel (AnimationEffect_ShowPanel) = 14, HideEdgeUI (AnimationEffect_HideEdgeUI) = 15, HidePanel (AnimationEffect_HidePanel) = 16, ShowPopup (AnimationEffect_ShowPopup) = 17, HidePopup (AnimationEffect_HidePopup) = 18, PointerDown (AnimationEffect_PointerDown) = 19, PointerUp (AnimationEffect_PointerUp) = 20, DragSourceStart (AnimationEffect_DragSourceStart) = 21, DragSourceEnd (AnimationEffect_DragSourceEnd) = 22, TransitionContent (AnimationEffect_TransitionContent) = 23, Reveal (AnimationEffect_Reveal) = 24, Hide (AnimationEffect_Hide) = 25, DragBetweenEnter (AnimationEffect_DragBetweenEnter) = 26, DragBetweenLeave (AnimationEffect_DragBetweenLeave) = 27, SwipeSelect (AnimationEffect_SwipeSelect) = 28, SwipeDeselect (AnimationEffect_SwipeDeselect) = 29, SwipeReveal (AnimationEffect_SwipeReveal) = 30, EnterPage (AnimationEffect_EnterPage) = 31, TransitionPage (AnimationEffect_TransitionPage) = 32, CrossFade (AnimationEffect_CrossFade) = 33, Peek (AnimationEffect_Peek) = 34, UpdateBadge (AnimationEffect_UpdateBadge) = 35,
 }}
-RT_ENUM! { enum AnimationEffectTarget: i32 {
+RT_ENUM! { enum AnimationEffectTarget: i32 ["Windows.UI.Core.AnimationMetrics.AnimationEffectTarget"] {
     Primary (AnimationEffectTarget_Primary) = 0, Added (AnimationEffectTarget_Added) = 1, Affected (AnimationEffectTarget_Affected) = 2, Background (AnimationEffectTarget_Background) = 3, Content (AnimationEffectTarget_Content) = 4, Deleted (AnimationEffectTarget_Deleted) = 5, Deselected (AnimationEffectTarget_Deselected) = 6, DragSource (AnimationEffectTarget_DragSource) = 7, Hidden (AnimationEffectTarget_Hidden) = 8, Incoming (AnimationEffectTarget_Incoming) = 9, Outgoing (AnimationEffectTarget_Outgoing) = 10, Outline (AnimationEffectTarget_Outline) = 11, Remaining (AnimationEffectTarget_Remaining) = 12, Revealed (AnimationEffectTarget_Revealed) = 13, RowIn (AnimationEffectTarget_RowIn) = 14, RowOut (AnimationEffectTarget_RowOut) = 15, Selected (AnimationEffectTarget_Selected) = 16, Selection (AnimationEffectTarget_Selection) = 17, Shown (AnimationEffectTarget_Shown) = 18, Tapped (AnimationEffectTarget_Tapped) = 19,
 }}
 DEFINE_IID!(IID_IOpacityAnimation, 2151328741, 61054, 17759, 132, 233, 37, 6, 175, 184, 210, 180);
@@ -8825,7 +8825,7 @@ impl IOpacityAnimation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class OpacityAnimation: IOpacityAnimation}
+RT_CLASS!{class OpacityAnimation: IOpacityAnimation ["Windows.UI.Core.AnimationMetrics.OpacityAnimation"]}
 DEFINE_IID!(IID_IPropertyAnimation, 973190362, 19852, 16670, 182, 21, 26, 222, 104, 58, 153, 3);
 RT_INTERFACE!{interface IPropertyAnimation(IPropertyAnimationVtbl): IInspectable(IInspectableVtbl) [IID_IPropertyAnimation] {
     fn get_Type(&self, out: *mut PropertyAnimationType) -> HRESULT,
@@ -8861,8 +8861,8 @@ impl IPropertyAnimation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PropertyAnimation: IPropertyAnimation}
-RT_ENUM! { enum PropertyAnimationType: i32 {
+RT_CLASS!{class PropertyAnimation: IPropertyAnimation ["Windows.UI.Core.AnimationMetrics.PropertyAnimation"]}
+RT_ENUM! { enum PropertyAnimationType: i32 ["Windows.UI.Core.AnimationMetrics.PropertyAnimationType"] {
     Scale (PropertyAnimationType_Scale) = 0, Translation (PropertyAnimationType_Translation) = 1, Opacity (PropertyAnimationType_Opacity) = 2,
 }}
 DEFINE_IID!(IID_IScaleAnimation, 37049031, 29099, 17036, 156, 159, 211, 23, 128, 150, 73, 149);
@@ -8900,8 +8900,8 @@ impl IScaleAnimation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScaleAnimation: IScaleAnimation}
-RT_CLASS!{class TranslationAnimation: IPropertyAnimation}
+RT_CLASS!{class ScaleAnimation: IScaleAnimation ["Windows.UI.Core.AnimationMetrics.ScaleAnimation"]}
+RT_CLASS!{class TranslationAnimation: IPropertyAnimation ["Windows.UI.Core.AnimationMetrics.TranslationAnimation"]}
 } // Windows.UI.Core.AnimationMetrics
 pub mod preview { // Windows.UI.Core.Preview
 use ::prelude::*;
@@ -8927,7 +8927,7 @@ impl ISystemNavigationCloseRequestedPreviewEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemNavigationCloseRequestedPreviewEventArgs: ISystemNavigationCloseRequestedPreviewEventArgs}
+RT_CLASS!{class SystemNavigationCloseRequestedPreviewEventArgs: ISystemNavigationCloseRequestedPreviewEventArgs ["Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs"]}
 DEFINE_IID!(IID_ISystemNavigationManagerPreview, 3965650056, 25637, 18295, 165, 54, 203, 86, 52, 66, 127, 13);
 RT_INTERFACE!{interface ISystemNavigationManagerPreview(ISystemNavigationManagerPreviewVtbl): IInspectable(IInspectableVtbl) [IID_ISystemNavigationManagerPreview] {
     fn add_CloseRequested(&self, handler: *mut foundation::EventHandler<SystemNavigationCloseRequestedPreviewEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -8944,7 +8944,7 @@ impl ISystemNavigationManagerPreview {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SystemNavigationManagerPreview: ISystemNavigationManagerPreview}
+RT_CLASS!{class SystemNavigationManagerPreview: ISystemNavigationManagerPreview ["Windows.UI.Core.Preview.SystemNavigationManagerPreview"]}
 impl RtActivatable<ISystemNavigationManagerPreviewStatics> for SystemNavigationManagerPreview {}
 impl SystemNavigationManagerPreview {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<SystemNavigationManagerPreview>>> {
@@ -8967,7 +8967,7 @@ impl ISystemNavigationManagerPreviewStatics {
 } // Windows.UI.Core
 pub mod input { // Windows.UI.Input
 use ::prelude::*;
-RT_STRUCT! { struct CrossSlideThresholds {
+RT_STRUCT! { struct CrossSlideThresholds ["Windows.UI.Input.CrossSlideThresholds"] {
     SelectionStart: f32, SpeedBumpStart: f32, SpeedBumpEnd: f32, RearrangeStart: f32,
 }}
 DEFINE_IID!(IID_ICrossSlidingEventArgs, 3912714040, 28552, 16857, 135, 32, 120, 224, 142, 57, 131, 73);
@@ -8994,8 +8994,8 @@ impl ICrossSlidingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CrossSlidingEventArgs: ICrossSlidingEventArgs}
-RT_ENUM! { enum CrossSlidingState: i32 {
+RT_CLASS!{class CrossSlidingEventArgs: ICrossSlidingEventArgs ["Windows.UI.Input.CrossSlidingEventArgs"]}
+RT_ENUM! { enum CrossSlidingState: i32 ["Windows.UI.Input.CrossSlidingState"] {
     Started (CrossSlidingState_Started) = 0, Dragging (CrossSlidingState_Dragging) = 1, Selecting (CrossSlidingState_Selecting) = 2, SelectSpeedBumping (CrossSlidingState_SelectSpeedBumping) = 3, SpeedBumping (CrossSlidingState_SpeedBumping) = 4, Rearranging (CrossSlidingState_Rearranging) = 5, Completed (CrossSlidingState_Completed) = 6,
 }}
 DEFINE_IID!(IID_IDraggingEventArgs, 479220612, 2108, 19411, 181, 89, 23, 156, 221, 235, 51, 236);
@@ -9022,8 +9022,8 @@ impl IDraggingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class DraggingEventArgs: IDraggingEventArgs}
-RT_ENUM! { enum DraggingState: i32 {
+RT_CLASS!{class DraggingEventArgs: IDraggingEventArgs ["Windows.UI.Input.DraggingEventArgs"]}
+RT_ENUM! { enum DraggingState: i32 ["Windows.UI.Input.DraggingState"] {
     Started (DraggingState_Started) = 0, Continuing (DraggingState_Continuing) = 1, Completed (DraggingState_Completed) = 2,
 }}
 DEFINE_IID!(IID_IEdgeGesture, 1477268114, 10929, 18858, 167, 240, 51, 189, 63, 141, 249, 241);
@@ -9064,7 +9064,7 @@ impl IEdgeGesture {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EdgeGesture: IEdgeGesture}
+RT_CLASS!{class EdgeGesture: IEdgeGesture ["Windows.UI.Input.EdgeGesture"]}
 impl RtActivatable<IEdgeGestureStatics> for EdgeGesture {}
 impl EdgeGesture {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<EdgeGesture>>> {
@@ -9083,8 +9083,8 @@ impl IEdgeGestureEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class EdgeGestureEventArgs: IEdgeGestureEventArgs}
-RT_ENUM! { enum EdgeGestureKind: i32 {
+RT_CLASS!{class EdgeGestureEventArgs: IEdgeGestureEventArgs ["Windows.UI.Input.EdgeGestureEventArgs"]}
+RT_ENUM! { enum EdgeGestureKind: i32 ["Windows.UI.Input.EdgeGestureKind"] {
     Touch (EdgeGestureKind_Touch) = 0, Keyboard (EdgeGestureKind_Keyboard) = 1, Mouse (EdgeGestureKind_Mouse) = 2,
 }}
 DEFINE_IID!(IID_IEdgeGestureStatics, 3161097497, 6382, 16451, 152, 57, 79, 197, 132, 214, 10, 20);
@@ -9421,10 +9421,10 @@ impl IGestureRecognizer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class GestureRecognizer: IGestureRecognizer}
+RT_CLASS!{class GestureRecognizer: IGestureRecognizer ["Windows.UI.Input.GestureRecognizer"]}
 impl RtActivatable<IActivationFactory> for GestureRecognizer {}
 DEFINE_CLSID!(GestureRecognizer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,71,101,115,116,117,114,101,82,101,99,111,103,110,105,122,101,114,0]) [CLSID_GestureRecognizer]);
-RT_ENUM! { enum GestureSettings: u32 {
+RT_ENUM! { enum GestureSettings: u32 ["Windows.UI.Input.GestureSettings"] {
     None (GestureSettings_None) = 0, Tap (GestureSettings_Tap) = 1, DoubleTap (GestureSettings_DoubleTap) = 2, Hold (GestureSettings_Hold) = 4, HoldWithMouse (GestureSettings_HoldWithMouse) = 8, RightTap (GestureSettings_RightTap) = 16, Drag (GestureSettings_Drag) = 32, ManipulationTranslateX (GestureSettings_ManipulationTranslateX) = 64, ManipulationTranslateY (GestureSettings_ManipulationTranslateY) = 128, ManipulationTranslateRailsX (GestureSettings_ManipulationTranslateRailsX) = 256, ManipulationTranslateRailsY (GestureSettings_ManipulationTranslateRailsY) = 512, ManipulationRotate (GestureSettings_ManipulationRotate) = 1024, ManipulationScale (GestureSettings_ManipulationScale) = 2048, ManipulationTranslateInertia (GestureSettings_ManipulationTranslateInertia) = 4096, ManipulationRotateInertia (GestureSettings_ManipulationRotateInertia) = 8192, ManipulationScaleInertia (GestureSettings_ManipulationScaleInertia) = 16384, CrossSlide (GestureSettings_CrossSlide) = 32768, ManipulationMultipleFingerPanning (GestureSettings_ManipulationMultipleFingerPanning) = 65536,
 }}
 DEFINE_IID!(IID_IHoldingEventArgs, 737629637, 59289, 16820, 187, 64, 36, 47, 64, 149, 155, 113);
@@ -9451,8 +9451,8 @@ impl IHoldingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HoldingEventArgs: IHoldingEventArgs}
-RT_ENUM! { enum HoldingState: i32 {
+RT_CLASS!{class HoldingEventArgs: IHoldingEventArgs ["Windows.UI.Input.HoldingEventArgs"]}
+RT_ENUM! { enum HoldingState: i32 ["Windows.UI.Input.HoldingState"] {
     Started (HoldingState_Started) = 0, Completed (HoldingState_Completed) = 1, Canceled (HoldingState_Canceled) = 2,
 }}
 DEFINE_IID!(IID_IKeyboardDeliveryInterceptor, 3032150120, 36681, 17516, 141, 181, 140, 15, 254, 133, 204, 158);
@@ -9493,7 +9493,7 @@ impl IKeyboardDeliveryInterceptor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class KeyboardDeliveryInterceptor: IKeyboardDeliveryInterceptor}
+RT_CLASS!{class KeyboardDeliveryInterceptor: IKeyboardDeliveryInterceptor ["Windows.UI.Input.KeyboardDeliveryInterceptor"]}
 impl RtActivatable<IKeyboardDeliveryInterceptorStatics> for KeyboardDeliveryInterceptor {}
 impl KeyboardDeliveryInterceptor {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<KeyboardDeliveryInterceptor>>> {
@@ -9542,8 +9542,8 @@ impl IManipulationCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ManipulationCompletedEventArgs: IManipulationCompletedEventArgs}
-RT_STRUCT! { struct ManipulationDelta {
+RT_CLASS!{class ManipulationCompletedEventArgs: IManipulationCompletedEventArgs ["Windows.UI.Input.ManipulationCompletedEventArgs"]}
+RT_STRUCT! { struct ManipulationDelta ["Windows.UI.Input.ManipulationDelta"] {
     Translation: foundation::Point, Scale: f32, Rotation: f32, Expansion: f32,
 }}
 DEFINE_IID!(IID_IManipulationInertiaStartingEventArgs, 3711412376, 9919, 18042, 156, 229, 204, 243, 251, 17, 55, 30);
@@ -9582,7 +9582,7 @@ impl IManipulationInertiaStartingEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ManipulationInertiaStartingEventArgs: IManipulationInertiaStartingEventArgs}
+RT_CLASS!{class ManipulationInertiaStartingEventArgs: IManipulationInertiaStartingEventArgs ["Windows.UI.Input.ManipulationInertiaStartingEventArgs"]}
 DEFINE_IID!(IID_IManipulationStartedEventArgs, 3723265854, 53198, 18738, 140, 29, 60, 61, 1, 26, 52, 192);
 RT_INTERFACE!{interface IManipulationStartedEventArgs(IManipulationStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IManipulationStartedEventArgs] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -9607,7 +9607,7 @@ impl IManipulationStartedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ManipulationStartedEventArgs: IManipulationStartedEventArgs}
+RT_CLASS!{class ManipulationStartedEventArgs: IManipulationStartedEventArgs ["Windows.UI.Input.ManipulationStartedEventArgs"]}
 DEFINE_IID!(IID_IManipulationUpdatedEventArgs, 3409267941, 43960, 20383, 179, 206, 129, 129, 170, 97, 173, 130);
 RT_INTERFACE!{interface IManipulationUpdatedEventArgs(IManipulationUpdatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IManipulationUpdatedEventArgs] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -9644,8 +9644,8 @@ impl IManipulationUpdatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ManipulationUpdatedEventArgs: IManipulationUpdatedEventArgs}
-RT_STRUCT! { struct ManipulationVelocities {
+RT_CLASS!{class ManipulationUpdatedEventArgs: IManipulationUpdatedEventArgs ["Windows.UI.Input.ManipulationUpdatedEventArgs"]}
+RT_STRUCT! { struct ManipulationVelocities ["Windows.UI.Input.ManipulationVelocities"] {
     Linear: foundation::Point, Angular: f32, Expansion: f32,
 }}
 DEFINE_IID!(IID_IMouseWheelParameters, 3939551812, 40429, 16439, 129, 73, 94, 76, 194, 86, 68, 104);
@@ -9697,7 +9697,7 @@ impl IMouseWheelParameters {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MouseWheelParameters: IMouseWheelParameters}
+RT_CLASS!{class MouseWheelParameters: IMouseWheelParameters ["Windows.UI.Input.MouseWheelParameters"]}
 DEFINE_IID!(IID_IPointerPoint, 3918868861, 29334, 17113, 130, 51, 197, 190, 115, 183, 74, 74);
 RT_INTERFACE!{interface IPointerPoint(IPointerPointVtbl): IInspectable(IInspectableVtbl) [IID_IPointerPoint] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -9752,7 +9752,7 @@ impl IPointerPoint {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PointerPoint: IPointerPoint}
+RT_CLASS!{class PointerPoint: IPointerPoint ["Windows.UI.Input.PointerPoint"]}
 impl RtActivatable<IPointerPointStatics> for PointerPoint {}
 impl PointerPoint {
     #[inline] pub fn get_current_point(pointerId: u32) -> Result<Option<ComPtr<PointerPoint>>> {
@@ -9918,7 +9918,7 @@ impl IPointerPointProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PointerPointProperties: IPointerPointProperties}
+RT_CLASS!{class PointerPointProperties: IPointerPointProperties ["Windows.UI.Input.PointerPointProperties"]}
 DEFINE_IID!(IID_IPointerPointProperties2, 583222074, 51259, 16832, 162, 150, 94, 35, 45, 100, 214, 175);
 RT_INTERFACE!{interface IPointerPointProperties2(IPointerPointProperties2Vtbl): IInspectable(IInspectableVtbl) [IID_IPointerPointProperties2] {
     fn get_ZDistance(&self, out: *mut *mut foundation::IReference<f32>) -> HRESULT
@@ -9982,7 +9982,7 @@ impl IPointerPointTransform {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PointerUpdateKind: i32 {
+RT_ENUM! { enum PointerUpdateKind: i32 ["Windows.UI.Input.PointerUpdateKind"] {
     Other (PointerUpdateKind_Other) = 0, LeftButtonPressed (PointerUpdateKind_LeftButtonPressed) = 1, LeftButtonReleased (PointerUpdateKind_LeftButtonReleased) = 2, RightButtonPressed (PointerUpdateKind_RightButtonPressed) = 3, RightButtonReleased (PointerUpdateKind_RightButtonReleased) = 4, MiddleButtonPressed (PointerUpdateKind_MiddleButtonPressed) = 5, MiddleButtonReleased (PointerUpdateKind_MiddleButtonReleased) = 6, XButton1Pressed (PointerUpdateKind_XButton1Pressed) = 7, XButton1Released (PointerUpdateKind_XButton1Released) = 8, XButton2Pressed (PointerUpdateKind_XButton2Pressed) = 9, XButton2Released (PointerUpdateKind_XButton2Released) = 10,
 }}
 DEFINE_IID!(IID_IPointerVisualizationSettings, 1293837409, 34039, 18845, 189, 145, 42, 54, 226, 183, 170, 162);
@@ -10012,7 +10012,7 @@ impl IPointerVisualizationSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PointerVisualizationSettings: IPointerVisualizationSettings}
+RT_CLASS!{class PointerVisualizationSettings: IPointerVisualizationSettings ["Windows.UI.Input.PointerVisualizationSettings"]}
 impl RtActivatable<IPointerVisualizationSettingsStatics> for PointerVisualizationSettings {}
 impl PointerVisualizationSettings {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<PointerVisualizationSettings>>> {
@@ -10141,7 +10141,7 @@ impl IRadialController {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialController: IRadialController}
+RT_CLASS!{class RadialController: IRadialController ["Windows.UI.Input.RadialController"]}
 impl RtActivatable<IRadialControllerStatics> for RadialController {}
 impl RadialController {
     #[inline] pub fn is_supported() -> Result<bool> {
@@ -10201,7 +10201,7 @@ impl IRadialControllerButtonClickedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerButtonClickedEventArgs: IRadialControllerButtonClickedEventArgs}
+RT_CLASS!{class RadialControllerButtonClickedEventArgs: IRadialControllerButtonClickedEventArgs ["Windows.UI.Input.RadialControllerButtonClickedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerButtonClickedEventArgs2, 1029144307, 15598, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerButtonClickedEventArgs2(IRadialControllerButtonClickedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerButtonClickedEventArgs2] {
     #[cfg(feature="windows-devices")] fn get_SimpleHapticsController(&self, out: *mut *mut super::super::devices::haptics::SimpleHapticsController) -> HRESULT
@@ -10230,7 +10230,7 @@ impl IRadialControllerButtonHoldingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerButtonHoldingEventArgs: IRadialControllerButtonHoldingEventArgs}
+RT_CLASS!{class RadialControllerButtonHoldingEventArgs: IRadialControllerButtonHoldingEventArgs ["Windows.UI.Input.RadialControllerButtonHoldingEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerButtonPressedEventArgs, 1029144301, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerButtonPressedEventArgs(IRadialControllerButtonPressedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerButtonPressedEventArgs] {
     fn get_Contact(&self, out: *mut *mut RadialControllerScreenContact) -> HRESULT,
@@ -10248,7 +10248,7 @@ impl IRadialControllerButtonPressedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerButtonPressedEventArgs: IRadialControllerButtonPressedEventArgs}
+RT_CLASS!{class RadialControllerButtonPressedEventArgs: IRadialControllerButtonPressedEventArgs ["Windows.UI.Input.RadialControllerButtonPressedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerButtonReleasedEventArgs, 1029144303, 15598, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerButtonReleasedEventArgs(IRadialControllerButtonReleasedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerButtonReleasedEventArgs] {
     fn get_Contact(&self, out: *mut *mut RadialControllerScreenContact) -> HRESULT,
@@ -10266,7 +10266,7 @@ impl IRadialControllerButtonReleasedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerButtonReleasedEventArgs: IRadialControllerButtonReleasedEventArgs}
+RT_CLASS!{class RadialControllerButtonReleasedEventArgs: IRadialControllerButtonReleasedEventArgs ["Windows.UI.Input.RadialControllerButtonReleasedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerConfiguration, 2797051595, 27218, 17456, 145, 12, 86, 55, 10, 157, 107, 66);
 RT_INTERFACE!{interface IRadialControllerConfiguration(IRadialControllerConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerConfiguration] {
     fn SetDefaultMenuItems(&self, buttons: *mut foundation::collections::IIterable<RadialControllerSystemMenuItemKind>) -> HRESULT,
@@ -10288,7 +10288,7 @@ impl IRadialControllerConfiguration {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerConfiguration: IRadialControllerConfiguration}
+RT_CLASS!{class RadialControllerConfiguration: IRadialControllerConfiguration ["Windows.UI.Input.RadialControllerConfiguration"]}
 impl RtActivatable<IRadialControllerConfigurationStatics> for RadialControllerConfiguration {}
 impl RtActivatable<IRadialControllerConfigurationStatics2> for RadialControllerConfiguration {}
 impl RadialControllerConfiguration {
@@ -10385,7 +10385,7 @@ impl IRadialControllerControlAcquiredEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerControlAcquiredEventArgs: IRadialControllerControlAcquiredEventArgs}
+RT_CLASS!{class RadialControllerControlAcquiredEventArgs: IRadialControllerControlAcquiredEventArgs ["Windows.UI.Input.RadialControllerControlAcquiredEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerControlAcquiredEventArgs2, 1029144308, 15598, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerControlAcquiredEventArgs2(IRadialControllerControlAcquiredEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerControlAcquiredEventArgs2] {
     fn get_IsButtonPressed(&self, out: *mut bool) -> HRESULT,
@@ -10442,7 +10442,7 @@ impl IRadialControllerMenu {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerMenu: IRadialControllerMenu}
+RT_CLASS!{class RadialControllerMenu: IRadialControllerMenu ["Windows.UI.Input.RadialControllerMenu"]}
 DEFINE_IID!(IID_IRadialControllerMenuItem, 3356477837, 44299, 19612, 143, 47, 19, 106, 35, 115, 166, 186);
 RT_INTERFACE!{interface IRadialControllerMenuItem(IRadialControllerMenuItemVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerMenuItem] {
     fn get_DisplayText(&self, out: *mut HSTRING) -> HRESULT,
@@ -10476,7 +10476,7 @@ impl IRadialControllerMenuItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerMenuItem: IRadialControllerMenuItem}
+RT_CLASS!{class RadialControllerMenuItem: IRadialControllerMenuItem ["Windows.UI.Input.RadialControllerMenuItem"]}
 impl RtActivatable<IRadialControllerMenuItemStatics> for RadialControllerMenuItem {}
 impl RtActivatable<IRadialControllerMenuItemStatics2> for RadialControllerMenuItem {}
 impl RadialControllerMenuItem {
@@ -10529,7 +10529,7 @@ impl IRadialControllerMenuItemStatics2 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RadialControllerMenuKnownIcon: i32 {
+RT_ENUM! { enum RadialControllerMenuKnownIcon: i32 ["Windows.UI.Input.RadialControllerMenuKnownIcon"] {
     Scroll (RadialControllerMenuKnownIcon_Scroll) = 0, Zoom (RadialControllerMenuKnownIcon_Zoom) = 1, UndoRedo (RadialControllerMenuKnownIcon_UndoRedo) = 2, Volume (RadialControllerMenuKnownIcon_Volume) = 3, NextPreviousTrack (RadialControllerMenuKnownIcon_NextPreviousTrack) = 4, Ruler (RadialControllerMenuKnownIcon_Ruler) = 5, InkColor (RadialControllerMenuKnownIcon_InkColor) = 6, InkThickness (RadialControllerMenuKnownIcon_InkThickness) = 7, PenType (RadialControllerMenuKnownIcon_PenType) = 8,
 }}
 DEFINE_IID!(IID_IRadialControllerRotationChangedEventArgs, 543859765, 58961, 4581, 191, 98, 44, 39, 215, 64, 78, 133);
@@ -10549,7 +10549,7 @@ impl IRadialControllerRotationChangedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerRotationChangedEventArgs: IRadialControllerRotationChangedEventArgs}
+RT_CLASS!{class RadialControllerRotationChangedEventArgs: IRadialControllerRotationChangedEventArgs ["Windows.UI.Input.RadialControllerRotationChangedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerRotationChangedEventArgs2, 1029144300, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerRotationChangedEventArgs2(IRadialControllerRotationChangedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerRotationChangedEventArgs2] {
     fn get_IsButtonPressed(&self, out: *mut bool) -> HRESULT,
@@ -10584,7 +10584,7 @@ impl IRadialControllerScreenContact {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerScreenContact: IRadialControllerScreenContact}
+RT_CLASS!{class RadialControllerScreenContact: IRadialControllerScreenContact ["Windows.UI.Input.RadialControllerScreenContact"]}
 DEFINE_IID!(IID_IRadialControllerScreenContactContinuedEventArgs, 543859767, 58961, 4581, 191, 98, 44, 39, 215, 64, 78, 133);
 RT_INTERFACE!{interface IRadialControllerScreenContactContinuedEventArgs(IRadialControllerScreenContactContinuedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerScreenContactContinuedEventArgs] {
     fn get_Contact(&self, out: *mut *mut RadialControllerScreenContact) -> HRESULT
@@ -10596,7 +10596,7 @@ impl IRadialControllerScreenContactContinuedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerScreenContactContinuedEventArgs: IRadialControllerScreenContactContinuedEventArgs}
+RT_CLASS!{class RadialControllerScreenContactContinuedEventArgs: IRadialControllerScreenContactContinuedEventArgs ["Windows.UI.Input.RadialControllerScreenContactContinuedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerScreenContactContinuedEventArgs2, 1029144305, 15598, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerScreenContactContinuedEventArgs2(IRadialControllerScreenContactContinuedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerScreenContactContinuedEventArgs2] {
     fn get_IsButtonPressed(&self, out: *mut bool) -> HRESULT,
@@ -10631,7 +10631,7 @@ impl IRadialControllerScreenContactEndedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerScreenContactEndedEventArgs: IRadialControllerScreenContactEndedEventArgs}
+RT_CLASS!{class RadialControllerScreenContactEndedEventArgs: IRadialControllerScreenContactEndedEventArgs ["Windows.UI.Input.RadialControllerScreenContactEndedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerScreenContactStartedEventArgs, 543859766, 58961, 4581, 191, 98, 44, 39, 215, 64, 78, 133);
 RT_INTERFACE!{interface IRadialControllerScreenContactStartedEventArgs(IRadialControllerScreenContactStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerScreenContactStartedEventArgs] {
     fn get_Contact(&self, out: *mut *mut RadialControllerScreenContact) -> HRESULT
@@ -10643,7 +10643,7 @@ impl IRadialControllerScreenContactStartedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerScreenContactStartedEventArgs: IRadialControllerScreenContactStartedEventArgs}
+RT_CLASS!{class RadialControllerScreenContactStartedEventArgs: IRadialControllerScreenContactStartedEventArgs ["Windows.UI.Input.RadialControllerScreenContactStartedEventArgs"]}
 DEFINE_IID!(IID_IRadialControllerScreenContactStartedEventArgs2, 1029144304, 15598, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
 RT_INTERFACE!{interface IRadialControllerScreenContactStartedEventArgs2(IRadialControllerScreenContactStartedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IRadialControllerScreenContactStartedEventArgs2] {
     fn get_IsButtonPressed(&self, out: *mut bool) -> HRESULT,
@@ -10678,7 +10678,7 @@ impl IRadialControllerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum RadialControllerSystemMenuItemKind: i32 {
+RT_ENUM! { enum RadialControllerSystemMenuItemKind: i32 ["Windows.UI.Input.RadialControllerSystemMenuItemKind"] {
     Scroll (RadialControllerSystemMenuItemKind_Scroll) = 0, Zoom (RadialControllerSystemMenuItemKind_Zoom) = 1, UndoRedo (RadialControllerSystemMenuItemKind_UndoRedo) = 2, Volume (RadialControllerSystemMenuItemKind_Volume) = 3, NextPreviousTrack (RadialControllerSystemMenuItemKind_NextPreviousTrack) = 4,
 }}
 DEFINE_IID!(IID_IRightTappedEventArgs, 1287602365, 44922, 18998, 148, 118, 177, 220, 225, 65, 112, 154);
@@ -10699,7 +10699,7 @@ impl IRightTappedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RightTappedEventArgs: IRightTappedEventArgs}
+RT_CLASS!{class RightTappedEventArgs: IRightTappedEventArgs ["Windows.UI.Input.RightTappedEventArgs"]}
 DEFINE_IID!(IID_ITappedEventArgs, 3483444964, 9530, 19516, 149, 59, 57, 92, 55, 174, 211, 9);
 RT_INTERFACE!{interface ITappedEventArgs(ITappedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ITappedEventArgs] {
     #[cfg(not(feature="windows-devices"))] fn __Dummy0(&self) -> (),
@@ -10724,7 +10724,7 @@ impl ITappedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TappedEventArgs: ITappedEventArgs}
+RT_CLASS!{class TappedEventArgs: ITappedEventArgs ["Windows.UI.Input.TappedEventArgs"]}
 pub mod core { // Windows.UI.Input.Core
 use ::prelude::*;
 DEFINE_IID!(IID_IRadialControllerIndependentInputSource, 1029144310, 19694, 4582, 181, 53, 0, 27, 220, 6, 171, 59);
@@ -10744,7 +10744,7 @@ impl IRadialControllerIndependentInputSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RadialControllerIndependentInputSource: IRadialControllerIndependentInputSource}
+RT_CLASS!{class RadialControllerIndependentInputSource: IRadialControllerIndependentInputSource ["Windows.UI.Input.Core.RadialControllerIndependentInputSource"]}
 impl RtActivatable<IRadialControllerIndependentInputSourceStatics> for RadialControllerIndependentInputSource {}
 impl RadialControllerIndependentInputSource {
     #[cfg(feature="windows-applicationmodel")] #[inline] pub fn create_for_view(view: &::rt::gen::windows::applicationmodel::core::CoreApplicationView) -> Result<Option<ComPtr<RadialControllerIndependentInputSource>>> {
@@ -10777,7 +10777,7 @@ impl IRadialControllerIndependentInputSourceStatics {
 } // Windows.UI.Input.Core
 pub mod inking { // Windows.UI.Input.Inking
 use ::prelude::*;
-RT_ENUM! { enum HandwritingLineHeight: i32 {
+RT_ENUM! { enum HandwritingLineHeight: i32 ["Windows.UI.Input.Inking.HandwritingLineHeight"] {
     Small (HandwritingLineHeight_Small) = 0, Medium (HandwritingLineHeight_Medium) = 1, Large (HandwritingLineHeight_Large) = 2,
 }}
 DEFINE_IID!(IID_IInkDrawingAttributes, 2543982444, 26484, 18605, 132, 240, 72, 245, 169, 190, 116, 249);
@@ -10840,7 +10840,7 @@ impl IInkDrawingAttributes {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkDrawingAttributes: IInkDrawingAttributes}
+RT_CLASS!{class InkDrawingAttributes: IInkDrawingAttributes ["Windows.UI.Input.Inking.InkDrawingAttributes"]}
 impl RtActivatable<IInkDrawingAttributesStatics> for InkDrawingAttributes {}
 impl RtActivatable<IActivationFactory> for InkDrawingAttributes {}
 impl InkDrawingAttributes {
@@ -10920,7 +10920,7 @@ impl IInkDrawingAttributes5 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum InkDrawingAttributesKind: i32 {
+RT_ENUM! { enum InkDrawingAttributesKind: i32 ["Windows.UI.Input.Inking.InkDrawingAttributesKind"] {
     Default (InkDrawingAttributesKind_Default) = 0, Pencil (InkDrawingAttributesKind_Pencil) = 1,
 }}
 DEFINE_IID!(IID_IInkDrawingAttributesPencilProperties, 1327838411, 11654, 16827, 176, 232, 228, 194, 160, 37, 60, 82);
@@ -10939,7 +10939,7 @@ impl IInkDrawingAttributesPencilProperties {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkDrawingAttributesPencilProperties: IInkDrawingAttributesPencilProperties}
+RT_CLASS!{class InkDrawingAttributesPencilProperties: IInkDrawingAttributesPencilProperties ["Windows.UI.Input.Inking.InkDrawingAttributesPencilProperties"]}
 DEFINE_IID!(IID_IInkDrawingAttributesStatics, 4147241023, 6757, 18530, 150, 203, 110, 22, 101, 225, 127, 109);
 RT_INTERFACE!{static interface IInkDrawingAttributesStatics(IInkDrawingAttributesStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IInkDrawingAttributesStatics] {
     fn CreateForPencil(&self, out: *mut *mut InkDrawingAttributes) -> HRESULT
@@ -10951,7 +10951,7 @@ impl IInkDrawingAttributesStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum InkHighContrastAdjustment: i32 {
+RT_ENUM! { enum InkHighContrastAdjustment: i32 ["Windows.UI.Input.Inking.InkHighContrastAdjustment"] {
     UseSystemColorsWhenNecessary (InkHighContrastAdjustment_UseSystemColorsWhenNecessary) = 0, UseSystemColors (InkHighContrastAdjustment_UseSystemColors) = 1, UseOriginalColors (InkHighContrastAdjustment_UseOriginalColors) = 2,
 }}
 DEFINE_IID!(IID_IInkInputConfiguration, 2477166020, 2939, 18903, 179, 79, 153, 1, 229, 36, 220, 242);
@@ -10981,7 +10981,7 @@ impl IInkInputConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkInputConfiguration: IInkInputConfiguration}
+RT_CLASS!{class InkInputConfiguration: IInkInputConfiguration ["Windows.UI.Input.Inking.InkInputConfiguration"]}
 DEFINE_IID!(IID_IInkInputProcessingConfiguration, 662231134, 13258, 19206, 166, 211, 172, 57, 69, 17, 109, 55);
 RT_INTERFACE!{interface IInkInputProcessingConfiguration(IInkInputProcessingConfigurationVtbl): IInspectable(IInspectableVtbl) [IID_IInkInputProcessingConfiguration] {
     fn get_Mode(&self, out: *mut InkInputProcessingMode) -> HRESULT,
@@ -11009,11 +11009,11 @@ impl IInkInputProcessingConfiguration {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkInputProcessingConfiguration: IInkInputProcessingConfiguration}
-RT_ENUM! { enum InkInputProcessingMode: i32 {
+RT_CLASS!{class InkInputProcessingConfiguration: IInkInputProcessingConfiguration ["Windows.UI.Input.Inking.InkInputProcessingConfiguration"]}
+RT_ENUM! { enum InkInputProcessingMode: i32 ["Windows.UI.Input.Inking.InkInputProcessingMode"] {
     None (InkInputProcessingMode_None) = 0, Inking (InkInputProcessingMode_Inking) = 1, Erasing (InkInputProcessingMode_Erasing) = 2,
 }}
-RT_ENUM! { enum InkInputRightDragAction: i32 {
+RT_ENUM! { enum InkInputRightDragAction: i32 ["Windows.UI.Input.Inking.InkInputRightDragAction"] {
     LeaveUnprocessed (InkInputRightDragAction_LeaveUnprocessed) = 0, AllowProcessing (InkInputRightDragAction_AllowProcessing) = 1,
 }}
 DEFINE_IID!(IID_IInkManager, 1195668349, 26395, 16739, 156, 149, 78, 141, 122, 3, 95, 225);
@@ -11060,10 +11060,10 @@ impl IInkManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkManager: IInkManager}
+RT_CLASS!{class InkManager: IInkManager ["Windows.UI.Input.Inking.InkManager"]}
 impl RtActivatable<IActivationFactory> for InkManager {}
 DEFINE_CLSID!(InkManager(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,77,97,110,97,103,101,114,0]) [CLSID_InkManager]);
-RT_ENUM! { enum InkManipulationMode: i32 {
+RT_ENUM! { enum InkManipulationMode: i32 ["Windows.UI.Input.Inking.InkManipulationMode"] {
     Inking (InkManipulationMode_Inking) = 0, Erasing (InkManipulationMode_Erasing) = 1, Selecting (InkManipulationMode_Selecting) = 2,
 }}
 DEFINE_IID!(IID_IInkModelerAttributes, 3134398247, 3289, 19453, 182, 243, 158, 3, 186, 141, 116, 84);
@@ -11093,8 +11093,8 @@ impl IInkModelerAttributes {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkModelerAttributes: IInkModelerAttributes}
-RT_ENUM! { enum InkPersistenceFormat: i32 {
+RT_CLASS!{class InkModelerAttributes: IInkModelerAttributes ["Windows.UI.Input.Inking.InkModelerAttributes"]}
+RT_ENUM! { enum InkPersistenceFormat: i32 ["Windows.UI.Input.Inking.InkPersistenceFormat"] {
     GifWithEmbeddedIsf (InkPersistenceFormat_GifWithEmbeddedIsf) = 0, Isf (InkPersistenceFormat_Isf) = 1,
 }}
 DEFINE_IID!(IID_IInkPoint, 2676434731, 34188, 18085, 155, 65, 209, 149, 151, 4, 89, 253);
@@ -11114,7 +11114,7 @@ impl IInkPoint {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkPoint: IInkPoint}
+RT_CLASS!{class InkPoint: IInkPoint ["Windows.UI.Input.Inking.InkPoint"]}
 impl RtActivatable<IInkPointFactory> for InkPoint {}
 impl RtActivatable<IInkPointFactory2> for InkPoint {}
 impl InkPoint {
@@ -11271,7 +11271,7 @@ impl IInkPresenter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkPresenter: IInkPresenter}
+RT_CLASS!{class InkPresenter: IInkPresenter ["Windows.UI.Input.Inking.InkPresenter"]}
 DEFINE_IID!(IID_IInkPresenter2, 3478382098, 39476, 4582, 159, 51, 162, 79, 192, 217, 100, 156);
 RT_INTERFACE!{interface IInkPresenter2(IInkPresenter2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkPresenter2] {
     fn get_HighContrastAdjustment(&self, out: *mut InkHighContrastAdjustment) -> HRESULT,
@@ -11299,7 +11299,7 @@ impl IInkPresenter3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum InkPresenterPredefinedConfiguration: i32 {
+RT_ENUM! { enum InkPresenterPredefinedConfiguration: i32 ["Windows.UI.Input.Inking.InkPresenterPredefinedConfiguration"] {
     SimpleSinglePointer (InkPresenterPredefinedConfiguration_SimpleSinglePointer) = 0, SimpleMultiplePointer (InkPresenterPredefinedConfiguration_SimpleMultiplePointer) = 1,
 }}
 DEFINE_IID!(IID_IInkPresenterProtractor, 2112090794, 61292, 20113, 167, 59, 91, 112, 213, 111, 189, 23);
@@ -11384,7 +11384,7 @@ impl IInkPresenterProtractor {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkPresenterProtractor: IInkPresenterProtractor}
+RT_CLASS!{class InkPresenterProtractor: IInkPresenterProtractor ["Windows.UI.Input.Inking.InkPresenterProtractor"]}
 impl RtActivatable<IInkPresenterProtractorFactory> for InkPresenterProtractor {}
 impl InkPresenterProtractor {
     #[inline] pub fn create(inkPresenter: &InkPresenter) -> Result<ComPtr<InkPresenterProtractor>> {
@@ -11430,7 +11430,7 @@ impl IInkPresenterRuler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkPresenterRuler: IInkPresenterRuler}
+RT_CLASS!{class InkPresenterRuler: IInkPresenterRuler ["Windows.UI.Input.Inking.InkPresenterRuler"]}
 impl RtActivatable<IInkPresenterRulerFactory> for InkPresenterRuler {}
 impl InkPresenterRuler {
     #[inline] pub fn create(inkPresenter: &InkPresenter) -> Result<ComPtr<InkPresenterRuler>> {
@@ -11531,7 +11531,7 @@ impl IInkPresenterStencil {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum InkPresenterStencilKind: i32 {
+RT_ENUM! { enum InkPresenterStencilKind: i32 ["Windows.UI.Input.Inking.InkPresenterStencilKind"] {
     Other (InkPresenterStencilKind_Other) = 0, Ruler (InkPresenterStencilKind_Ruler) = 1, Protractor (InkPresenterStencilKind_Protractor) = 2,
 }}
 DEFINE_IID!(IID_IInkRecognitionResult, 910563988, 20584, 16623, 138, 5, 44, 47, 182, 9, 8, 162);
@@ -11557,8 +11557,8 @@ impl IInkRecognitionResult {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkRecognitionResult: IInkRecognitionResult}
-RT_ENUM! { enum InkRecognitionTarget: i32 {
+RT_CLASS!{class InkRecognitionResult: IInkRecognitionResult ["Windows.UI.Input.Inking.InkRecognitionResult"]}
+RT_ENUM! { enum InkRecognitionTarget: i32 ["Windows.UI.Input.Inking.InkRecognitionTarget"] {
     All (InkRecognitionTarget_All) = 0, Selected (InkRecognitionTarget_Selected) = 1, Recent (InkRecognitionTarget_Recent) = 2,
 }}
 DEFINE_IID!(IID_IInkRecognizer, 125619875, 36941, 17450, 177, 81, 170, 202, 54, 49, 196, 59);
@@ -11572,7 +11572,7 @@ impl IInkRecognizer {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkRecognizer: IInkRecognizer}
+RT_CLASS!{class InkRecognizer: IInkRecognizer ["Windows.UI.Input.Inking.InkRecognizer"]}
 DEFINE_IID!(IID_IInkRecognizerContainer, 2806880817, 32839, 18072, 169, 18, 248, 42, 80, 133, 1, 47);
 RT_INTERFACE!{interface IInkRecognizerContainer(IInkRecognizerContainerVtbl): IInspectable(IInspectableVtbl) [IID_IInkRecognizerContainer] {
     fn SetDefaultRecognizer(&self, recognizer: *mut InkRecognizer) -> HRESULT,
@@ -11595,7 +11595,7 @@ impl IInkRecognizerContainer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkRecognizerContainer: IInkRecognizerContainer}
+RT_CLASS!{class InkRecognizerContainer: IInkRecognizerContainer ["Windows.UI.Input.Inking.InkRecognizerContainer"]}
 impl RtActivatable<IActivationFactory> for InkRecognizerContainer {}
 DEFINE_CLSID!(InkRecognizerContainer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,82,101,99,111,103,110,105,122,101,114,67,111,110,116,97,105,110,101,114,0]) [CLSID_InkRecognizerContainer]);
 DEFINE_IID!(IID_IInkStroke, 353652064, 52451, 20431, 157, 82, 17, 81, 138, 182, 175, 212);
@@ -11649,7 +11649,7 @@ impl IInkStroke {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStroke: IInkStroke}
+RT_CLASS!{class InkStroke: IInkStroke ["Windows.UI.Input.Inking.InkStroke"]}
 DEFINE_IID!(IID_IInkStroke2, 1572463860, 47866, 19937, 137, 211, 32, 27, 30, 215, 216, 155);
 RT_INTERFACE!{interface IInkStroke2(IInkStroke2Vtbl): IInspectable(IInspectableVtbl) [IID_IInkStroke2] {
     fn get_PointTransform(&self, out: *mut foundation::numerics::Matrix3x2) -> HRESULT,
@@ -11738,7 +11738,7 @@ impl IInkStrokeBuilder {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStrokeBuilder: IInkStrokeBuilder}
+RT_CLASS!{class InkStrokeBuilder: IInkStrokeBuilder ["Windows.UI.Input.Inking.InkStrokeBuilder"]}
 impl RtActivatable<IActivationFactory> for InkStrokeBuilder {}
 DEFINE_CLSID!(InkStrokeBuilder(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,83,116,114,111,107,101,66,117,105,108,100,101,114,0]) [CLSID_InkStrokeBuilder]);
 DEFINE_IID!(IID_IInkStrokeBuilder2, 3179461671, 29471, 19644, 187, 191, 109, 70, 128, 68, 241, 229);
@@ -11851,7 +11851,7 @@ impl IInkStrokeContainer {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStrokeContainer: IInkStrokeContainer}
+RT_CLASS!{class InkStrokeContainer: IInkStrokeContainer ["Windows.UI.Input.Inking.InkStrokeContainer"]}
 impl RtActivatable<IActivationFactory> for InkStrokeContainer {}
 DEFINE_CLSID!(InkStrokeContainer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,73,110,107,83,116,114,111,107,101,67,111,110,116,97,105,110,101,114,0]) [CLSID_InkStrokeContainer]);
 DEFINE_IID!(IID_IInkStrokeContainer2, 2298598244, 55862, 19407, 158, 92, 209, 149, 130, 89, 149, 180);
@@ -11942,7 +11942,7 @@ impl IInkStrokeInput {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStrokeInput: IInkStrokeInput}
+RT_CLASS!{class InkStrokeInput: IInkStrokeInput ["Windows.UI.Input.Inking.InkStrokeInput"]}
 DEFINE_IID!(IID_IInkStrokeRenderingSegment, 1750142751, 35043, 18298, 162, 250, 86, 159, 95, 31, 155, 213);
 RT_INTERFACE!{interface IInkStrokeRenderingSegment(IInkStrokeRenderingSegmentVtbl): IInspectable(IInspectableVtbl) [IID_IInkStrokeRenderingSegment] {
     fn get_Position(&self, out: *mut foundation::Point) -> HRESULT,
@@ -11990,7 +11990,7 @@ impl IInkStrokeRenderingSegment {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStrokeRenderingSegment: IInkStrokeRenderingSegment}
+RT_CLASS!{class InkStrokeRenderingSegment: IInkStrokeRenderingSegment ["Windows.UI.Input.Inking.InkStrokeRenderingSegment"]}
 DEFINE_IID!(IID_IInkStrokesCollectedEventArgs, 3304321577, 6456, 18780, 180, 217, 109, 228, 176, 141, 72, 17);
 RT_INTERFACE!{interface IInkStrokesCollectedEventArgs(IInkStrokesCollectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IInkStrokesCollectedEventArgs] {
     fn get_Strokes(&self, out: *mut *mut foundation::collections::IVectorView<InkStroke>) -> HRESULT
@@ -12002,7 +12002,7 @@ impl IInkStrokesCollectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStrokesCollectedEventArgs: IInkStrokesCollectedEventArgs}
+RT_CLASS!{class InkStrokesCollectedEventArgs: IInkStrokesCollectedEventArgs ["Windows.UI.Input.Inking.InkStrokesCollectedEventArgs"]}
 DEFINE_IID!(IID_IInkStrokesErasedEventArgs, 2753653282, 5379, 20159, 143, 245, 45, 232, 69, 132, 168, 170);
 RT_INTERFACE!{interface IInkStrokesErasedEventArgs(IInkStrokesErasedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IInkStrokesErasedEventArgs] {
     fn get_Strokes(&self, out: *mut *mut foundation::collections::IVectorView<InkStroke>) -> HRESULT
@@ -12014,7 +12014,7 @@ impl IInkStrokesErasedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkStrokesErasedEventArgs: IInkStrokesErasedEventArgs}
+RT_CLASS!{class InkStrokesErasedEventArgs: IInkStrokesErasedEventArgs ["Windows.UI.Input.Inking.InkStrokesErasedEventArgs"]}
 DEFINE_IID!(IID_IInkSynchronizer, 2610864480, 44699, 17913, 132, 7, 75, 73, 59, 22, 54, 97);
 RT_INTERFACE!{interface IInkSynchronizer(IInkSynchronizerVtbl): IInspectable(IInspectableVtbl) [IID_IInkSynchronizer] {
     fn BeginDry(&self, out: *mut *mut foundation::collections::IVectorView<InkStroke>) -> HRESULT,
@@ -12031,7 +12031,7 @@ impl IInkSynchronizer {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkSynchronizer: IInkSynchronizer}
+RT_CLASS!{class InkSynchronizer: IInkSynchronizer ["Windows.UI.Input.Inking.InkSynchronizer"]}
 DEFINE_IID!(IID_IInkUnprocessedInput, 3678684640, 33688, 18721, 172, 59, 171, 151, 140, 91, 162, 86);
 RT_INTERFACE!{interface IInkUnprocessedInput(IInkUnprocessedInputVtbl): IInspectable(IInspectableVtbl) [IID_IInkUnprocessedInput] {
     fn add_PointerEntered(&self, handler: *mut foundation::TypedEventHandler<InkUnprocessedInput, super::super::core::PointerEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -12120,7 +12120,7 @@ impl IInkUnprocessedInput {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkUnprocessedInput: IInkUnprocessedInput}
+RT_CLASS!{class InkUnprocessedInput: IInkUnprocessedInput ["Windows.UI.Input.Inking.InkUnprocessedInput"]}
 DEFINE_IID!(IID_IPenAndInkSettings, 3157060495, 102, 17576, 187, 122, 184, 57, 179, 222, 184, 245);
 RT_INTERFACE!{interface IPenAndInkSettings(IPenAndInkSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IPenAndInkSettings] {
     fn get_IsHandwritingDirectlyIntoTextFieldEnabled(&self, out: *mut bool) -> HRESULT,
@@ -12162,7 +12162,7 @@ impl IPenAndInkSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PenAndInkSettings: IPenAndInkSettings}
+RT_CLASS!{class PenAndInkSettings: IPenAndInkSettings ["Windows.UI.Input.Inking.PenAndInkSettings"]}
 impl RtActivatable<IPenAndInkSettingsStatics> for PenAndInkSettings {}
 impl PenAndInkSettings {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<PenAndInkSettings>>> {
@@ -12181,15 +12181,15 @@ impl IPenAndInkSettingsStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum PenHandedness: i32 {
+RT_ENUM! { enum PenHandedness: i32 ["Windows.UI.Input.Inking.PenHandedness"] {
     Right (PenHandedness_Right) = 0, Left (PenHandedness_Left) = 1,
 }}
-RT_ENUM! { enum PenTipShape: i32 {
+RT_ENUM! { enum PenTipShape: i32 ["Windows.UI.Input.Inking.PenTipShape"] {
     Circle (PenTipShape_Circle) = 0, Rectangle (PenTipShape_Rectangle) = 1,
 }}
 pub mod analysis { // Windows.UI.Input.Inking.Analysis
 use ::prelude::*;
-RT_ENUM! { enum InkAnalysisDrawingKind: i32 {
+RT_ENUM! { enum InkAnalysisDrawingKind: i32 ["Windows.UI.Input.Inking.Analysis.InkAnalysisDrawingKind"] {
     Drawing (InkAnalysisDrawingKind_Drawing) = 0, Circle (InkAnalysisDrawingKind_Circle) = 1, Ellipse (InkAnalysisDrawingKind_Ellipse) = 2, Triangle (InkAnalysisDrawingKind_Triangle) = 3, IsoscelesTriangle (InkAnalysisDrawingKind_IsoscelesTriangle) = 4, EquilateralTriangle (InkAnalysisDrawingKind_EquilateralTriangle) = 5, RightTriangle (InkAnalysisDrawingKind_RightTriangle) = 6, Quadrilateral (InkAnalysisDrawingKind_Quadrilateral) = 7, Rectangle (InkAnalysisDrawingKind_Rectangle) = 8, Square (InkAnalysisDrawingKind_Square) = 9, Diamond (InkAnalysisDrawingKind_Diamond) = 10, Trapezoid (InkAnalysisDrawingKind_Trapezoid) = 11, Parallelogram (InkAnalysisDrawingKind_Parallelogram) = 12, Pentagon (InkAnalysisDrawingKind_Pentagon) = 13, Hexagon (InkAnalysisDrawingKind_Hexagon) = 14,
 }}
 DEFINE_IID!(IID_IInkAnalysisInkBullet, 3993277288, 24848, 16694, 149, 249, 238, 128, 159, 194, 0, 48);
@@ -12203,7 +12203,7 @@ impl IInkAnalysisInkBullet {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisInkBullet: IInkAnalysisInkBullet}
+RT_CLASS!{class InkAnalysisInkBullet: IInkAnalysisInkBullet ["Windows.UI.Input.Inking.Analysis.InkAnalysisInkBullet"]}
 DEFINE_IID!(IID_IInkAnalysisInkDrawing, 1787161887, 8164, 19989, 137, 140, 142, 17, 35, 119, 224, 33);
 RT_INTERFACE!{interface IInkAnalysisInkDrawing(IInkAnalysisInkDrawingVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisInkDrawing] {
     fn get_DrawingKind(&self, out: *mut InkAnalysisDrawingKind) -> HRESULT,
@@ -12227,7 +12227,7 @@ impl IInkAnalysisInkDrawing {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisInkDrawing: IInkAnalysisInkDrawing}
+RT_CLASS!{class InkAnalysisInkDrawing: IInkAnalysisInkDrawing ["Windows.UI.Input.Inking.Analysis.InkAnalysisInkDrawing"]}
 DEFINE_IID!(IID_IInkAnalysisInkWord, 1272064173, 33711, 16436, 143, 59, 248, 104, 125, 255, 244, 54);
 RT_INTERFACE!{interface IInkAnalysisInkWord(IInkAnalysisInkWordVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisInkWord] {
     fn get_RecognizedText(&self, out: *mut HSTRING) -> HRESULT,
@@ -12245,7 +12245,7 @@ impl IInkAnalysisInkWord {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisInkWord: IInkAnalysisInkWord}
+RT_CLASS!{class InkAnalysisInkWord: IInkAnalysisInkWord ["Windows.UI.Input.Inking.Analysis.InkAnalysisInkWord"]}
 DEFINE_IID!(IID_IInkAnalysisLine, 2691499149, 11149, 18260, 173, 90, 208, 135, 17, 147, 169, 86);
 RT_INTERFACE!{interface IInkAnalysisLine(IInkAnalysisLineVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisLine] {
     fn get_RecognizedText(&self, out: *mut HSTRING) -> HRESULT,
@@ -12263,7 +12263,7 @@ impl IInkAnalysisLine {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisLine: IInkAnalysisLine}
+RT_CLASS!{class InkAnalysisLine: IInkAnalysisLine ["Windows.UI.Input.Inking.Analysis.InkAnalysisLine"]}
 DEFINE_IID!(IID_IInkAnalysisListItem, 3034825279, 50371, 19514, 161, 166, 157, 133, 84, 126, 229, 134);
 RT_INTERFACE!{interface IInkAnalysisListItem(IInkAnalysisListItemVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisListItem] {
     fn get_RecognizedText(&self, out: *mut HSTRING) -> HRESULT
@@ -12275,7 +12275,7 @@ impl IInkAnalysisListItem {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisListItem: IInkAnalysisListItem}
+RT_CLASS!{class InkAnalysisListItem: IInkAnalysisListItem ["Windows.UI.Input.Inking.Analysis.InkAnalysisListItem"]}
 DEFINE_IID!(IID_IInkAnalysisNode, 813899525, 24420, 18988, 186, 55, 79, 72, 135, 135, 149, 116);
 RT_INTERFACE!{interface IInkAnalysisNode(IInkAnalysisNodeVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisNode] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -12323,8 +12323,8 @@ impl IInkAnalysisNode {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisNode: IInkAnalysisNode}
-RT_ENUM! { enum InkAnalysisNodeKind: i32 {
+RT_CLASS!{class InkAnalysisNode: IInkAnalysisNode ["Windows.UI.Input.Inking.Analysis.InkAnalysisNode"]}
+RT_ENUM! { enum InkAnalysisNodeKind: i32 ["Windows.UI.Input.Inking.Analysis.InkAnalysisNodeKind"] {
     UnclassifiedInk (InkAnalysisNodeKind_UnclassifiedInk) = 0, Root (InkAnalysisNodeKind_Root) = 1, WritingRegion (InkAnalysisNodeKind_WritingRegion) = 2, Paragraph (InkAnalysisNodeKind_Paragraph) = 3, Line (InkAnalysisNodeKind_Line) = 4, InkWord (InkAnalysisNodeKind_InkWord) = 5, InkBullet (InkAnalysisNodeKind_InkBullet) = 6, InkDrawing (InkAnalysisNodeKind_InkDrawing) = 7, ListItem (InkAnalysisNodeKind_ListItem) = 8,
 }}
 DEFINE_IID!(IID_IInkAnalysisParagraph, 3651994716, 3281, 19924, 166, 139, 235, 31, 18, 179, 215, 39);
@@ -12338,7 +12338,7 @@ impl IInkAnalysisParagraph {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisParagraph: IInkAnalysisParagraph}
+RT_CLASS!{class InkAnalysisParagraph: IInkAnalysisParagraph ["Windows.UI.Input.Inking.Analysis.InkAnalysisParagraph"]}
 DEFINE_IID!(IID_IInkAnalysisResult, 2303244921, 41539, 19107, 162, 148, 31, 152, 189, 15, 245, 128);
 RT_INTERFACE!{interface IInkAnalysisResult(IInkAnalysisResultVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisResult] {
     fn get_Status(&self, out: *mut InkAnalysisStatus) -> HRESULT
@@ -12350,7 +12350,7 @@ impl IInkAnalysisResult {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisResult: IInkAnalysisResult}
+RT_CLASS!{class InkAnalysisResult: IInkAnalysisResult ["Windows.UI.Input.Inking.Analysis.InkAnalysisResult"]}
 DEFINE_IID!(IID_IInkAnalysisRoot, 1068934084, 12254, 16481, 133, 2, 169, 15, 50, 84, 91, 132);
 RT_INTERFACE!{interface IInkAnalysisRoot(IInkAnalysisRootVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalysisRoot] {
     fn get_RecognizedText(&self, out: *mut HSTRING) -> HRESULT,
@@ -12368,11 +12368,11 @@ impl IInkAnalysisRoot {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisRoot: IInkAnalysisRoot}
-RT_ENUM! { enum InkAnalysisStatus: i32 {
+RT_CLASS!{class InkAnalysisRoot: IInkAnalysisRoot ["Windows.UI.Input.Inking.Analysis.InkAnalysisRoot"]}
+RT_ENUM! { enum InkAnalysisStatus: i32 ["Windows.UI.Input.Inking.Analysis.InkAnalysisStatus"] {
     Updated (InkAnalysisStatus_Updated) = 0, Unchanged (InkAnalysisStatus_Unchanged) = 1,
 }}
-RT_ENUM! { enum InkAnalysisStrokeKind: i32 {
+RT_ENUM! { enum InkAnalysisStrokeKind: i32 ["Windows.UI.Input.Inking.Analysis.InkAnalysisStrokeKind"] {
     Auto (InkAnalysisStrokeKind_Auto) = 0, Writing (InkAnalysisStrokeKind_Writing) = 1, Drawing (InkAnalysisStrokeKind_Drawing) = 2,
 }}
 DEFINE_IID!(IID_IInkAnalysisWritingRegion, 3714933297, 48406, 18019, 181, 174, 148, 29, 48, 67, 239, 91);
@@ -12386,7 +12386,7 @@ impl IInkAnalysisWritingRegion {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalysisWritingRegion: IInkAnalysisWritingRegion}
+RT_CLASS!{class InkAnalysisWritingRegion: IInkAnalysisWritingRegion ["Windows.UI.Input.Inking.Analysis.InkAnalysisWritingRegion"]}
 DEFINE_IID!(IID_IInkAnalyzer, 4046163861, 2150, 19909, 140, 119, 248, 134, 20, 223, 227, 140);
 RT_INTERFACE!{interface IInkAnalyzer(IInkAnalyzerVtbl): IInspectable(IInspectableVtbl) [IID_IInkAnalyzer] {
     fn get_AnalysisRoot(&self, out: *mut *mut InkAnalysisRoot) -> HRESULT,
@@ -12445,7 +12445,7 @@ impl IInkAnalyzer {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InkAnalyzer: IInkAnalyzer}
+RT_CLASS!{class InkAnalyzer: IInkAnalyzer ["Windows.UI.Input.Inking.Analysis.InkAnalyzer"]}
 impl RtActivatable<IActivationFactory> for InkAnalyzer {}
 DEFINE_CLSID!(InkAnalyzer(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,65,110,97,108,121,115,105,115,46,73,110,107,65,110,97,108,121,122,101,114,0]) [CLSID_InkAnalyzer]);
 DEFINE_IID!(IID_IInkAnalyzerFactory, 689145478, 6499, 18904, 149, 137, 225, 67, 132, 199, 105, 227);
@@ -12497,7 +12497,7 @@ impl ICoreIncrementalInkStroke {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreIncrementalInkStroke: ICoreIncrementalInkStroke}
+RT_CLASS!{class CoreIncrementalInkStroke: ICoreIncrementalInkStroke ["Windows.UI.Input.Inking.Core.CoreIncrementalInkStroke"]}
 impl RtActivatable<ICoreIncrementalInkStrokeFactory> for CoreIncrementalInkStroke {}
 impl CoreIncrementalInkStroke {
     #[inline] pub fn create(drawingAttributes: &super::InkDrawingAttributes, pointTransform: foundation::numerics::Matrix3x2) -> Result<ComPtr<CoreIncrementalInkStroke>> {
@@ -12604,7 +12604,7 @@ impl ICoreInkIndependentInputSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreInkIndependentInputSource: ICoreInkIndependentInputSource}
+RT_CLASS!{class CoreInkIndependentInputSource: ICoreInkIndependentInputSource ["Windows.UI.Input.Inking.Core.CoreInkIndependentInputSource"]}
 impl RtActivatable<ICoreInkIndependentInputSourceStatics> for CoreInkIndependentInputSource {}
 impl CoreInkIndependentInputSource {
     #[inline] pub fn create(inkPresenter: &super::InkPresenter) -> Result<Option<ComPtr<CoreInkIndependentInputSource>>> {
@@ -12645,10 +12645,10 @@ impl ICoreInkPresenterHost {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreInkPresenterHost: ICoreInkPresenterHost}
+RT_CLASS!{class CoreInkPresenterHost: ICoreInkPresenterHost ["Windows.UI.Input.Inking.Core.CoreInkPresenterHost"]}
 impl RtActivatable<IActivationFactory> for CoreInkPresenterHost {}
 DEFINE_CLSID!(CoreInkPresenterHost(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,73,110,107,105,110,103,46,67,111,114,101,46,67,111,114,101,73,110,107,80,114,101,115,101,110,116,101,114,72,111,115,116,0]) [CLSID_CoreInkPresenterHost]);
-RT_ENUM! { enum CoreWetStrokeDisposition: i32 {
+RT_ENUM! { enum CoreWetStrokeDisposition: i32 ["Windows.UI.Input.Inking.Core.CoreWetStrokeDisposition"] {
     Inking (CoreWetStrokeDisposition_Inking) = 0, Completed (CoreWetStrokeDisposition_Completed) = 1, Canceled (CoreWetStrokeDisposition_Canceled) = 2,
 }}
 DEFINE_IID!(IID_ICoreWetStrokeUpdateEventArgs, 4211593548, 13184, 17786, 169, 135, 153, 19, 87, 137, 108, 27);
@@ -12679,7 +12679,7 @@ impl ICoreWetStrokeUpdateEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWetStrokeUpdateEventArgs: ICoreWetStrokeUpdateEventArgs}
+RT_CLASS!{class CoreWetStrokeUpdateEventArgs: ICoreWetStrokeUpdateEventArgs ["Windows.UI.Input.Inking.Core.CoreWetStrokeUpdateEventArgs"]}
 DEFINE_IID!(IID_ICoreWetStrokeUpdateSource, 527535650, 61010, 19968, 130, 9, 76, 62, 91, 33, 163, 204);
 RT_INTERFACE!{interface ICoreWetStrokeUpdateSource(ICoreWetStrokeUpdateSourceVtbl): IInspectable(IInspectableVtbl) [IID_ICoreWetStrokeUpdateSource] {
     fn add_WetStrokeStarting(&self, handler: *mut foundation::TypedEventHandler<CoreWetStrokeUpdateSource, CoreWetStrokeUpdateEventArgs>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -12746,7 +12746,7 @@ impl ICoreWetStrokeUpdateSource {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreWetStrokeUpdateSource: ICoreWetStrokeUpdateSource}
+RT_CLASS!{class CoreWetStrokeUpdateSource: ICoreWetStrokeUpdateSource ["Windows.UI.Input.Inking.Core.CoreWetStrokeUpdateSource"]}
 impl RtActivatable<ICoreWetStrokeUpdateSourceStatics> for CoreWetStrokeUpdateSource {}
 impl CoreWetStrokeUpdateSource {
     #[inline] pub fn create(inkPresenter: &super::InkPresenter) -> Result<Option<ComPtr<CoreWetStrokeUpdateSource>>> {
@@ -12772,7 +12772,7 @@ DEFINE_IID!(IID_IPalmRejectionDelayZonePreview, 1656002251, 21405, 21315, 166, 9
 RT_INTERFACE!{interface IPalmRejectionDelayZonePreview(IPalmRejectionDelayZonePreviewVtbl): IInspectable(IInspectableVtbl) [IID_IPalmRejectionDelayZonePreview] {
     
 }}
-RT_CLASS!{class PalmRejectionDelayZonePreview: IPalmRejectionDelayZonePreview}
+RT_CLASS!{class PalmRejectionDelayZonePreview: IPalmRejectionDelayZonePreview ["Windows.UI.Input.Inking.Preview.PalmRejectionDelayZonePreview"]}
 impl RtActivatable<IPalmRejectionDelayZonePreviewStatics> for PalmRejectionDelayZonePreview {}
 impl PalmRejectionDelayZonePreview {
     #[inline] pub fn create_for_visual(inputPanelVisual: &super::super::super::composition::Visual, inputPanelRect: foundation::Rect) -> Result<Option<ComPtr<PalmRejectionDelayZonePreview>>> {
@@ -12805,7 +12805,7 @@ impl IPalmRejectionDelayZonePreviewStatics {
 pub mod preview { // Windows.UI.Input.Preview
 pub mod injection { // Windows.UI.Input.Preview.Injection
 use ::prelude::*;
-RT_ENUM! { enum InjectedInputButtonChangeKind: i32 {
+RT_ENUM! { enum InjectedInputButtonChangeKind: i32 ["Windows.UI.Input.Preview.Injection.InjectedInputButtonChangeKind"] {
     None (InjectedInputButtonChangeKind_None) = 0, FirstButtonDown (InjectedInputButtonChangeKind_FirstButtonDown) = 1, FirstButtonUp (InjectedInputButtonChangeKind_FirstButtonUp) = 2, SecondButtonDown (InjectedInputButtonChangeKind_SecondButtonDown) = 3, SecondButtonUp (InjectedInputButtonChangeKind_SecondButtonUp) = 4, ThirdButtonDown (InjectedInputButtonChangeKind_ThirdButtonDown) = 5, ThirdButtonUp (InjectedInputButtonChangeKind_ThirdButtonUp) = 6, FourthButtonDown (InjectedInputButtonChangeKind_FourthButtonDown) = 7, FourthButtonUp (InjectedInputButtonChangeKind_FourthButtonUp) = 8, FifthButtonDown (InjectedInputButtonChangeKind_FifthButtonDown) = 9, FifthButtonUp (InjectedInputButtonChangeKind_FifthButtonUp) = 10,
 }}
 DEFINE_IID!(IID_IInjectedInputGamepadInfo, 548313663, 57105, 17778, 169, 171, 215, 91, 138, 94, 72, 173);
@@ -12892,7 +12892,7 @@ impl IInjectedInputGamepadInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InjectedInputGamepadInfo: IInjectedInputGamepadInfo}
+RT_CLASS!{class InjectedInputGamepadInfo: IInjectedInputGamepadInfo ["Windows.UI.Input.Preview.Injection.InjectedInputGamepadInfo"]}
 impl RtActivatable<IInjectedInputGamepadInfoFactory> for InjectedInputGamepadInfo {}
 impl RtActivatable<IActivationFactory> for InjectedInputGamepadInfo {}
 impl InjectedInputGamepadInfo {
@@ -12950,10 +12950,10 @@ impl IInjectedInputKeyboardInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InjectedInputKeyboardInfo: IInjectedInputKeyboardInfo}
+RT_CLASS!{class InjectedInputKeyboardInfo: IInjectedInputKeyboardInfo ["Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo"]}
 impl RtActivatable<IActivationFactory> for InjectedInputKeyboardInfo {}
 DEFINE_CLSID!(InjectedInputKeyboardInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,75,101,121,98,111,97,114,100,73,110,102,111,0]) [CLSID_InjectedInputKeyboardInfo]);
-RT_ENUM! { enum InjectedInputKeyOptions: u32 {
+RT_ENUM! { enum InjectedInputKeyOptions: u32 ["Windows.UI.Input.Preview.Injection.InjectedInputKeyOptions"] {
     None (InjectedInputKeyOptions_None) = 0, ExtendedKey (InjectedInputKeyOptions_ExtendedKey) = 1, KeyUp (InjectedInputKeyOptions_KeyUp) = 2, ScanCode (InjectedInputKeyOptions_ScanCode) = 8, Unicode (InjectedInputKeyOptions_Unicode) = 4,
 }}
 DEFINE_IID!(IID_IInjectedInputMouseInfo, 2532666987, 58490, 23796, 65, 141, 138, 95, 185, 103, 12, 125);
@@ -13016,13 +13016,13 @@ impl IInjectedInputMouseInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InjectedInputMouseInfo: IInjectedInputMouseInfo}
+RT_CLASS!{class InjectedInputMouseInfo: IInjectedInputMouseInfo ["Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo"]}
 impl RtActivatable<IActivationFactory> for InjectedInputMouseInfo {}
 DEFINE_CLSID!(InjectedInputMouseInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,77,111,117,115,101,73,110,102,111,0]) [CLSID_InjectedInputMouseInfo]);
-RT_ENUM! { enum InjectedInputMouseOptions: u32 {
+RT_ENUM! { enum InjectedInputMouseOptions: u32 ["Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions"] {
     None (InjectedInputMouseOptions_None) = 0, Move (InjectedInputMouseOptions_Move) = 1, LeftDown (InjectedInputMouseOptions_LeftDown) = 2, LeftUp (InjectedInputMouseOptions_LeftUp) = 4, RightDown (InjectedInputMouseOptions_RightDown) = 8, RightUp (InjectedInputMouseOptions_RightUp) = 16, MiddleDown (InjectedInputMouseOptions_MiddleDown) = 32, MiddleUp (InjectedInputMouseOptions_MiddleUp) = 64, XDown (InjectedInputMouseOptions_XDown) = 128, XUp (InjectedInputMouseOptions_XUp) = 256, Wheel (InjectedInputMouseOptions_Wheel) = 2048, HWheel (InjectedInputMouseOptions_HWheel) = 4096, MoveNoCoalesce (InjectedInputMouseOptions_MoveNoCoalesce) = 8192, VirtualDesk (InjectedInputMouseOptions_VirtualDesk) = 16384, Absolute (InjectedInputMouseOptions_Absolute) = 32768,
 }}
-RT_ENUM! { enum InjectedInputPenButtons: u32 {
+RT_ENUM! { enum InjectedInputPenButtons: u32 ["Windows.UI.Input.Preview.Injection.InjectedInputPenButtons"] {
     None (InjectedInputPenButtons_None) = 0, Barrel (InjectedInputPenButtons_Barrel) = 1, Inverted (InjectedInputPenButtons_Inverted) = 2, Eraser (InjectedInputPenButtons_Eraser) = 4,
 }}
 DEFINE_IID!(IID_IInjectedInputPenInfo, 1799400707, 51742, 21799, 126, 2, 40, 40, 84, 11, 177, 212);
@@ -13107,25 +13107,25 @@ impl IInjectedInputPenInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InjectedInputPenInfo: IInjectedInputPenInfo}
+RT_CLASS!{class InjectedInputPenInfo: IInjectedInputPenInfo ["Windows.UI.Input.Preview.Injection.InjectedInputPenInfo"]}
 impl RtActivatable<IActivationFactory> for InjectedInputPenInfo {}
 DEFINE_CLSID!(InjectedInputPenInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,80,101,110,73,110,102,111,0]) [CLSID_InjectedInputPenInfo]);
-RT_ENUM! { enum InjectedInputPenParameters: u32 {
+RT_ENUM! { enum InjectedInputPenParameters: u32 ["Windows.UI.Input.Preview.Injection.InjectedInputPenParameters"] {
     None (InjectedInputPenParameters_None) = 0, Pressure (InjectedInputPenParameters_Pressure) = 1, Rotation (InjectedInputPenParameters_Rotation) = 2, TiltX (InjectedInputPenParameters_TiltX) = 4, TiltY (InjectedInputPenParameters_TiltY) = 8,
 }}
-RT_STRUCT! { struct InjectedInputPoint {
+RT_STRUCT! { struct InjectedInputPoint ["Windows.UI.Input.Preview.Injection.InjectedInputPoint"] {
     PositionX: i32, PositionY: i32,
 }}
-RT_STRUCT! { struct InjectedInputPointerInfo {
+RT_STRUCT! { struct InjectedInputPointerInfo ["Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo"] {
     PointerId: u32, PointerOptions: InjectedInputPointerOptions, PixelLocation: InjectedInputPoint, TimeOffsetInMilliseconds: u32, PerformanceCount: u64,
 }}
-RT_ENUM! { enum InjectedInputPointerOptions: u32 {
+RT_ENUM! { enum InjectedInputPointerOptions: u32 ["Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions"] {
     None (InjectedInputPointerOptions_None) = 0, New (InjectedInputPointerOptions_New) = 1, InRange (InjectedInputPointerOptions_InRange) = 2, InContact (InjectedInputPointerOptions_InContact) = 4, FirstButton (InjectedInputPointerOptions_FirstButton) = 16, SecondButton (InjectedInputPointerOptions_SecondButton) = 32, Primary (InjectedInputPointerOptions_Primary) = 8192, Confidence (InjectedInputPointerOptions_Confidence) = 16384, Canceled (InjectedInputPointerOptions_Canceled) = 32768, PointerDown (InjectedInputPointerOptions_PointerDown) = 65536, Update (InjectedInputPointerOptions_Update) = 131072, PointerUp (InjectedInputPointerOptions_PointerUp) = 262144, CaptureChanged (InjectedInputPointerOptions_CaptureChanged) = 2097152,
 }}
-RT_STRUCT! { struct InjectedInputRectangle {
+RT_STRUCT! { struct InjectedInputRectangle ["Windows.UI.Input.Preview.Injection.InjectedInputRectangle"] {
     Left: i32, Top: i32, Bottom: i32, Right: i32,
 }}
-RT_ENUM! { enum InjectedInputShortcut: i32 {
+RT_ENUM! { enum InjectedInputShortcut: i32 ["Windows.UI.Input.Preview.Injection.InjectedInputShortcut"] {
     Back (InjectedInputShortcut_Back) = 0, Start (InjectedInputShortcut_Start) = 1, Search (InjectedInputShortcut_Search) = 2,
 }}
 DEFINE_IID!(IID_IInjectedInputTouchInfo, 575656415, 17384, 24309, 81, 10, 105, 202, 140, 155, 76, 40);
@@ -13188,13 +13188,13 @@ impl IInjectedInputTouchInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InjectedInputTouchInfo: IInjectedInputTouchInfo}
+RT_CLASS!{class InjectedInputTouchInfo: IInjectedInputTouchInfo ["Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo"]}
 impl RtActivatable<IActivationFactory> for InjectedInputTouchInfo {}
 DEFINE_CLSID!(InjectedInputTouchInfo(&[87,105,110,100,111,119,115,46,85,73,46,73,110,112,117,116,46,80,114,101,118,105,101,119,46,73,110,106,101,99,116,105,111,110,46,73,110,106,101,99,116,101,100,73,110,112,117,116,84,111,117,99,104,73,110,102,111,0]) [CLSID_InjectedInputTouchInfo]);
-RT_ENUM! { enum InjectedInputTouchParameters: u32 {
+RT_ENUM! { enum InjectedInputTouchParameters: u32 ["Windows.UI.Input.Preview.Injection.InjectedInputTouchParameters"] {
     None (InjectedInputTouchParameters_None) = 0, Contact (InjectedInputTouchParameters_Contact) = 1, Orientation (InjectedInputTouchParameters_Orientation) = 2, Pressure (InjectedInputTouchParameters_Pressure) = 4,
 }}
-RT_ENUM! { enum InjectedInputVisualizationMode: i32 {
+RT_ENUM! { enum InjectedInputVisualizationMode: i32 ["Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode"] {
     None (InjectedInputVisualizationMode_None) = 0, Default (InjectedInputVisualizationMode_Default) = 1, Indirect (InjectedInputVisualizationMode_Indirect) = 2,
 }}
 DEFINE_IID!(IID_IInputInjector, 2395107204, 2818, 19410, 173, 122, 61, 70, 88, 190, 62, 24);
@@ -13247,7 +13247,7 @@ impl IInputInjector {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InputInjector: IInputInjector}
+RT_CLASS!{class InputInjector: IInputInjector ["Windows.UI.Input.Preview.Injection.InputInjector"]}
 impl RtActivatable<IInputInjectorStatics> for InputInjector {}
 impl RtActivatable<IInputInjectorStatics2> for InputInjector {}
 impl InputInjector {
@@ -13486,7 +13486,7 @@ impl ISpatialGestureRecognizer {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialGestureRecognizer: ISpatialGestureRecognizer}
+RT_CLASS!{class SpatialGestureRecognizer: ISpatialGestureRecognizer ["Windows.UI.Input.Spatial.SpatialGestureRecognizer"]}
 impl RtActivatable<ISpatialGestureRecognizerFactory> for SpatialGestureRecognizer {}
 impl SpatialGestureRecognizer {
     #[inline] pub fn create(settings: SpatialGestureSettings) -> Result<ComPtr<SpatialGestureRecognizer>> {
@@ -13505,7 +13505,7 @@ impl ISpatialGestureRecognizerFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialGestureSettings: u32 {
+RT_ENUM! { enum SpatialGestureSettings: u32 ["Windows.UI.Input.Spatial.SpatialGestureSettings"] {
     None (SpatialGestureSettings_None) = 0, Tap (SpatialGestureSettings_Tap) = 1, DoubleTap (SpatialGestureSettings_DoubleTap) = 2, Hold (SpatialGestureSettings_Hold) = 4, ManipulationTranslate (SpatialGestureSettings_ManipulationTranslate) = 8, NavigationX (SpatialGestureSettings_NavigationX) = 16, NavigationY (SpatialGestureSettings_NavigationY) = 32, NavigationZ (SpatialGestureSettings_NavigationZ) = 64, NavigationRailsX (SpatialGestureSettings_NavigationRailsX) = 128, NavigationRailsY (SpatialGestureSettings_NavigationRailsY) = 256, NavigationRailsZ (SpatialGestureSettings_NavigationRailsZ) = 512,
 }}
 DEFINE_IID!(IID_ISpatialHoldCanceledEventArgs, 1576842855, 19626, 16531, 140, 53, 182, 1, 168, 57, 243, 27);
@@ -13519,7 +13519,7 @@ impl ISpatialHoldCanceledEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialHoldCanceledEventArgs: ISpatialHoldCanceledEventArgs}
+RT_CLASS!{class SpatialHoldCanceledEventArgs: ISpatialHoldCanceledEventArgs ["Windows.UI.Input.Spatial.SpatialHoldCanceledEventArgs"]}
 DEFINE_IID!(IID_ISpatialHoldCompletedEventArgs, 1063536395, 19709, 17370, 141, 196, 230, 69, 82, 23, 57, 113);
 RT_INTERFACE!{interface ISpatialHoldCompletedEventArgs(ISpatialHoldCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialHoldCompletedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT
@@ -13531,7 +13531,7 @@ impl ISpatialHoldCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialHoldCompletedEventArgs: ISpatialHoldCompletedEventArgs}
+RT_CLASS!{class SpatialHoldCompletedEventArgs: ISpatialHoldCompletedEventArgs ["Windows.UI.Input.Spatial.SpatialHoldCompletedEventArgs"]}
 DEFINE_IID!(IID_ISpatialHoldStartedEventArgs, 2385788281, 44214, 16708, 134, 21, 44, 251, 168, 163, 203, 63);
 RT_INTERFACE!{interface ISpatialHoldStartedEventArgs(ISpatialHoldStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialHoldStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -13549,7 +13549,7 @@ impl ISpatialHoldStartedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialHoldStartedEventArgs: ISpatialHoldStartedEventArgs}
+RT_CLASS!{class SpatialHoldStartedEventArgs: ISpatialHoldStartedEventArgs ["Windows.UI.Input.Spatial.SpatialHoldStartedEventArgs"]}
 DEFINE_IID!(IID_ISpatialInteraction, 4237719097, 35046, 17990, 145, 18, 67, 68, 170, 236, 157, 250);
 RT_INTERFACE!{interface ISpatialInteraction(ISpatialInteractionVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteraction] {
     fn get_SourceState(&self, out: *mut *mut SpatialInteractionSourceState) -> HRESULT
@@ -13561,7 +13561,7 @@ impl ISpatialInteraction {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteraction: ISpatialInteraction}
+RT_CLASS!{class SpatialInteraction: ISpatialInteraction ["Windows.UI.Input.Spatial.SpatialInteraction"]}
 DEFINE_IID!(IID_ISpatialInteractionController, 1594776483, 2388, 20119, 134, 197, 231, 243, 11, 17, 77, 253);
 RT_INTERFACE!{interface ISpatialInteractionController(ISpatialInteractionControllerVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionController] {
     fn get_HasTouchpad(&self, out: *mut bool) -> HRESULT,
@@ -13604,7 +13604,7 @@ impl ISpatialInteractionController {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionController: ISpatialInteractionController}
+RT_CLASS!{class SpatialInteractionController: ISpatialInteractionController ["Windows.UI.Input.Spatial.SpatialInteractionController"]}
 DEFINE_IID!(IID_ISpatialInteractionController2, 901175588, 51106, 18871, 183, 46, 84, 54, 178, 251, 143, 156);
 RT_INTERFACE!{interface ISpatialInteractionController2(ISpatialInteractionController2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionController2] {
     #[cfg(feature="windows-storage")] fn TryGetRenderableModelAsync(&self, out: *mut *mut foundation::IAsyncOperation<::rt::gen::windows::storage::streams::IRandomAccessStreamWithContentType>) -> HRESULT
@@ -13674,7 +13674,7 @@ impl ISpatialInteractionControllerProperties {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionControllerProperties: ISpatialInteractionControllerProperties}
+RT_CLASS!{class SpatialInteractionControllerProperties: ISpatialInteractionControllerProperties ["Windows.UI.Input.Spatial.SpatialInteractionControllerProperties"]}
 DEFINE_IID!(IID_ISpatialInteractionDetectedEventArgs, 123238628, 22881, 15169, 157, 251, 206, 165, 216, 156, 195, 138);
 RT_INTERFACE!{interface ISpatialInteractionDetectedEventArgs(ISpatialInteractionDetectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionDetectedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -13699,7 +13699,7 @@ impl ISpatialInteractionDetectedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionDetectedEventArgs: ISpatialInteractionDetectedEventArgs}
+RT_CLASS!{class SpatialInteractionDetectedEventArgs: ISpatialInteractionDetectedEventArgs ["Windows.UI.Input.Spatial.SpatialInteractionDetectedEventArgs"]}
 DEFINE_IID!(IID_ISpatialInteractionDetectedEventArgs2, 2066103955, 24339, 16796, 151, 213, 131, 70, 120, 38, 106, 166);
 RT_INTERFACE!{interface ISpatialInteractionDetectedEventArgs2(ISpatialInteractionDetectedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionDetectedEventArgs2] {
     fn get_InteractionSource(&self, out: *mut *mut SpatialInteractionSource) -> HRESULT
@@ -13788,7 +13788,7 @@ impl ISpatialInteractionManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionManager: ISpatialInteractionManager}
+RT_CLASS!{class SpatialInteractionManager: ISpatialInteractionManager ["Windows.UI.Input.Spatial.SpatialInteractionManager"]}
 impl RtActivatable<ISpatialInteractionManagerStatics> for SpatialInteractionManager {}
 impl SpatialInteractionManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<SpatialInteractionManager>>> {
@@ -13807,7 +13807,7 @@ impl ISpatialInteractionManagerStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialInteractionPressKind: i32 {
+RT_ENUM! { enum SpatialInteractionPressKind: i32 ["Windows.UI.Input.Spatial.SpatialInteractionPressKind"] {
     None (SpatialInteractionPressKind_None) = 0, Select (SpatialInteractionPressKind_Select) = 1, Menu (SpatialInteractionPressKind_Menu) = 2, Grasp (SpatialInteractionPressKind_Grasp) = 3, Touchpad (SpatialInteractionPressKind_Touchpad) = 4, Thumbstick (SpatialInteractionPressKind_Thumbstick) = 5,
 }}
 DEFINE_IID!(IID_ISpatialInteractionSource, 4216599482, 45235, 12616, 159, 59, 233, 245, 222, 86, 143, 93);
@@ -13827,7 +13827,7 @@ impl ISpatialInteractionSource {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionSource: ISpatialInteractionSource}
+RT_CLASS!{class SpatialInteractionSource: ISpatialInteractionSource ["Windows.UI.Input.Spatial.SpatialInteractionSource"]}
 DEFINE_IID!(IID_ISpatialInteractionSource2, 3838162700, 1136, 16424, 136, 192, 160, 235, 68, 211, 78, 254);
 RT_INTERFACE!{interface ISpatialInteractionSource2(ISpatialInteractionSource2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionSource2] {
     fn get_IsPointingSupported(&self, out: *mut bool) -> HRESULT,
@@ -13885,7 +13885,7 @@ impl ISpatialInteractionSourceEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionSourceEventArgs: ISpatialInteractionSourceEventArgs}
+RT_CLASS!{class SpatialInteractionSourceEventArgs: ISpatialInteractionSourceEventArgs ["Windows.UI.Input.Spatial.SpatialInteractionSourceEventArgs"]}
 DEFINE_IID!(IID_ISpatialInteractionSourceEventArgs2, 3635721319, 58952, 19794, 171, 73, 224, 210, 39, 25, 159, 99);
 RT_INTERFACE!{interface ISpatialInteractionSourceEventArgs2(ISpatialInteractionSourceEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionSourceEventArgs2] {
     fn get_PressKind(&self, out: *mut SpatialInteractionPressKind) -> HRESULT
@@ -13897,10 +13897,10 @@ impl ISpatialInteractionSourceEventArgs2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialInteractionSourceHandedness: i32 {
+RT_ENUM! { enum SpatialInteractionSourceHandedness: i32 ["Windows.UI.Input.Spatial.SpatialInteractionSourceHandedness"] {
     Unspecified (SpatialInteractionSourceHandedness_Unspecified) = 0, Left (SpatialInteractionSourceHandedness_Left) = 1, Right (SpatialInteractionSourceHandedness_Right) = 2,
 }}
-RT_ENUM! { enum SpatialInteractionSourceKind: i32 {
+RT_ENUM! { enum SpatialInteractionSourceKind: i32 ["Windows.UI.Input.Spatial.SpatialInteractionSourceKind"] {
     Other (SpatialInteractionSourceKind_Other) = 0, Hand (SpatialInteractionSourceKind_Hand) = 1, Voice (SpatialInteractionSourceKind_Voice) = 2, Controller (SpatialInteractionSourceKind_Controller) = 3,
 }}
 DEFINE_IID!(IID_ISpatialInteractionSourceLocation, 3930494660, 32395, 12490, 188, 197, 199, 113, 137, 206, 163, 10);
@@ -13920,7 +13920,7 @@ impl ISpatialInteractionSourceLocation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionSourceLocation: ISpatialInteractionSourceLocation}
+RT_CLASS!{class SpatialInteractionSourceLocation: ISpatialInteractionSourceLocation ["Windows.UI.Input.Spatial.SpatialInteractionSourceLocation"]}
 DEFINE_IID!(IID_ISpatialInteractionSourceLocation2, 1281822789, 14615, 16636, 169, 172, 49, 201, 207, 95, 249, 27);
 RT_INTERFACE!{interface ISpatialInteractionSourceLocation2(ISpatialInteractionSourceLocation2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionSourceLocation2] {
     fn get_Orientation(&self, out: *mut *mut foundation::IReference<foundation::numerics::Quaternion>) -> HRESULT
@@ -13955,7 +13955,7 @@ impl ISpatialInteractionSourceLocation3 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SpatialInteractionSourcePositionAccuracy: i32 {
+RT_ENUM! { enum SpatialInteractionSourcePositionAccuracy: i32 ["Windows.UI.Input.Spatial.SpatialInteractionSourcePositionAccuracy"] {
     High (SpatialInteractionSourcePositionAccuracy_High) = 0, Approximate (SpatialInteractionSourcePositionAccuracy_Approximate) = 1,
 }}
 DEFINE_IID!(IID_ISpatialInteractionSourceProperties, 90195266, 16119, 12834, 159, 83, 99, 201, 203, 126, 59, 199);
@@ -13981,7 +13981,7 @@ impl ISpatialInteractionSourceProperties {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionSourceProperties: ISpatialInteractionSourceProperties}
+RT_CLASS!{class SpatialInteractionSourceProperties: ISpatialInteractionSourceProperties ["Windows.UI.Input.Spatial.SpatialInteractionSourceProperties"]}
 DEFINE_IID!(IID_ISpatialInteractionSourceState, 3586422255, 19299, 14316, 152, 185, 159, 198, 82, 185, 210, 242);
 RT_INTERFACE!{interface ISpatialInteractionSourceState(ISpatialInteractionSourceStateVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionSourceState] {
     fn get_Source(&self, out: *mut *mut SpatialInteractionSource) -> HRESULT,
@@ -14017,7 +14017,7 @@ impl ISpatialInteractionSourceState {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialInteractionSourceState: ISpatialInteractionSourceState}
+RT_CLASS!{class SpatialInteractionSourceState: ISpatialInteractionSourceState ["Windows.UI.Input.Spatial.SpatialInteractionSourceState"]}
 DEFINE_IID!(IID_ISpatialInteractionSourceState2, 1173803197, 6003, 18734, 155, 163, 138, 193, 203, 231, 124, 8);
 RT_INTERFACE!{interface ISpatialInteractionSourceState2(ISpatialInteractionSourceState2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialInteractionSourceState2] {
     fn get_IsSelectPressed(&self, out: *mut bool) -> HRESULT,
@@ -14064,7 +14064,7 @@ impl ISpatialManipulationCanceledEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialManipulationCanceledEventArgs: ISpatialManipulationCanceledEventArgs}
+RT_CLASS!{class SpatialManipulationCanceledEventArgs: ISpatialManipulationCanceledEventArgs ["Windows.UI.Input.Spatial.SpatialManipulationCanceledEventArgs"]}
 DEFINE_IID!(IID_ISpatialManipulationCompletedEventArgs, 84436994, 62209, 17219, 146, 80, 47, 186, 165, 248, 122, 55);
 RT_INTERFACE!{interface ISpatialManipulationCompletedEventArgs(ISpatialManipulationCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationCompletedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14082,7 +14082,7 @@ impl ISpatialManipulationCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialManipulationCompletedEventArgs: ISpatialManipulationCompletedEventArgs}
+RT_CLASS!{class SpatialManipulationCompletedEventArgs: ISpatialManipulationCompletedEventArgs ["Windows.UI.Input.Spatial.SpatialManipulationCompletedEventArgs"]}
 DEFINE_IID!(IID_ISpatialManipulationDelta, 2817300090, 53539, 14977, 161, 91, 153, 41, 35, 220, 190, 145);
 RT_INTERFACE!{interface ISpatialManipulationDelta(ISpatialManipulationDeltaVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationDelta] {
     fn get_Translation(&self, out: *mut foundation::numerics::Vector3) -> HRESULT
@@ -14094,7 +14094,7 @@ impl ISpatialManipulationDelta {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialManipulationDelta: ISpatialManipulationDelta}
+RT_CLASS!{class SpatialManipulationDelta: ISpatialManipulationDelta ["Windows.UI.Input.Spatial.SpatialManipulationDelta"]}
 DEFINE_IID!(IID_ISpatialManipulationStartedEventArgs, 2715204558, 17061, 14203, 173, 166, 210, 142, 61, 56, 71, 55);
 RT_INTERFACE!{interface ISpatialManipulationStartedEventArgs(ISpatialManipulationStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14112,7 +14112,7 @@ impl ISpatialManipulationStartedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialManipulationStartedEventArgs: ISpatialManipulationStartedEventArgs}
+RT_CLASS!{class SpatialManipulationStartedEventArgs: ISpatialManipulationStartedEventArgs ["Windows.UI.Input.Spatial.SpatialManipulationStartedEventArgs"]}
 DEFINE_IID!(IID_ISpatialManipulationUpdatedEventArgs, 1596132251, 24774, 19910, 189, 201, 159, 74, 111, 21, 254, 73);
 RT_INTERFACE!{interface ISpatialManipulationUpdatedEventArgs(ISpatialManipulationUpdatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialManipulationUpdatedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14130,7 +14130,7 @@ impl ISpatialManipulationUpdatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialManipulationUpdatedEventArgs: ISpatialManipulationUpdatedEventArgs}
+RT_CLASS!{class SpatialManipulationUpdatedEventArgs: ISpatialManipulationUpdatedEventArgs ["Windows.UI.Input.Spatial.SpatialManipulationUpdatedEventArgs"]}
 DEFINE_IID!(IID_ISpatialNavigationCanceledEventArgs, 3461365468, 59557, 18160, 146, 212, 60, 18, 43, 53, 17, 42);
 RT_INTERFACE!{interface ISpatialNavigationCanceledEventArgs(ISpatialNavigationCanceledEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialNavigationCanceledEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT
@@ -14142,7 +14142,7 @@ impl ISpatialNavigationCanceledEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialNavigationCanceledEventArgs: ISpatialNavigationCanceledEventArgs}
+RT_CLASS!{class SpatialNavigationCanceledEventArgs: ISpatialNavigationCanceledEventArgs ["Windows.UI.Input.Spatial.SpatialNavigationCanceledEventArgs"]}
 DEFINE_IID!(IID_ISpatialNavigationCompletedEventArgs, 19824823, 44859, 17090, 158, 65, 186, 170, 14, 114, 31, 58);
 RT_INTERFACE!{interface ISpatialNavigationCompletedEventArgs(ISpatialNavigationCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialNavigationCompletedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14160,7 +14160,7 @@ impl ISpatialNavigationCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialNavigationCompletedEventArgs: ISpatialNavigationCompletedEventArgs}
+RT_CLASS!{class SpatialNavigationCompletedEventArgs: ISpatialNavigationCompletedEventArgs ["Windows.UI.Input.Spatial.SpatialNavigationCompletedEventArgs"]}
 DEFINE_IID!(IID_ISpatialNavigationStartedEventArgs, 1967797386, 64356, 18006, 142, 189, 157, 238, 202, 175, 228, 117);
 RT_INTERFACE!{interface ISpatialNavigationStartedEventArgs(ISpatialNavigationStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialNavigationStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14197,7 +14197,7 @@ impl ISpatialNavigationStartedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialNavigationStartedEventArgs: ISpatialNavigationStartedEventArgs}
+RT_CLASS!{class SpatialNavigationStartedEventArgs: ISpatialNavigationStartedEventArgs ["Windows.UI.Input.Spatial.SpatialNavigationStartedEventArgs"]}
 DEFINE_IID!(IID_ISpatialNavigationUpdatedEventArgs, 2607890391, 33693, 19060, 135, 50, 69, 70, 111, 192, 68, 181);
 RT_INTERFACE!{interface ISpatialNavigationUpdatedEventArgs(ISpatialNavigationUpdatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialNavigationUpdatedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14215,7 +14215,7 @@ impl ISpatialNavigationUpdatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialNavigationUpdatedEventArgs: ISpatialNavigationUpdatedEventArgs}
+RT_CLASS!{class SpatialNavigationUpdatedEventArgs: ISpatialNavigationUpdatedEventArgs ["Windows.UI.Input.Spatial.SpatialNavigationUpdatedEventArgs"]}
 DEFINE_IID!(IID_ISpatialPointerInteractionSourcePose, 2802860807, 11307, 19770, 146, 167, 128, 206, 215, 196, 160, 208);
 RT_INTERFACE!{interface ISpatialPointerInteractionSourcePose(ISpatialPointerInteractionSourcePoseVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialPointerInteractionSourcePose] {
     fn get_Position(&self, out: *mut foundation::numerics::Vector3) -> HRESULT,
@@ -14239,7 +14239,7 @@ impl ISpatialPointerInteractionSourcePose {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialPointerInteractionSourcePose: ISpatialPointerInteractionSourcePose}
+RT_CLASS!{class SpatialPointerInteractionSourcePose: ISpatialPointerInteractionSourcePose ["Windows.UI.Input.Spatial.SpatialPointerInteractionSourcePose"]}
 DEFINE_IID!(IID_ISpatialPointerInteractionSourcePose2, 3972892344, 21211, 18079, 158, 63, 128, 196, 127, 116, 188, 233);
 RT_INTERFACE!{interface ISpatialPointerInteractionSourcePose2(ISpatialPointerInteractionSourcePose2Vtbl): IInspectable(IInspectableVtbl) [IID_ISpatialPointerInteractionSourcePose2] {
     fn get_Orientation(&self, out: *mut foundation::numerics::Quaternion) -> HRESULT,
@@ -14274,7 +14274,7 @@ impl ISpatialPointerPose {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialPointerPose: ISpatialPointerPose}
+RT_CLASS!{class SpatialPointerPose: ISpatialPointerPose ["Windows.UI.Input.Spatial.SpatialPointerPose"]}
 impl RtActivatable<ISpatialPointerPoseStatics> for SpatialPointerPose {}
 impl SpatialPointerPose {
     #[cfg(feature="windows-perception")] #[inline] pub fn try_get_at_timestamp(coordinateSystem: &::rt::gen::windows::perception::spatial::SpatialCoordinateSystem, timestamp: &::rt::gen::windows::perception::PerceptionTimestamp) -> Result<Option<ComPtr<SpatialPointerPose>>> {
@@ -14315,7 +14315,7 @@ impl ISpatialRecognitionEndedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialRecognitionEndedEventArgs: ISpatialRecognitionEndedEventArgs}
+RT_CLASS!{class SpatialRecognitionEndedEventArgs: ISpatialRecognitionEndedEventArgs ["Windows.UI.Input.Spatial.SpatialRecognitionEndedEventArgs"]}
 DEFINE_IID!(IID_ISpatialRecognitionStartedEventArgs, 618271375, 8, 19053, 170, 80, 42, 118, 249, 207, 178, 100);
 RT_INTERFACE!{interface ISpatialRecognitionStartedEventArgs(ISpatialRecognitionStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialRecognitionStartedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14340,7 +14340,7 @@ impl ISpatialRecognitionStartedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialRecognitionStartedEventArgs: ISpatialRecognitionStartedEventArgs}
+RT_CLASS!{class SpatialRecognitionStartedEventArgs: ISpatialRecognitionStartedEventArgs ["Windows.UI.Input.Spatial.SpatialRecognitionStartedEventArgs"]}
 DEFINE_IID!(IID_ISpatialTappedEventArgs, 695043038, 62532, 19105, 178, 191, 157, 200, 141, 86, 125, 166);
 RT_INTERFACE!{interface ISpatialTappedEventArgs(ISpatialTappedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ISpatialTappedEventArgs] {
     fn get_InteractionSourceKind(&self, out: *mut SpatialInteractionSourceKind) -> HRESULT,
@@ -14365,7 +14365,7 @@ impl ISpatialTappedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SpatialTappedEventArgs: ISpatialTappedEventArgs}
+RT_CLASS!{class SpatialTappedEventArgs: ISpatialTappedEventArgs ["Windows.UI.Input.Spatial.SpatialTappedEventArgs"]}
 } // Windows.UI.Input.Spatial
 } // Windows.UI.Input
 pub mod notifications { // Windows.UI.Notifications
@@ -14387,7 +14387,7 @@ impl IAdaptiveNotificationContent {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum AdaptiveNotificationContentKind: i32 {
+RT_ENUM! { enum AdaptiveNotificationContentKind: i32 ["Windows.UI.Notifications.AdaptiveNotificationContentKind"] {
     Text (AdaptiveNotificationContentKind_Text) = 0,
 }}
 DEFINE_IID!(IID_IAdaptiveNotificationText, 1188340670, 24730, 17190, 164, 11, 191, 222, 135, 32, 52, 163);
@@ -14417,7 +14417,7 @@ impl IAdaptiveNotificationText {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AdaptiveNotificationText: IAdaptiveNotificationText}
+RT_CLASS!{class AdaptiveNotificationText: IAdaptiveNotificationText ["Windows.UI.Notifications.AdaptiveNotificationText"]}
 impl RtActivatable<IActivationFactory> for AdaptiveNotificationText {}
 DEFINE_CLSID!(AdaptiveNotificationText(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,65,100,97,112,116,105,118,101,78,111,116,105,102,105,99,97,116,105,111,110,84,101,120,116,0]) [CLSID_AdaptiveNotificationText]);
 DEFINE_IID!(IID_IBadgeNotification, 123516106, 53386, 20015, 146, 51, 126, 40, 156, 31, 119, 34);
@@ -14443,7 +14443,7 @@ impl IBadgeNotification {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BadgeNotification: IBadgeNotification}
+RT_CLASS!{class BadgeNotification: IBadgeNotification ["Windows.UI.Notifications.BadgeNotification"]}
 impl RtActivatable<IBadgeNotificationFactory> for BadgeNotification {}
 impl BadgeNotification {
     #[cfg(feature="windows-data")] #[inline] pub fn create_badge_notification(content: &super::super::data::xml::dom::XmlDocument) -> Result<ComPtr<BadgeNotification>> {
@@ -14462,7 +14462,7 @@ impl IBadgeNotificationFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum BadgeTemplateType: i32 {
+RT_ENUM! { enum BadgeTemplateType: i32 ["Windows.UI.Notifications.BadgeTemplateType"] {
     BadgeGlyph (BadgeTemplateType_BadgeGlyph) = 0, BadgeNumber (BadgeTemplateType_BadgeNumber) = 1,
 }}
 RT_CLASS!{static class BadgeUpdateManager}
@@ -14515,7 +14515,7 @@ impl IBadgeUpdateManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BadgeUpdateManagerForUser: IBadgeUpdateManagerForUser}
+RT_CLASS!{class BadgeUpdateManagerForUser: IBadgeUpdateManagerForUser ["Windows.UI.Notifications.BadgeUpdateManagerForUser"]}
 DEFINE_IID!(IID_IBadgeUpdateManagerStatics, 859836330, 28117, 16645, 174, 188, 155, 80, 252, 164, 146, 218);
 RT_INTERFACE!{static interface IBadgeUpdateManagerStatics(IBadgeUpdateManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IBadgeUpdateManagerStatics] {
     fn CreateBadgeUpdaterForApplication(&self, out: *mut *mut BadgeUpdater) -> HRESULT,
@@ -14586,7 +14586,7 @@ impl IBadgeUpdater {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class BadgeUpdater: IBadgeUpdater}
+RT_CLASS!{class BadgeUpdater: IBadgeUpdater ["Windows.UI.Notifications.BadgeUpdater"]}
 RT_CLASS!{static class KnownAdaptiveNotificationHints}
 impl RtActivatable<IKnownAdaptiveNotificationHintsStatics> for KnownAdaptiveNotificationHints {}
 impl KnownAdaptiveNotificationHints {
@@ -14878,7 +14878,7 @@ impl INotification {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Notification: INotification}
+RT_CLASS!{class Notification: INotification ["Windows.UI.Notifications.Notification"]}
 impl RtActivatable<IActivationFactory> for Notification {}
 DEFINE_CLSID!(Notification(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,78,111,116,105,102,105,99,97,116,105,111,110,0]) [CLSID_Notification]);
 DEFINE_IID!(IID_INotificationBinding, 4070460293, 880, 19155, 180, 234, 218, 158, 53, 231, 234, 191);
@@ -14920,7 +14920,7 @@ impl INotificationBinding {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NotificationBinding: INotificationBinding}
+RT_CLASS!{class NotificationBinding: INotificationBinding ["Windows.UI.Notifications.NotificationBinding"]}
 DEFINE_IID!(IID_INotificationData, 2684166930, 40298, 19119, 182, 172, 255, 23, 240, 193, 242, 128);
 RT_INTERFACE!{interface INotificationData(INotificationDataVtbl): IInspectable(IInspectableVtbl) [IID_INotificationData] {
     fn get_Values(&self, out: *mut *mut foundation::collections::IMap<HString, HString>) -> HRESULT,
@@ -14943,7 +14943,7 @@ impl INotificationData {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NotificationData: INotificationData}
+RT_CLASS!{class NotificationData: INotificationData ["Windows.UI.Notifications.NotificationData"]}
 impl RtActivatable<INotificationDataFactory> for NotificationData {}
 impl RtActivatable<IActivationFactory> for NotificationData {}
 impl NotificationData {
@@ -14972,16 +14972,16 @@ impl INotificationDataFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum NotificationKinds: u32 {
+RT_ENUM! { enum NotificationKinds: u32 ["Windows.UI.Notifications.NotificationKinds"] {
     Unknown (NotificationKinds_Unknown) = 0, Toast (NotificationKinds_Toast) = 1,
 }}
-RT_ENUM! { enum NotificationMirroring: i32 {
+RT_ENUM! { enum NotificationMirroring: i32 ["Windows.UI.Notifications.NotificationMirroring"] {
     Allowed (NotificationMirroring_Allowed) = 0, Disabled (NotificationMirroring_Disabled) = 1,
 }}
-RT_ENUM! { enum NotificationSetting: i32 {
+RT_ENUM! { enum NotificationSetting: i32 ["Windows.UI.Notifications.NotificationSetting"] {
     Enabled (NotificationSetting_Enabled) = 0, DisabledForApplication (NotificationSetting_DisabledForApplication) = 1, DisabledForUser (NotificationSetting_DisabledForUser) = 2, DisabledByGroupPolicy (NotificationSetting_DisabledByGroupPolicy) = 3, DisabledByManifest (NotificationSetting_DisabledByManifest) = 4,
 }}
-RT_ENUM! { enum NotificationUpdateResult: i32 {
+RT_ENUM! { enum NotificationUpdateResult: i32 ["Windows.UI.Notifications.NotificationUpdateResult"] {
     Succeeded (NotificationUpdateResult_Succeeded) = 0, Failed (NotificationUpdateResult_Failed) = 1, NotificationNotFound (NotificationUpdateResult_NotificationNotFound) = 2,
 }}
 DEFINE_IID!(IID_INotificationVisual, 1753439118, 43606, 19985, 134, 211, 95, 154, 105, 87, 188, 91);
@@ -15012,8 +15012,8 @@ impl INotificationVisual {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NotificationVisual: INotificationVisual}
-RT_ENUM! { enum PeriodicUpdateRecurrence: i32 {
+RT_CLASS!{class NotificationVisual: INotificationVisual ["Windows.UI.Notifications.NotificationVisual"]}
+RT_ENUM! { enum PeriodicUpdateRecurrence: i32 ["Windows.UI.Notifications.PeriodicUpdateRecurrence"] {
     HalfHour (PeriodicUpdateRecurrence_HalfHour) = 0, Hour (PeriodicUpdateRecurrence_Hour) = 1, SixHours (PeriodicUpdateRecurrence_SixHours) = 2, TwelveHours (PeriodicUpdateRecurrence_TwelveHours) = 3, Daily (PeriodicUpdateRecurrence_Daily) = 4,
 }}
 DEFINE_IID!(IID_IScheduledTileNotification, 180135637, 39388, 19576, 161, 28, 201, 231, 248, 109, 126, 247);
@@ -15067,7 +15067,7 @@ impl IScheduledTileNotification {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScheduledTileNotification: IScheduledTileNotification}
+RT_CLASS!{class ScheduledTileNotification: IScheduledTileNotification ["Windows.UI.Notifications.ScheduledTileNotification"]}
 impl RtActivatable<IScheduledTileNotificationFactory> for ScheduledTileNotification {}
 impl ScheduledTileNotification {
     #[cfg(feature="windows-data")] #[inline] pub fn create_scheduled_tile_notification(content: &super::super::data::xml::dom::XmlDocument, deliveryTime: foundation::DateTime) -> Result<ComPtr<ScheduledTileNotification>> {
@@ -15127,7 +15127,7 @@ impl IScheduledToastNotification {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScheduledToastNotification: IScheduledToastNotification}
+RT_CLASS!{class ScheduledToastNotification: IScheduledToastNotification ["Windows.UI.Notifications.ScheduledToastNotification"]}
 impl RtActivatable<IScheduledToastNotificationFactory> for ScheduledToastNotification {}
 impl ScheduledToastNotification {
     #[cfg(feature="windows-data")] #[inline] pub fn create_scheduled_toast_notification(content: &super::super::data::xml::dom::XmlDocument, deliveryTime: foundation::DateTime) -> Result<ComPtr<ScheduledToastNotification>> {
@@ -15264,7 +15264,7 @@ impl IScheduledToastNotificationShowingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ScheduledToastNotificationShowingEventArgs: IScheduledToastNotificationShowingEventArgs}
+RT_CLASS!{class ScheduledToastNotificationShowingEventArgs: IScheduledToastNotificationShowingEventArgs ["Windows.UI.Notifications.ScheduledToastNotificationShowingEventArgs"]}
 DEFINE_IID!(IID_IShownTileNotification, 875399560, 23282, 18458, 166, 163, 242, 253, 199, 141, 232, 142);
 RT_INTERFACE!{interface IShownTileNotification(IShownTileNotificationVtbl): IInspectable(IInspectableVtbl) [IID_IShownTileNotification] {
     fn get_Arguments(&self, out: *mut HSTRING) -> HRESULT
@@ -15276,7 +15276,7 @@ impl IShownTileNotification {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ShownTileNotification: IShownTileNotification}
+RT_CLASS!{class ShownTileNotification: IShownTileNotification ["Windows.UI.Notifications.ShownTileNotification"]}
 DEFINE_IID!(IID_ITileFlyoutNotification, 2589176417, 50956, 17086, 178, 243, 244, 42, 169, 125, 52, 229);
 RT_INTERFACE!{interface ITileFlyoutNotification(ITileFlyoutNotificationVtbl): IInspectable(IInspectableVtbl) [IID_ITileFlyoutNotification] {
     #[cfg(not(feature="windows-data"))] fn __Dummy0(&self) -> (),
@@ -15300,7 +15300,7 @@ impl ITileFlyoutNotification {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileFlyoutNotification: ITileFlyoutNotification}
+RT_CLASS!{class TileFlyoutNotification: ITileFlyoutNotification ["Windows.UI.Notifications.TileFlyoutNotification"]}
 impl RtActivatable<ITileFlyoutNotificationFactory> for TileFlyoutNotification {}
 impl TileFlyoutNotification {
     #[cfg(feature="windows-data")] #[inline] pub fn create_tile_flyout_notification(content: &super::super::data::xml::dom::XmlDocument) -> Result<ComPtr<TileFlyoutNotification>> {
@@ -15319,7 +15319,7 @@ impl ITileFlyoutNotificationFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TileFlyoutTemplateType: i32 {
+RT_ENUM! { enum TileFlyoutTemplateType: i32 ["Windows.UI.Notifications.TileFlyoutTemplateType"] {
     TileFlyoutTemplate01 (TileFlyoutTemplateType_TileFlyoutTemplate01) = 0,
 }}
 RT_CLASS!{static class TileFlyoutUpdateManager}
@@ -15404,7 +15404,7 @@ impl ITileFlyoutUpdater {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileFlyoutUpdater: ITileFlyoutUpdater}
+RT_CLASS!{class TileFlyoutUpdater: ITileFlyoutUpdater ["Windows.UI.Notifications.TileFlyoutUpdater"]}
 DEFINE_IID!(IID_ITileNotification, 3954100474, 20716, 19480, 180, 208, 58, 240, 46, 85, 64, 171);
 RT_INTERFACE!{interface ITileNotification(ITileNotificationVtbl): IInspectable(IInspectableVtbl) [IID_ITileNotification] {
     #[cfg(not(feature="windows-data"))] fn __Dummy0(&self) -> (),
@@ -15439,7 +15439,7 @@ impl ITileNotification {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileNotification: ITileNotification}
+RT_CLASS!{class TileNotification: ITileNotification ["Windows.UI.Notifications.TileNotification"]}
 impl RtActivatable<ITileNotificationFactory> for TileNotification {}
 impl TileNotification {
     #[cfg(feature="windows-data")] #[inline] pub fn create_tile_notification(content: &super::super::data::xml::dom::XmlDocument) -> Result<ComPtr<TileNotification>> {
@@ -15458,7 +15458,7 @@ impl ITileNotificationFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TileTemplateType: i32 {
+RT_ENUM! { enum TileTemplateType: i32 ["Windows.UI.Notifications.TileTemplateType"] {
     TileSquareImage (TileTemplateType_TileSquareImage) = 0, TileSquareBlock (TileTemplateType_TileSquareBlock) = 1, TileSquareText01 (TileTemplateType_TileSquareText01) = 2, TileSquareText02 (TileTemplateType_TileSquareText02) = 3, TileSquareText03 (TileTemplateType_TileSquareText03) = 4, TileSquareText04 (TileTemplateType_TileSquareText04) = 5, TileSquarePeekImageAndText01 (TileTemplateType_TileSquarePeekImageAndText01) = 6, TileSquarePeekImageAndText02 (TileTemplateType_TileSquarePeekImageAndText02) = 7, TileSquarePeekImageAndText03 (TileTemplateType_TileSquarePeekImageAndText03) = 8, TileSquarePeekImageAndText04 (TileTemplateType_TileSquarePeekImageAndText04) = 9, TileWideImage (TileTemplateType_TileWideImage) = 10, TileWideImageCollection (TileTemplateType_TileWideImageCollection) = 11, TileWideImageAndText01 (TileTemplateType_TileWideImageAndText01) = 12, TileWideImageAndText02 (TileTemplateType_TileWideImageAndText02) = 13, TileWideBlockAndText01 (TileTemplateType_TileWideBlockAndText01) = 14, TileWideBlockAndText02 (TileTemplateType_TileWideBlockAndText02) = 15, TileWidePeekImageCollection01 (TileTemplateType_TileWidePeekImageCollection01) = 16, TileWidePeekImageCollection02 (TileTemplateType_TileWidePeekImageCollection02) = 17, TileWidePeekImageCollection03 (TileTemplateType_TileWidePeekImageCollection03) = 18, TileWidePeekImageCollection04 (TileTemplateType_TileWidePeekImageCollection04) = 19, TileWidePeekImageCollection05 (TileTemplateType_TileWidePeekImageCollection05) = 20, TileWidePeekImageCollection06 (TileTemplateType_TileWidePeekImageCollection06) = 21, TileWidePeekImageAndText01 (TileTemplateType_TileWidePeekImageAndText01) = 22, TileWidePeekImageAndText02 (TileTemplateType_TileWidePeekImageAndText02) = 23, TileWidePeekImage01 (TileTemplateType_TileWidePeekImage01) = 24, TileWidePeekImage02 (TileTemplateType_TileWidePeekImage02) = 25, TileWidePeekImage03 (TileTemplateType_TileWidePeekImage03) = 26, TileWidePeekImage04 (TileTemplateType_TileWidePeekImage04) = 27, TileWidePeekImage05 (TileTemplateType_TileWidePeekImage05) = 28, TileWidePeekImage06 (TileTemplateType_TileWidePeekImage06) = 29, TileWideSmallImageAndText01 (TileTemplateType_TileWideSmallImageAndText01) = 30, TileWideSmallImageAndText02 (TileTemplateType_TileWideSmallImageAndText02) = 31, TileWideSmallImageAndText03 (TileTemplateType_TileWideSmallImageAndText03) = 32, TileWideSmallImageAndText04 (TileTemplateType_TileWideSmallImageAndText04) = 33, TileWideSmallImageAndText05 (TileTemplateType_TileWideSmallImageAndText05) = 34, TileWideText01 (TileTemplateType_TileWideText01) = 35, TileWideText02 (TileTemplateType_TileWideText02) = 36, TileWideText03 (TileTemplateType_TileWideText03) = 37, TileWideText04 (TileTemplateType_TileWideText04) = 38, TileWideText05 (TileTemplateType_TileWideText05) = 39, TileWideText06 (TileTemplateType_TileWideText06) = 40, TileWideText07 (TileTemplateType_TileWideText07) = 41, TileWideText08 (TileTemplateType_TileWideText08) = 42, TileWideText09 (TileTemplateType_TileWideText09) = 43, TileWideText10 (TileTemplateType_TileWideText10) = 44, TileWideText11 (TileTemplateType_TileWideText11) = 45, TileSquare150x150Image (TileTemplateType_TileSquare150x150Image) = 0, TileSquare150x150Block (TileTemplateType_TileSquare150x150Block) = 1, TileSquare150x150Text01 (TileTemplateType_TileSquare150x150Text01) = 2, TileSquare150x150Text02 (TileTemplateType_TileSquare150x150Text02) = 3, TileSquare150x150Text03 (TileTemplateType_TileSquare150x150Text03) = 4, TileSquare150x150Text04 (TileTemplateType_TileSquare150x150Text04) = 5, TileSquare150x150PeekImageAndText01 (TileTemplateType_TileSquare150x150PeekImageAndText01) = 6, TileSquare150x150PeekImageAndText02 (TileTemplateType_TileSquare150x150PeekImageAndText02) = 7, TileSquare150x150PeekImageAndText03 (TileTemplateType_TileSquare150x150PeekImageAndText03) = 8, TileSquare150x150PeekImageAndText04 (TileTemplateType_TileSquare150x150PeekImageAndText04) = 9, TileWide310x150Image (TileTemplateType_TileWide310x150Image) = 10, TileWide310x150ImageCollection (TileTemplateType_TileWide310x150ImageCollection) = 11, TileWide310x150ImageAndText01 (TileTemplateType_TileWide310x150ImageAndText01) = 12, TileWide310x150ImageAndText02 (TileTemplateType_TileWide310x150ImageAndText02) = 13, TileWide310x150BlockAndText01 (TileTemplateType_TileWide310x150BlockAndText01) = 14, TileWide310x150BlockAndText02 (TileTemplateType_TileWide310x150BlockAndText02) = 15, TileWide310x150PeekImageCollection01 (TileTemplateType_TileWide310x150PeekImageCollection01) = 16, TileWide310x150PeekImageCollection02 (TileTemplateType_TileWide310x150PeekImageCollection02) = 17, TileWide310x150PeekImageCollection03 (TileTemplateType_TileWide310x150PeekImageCollection03) = 18, TileWide310x150PeekImageCollection04 (TileTemplateType_TileWide310x150PeekImageCollection04) = 19, TileWide310x150PeekImageCollection05 (TileTemplateType_TileWide310x150PeekImageCollection05) = 20, TileWide310x150PeekImageCollection06 (TileTemplateType_TileWide310x150PeekImageCollection06) = 21, TileWide310x150PeekImageAndText01 (TileTemplateType_TileWide310x150PeekImageAndText01) = 22, TileWide310x150PeekImageAndText02 (TileTemplateType_TileWide310x150PeekImageAndText02) = 23, TileWide310x150PeekImage01 (TileTemplateType_TileWide310x150PeekImage01) = 24, TileWide310x150PeekImage02 (TileTemplateType_TileWide310x150PeekImage02) = 25, TileWide310x150PeekImage03 (TileTemplateType_TileWide310x150PeekImage03) = 26, TileWide310x150PeekImage04 (TileTemplateType_TileWide310x150PeekImage04) = 27, TileWide310x150PeekImage05 (TileTemplateType_TileWide310x150PeekImage05) = 28, TileWide310x150PeekImage06 (TileTemplateType_TileWide310x150PeekImage06) = 29, TileWide310x150SmallImageAndText01 (TileTemplateType_TileWide310x150SmallImageAndText01) = 30, TileWide310x150SmallImageAndText02 (TileTemplateType_TileWide310x150SmallImageAndText02) = 31, TileWide310x150SmallImageAndText03 (TileTemplateType_TileWide310x150SmallImageAndText03) = 32, TileWide310x150SmallImageAndText04 (TileTemplateType_TileWide310x150SmallImageAndText04) = 33, TileWide310x150SmallImageAndText05 (TileTemplateType_TileWide310x150SmallImageAndText05) = 34, TileWide310x150Text01 (TileTemplateType_TileWide310x150Text01) = 35, TileWide310x150Text02 (TileTemplateType_TileWide310x150Text02) = 36, TileWide310x150Text03 (TileTemplateType_TileWide310x150Text03) = 37, TileWide310x150Text04 (TileTemplateType_TileWide310x150Text04) = 38, TileWide310x150Text05 (TileTemplateType_TileWide310x150Text05) = 39, TileWide310x150Text06 (TileTemplateType_TileWide310x150Text06) = 40, TileWide310x150Text07 (TileTemplateType_TileWide310x150Text07) = 41, TileWide310x150Text08 (TileTemplateType_TileWide310x150Text08) = 42, TileWide310x150Text09 (TileTemplateType_TileWide310x150Text09) = 43, TileWide310x150Text10 (TileTemplateType_TileWide310x150Text10) = 44, TileWide310x150Text11 (TileTemplateType_TileWide310x150Text11) = 45, TileSquare310x310BlockAndText01 (TileTemplateType_TileSquare310x310BlockAndText01) = 46, TileSquare310x310BlockAndText02 (TileTemplateType_TileSquare310x310BlockAndText02) = 47, TileSquare310x310Image (TileTemplateType_TileSquare310x310Image) = 48, TileSquare310x310ImageAndText01 (TileTemplateType_TileSquare310x310ImageAndText01) = 49, TileSquare310x310ImageAndText02 (TileTemplateType_TileSquare310x310ImageAndText02) = 50, TileSquare310x310ImageAndTextOverlay01 (TileTemplateType_TileSquare310x310ImageAndTextOverlay01) = 51, TileSquare310x310ImageAndTextOverlay02 (TileTemplateType_TileSquare310x310ImageAndTextOverlay02) = 52, TileSquare310x310ImageAndTextOverlay03 (TileTemplateType_TileSquare310x310ImageAndTextOverlay03) = 53, TileSquare310x310ImageCollectionAndText01 (TileTemplateType_TileSquare310x310ImageCollectionAndText01) = 54, TileSquare310x310ImageCollectionAndText02 (TileTemplateType_TileSquare310x310ImageCollectionAndText02) = 55, TileSquare310x310ImageCollection (TileTemplateType_TileSquare310x310ImageCollection) = 56, TileSquare310x310SmallImagesAndTextList01 (TileTemplateType_TileSquare310x310SmallImagesAndTextList01) = 57, TileSquare310x310SmallImagesAndTextList02 (TileTemplateType_TileSquare310x310SmallImagesAndTextList02) = 58, TileSquare310x310SmallImagesAndTextList03 (TileTemplateType_TileSquare310x310SmallImagesAndTextList03) = 59, TileSquare310x310SmallImagesAndTextList04 (TileTemplateType_TileSquare310x310SmallImagesAndTextList04) = 60, TileSquare310x310Text01 (TileTemplateType_TileSquare310x310Text01) = 61, TileSquare310x310Text02 (TileTemplateType_TileSquare310x310Text02) = 62, TileSquare310x310Text03 (TileTemplateType_TileSquare310x310Text03) = 63, TileSquare310x310Text04 (TileTemplateType_TileSquare310x310Text04) = 64, TileSquare310x310Text05 (TileTemplateType_TileSquare310x310Text05) = 65, TileSquare310x310Text06 (TileTemplateType_TileSquare310x310Text06) = 66, TileSquare310x310Text07 (TileTemplateType_TileSquare310x310Text07) = 67, TileSquare310x310Text08 (TileTemplateType_TileSquare310x310Text08) = 68, TileSquare310x310TextList01 (TileTemplateType_TileSquare310x310TextList01) = 69, TileSquare310x310TextList02 (TileTemplateType_TileSquare310x310TextList02) = 70, TileSquare310x310TextList03 (TileTemplateType_TileSquare310x310TextList03) = 71, TileSquare310x310SmallImageAndText01 (TileTemplateType_TileSquare310x310SmallImageAndText01) = 72, TileSquare310x310SmallImagesAndTextList05 (TileTemplateType_TileSquare310x310SmallImagesAndTextList05) = 73, TileSquare310x310Text09 (TileTemplateType_TileSquare310x310Text09) = 74, TileSquare71x71IconWithBadge (TileTemplateType_TileSquare71x71IconWithBadge) = 75, TileSquare150x150IconWithBadge (TileTemplateType_TileSquare150x150IconWithBadge) = 76, TileWide310x150IconWithBadgeAndText (TileTemplateType_TileWide310x150IconWithBadgeAndText) = 77, TileSquare71x71Image (TileTemplateType_TileSquare71x71Image) = 78, TileTall150x310Image (TileTemplateType_TileTall150x310Image) = 79,
 }}
 RT_CLASS!{static class TileUpdateManager}
@@ -15511,7 +15511,7 @@ impl ITileUpdateManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileUpdateManagerForUser: ITileUpdateManagerForUser}
+RT_CLASS!{class TileUpdateManagerForUser: ITileUpdateManagerForUser ["Windows.UI.Notifications.TileUpdateManagerForUser"]}
 DEFINE_IID!(IID_ITileUpdateManagerStatics, 3658849885, 16041, 18822, 141, 132, 176, 157, 94, 18, 39, 109);
 RT_INTERFACE!{static interface ITileUpdateManagerStatics(ITileUpdateManagerStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ITileUpdateManagerStatics] {
     fn CreateTileUpdaterForApplication(&self, out: *mut *mut TileUpdater) -> HRESULT,
@@ -15619,7 +15619,7 @@ impl ITileUpdater {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileUpdater: ITileUpdater}
+RT_CLASS!{class TileUpdater: ITileUpdater ["Windows.UI.Notifications.TileUpdater"]}
 DEFINE_IID!(IID_ITileUpdater2, 2720427538, 5614, 17389, 131, 245, 101, 179, 82, 187, 26, 132);
 RT_INTERFACE!{interface ITileUpdater2(ITileUpdater2Vtbl): IInspectable(IInspectableVtbl) [IID_ITileUpdater2] {
     fn EnableNotificationQueueForSquare150x150(&self, enable: bool) -> HRESULT,
@@ -15651,7 +15651,7 @@ impl IToastActivatedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastActivatedEventArgs: IToastActivatedEventArgs}
+RT_CLASS!{class ToastActivatedEventArgs: IToastActivatedEventArgs ["Windows.UI.Notifications.ToastActivatedEventArgs"]}
 DEFINE_IID!(IID_IToastCollection, 176931760, 57534, 18520, 188, 42, 137, 223, 224, 179, 40, 99);
 RT_INTERFACE!{interface IToastCollection(IToastCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IToastCollection] {
     fn get_Id(&self, out: *mut HSTRING) -> HRESULT,
@@ -15696,7 +15696,7 @@ impl IToastCollection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastCollection: IToastCollection}
+RT_CLASS!{class ToastCollection: IToastCollection ["Windows.UI.Notifications.ToastCollection"]}
 impl RtActivatable<IToastCollectionFactory> for ToastCollection {}
 impl ToastCollection {
     #[inline] pub fn create_instance(collectionId: &HStringArg, displayName: &HStringArg, launchArgs: &HStringArg, iconUri: &foundation::Uri) -> Result<ComPtr<ToastCollection>> {
@@ -15763,8 +15763,8 @@ impl IToastCollectionManager {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastCollectionManager: IToastCollectionManager}
-RT_ENUM! { enum ToastDismissalReason: i32 {
+RT_CLASS!{class ToastCollectionManager: IToastCollectionManager ["Windows.UI.Notifications.ToastCollectionManager"]}
+RT_ENUM! { enum ToastDismissalReason: i32 ["Windows.UI.Notifications.ToastDismissalReason"] {
     UserCanceled (ToastDismissalReason_UserCanceled) = 0, ApplicationHidden (ToastDismissalReason_ApplicationHidden) = 1, TimedOut (ToastDismissalReason_TimedOut) = 2,
 }}
 DEFINE_IID!(IID_IToastDismissedEventArgs, 1065998645, 55755, 17720, 160, 240, 255, 231, 101, 153, 56, 248);
@@ -15778,7 +15778,7 @@ impl IToastDismissedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastDismissedEventArgs: IToastDismissedEventArgs}
+RT_CLASS!{class ToastDismissedEventArgs: IToastDismissedEventArgs ["Windows.UI.Notifications.ToastDismissedEventArgs"]}
 DEFINE_IID!(IID_IToastFailedEventArgs, 890726498, 53204, 17656, 173, 100, 245, 0, 253, 137, 108, 59);
 RT_INTERFACE!{interface IToastFailedEventArgs(IToastFailedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IToastFailedEventArgs] {
     fn get_ErrorCode(&self, out: *mut foundation::HResult) -> HRESULT
@@ -15790,8 +15790,8 @@ impl IToastFailedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastFailedEventArgs: IToastFailedEventArgs}
-RT_ENUM! { enum ToastHistoryChangedType: i32 {
+RT_CLASS!{class ToastFailedEventArgs: IToastFailedEventArgs ["Windows.UI.Notifications.ToastFailedEventArgs"]}
+RT_ENUM! { enum ToastHistoryChangedType: i32 ["Windows.UI.Notifications.ToastHistoryChangedType"] {
     Cleared (ToastHistoryChangedType_Cleared) = 0, Removed (ToastHistoryChangedType_Removed) = 1, Expired (ToastHistoryChangedType_Expired) = 2, Added (ToastHistoryChangedType_Added) = 3,
 }}
 DEFINE_IID!(IID_IToastNotification, 2575181429, 1438, 20064, 139, 6, 23, 96, 145, 124, 139, 128);
@@ -15850,7 +15850,7 @@ impl IToastNotification {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotification: IToastNotification}
+RT_CLASS!{class ToastNotification: IToastNotification ["Windows.UI.Notifications.ToastNotification"]}
 impl RtActivatable<IToastNotificationFactory> for ToastNotification {}
 impl ToastNotification {
     #[cfg(feature="windows-data")] #[inline] pub fn create_toast_notification(content: &super::super::data::xml::dom::XmlDocument) -> Result<ComPtr<ToastNotification>> {
@@ -15967,7 +15967,7 @@ impl IToastNotificationActionTriggerDetail {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationActionTriggerDetail: IToastNotificationActionTriggerDetail}
+RT_CLASS!{class ToastNotificationActionTriggerDetail: IToastNotificationActionTriggerDetail ["Windows.UI.Notifications.ToastNotificationActionTriggerDetail"]}
 DEFINE_IID!(IID_IToastNotificationFactory, 68307744, 33478, 16937, 177, 9, 253, 158, 212, 102, 43, 83);
 RT_INTERFACE!{static interface IToastNotificationFactory(IToastNotificationFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationFactory] {
     #[cfg(feature="windows-data")] fn CreateToastNotification(&self, content: *mut super::super::data::xml::dom::XmlDocument, out: *mut *mut ToastNotification) -> HRESULT
@@ -16019,7 +16019,7 @@ impl IToastNotificationHistory {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationHistory: IToastNotificationHistory}
+RT_CLASS!{class ToastNotificationHistory: IToastNotificationHistory ["Windows.UI.Notifications.ToastNotificationHistory"]}
 DEFINE_IID!(IID_IToastNotificationHistory2, 1002689107, 12081, 16530, 145, 41, 138, 213, 171, 240, 103, 218);
 RT_INTERFACE!{interface IToastNotificationHistory2(IToastNotificationHistory2Vtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationHistory2] {
     fn GetHistory(&self, out: *mut *mut foundation::collections::IVectorView<ToastNotification>) -> HRESULT,
@@ -16048,7 +16048,7 @@ impl IToastNotificationHistoryChangedTriggerDetail {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationHistoryChangedTriggerDetail: IToastNotificationHistoryChangedTriggerDetail}
+RT_CLASS!{class ToastNotificationHistoryChangedTriggerDetail: IToastNotificationHistoryChangedTriggerDetail ["Windows.UI.Notifications.ToastNotificationHistoryChangedTriggerDetail"]}
 DEFINE_IID!(IID_IToastNotificationHistoryChangedTriggerDetail2, 188148098, 51313, 18939, 186, 187, 37, 189, 188, 76, 196, 91);
 RT_INTERFACE!{interface IToastNotificationHistoryChangedTriggerDetail2(IToastNotificationHistoryChangedTriggerDetail2Vtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationHistoryChangedTriggerDetail2] {
     fn get_CollectionId(&self, out: *mut HSTRING) -> HRESULT
@@ -16118,7 +16118,7 @@ impl IToastNotificationManagerForUser {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotificationManagerForUser: IToastNotificationManagerForUser}
+RT_CLASS!{class ToastNotificationManagerForUser: IToastNotificationManagerForUser ["Windows.UI.Notifications.ToastNotificationManagerForUser"]}
 DEFINE_IID!(IID_IToastNotificationManagerForUser2, 1738302647, 33195, 17090, 136, 25, 201, 88, 118, 119, 83, 244);
 RT_INTERFACE!{interface IToastNotificationManagerForUser2(IToastNotificationManagerForUser2Vtbl): IInspectable(IInspectableVtbl) [IID_IToastNotificationManagerForUser2] {
     fn GetToastNotifierForToastCollectionIdAsync(&self, collectionId: HSTRING, out: *mut *mut foundation::IAsyncOperation<ToastNotifier>) -> HRESULT,
@@ -16210,7 +16210,7 @@ impl IToastNotificationManagerStatics5 {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ToastNotificationPriority: i32 {
+RT_ENUM! { enum ToastNotificationPriority: i32 ["Windows.UI.Notifications.ToastNotificationPriority"] {
     Default (ToastNotificationPriority_Default) = 0, High (ToastNotificationPriority_High) = 1,
 }}
 DEFINE_IID!(IID_IToastNotifier, 1972534163, 1011, 16876, 145, 211, 110, 91, 172, 27, 56, 231);
@@ -16250,7 +16250,7 @@ impl IToastNotifier {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ToastNotifier: IToastNotifier}
+RT_CLASS!{class ToastNotifier: IToastNotifier ["Windows.UI.Notifications.ToastNotifier"]}
 DEFINE_IID!(IID_IToastNotifier2, 893618630, 31745, 19413, 156, 32, 96, 67, 64, 205, 43, 116);
 RT_INTERFACE!{interface IToastNotifier2(IToastNotifier2Vtbl): IInspectable(IInspectableVtbl) [IID_IToastNotifier2] {
     fn UpdateWithTagAndGroup(&self, data: *mut NotificationData, tag: HSTRING, group: HSTRING, out: *mut NotificationUpdateResult) -> HRESULT,
@@ -16284,7 +16284,7 @@ impl IToastNotifier3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ToastTemplateType: i32 {
+RT_ENUM! { enum ToastTemplateType: i32 ["Windows.UI.Notifications.ToastTemplateType"] {
     ToastImageAndText01 (ToastTemplateType_ToastImageAndText01) = 0, ToastImageAndText02 (ToastTemplateType_ToastImageAndText02) = 1, ToastImageAndText03 (ToastTemplateType_ToastImageAndText03) = 2, ToastImageAndText04 (ToastTemplateType_ToastImageAndText04) = 3, ToastText01 (ToastTemplateType_ToastText01) = 4, ToastText02 (ToastTemplateType_ToastText02) = 5, ToastText03 (ToastTemplateType_ToastText03) = 6, ToastText04 (ToastTemplateType_ToastText04) = 7,
 }}
 DEFINE_IID!(IID_IUserNotification, 2918704431, 20051, 17109, 156, 51, 235, 94, 165, 21, 178, 62);
@@ -16317,7 +16317,7 @@ impl IUserNotification {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserNotification: IUserNotification}
+RT_CLASS!{class UserNotification: IUserNotification ["Windows.UI.Notifications.UserNotification"]}
 DEFINE_IID!(IID_IUserNotificationChangedEventArgs, 3065866297, 31183, 19237, 130, 192, 12, 225, 238, 248, 31, 140);
 RT_INTERFACE!{interface IUserNotificationChangedEventArgs(IUserNotificationChangedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IUserNotificationChangedEventArgs] {
     fn get_ChangeKind(&self, out: *mut UserNotificationChangedKind) -> HRESULT,
@@ -16335,8 +16335,8 @@ impl IUserNotificationChangedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserNotificationChangedEventArgs: IUserNotificationChangedEventArgs}
-RT_ENUM! { enum UserNotificationChangedKind: i32 {
+RT_CLASS!{class UserNotificationChangedEventArgs: IUserNotificationChangedEventArgs ["Windows.UI.Notifications.UserNotificationChangedEventArgs"]}
+RT_ENUM! { enum UserNotificationChangedKind: i32 ["Windows.UI.Notifications.UserNotificationChangedKind"] {
     Added (UserNotificationChangedKind_Added) = 0, Removed (UserNotificationChangedKind_Removed) = 1,
 }}
 pub mod management { // Windows.UI.Notifications.Management
@@ -16391,7 +16391,7 @@ impl IUserNotificationListener {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UserNotificationListener: IUserNotificationListener}
+RT_CLASS!{class UserNotificationListener: IUserNotificationListener ["Windows.UI.Notifications.Management.UserNotificationListener"]}
 impl RtActivatable<IUserNotificationListenerStatics> for UserNotificationListener {}
 impl UserNotificationListener {
     #[inline] pub fn get_current() -> Result<Option<ComPtr<UserNotificationListener>>> {
@@ -16399,7 +16399,7 @@ impl UserNotificationListener {
     }
 }
 DEFINE_CLSID!(UserNotificationListener(&[87,105,110,100,111,119,115,46,85,73,46,78,111,116,105,102,105,99,97,116,105,111,110,115,46,77,97,110,97,103,101,109,101,110,116,46,85,115,101,114,78,111,116,105,102,105,99,97,116,105,111,110,76,105,115,116,101,110,101,114,0]) [CLSID_UserNotificationListener]);
-RT_ENUM! { enum UserNotificationListenerAccessStatus: i32 {
+RT_ENUM! { enum UserNotificationListenerAccessStatus: i32 ["Windows.UI.Notifications.Management.UserNotificationListenerAccessStatus"] {
     Unspecified (UserNotificationListenerAccessStatus_Unspecified) = 0, Allowed (UserNotificationListenerAccessStatus_Allowed) = 1, Denied (UserNotificationListenerAccessStatus_Denied) = 2,
 }}
 DEFINE_IID!(IID_IUserNotificationListenerStatics, 4284556239, 17286, 19107, 183, 61, 184, 4, 229, 182, 59, 35);
@@ -16489,7 +16489,7 @@ impl IMessageDialog {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class MessageDialog: IMessageDialog}
+RT_CLASS!{class MessageDialog: IMessageDialog ["Windows.UI.Popups.MessageDialog"]}
 impl RtActivatable<IMessageDialogFactory> for MessageDialog {}
 impl MessageDialog {
     #[inline] pub fn create(content: &HStringArg) -> Result<ComPtr<MessageDialog>> {
@@ -16517,10 +16517,10 @@ impl IMessageDialogFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum MessageDialogOptions: u32 {
+RT_ENUM! { enum MessageDialogOptions: u32 ["Windows.UI.Popups.MessageDialogOptions"] {
     None (MessageDialogOptions_None) = 0, AcceptUserInputAfterDelay (MessageDialogOptions_AcceptUserInputAfterDelay) = 1,
 }}
-RT_ENUM! { enum Placement: i32 {
+RT_ENUM! { enum Placement: i32 ["Windows.UI.Popups.Placement"] {
     Default (Placement_Default) = 0, Above (Placement_Above) = 1, Below (Placement_Below) = 2, Left (Placement_Left) = 3, Right (Placement_Right) = 4,
 }}
 DEFINE_IID!(IID_IPopupMenu, 1318831836, 34829, 18428, 160, 161, 114, 182, 57, 230, 37, 89);
@@ -16552,7 +16552,7 @@ impl IPopupMenu {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class PopupMenu: IPopupMenu}
+RT_CLASS!{class PopupMenu: IPopupMenu ["Windows.UI.Popups.PopupMenu"]}
 impl RtActivatable<IActivationFactory> for PopupMenu {}
 DEFINE_CLSID!(PopupMenu(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,80,111,112,117,112,77,101,110,117,0]) [CLSID_PopupMenu]);
 DEFINE_IID!(IID_IUICommand, 1341733493, 16709, 18431, 172, 127, 223, 241, 193, 250, 91, 15);
@@ -16593,7 +16593,7 @@ impl IUICommand {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UICommand: IUICommand}
+RT_CLASS!{class UICommand: IUICommand ["Windows.UI.Popups.UICommand"]}
 impl RtActivatable<IUICommandFactory> for UICommand {}
 impl RtActivatable<IActivationFactory> for UICommand {}
 impl UICommand {
@@ -16641,7 +16641,7 @@ impl UICommandInvokedHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UICommandSeparator: IUICommand}
+RT_CLASS!{class UICommandSeparator: IUICommand ["Windows.UI.Popups.UICommandSeparator"]}
 impl RtActivatable<IActivationFactory> for UICommandSeparator {}
 DEFINE_CLSID!(UICommandSeparator(&[87,105,110,100,111,119,115,46,85,73,46,80,111,112,117,112,115,46,85,73,67,111,109,109,97,110,100,83,101,112,97,114,97,116,111,114,0]) [CLSID_UICommandSeparator]);
 } // Windows.UI.Popups
@@ -16677,7 +16677,7 @@ impl IAdaptiveCardBuilderStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SecurityAppKind: i32 {
+RT_ENUM! { enum SecurityAppKind: i32 ["Windows.UI.Shell.SecurityAppKind"] {
     WebProtection (SecurityAppKind_WebProtection) = 0,
 }}
 DEFINE_IID!(IID_ISecurityAppManager, 2527875084, 44756, 22045, 189, 232, 149, 53, 32, 52, 58, 45);
@@ -16701,13 +16701,13 @@ impl ISecurityAppManager {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecurityAppManager: ISecurityAppManager}
+RT_CLASS!{class SecurityAppManager: ISecurityAppManager ["Windows.UI.Shell.SecurityAppManager"]}
 impl RtActivatable<IActivationFactory> for SecurityAppManager {}
 DEFINE_CLSID!(SecurityAppManager(&[87,105,110,100,111,119,115,46,85,73,46,83,104,101,108,108,46,83,101,99,117,114,105,116,121,65,112,112,77,97,110,97,103,101,114,0]) [CLSID_SecurityAppManager]);
-RT_ENUM! { enum SecurityAppState: i32 {
+RT_ENUM! { enum SecurityAppState: i32 ["Windows.UI.Shell.SecurityAppState"] {
     Disabled (SecurityAppState_Disabled) = 0, Enabled (SecurityAppState_Enabled) = 1,
 }}
-RT_ENUM! { enum SecurityAppSubstatus: i32 {
+RT_ENUM! { enum SecurityAppSubstatus: i32 ["Windows.UI.Shell.SecurityAppSubstatus"] {
     Undetermined (SecurityAppSubstatus_Undetermined) = 0, NoActionNeeded (SecurityAppSubstatus_NoActionNeeded) = 1, ActionRecommended (SecurityAppSubstatus_ActionRecommended) = 2, ActionNeeded (SecurityAppSubstatus_ActionNeeded) = 3,
 }}
 DEFINE_IID!(IID_ITaskbarManager, 2269710873, 6873, 18932, 178, 232, 134, 115, 141, 197, 172, 64);
@@ -16751,7 +16751,7 @@ impl ITaskbarManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TaskbarManager: ITaskbarManager}
+RT_CLASS!{class TaskbarManager: ITaskbarManager ["Windows.UI.Shell.TaskbarManager"]}
 impl RtActivatable<ITaskbarManagerStatics> for TaskbarManager {}
 impl TaskbarManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<TaskbarManager>>> {
@@ -16796,7 +16796,7 @@ impl ITaskbarManagerStatics {
 } // Windows.UI.Shell
 pub mod startscreen { // Windows.UI.StartScreen
 use ::prelude::*;
-RT_ENUM! { enum ForegroundText: i32 {
+RT_ENUM! { enum ForegroundText: i32 ["Windows.UI.StartScreen.ForegroundText"] {
     Dark (ForegroundText_Dark) = 0, Light (ForegroundText_Light) = 1,
 }}
 DEFINE_IID!(IID_IJumpList, 2955103294, 52591, 19638, 166, 17, 97, 253, 80, 95, 62, 209);
@@ -16827,7 +16827,7 @@ impl IJumpList {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class JumpList: IJumpList}
+RT_CLASS!{class JumpList: IJumpList ["Windows.UI.StartScreen.JumpList"]}
 impl RtActivatable<IJumpListStatics> for JumpList {}
 impl JumpList {
     #[inline] pub fn load_current_async() -> Result<ComPtr<foundation::IAsyncOperation<JumpList>>> {
@@ -16905,7 +16905,7 @@ impl IJumpListItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class JumpListItem: IJumpListItem}
+RT_CLASS!{class JumpListItem: IJumpListItem ["Windows.UI.StartScreen.JumpListItem"]}
 impl RtActivatable<IJumpListItemStatics> for JumpListItem {}
 impl JumpListItem {
     #[inline] pub fn create_with_arguments(arguments: &HStringArg, displayName: &HStringArg) -> Result<Option<ComPtr<JumpListItem>>> {
@@ -16916,7 +16916,7 @@ impl JumpListItem {
     }
 }
 DEFINE_CLSID!(JumpListItem(&[87,105,110,100,111,119,115,46,85,73,46,83,116,97,114,116,83,99,114,101,101,110,46,74,117,109,112,76,105,115,116,73,116,101,109,0]) [CLSID_JumpListItem]);
-RT_ENUM! { enum JumpListItemKind: i32 {
+RT_ENUM! { enum JumpListItemKind: i32 ["Windows.UI.StartScreen.JumpListItemKind"] {
     Arguments (JumpListItemKind_Arguments) = 0, Separator (JumpListItemKind_Separator) = 1,
 }}
 DEFINE_IID!(IID_IJumpListItemStatics, 4055876840, 51114, 18891, 141, 222, 236, 252, 205, 122, 215, 228);
@@ -16953,7 +16953,7 @@ impl IJumpListStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum JumpListSystemGroupKind: i32 {
+RT_ENUM! { enum JumpListSystemGroupKind: i32 ["Windows.UI.StartScreen.JumpListSystemGroupKind"] {
     None (JumpListSystemGroupKind_None) = 0, Frequent (JumpListSystemGroupKind_Frequent) = 1, Recent (JumpListSystemGroupKind_Recent) = 2,
 }}
 DEFINE_IID!(IID_ISecondaryTile, 2661175776, 11189, 19392, 187, 141, 66, 178, 58, 188, 200, 141);
@@ -17147,7 +17147,7 @@ impl ISecondaryTile {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryTile: ISecondaryTile}
+RT_CLASS!{class SecondaryTile: ISecondaryTile ["Windows.UI.StartScreen.SecondaryTile"]}
 impl RtActivatable<ISecondaryTileFactory> for SecondaryTile {}
 impl RtActivatable<ISecondaryTileFactory2> for SecondaryTile {}
 impl RtActivatable<ISecondaryTileStatics> for SecondaryTile {}
@@ -17401,7 +17401,7 @@ impl ISecondaryTileVisualElements {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SecondaryTileVisualElements: ISecondaryTileVisualElements}
+RT_CLASS!{class SecondaryTileVisualElements: ISecondaryTileVisualElements ["Windows.UI.StartScreen.SecondaryTileVisualElements"]}
 DEFINE_IID!(IID_ISecondaryTileVisualElements2, 4247663056, 22492, 18324, 142, 207, 86, 130, 245, 243, 230, 239);
 RT_INTERFACE!{interface ISecondaryTileVisualElements2(ISecondaryTileVisualElements2Vtbl): IInspectable(IInspectableVtbl) [IID_ISecondaryTileVisualElements2] {
     fn put_Square71x71Logo(&self, value: *mut foundation::Uri) -> HRESULT,
@@ -17475,7 +17475,7 @@ impl IStartScreenManager {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class StartScreenManager: IStartScreenManager}
+RT_CLASS!{class StartScreenManager: IStartScreenManager ["Windows.UI.StartScreen.StartScreenManager"]}
 impl RtActivatable<IStartScreenManagerStatics> for StartScreenManager {}
 impl StartScreenManager {
     #[inline] pub fn get_default() -> Result<Option<ComPtr<StartScreenManager>>> {
@@ -17547,7 +17547,7 @@ impl ITileMixedRealityModel {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class TileMixedRealityModel: ITileMixedRealityModel}
+RT_CLASS!{class TileMixedRealityModel: ITileMixedRealityModel ["Windows.UI.StartScreen.TileMixedRealityModel"]}
 DEFINE_IID!(IID_ITileMixedRealityModel2, 1133801650, 55237, 16651, 131, 25, 148, 134, 162, 123, 108, 103);
 RT_INTERFACE!{interface ITileMixedRealityModel2(ITileMixedRealityModel2Vtbl): IInspectable(IInspectableVtbl) [IID_ITileMixedRealityModel2] {
     fn put_ActivationBehavior(&self, value: TileMixedRealityModelActivationBehavior) -> HRESULT,
@@ -17564,13 +17564,13 @@ impl ITileMixedRealityModel2 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TileMixedRealityModelActivationBehavior: i32 {
+RT_ENUM! { enum TileMixedRealityModelActivationBehavior: i32 ["Windows.UI.StartScreen.TileMixedRealityModelActivationBehavior"] {
     Default (TileMixedRealityModelActivationBehavior_Default) = 0, None (TileMixedRealityModelActivationBehavior_None) = 1,
 }}
-RT_ENUM! { enum TileOptions: u32 {
+RT_ENUM! { enum TileOptions: u32 ["Windows.UI.StartScreen.TileOptions"] {
     None (TileOptions_None) = 0, ShowNameOnLogo (TileOptions_ShowNameOnLogo) = 1, ShowNameOnWideLogo (TileOptions_ShowNameOnWideLogo) = 2, CopyOnDeployment (TileOptions_CopyOnDeployment) = 4,
 }}
-RT_ENUM! { enum TileSize: i32 {
+RT_ENUM! { enum TileSize: i32 ["Windows.UI.StartScreen.TileSize"] {
     Default (TileSize_Default) = 0, Square30x30 (TileSize_Square30x30) = 1, Square70x70 (TileSize_Square70x70) = 2, Square150x150 (TileSize_Square150x150) = 3, Wide310x150 (TileSize_Wide310x150) = 4, Square310x310 (TileSize_Square310x310) = 5, Square71x71 (TileSize_Square71x71) = 6, Square44x44 (TileSize_Square44x44) = 7,
 }}
 DEFINE_IID!(IID_IVisualElementsRequest, 3241685818, 37640, 16498, 136, 204, 208, 104, 219, 52, 124, 104);
@@ -17602,7 +17602,7 @@ impl IVisualElementsRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisualElementsRequest: IVisualElementsRequest}
+RT_CLASS!{class VisualElementsRequest: IVisualElementsRequest ["Windows.UI.StartScreen.VisualElementsRequest"]}
 DEFINE_IID!(IID_IVisualElementsRequestDeferral, 2707779248, 294, 17239, 130, 4, 189, 130, 187, 42, 4, 109);
 RT_INTERFACE!{interface IVisualElementsRequestDeferral(IVisualElementsRequestDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IVisualElementsRequestDeferral] {
     fn Complete(&self) -> HRESULT
@@ -17613,7 +17613,7 @@ impl IVisualElementsRequestDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisualElementsRequestDeferral: IVisualElementsRequestDeferral}
+RT_CLASS!{class VisualElementsRequestDeferral: IVisualElementsRequestDeferral ["Windows.UI.StartScreen.VisualElementsRequestDeferral"]}
 DEFINE_IID!(IID_IVisualElementsRequestedEventArgs, 2070923650, 14861, 20174, 175, 150, 205, 23, 225, 176, 11, 45);
 RT_INTERFACE!{interface IVisualElementsRequestedEventArgs(IVisualElementsRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IVisualElementsRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut VisualElementsRequest) -> HRESULT
@@ -17625,11 +17625,11 @@ impl IVisualElementsRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class VisualElementsRequestedEventArgs: IVisualElementsRequestedEventArgs}
+RT_CLASS!{class VisualElementsRequestedEventArgs: IVisualElementsRequestedEventArgs ["Windows.UI.StartScreen.VisualElementsRequestedEventArgs"]}
 } // Windows.UI.StartScreen
 pub mod text { // Windows.UI.Text
 use ::prelude::*;
-RT_ENUM! { enum CaretType: i32 {
+RT_ENUM! { enum CaretType: i32 ["Windows.UI.Text.CaretType"] {
     Normal (CaretType_Normal) = 0, Null (CaretType_Null) = 1,
 }}
 DEFINE_IID!(IID_IContentLinkInfo, 517285157, 7263, 18635, 179, 53, 120, 181, 10, 46, 230, 66);
@@ -17692,26 +17692,26 @@ impl IContentLinkInfo {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ContentLinkInfo: IContentLinkInfo}
+RT_CLASS!{class ContentLinkInfo: IContentLinkInfo ["Windows.UI.Text.ContentLinkInfo"]}
 impl RtActivatable<IActivationFactory> for ContentLinkInfo {}
 DEFINE_CLSID!(ContentLinkInfo(&[87,105,110,100,111,119,115,46,85,73,46,84,101,120,116,46,67,111,110,116,101,110,116,76,105,110,107,73,110,102,111,0]) [CLSID_ContentLinkInfo]);
-RT_ENUM! { enum FindOptions: u32 {
+RT_ENUM! { enum FindOptions: u32 ["Windows.UI.Text.FindOptions"] {
     None (FindOptions_None) = 0, Word (FindOptions_Word) = 2, Case (FindOptions_Case) = 4,
 }}
-RT_ENUM! { enum FontStretch: i32 {
+RT_ENUM! { enum FontStretch: i32 ["Windows.UI.Text.FontStretch"] {
     Undefined (FontStretch_Undefined) = 0, UltraCondensed (FontStretch_UltraCondensed) = 1, ExtraCondensed (FontStretch_ExtraCondensed) = 2, Condensed (FontStretch_Condensed) = 3, SemiCondensed (FontStretch_SemiCondensed) = 4, Normal (FontStretch_Normal) = 5, SemiExpanded (FontStretch_SemiExpanded) = 6, Expanded (FontStretch_Expanded) = 7, ExtraExpanded (FontStretch_ExtraExpanded) = 8, UltraExpanded (FontStretch_UltraExpanded) = 9,
 }}
-RT_ENUM! { enum FontStyle: i32 {
+RT_ENUM! { enum FontStyle: i32 ["Windows.UI.Text.FontStyle"] {
     Normal (FontStyle_Normal) = 0, Oblique (FontStyle_Oblique) = 1, Italic (FontStyle_Italic) = 2,
 }}
-RT_STRUCT! { struct FontWeight {
+RT_STRUCT! { struct FontWeight ["Windows.UI.Text.FontWeight"] {
     Weight: u16,
 }}
 DEFINE_IID!(IID_IFontWeights, 2021696580, 427, 18839, 133, 23, 223, 130, 42, 12, 69, 241);
 RT_INTERFACE!{interface IFontWeights(IFontWeightsVtbl): IInspectable(IInspectableVtbl) [IID_IFontWeights] {
     
 }}
-RT_CLASS!{class FontWeights: IFontWeights}
+RT_CLASS!{class FontWeights: IFontWeights ["Windows.UI.Text.FontWeights"]}
 impl RtActivatable<IFontWeightsStatics> for FontWeights {}
 impl FontWeights {
     #[inline] pub fn get_black() -> Result<FontWeight> {
@@ -17820,43 +17820,43 @@ impl IFontWeightsStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum FormatEffect: i32 {
+RT_ENUM! { enum FormatEffect: i32 ["Windows.UI.Text.FormatEffect"] {
     Off (FormatEffect_Off) = 0, On (FormatEffect_On) = 1, Toggle (FormatEffect_Toggle) = 2, Undefined (FormatEffect_Undefined) = 3,
 }}
-RT_ENUM! { enum HorizontalCharacterAlignment: i32 {
+RT_ENUM! { enum HorizontalCharacterAlignment: i32 ["Windows.UI.Text.HorizontalCharacterAlignment"] {
     Left (HorizontalCharacterAlignment_Left) = 0, Right (HorizontalCharacterAlignment_Right) = 1, Center (HorizontalCharacterAlignment_Center) = 2,
 }}
-RT_ENUM! { enum LetterCase: i32 {
+RT_ENUM! { enum LetterCase: i32 ["Windows.UI.Text.LetterCase"] {
     Lower (LetterCase_Lower) = 0, Upper (LetterCase_Upper) = 1,
 }}
-RT_ENUM! { enum LineSpacingRule: i32 {
+RT_ENUM! { enum LineSpacingRule: i32 ["Windows.UI.Text.LineSpacingRule"] {
     Undefined (LineSpacingRule_Undefined) = 0, Single (LineSpacingRule_Single) = 1, OneAndHalf (LineSpacingRule_OneAndHalf) = 2, Double (LineSpacingRule_Double) = 3, AtLeast (LineSpacingRule_AtLeast) = 4, Exactly (LineSpacingRule_Exactly) = 5, Multiple (LineSpacingRule_Multiple) = 6, Percent (LineSpacingRule_Percent) = 7,
 }}
-RT_ENUM! { enum LinkType: i32 {
+RT_ENUM! { enum LinkType: i32 ["Windows.UI.Text.LinkType"] {
     Undefined (LinkType_Undefined) = 0, NotALink (LinkType_NotALink) = 1, ClientLink (LinkType_ClientLink) = 2, FriendlyLinkName (LinkType_FriendlyLinkName) = 3, FriendlyLinkAddress (LinkType_FriendlyLinkAddress) = 4, AutoLink (LinkType_AutoLink) = 5, AutoLinkEmail (LinkType_AutoLinkEmail) = 6, AutoLinkPhone (LinkType_AutoLinkPhone) = 7, AutoLinkPath (LinkType_AutoLinkPath) = 8,
 }}
-RT_ENUM! { enum MarkerAlignment: i32 {
+RT_ENUM! { enum MarkerAlignment: i32 ["Windows.UI.Text.MarkerAlignment"] {
     Undefined (MarkerAlignment_Undefined) = 0, Left (MarkerAlignment_Left) = 1, Center (MarkerAlignment_Center) = 2, Right (MarkerAlignment_Right) = 3,
 }}
-RT_ENUM! { enum MarkerStyle: i32 {
+RT_ENUM! { enum MarkerStyle: i32 ["Windows.UI.Text.MarkerStyle"] {
     Undefined (MarkerStyle_Undefined) = 0, Parenthesis (MarkerStyle_Parenthesis) = 1, Parentheses (MarkerStyle_Parentheses) = 2, Period (MarkerStyle_Period) = 3, Plain (MarkerStyle_Plain) = 4, Minus (MarkerStyle_Minus) = 5, NoNumber (MarkerStyle_NoNumber) = 6,
 }}
-RT_ENUM! { enum MarkerType: i32 {
+RT_ENUM! { enum MarkerType: i32 ["Windows.UI.Text.MarkerType"] {
     Undefined (MarkerType_Undefined) = 0, None (MarkerType_None) = 1, Bullet (MarkerType_Bullet) = 2, Arabic (MarkerType_Arabic) = 3, LowercaseEnglishLetter (MarkerType_LowercaseEnglishLetter) = 4, UppercaseEnglishLetter (MarkerType_UppercaseEnglishLetter) = 5, LowercaseRoman (MarkerType_LowercaseRoman) = 6, UppercaseRoman (MarkerType_UppercaseRoman) = 7, UnicodeSequence (MarkerType_UnicodeSequence) = 8, CircledNumber (MarkerType_CircledNumber) = 9, BlackCircleWingding (MarkerType_BlackCircleWingding) = 10, WhiteCircleWingding (MarkerType_WhiteCircleWingding) = 11, ArabicWide (MarkerType_ArabicWide) = 12, SimplifiedChinese (MarkerType_SimplifiedChinese) = 13, TraditionalChinese (MarkerType_TraditionalChinese) = 14, JapanSimplifiedChinese (MarkerType_JapanSimplifiedChinese) = 15, JapanKorea (MarkerType_JapanKorea) = 16, ArabicDictionary (MarkerType_ArabicDictionary) = 17, ArabicAbjad (MarkerType_ArabicAbjad) = 18, Hebrew (MarkerType_Hebrew) = 19, ThaiAlphabetic (MarkerType_ThaiAlphabetic) = 20, ThaiNumeric (MarkerType_ThaiNumeric) = 21, DevanagariVowel (MarkerType_DevanagariVowel) = 22, DevanagariConsonant (MarkerType_DevanagariConsonant) = 23, DevanagariNumeric (MarkerType_DevanagariNumeric) = 24,
 }}
-RT_ENUM! { enum ParagraphAlignment: i32 {
+RT_ENUM! { enum ParagraphAlignment: i32 ["Windows.UI.Text.ParagraphAlignment"] {
     Undefined (ParagraphAlignment_Undefined) = 0, Left (ParagraphAlignment_Left) = 1, Center (ParagraphAlignment_Center) = 2, Right (ParagraphAlignment_Right) = 3, Justify (ParagraphAlignment_Justify) = 4,
 }}
-RT_ENUM! { enum ParagraphStyle: i32 {
+RT_ENUM! { enum ParagraphStyle: i32 ["Windows.UI.Text.ParagraphStyle"] {
     Undefined (ParagraphStyle_Undefined) = 0, None (ParagraphStyle_None) = 1, Normal (ParagraphStyle_Normal) = 2, Heading1 (ParagraphStyle_Heading1) = 3, Heading2 (ParagraphStyle_Heading2) = 4, Heading3 (ParagraphStyle_Heading3) = 5, Heading4 (ParagraphStyle_Heading4) = 6, Heading5 (ParagraphStyle_Heading5) = 7, Heading6 (ParagraphStyle_Heading6) = 8, Heading7 (ParagraphStyle_Heading7) = 9, Heading8 (ParagraphStyle_Heading8) = 10, Heading9 (ParagraphStyle_Heading9) = 11,
 }}
-RT_ENUM! { enum PointOptions: u32 {
+RT_ENUM! { enum PointOptions: u32 ["Windows.UI.Text.PointOptions"] {
     None (PointOptions_None) = 0, IncludeInset (PointOptions_IncludeInset) = 1, Start (PointOptions_Start) = 32, ClientCoordinates (PointOptions_ClientCoordinates) = 256, AllowOffClient (PointOptions_AllowOffClient) = 512, Transform (PointOptions_Transform) = 1024, NoHorizontalScroll (PointOptions_NoHorizontalScroll) = 65536, NoVerticalScroll (PointOptions_NoVerticalScroll) = 262144,
 }}
-RT_ENUM! { enum RangeGravity: i32 {
+RT_ENUM! { enum RangeGravity: i32 ["Windows.UI.Text.RangeGravity"] {
     UIBehavior (RangeGravity_UIBehavior) = 0, Backward (RangeGravity_Backward) = 1, Forward (RangeGravity_Forward) = 2, Inward (RangeGravity_Inward) = 3, Outward (RangeGravity_Outward) = 4,
 }}
-RT_CLASS!{class RichEditTextDocument: ITextDocument}
+RT_CLASS!{class RichEditTextDocument: ITextDocument ["Windows.UI.Text.RichEditTextDocument"]}
 DEFINE_IID!(IID_IRichEditTextRange, 927872277, 47754, 19054, 140, 89, 13, 222, 61, 12, 245, 205);
 RT_INTERFACE!{interface IRichEditTextRange(IRichEditTextRangeVtbl): IInspectable(IInspectableVtbl) [IID_IRichEditTextRange] {
     fn get_ContentLinkInfo(&self, out: *mut *mut ContentLinkInfo) -> HRESULT,
@@ -17873,17 +17873,17 @@ impl IRichEditTextRange {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class RichEditTextRange: ITextRange}
-RT_ENUM! { enum SelectionOptions: u32 {
+RT_CLASS!{class RichEditTextRange: ITextRange ["Windows.UI.Text.RichEditTextRange"]}
+RT_ENUM! { enum SelectionOptions: u32 ["Windows.UI.Text.SelectionOptions"] {
     StartActive (SelectionOptions_StartActive) = 1, AtEndOfLine (SelectionOptions_AtEndOfLine) = 2, Overtype (SelectionOptions_Overtype) = 4, Active (SelectionOptions_Active) = 8, Replace (SelectionOptions_Replace) = 16,
 }}
-RT_ENUM! { enum SelectionType: i32 {
+RT_ENUM! { enum SelectionType: i32 ["Windows.UI.Text.SelectionType"] {
     None (SelectionType_None) = 0, InsertionPoint (SelectionType_InsertionPoint) = 1, Normal (SelectionType_Normal) = 2, InlineShape (SelectionType_InlineShape) = 7, Shape (SelectionType_Shape) = 8,
 }}
-RT_ENUM! { enum TabAlignment: i32 {
+RT_ENUM! { enum TabAlignment: i32 ["Windows.UI.Text.TabAlignment"] {
     Left (TabAlignment_Left) = 0, Center (TabAlignment_Center) = 1, Right (TabAlignment_Right) = 2, Decimal (TabAlignment_Decimal) = 3, Bar (TabAlignment_Bar) = 4,
 }}
-RT_ENUM! { enum TabLeader: i32 {
+RT_ENUM! { enum TabLeader: i32 ["Windows.UI.Text.TabLeader"] {
     Spaces (TabLeader_Spaces) = 0, Dots (TabLeader_Dots) = 1, Dashes (TabLeader_Dashes) = 2, Lines (TabLeader_Lines) = 3, ThickLines (TabLeader_ThickLines) = 4, Equals (TabLeader_Equals) = 5,
 }}
 DEFINE_IID!(IID_ITextCharacterFormat, 1524560859, 1531, 17453, 128, 101, 100, 42, 254, 160, 44, 237);
@@ -18249,7 +18249,7 @@ impl ITextConstantsStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TextDecorations: u32 {
+RT_ENUM! { enum TextDecorations: u32 ["Windows.UI.Text.TextDecorations"] {
     None (TextDecorations_None) = 0, Underline (TextDecorations_Underline) = 1, Strikethrough (TextDecorations_Strikethrough) = 2,
 }}
 DEFINE_IID!(IID_ITextDocument, 3203288539, 37042, 16524, 162, 246, 10, 10, 195, 30, 51, 228);
@@ -18446,7 +18446,7 @@ impl ITextDocument3 {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TextGetOptions: u32 {
+RT_ENUM! { enum TextGetOptions: u32 ["Windows.UI.Text.TextGetOptions"] {
     None (TextGetOptions_None) = 0, AdjustCrlf (TextGetOptions_AdjustCrlf) = 1, UseCrlf (TextGetOptions_UseCrlf) = 2, UseObjectText (TextGetOptions_UseObjectText) = 4, AllowFinalEop (TextGetOptions_AllowFinalEop) = 8, NoHidden (TextGetOptions_NoHidden) = 32, IncludeNumbering (TextGetOptions_IncludeNumbering) = 64, FormatRtf (TextGetOptions_FormatRtf) = 8192, UseLf (TextGetOptions_UseLf) = 16777216,
 }}
 DEFINE_IID!(IID_ITextParagraphFormat, 754503590, 18038, 18826, 147, 245, 187, 219, 252, 11, 216, 131);
@@ -19016,10 +19016,10 @@ impl ITextRange {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TextRangeUnit: i32 {
+RT_ENUM! { enum TextRangeUnit: i32 ["Windows.UI.Text.TextRangeUnit"] {
     Character (TextRangeUnit_Character) = 0, Word (TextRangeUnit_Word) = 1, Sentence (TextRangeUnit_Sentence) = 2, Paragraph (TextRangeUnit_Paragraph) = 3, Line (TextRangeUnit_Line) = 4, Story (TextRangeUnit_Story) = 5, Screen (TextRangeUnit_Screen) = 6, Section (TextRangeUnit_Section) = 7, Window (TextRangeUnit_Window) = 8, CharacterFormat (TextRangeUnit_CharacterFormat) = 9, ParagraphFormat (TextRangeUnit_ParagraphFormat) = 10, Object (TextRangeUnit_Object) = 11, HardParagraph (TextRangeUnit_HardParagraph) = 12, Cluster (TextRangeUnit_Cluster) = 13, Bold (TextRangeUnit_Bold) = 14, Italic (TextRangeUnit_Italic) = 15, Underline (TextRangeUnit_Underline) = 16, Strikethrough (TextRangeUnit_Strikethrough) = 17, ProtectedText (TextRangeUnit_ProtectedText) = 18, Link (TextRangeUnit_Link) = 19, SmallCaps (TextRangeUnit_SmallCaps) = 20, AllCaps (TextRangeUnit_AllCaps) = 21, Hidden (TextRangeUnit_Hidden) = 22, Outline (TextRangeUnit_Outline) = 23, Shadow (TextRangeUnit_Shadow) = 24, Imprint (TextRangeUnit_Imprint) = 25, Disabled (TextRangeUnit_Disabled) = 26, Revised (TextRangeUnit_Revised) = 27, Subscript (TextRangeUnit_Subscript) = 28, Superscript (TextRangeUnit_Superscript) = 29, FontBound (TextRangeUnit_FontBound) = 30, LinkProtected (TextRangeUnit_LinkProtected) = 31, ContentLink (TextRangeUnit_ContentLink) = 32,
 }}
-RT_ENUM! { enum TextScript: i32 {
+RT_ENUM! { enum TextScript: i32 ["Windows.UI.Text.TextScript"] {
     Undefined (TextScript_Undefined) = 0, Ansi (TextScript_Ansi) = 1, EastEurope (TextScript_EastEurope) = 2, Cyrillic (TextScript_Cyrillic) = 3, Greek (TextScript_Greek) = 4, Turkish (TextScript_Turkish) = 5, Hebrew (TextScript_Hebrew) = 6, Arabic (TextScript_Arabic) = 7, Baltic (TextScript_Baltic) = 8, Vietnamese (TextScript_Vietnamese) = 9, Default (TextScript_Default) = 10, Symbol (TextScript_Symbol) = 11, Thai (TextScript_Thai) = 12, ShiftJis (TextScript_ShiftJis) = 13, GB2312 (TextScript_GB2312) = 14, Hangul (TextScript_Hangul) = 15, Big5 (TextScript_Big5) = 16, PC437 (TextScript_PC437) = 17, Oem (TextScript_Oem) = 18, Mac (TextScript_Mac) = 19, Armenian (TextScript_Armenian) = 20, Syriac (TextScript_Syriac) = 21, Thaana (TextScript_Thaana) = 22, Devanagari (TextScript_Devanagari) = 23, Bengali (TextScript_Bengali) = 24, Gurmukhi (TextScript_Gurmukhi) = 25, Gujarati (TextScript_Gujarati) = 26, Oriya (TextScript_Oriya) = 27, Tamil (TextScript_Tamil) = 28, Telugu (TextScript_Telugu) = 29, Kannada (TextScript_Kannada) = 30, Malayalam (TextScript_Malayalam) = 31, Sinhala (TextScript_Sinhala) = 32, Lao (TextScript_Lao) = 33, Tibetan (TextScript_Tibetan) = 34, Myanmar (TextScript_Myanmar) = 35, Georgian (TextScript_Georgian) = 36, Jamo (TextScript_Jamo) = 37, Ethiopic (TextScript_Ethiopic) = 38, Cherokee (TextScript_Cherokee) = 39, Aboriginal (TextScript_Aboriginal) = 40, Ogham (TextScript_Ogham) = 41, Runic (TextScript_Runic) = 42, Khmer (TextScript_Khmer) = 43, Mongolian (TextScript_Mongolian) = 44, Braille (TextScript_Braille) = 45, Yi (TextScript_Yi) = 46, Limbu (TextScript_Limbu) = 47, TaiLe (TextScript_TaiLe) = 48, NewTaiLue (TextScript_NewTaiLue) = 49, SylotiNagri (TextScript_SylotiNagri) = 50, Kharoshthi (TextScript_Kharoshthi) = 51, Kayahli (TextScript_Kayahli) = 52, UnicodeSymbol (TextScript_UnicodeSymbol) = 53, Emoji (TextScript_Emoji) = 54, Glagolitic (TextScript_Glagolitic) = 55, Lisu (TextScript_Lisu) = 56, Vai (TextScript_Vai) = 57, NKo (TextScript_NKo) = 58, Osmanya (TextScript_Osmanya) = 59, PhagsPa (TextScript_PhagsPa) = 60, Gothic (TextScript_Gothic) = 61, Deseret (TextScript_Deseret) = 62, Tifinagh (TextScript_Tifinagh) = 63,
 }}
 DEFINE_IID!(IID_ITextSelection, 2798872356, 62095, 17162, 178, 207, 195, 67, 103, 30, 192, 233);
@@ -19085,13 +19085,13 @@ impl ITextSelection {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum TextSetOptions: u32 {
+RT_ENUM! { enum TextSetOptions: u32 ["Windows.UI.Text.TextSetOptions"] {
     None (TextSetOptions_None) = 0, UnicodeBidi (TextSetOptions_UnicodeBidi) = 1, Unlink (TextSetOptions_Unlink) = 8, Unhide (TextSetOptions_Unhide) = 16, CheckTextLimit (TextSetOptions_CheckTextLimit) = 32, FormatRtf (TextSetOptions_FormatRtf) = 8192, ApplyRtfDocumentDefaults (TextSetOptions_ApplyRtfDocumentDefaults) = 16384,
 }}
-RT_ENUM! { enum UnderlineType: i32 {
+RT_ENUM! { enum UnderlineType: i32 ["Windows.UI.Text.UnderlineType"] {
     Undefined (UnderlineType_Undefined) = 0, None (UnderlineType_None) = 1, Single (UnderlineType_Single) = 2, Words (UnderlineType_Words) = 3, Double (UnderlineType_Double) = 4, Dotted (UnderlineType_Dotted) = 5, Dash (UnderlineType_Dash) = 6, DashDot (UnderlineType_DashDot) = 7, DashDotDot (UnderlineType_DashDotDot) = 8, Wave (UnderlineType_Wave) = 9, Thick (UnderlineType_Thick) = 10, Thin (UnderlineType_Thin) = 11, DoubleWave (UnderlineType_DoubleWave) = 12, HeavyWave (UnderlineType_HeavyWave) = 13, LongDash (UnderlineType_LongDash) = 14, ThickDash (UnderlineType_ThickDash) = 15, ThickDashDot (UnderlineType_ThickDashDot) = 16, ThickDashDotDot (UnderlineType_ThickDashDotDot) = 17, ThickDotted (UnderlineType_ThickDotted) = 18, ThickLongDash (UnderlineType_ThickLongDash) = 19,
 }}
-RT_ENUM! { enum VerticalCharacterAlignment: i32 {
+RT_ENUM! { enum VerticalCharacterAlignment: i32 ["Windows.UI.Text.VerticalCharacterAlignment"] {
     Top (VerticalCharacterAlignment_Top) = 0, Baseline (VerticalCharacterAlignment_Baseline) = 1, Bottom (VerticalCharacterAlignment_Bottom) = 2,
 }}
 pub mod core { // Windows.UI.Text.Core
@@ -19119,7 +19119,7 @@ impl ICoreTextCompositionCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextCompositionCompletedEventArgs: ICoreTextCompositionCompletedEventArgs}
+RT_CLASS!{class CoreTextCompositionCompletedEventArgs: ICoreTextCompositionCompletedEventArgs ["Windows.UI.Text.Core.CoreTextCompositionCompletedEventArgs"]}
 DEFINE_IID!(IID_ICoreTextCompositionSegment, 2003594201, 20141, 19879, 143, 71, 58, 136, 181, 35, 204, 52);
 RT_INTERFACE!{interface ICoreTextCompositionSegment(ICoreTextCompositionSegmentVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextCompositionSegment] {
     fn get_PreconversionString(&self, out: *mut HSTRING) -> HRESULT,
@@ -19137,7 +19137,7 @@ impl ICoreTextCompositionSegment {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextCompositionSegment: ICoreTextCompositionSegment}
+RT_CLASS!{class CoreTextCompositionSegment: ICoreTextCompositionSegment ["Windows.UI.Text.Core.CoreTextCompositionSegment"]}
 DEFINE_IID!(IID_ICoreTextCompositionStartedEventArgs, 661329577, 25831, 19120, 188, 75, 160, 45, 115, 131, 91, 251);
 RT_INTERFACE!{interface ICoreTextCompositionStartedEventArgs(ICoreTextCompositionStartedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextCompositionStartedEventArgs] {
     fn get_IsCanceled(&self, out: *mut bool) -> HRESULT,
@@ -19155,7 +19155,7 @@ impl ICoreTextCompositionStartedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextCompositionStartedEventArgs: ICoreTextCompositionStartedEventArgs}
+RT_CLASS!{class CoreTextCompositionStartedEventArgs: ICoreTextCompositionStartedEventArgs ["Windows.UI.Text.Core.CoreTextCompositionStartedEventArgs"]}
 DEFINE_IID!(IID_ICoreTextEditContext, 3211135151, 16449, 18371, 178, 99, 169, 24, 235, 94, 174, 242);
 RT_INTERFACE!{interface ICoreTextEditContext(ICoreTextEditContextVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextEditContext] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -19329,7 +19329,7 @@ impl ICoreTextEditContext {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextEditContext: ICoreTextEditContext}
+RT_CLASS!{class CoreTextEditContext: ICoreTextEditContext ["Windows.UI.Text.Core.CoreTextEditContext"]}
 DEFINE_IID!(IID_ICoreTextEditContext2, 2978381243, 2107, 18913, 178, 129, 43, 53, 214, 43, 244, 102);
 RT_INTERFACE!{interface ICoreTextEditContext2(ICoreTextEditContext2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextEditContext2] {
     fn add_NotifyFocusLeaveCompleted(&self, handler: *mut foundation::TypedEventHandler<CoreTextEditContext, IInspectable>, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -19410,17 +19410,17 @@ impl ICoreTextFormatUpdatingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextFormatUpdatingEventArgs: ICoreTextFormatUpdatingEventArgs}
-RT_ENUM! { enum CoreTextFormatUpdatingReason: i32 {
+RT_CLASS!{class CoreTextFormatUpdatingEventArgs: ICoreTextFormatUpdatingEventArgs ["Windows.UI.Text.Core.CoreTextFormatUpdatingEventArgs"]}
+RT_ENUM! { enum CoreTextFormatUpdatingReason: i32 ["Windows.UI.Text.Core.CoreTextFormatUpdatingReason"] {
     None (CoreTextFormatUpdatingReason_None) = 0, CompositionUnconverted (CoreTextFormatUpdatingReason_CompositionUnconverted) = 1, CompositionConverted (CoreTextFormatUpdatingReason_CompositionConverted) = 2, CompositionTargetUnconverted (CoreTextFormatUpdatingReason_CompositionTargetUnconverted) = 3, CompositionTargetConverted (CoreTextFormatUpdatingReason_CompositionTargetConverted) = 4,
 }}
-RT_ENUM! { enum CoreTextFormatUpdatingResult: i32 {
+RT_ENUM! { enum CoreTextFormatUpdatingResult: i32 ["Windows.UI.Text.Core.CoreTextFormatUpdatingResult"] {
     Succeeded (CoreTextFormatUpdatingResult_Succeeded) = 0, Failed (CoreTextFormatUpdatingResult_Failed) = 1,
 }}
-RT_ENUM! { enum CoreTextInputPaneDisplayPolicy: i32 {
+RT_ENUM! { enum CoreTextInputPaneDisplayPolicy: i32 ["Windows.UI.Text.Core.CoreTextInputPaneDisplayPolicy"] {
     Automatic (CoreTextInputPaneDisplayPolicy_Automatic) = 0, Manual (CoreTextInputPaneDisplayPolicy_Manual) = 1,
 }}
-RT_ENUM! { enum CoreTextInputScope: i32 {
+RT_ENUM! { enum CoreTextInputScope: i32 ["Windows.UI.Text.Core.CoreTextInputScope"] {
     Default (CoreTextInputScope_Default) = 0, Url (CoreTextInputScope_Url) = 1, FilePath (CoreTextInputScope_FilePath) = 2, FileName (CoreTextInputScope_FileName) = 3, EmailUserName (CoreTextInputScope_EmailUserName) = 4, EmailAddress (CoreTextInputScope_EmailAddress) = 5, UserName (CoreTextInputScope_UserName) = 6, PersonalFullName (CoreTextInputScope_PersonalFullName) = 7, PersonalNamePrefix (CoreTextInputScope_PersonalNamePrefix) = 8, PersonalGivenName (CoreTextInputScope_PersonalGivenName) = 9, PersonalMiddleName (CoreTextInputScope_PersonalMiddleName) = 10, PersonalSurname (CoreTextInputScope_PersonalSurname) = 11, PersonalNameSuffix (CoreTextInputScope_PersonalNameSuffix) = 12, Address (CoreTextInputScope_Address) = 13, AddressPostalCode (CoreTextInputScope_AddressPostalCode) = 14, AddressStreet (CoreTextInputScope_AddressStreet) = 15, AddressStateOrProvince (CoreTextInputScope_AddressStateOrProvince) = 16, AddressCity (CoreTextInputScope_AddressCity) = 17, AddressCountryName (CoreTextInputScope_AddressCountryName) = 18, AddressCountryShortName (CoreTextInputScope_AddressCountryShortName) = 19, CurrencyAmountAndSymbol (CoreTextInputScope_CurrencyAmountAndSymbol) = 20, CurrencyAmount (CoreTextInputScope_CurrencyAmount) = 21, Date (CoreTextInputScope_Date) = 22, DateMonth (CoreTextInputScope_DateMonth) = 23, DateDay (CoreTextInputScope_DateDay) = 24, DateYear (CoreTextInputScope_DateYear) = 25, DateMonthName (CoreTextInputScope_DateMonthName) = 26, DateDayName (CoreTextInputScope_DateDayName) = 27, Number (CoreTextInputScope_Number) = 29, SingleCharacter (CoreTextInputScope_SingleCharacter) = 30, Password (CoreTextInputScope_Password) = 31, TelephoneNumber (CoreTextInputScope_TelephoneNumber) = 32, TelephoneCountryCode (CoreTextInputScope_TelephoneCountryCode) = 33, TelephoneAreaCode (CoreTextInputScope_TelephoneAreaCode) = 34, TelephoneLocalNumber (CoreTextInputScope_TelephoneLocalNumber) = 35, Time (CoreTextInputScope_Time) = 36, TimeHour (CoreTextInputScope_TimeHour) = 37, TimeMinuteOrSecond (CoreTextInputScope_TimeMinuteOrSecond) = 38, NumberFullWidth (CoreTextInputScope_NumberFullWidth) = 39, AlphanumericHalfWidth (CoreTextInputScope_AlphanumericHalfWidth) = 40, AlphanumericFullWidth (CoreTextInputScope_AlphanumericFullWidth) = 41, CurrencyChinese (CoreTextInputScope_CurrencyChinese) = 42, Bopomofo (CoreTextInputScope_Bopomofo) = 43, Hiragana (CoreTextInputScope_Hiragana) = 44, KatakanaHalfWidth (CoreTextInputScope_KatakanaHalfWidth) = 45, KatakanaFullWidth (CoreTextInputScope_KatakanaFullWidth) = 46, Hanja (CoreTextInputScope_Hanja) = 47, HangulHalfWidth (CoreTextInputScope_HangulHalfWidth) = 48, HangulFullWidth (CoreTextInputScope_HangulFullWidth) = 49, Search (CoreTextInputScope_Search) = 50, Formula (CoreTextInputScope_Formula) = 51, SearchIncremental (CoreTextInputScope_SearchIncremental) = 52, ChineseHalfWidth (CoreTextInputScope_ChineseHalfWidth) = 53, ChineseFullWidth (CoreTextInputScope_ChineseFullWidth) = 54, NativeScript (CoreTextInputScope_NativeScript) = 55, Text (CoreTextInputScope_Text) = 57, Chat (CoreTextInputScope_Chat) = 58, NameOrPhoneNumber (CoreTextInputScope_NameOrPhoneNumber) = 59, EmailUserNameOrAddress (CoreTextInputScope_EmailUserNameOrAddress) = 60, Private (CoreTextInputScope_Private) = 61, Maps (CoreTextInputScope_Maps) = 62, PasswordNumeric (CoreTextInputScope_PasswordNumeric) = 63, FormulaNumber (CoreTextInputScope_FormulaNumber) = 67, ChatWithoutEmoji (CoreTextInputScope_ChatWithoutEmoji) = 68, Digits (CoreTextInputScope_Digits) = 28, PinNumeric (CoreTextInputScope_PinNumeric) = 64, PinAlphanumeric (CoreTextInputScope_PinAlphanumeric) = 65,
 }}
 DEFINE_IID!(IID_ICoreTextLayoutBounds, 3916614004, 17462, 18711, 128, 208, 165, 37, 228, 202, 103, 128);
@@ -19450,7 +19450,7 @@ impl ICoreTextLayoutBounds {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextLayoutBounds: ICoreTextLayoutBounds}
+RT_CLASS!{class CoreTextLayoutBounds: ICoreTextLayoutBounds ["Windows.UI.Text.Core.CoreTextLayoutBounds"]}
 DEFINE_IID!(IID_ICoreTextLayoutRequest, 626370764, 20989, 20227, 152, 191, 172, 120, 23, 77, 104, 224);
 RT_INTERFACE!{interface ICoreTextLayoutRequest(ICoreTextLayoutRequestVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextLayoutRequest] {
     fn get_Range(&self, out: *mut CoreTextRange) -> HRESULT,
@@ -19480,7 +19480,7 @@ impl ICoreTextLayoutRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextLayoutRequest: ICoreTextLayoutRequest}
+RT_CLASS!{class CoreTextLayoutRequest: ICoreTextLayoutRequest ["Windows.UI.Text.Core.CoreTextLayoutRequest"]}
 DEFINE_IID!(IID_ICoreTextLayoutRequest2, 1735255588, 52541, 19405, 191, 1, 127, 113, 16, 149, 69, 17);
 RT_INTERFACE!{interface ICoreTextLayoutRequest2(ICoreTextLayoutRequest2Vtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextLayoutRequest2] {
     fn get_LayoutBoundsVisualPixels(&self, out: *mut *mut CoreTextLayoutBounds) -> HRESULT
@@ -19503,8 +19503,8 @@ impl ICoreTextLayoutRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextLayoutRequestedEventArgs: ICoreTextLayoutRequestedEventArgs}
-RT_STRUCT! { struct CoreTextRange {
+RT_CLASS!{class CoreTextLayoutRequestedEventArgs: ICoreTextLayoutRequestedEventArgs ["Windows.UI.Text.Core.CoreTextLayoutRequestedEventArgs"]}
+RT_STRUCT! { struct CoreTextRange ["Windows.UI.Text.Core.CoreTextRange"] {
     StartCaretPosition: i32, EndCaretPosition: i32,
 }}
 DEFINE_IID!(IID_ICoreTextSelectionRequest, 4037477379, 8331, 17153, 136, 60, 116, 202, 116, 133, 253, 141);
@@ -19535,7 +19535,7 @@ impl ICoreTextSelectionRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextSelectionRequest: ICoreTextSelectionRequest}
+RT_CLASS!{class CoreTextSelectionRequest: ICoreTextSelectionRequest ["Windows.UI.Text.Core.CoreTextSelectionRequest"]}
 DEFINE_IID!(IID_ICoreTextSelectionRequestedEventArgs, 331769899, 62996, 16922, 143, 75, 158, 200, 165, 163, 127, 205);
 RT_INTERFACE!{interface ICoreTextSelectionRequestedEventArgs(ICoreTextSelectionRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextSelectionRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut CoreTextSelectionRequest) -> HRESULT
@@ -19547,7 +19547,7 @@ impl ICoreTextSelectionRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextSelectionRequestedEventArgs: ICoreTextSelectionRequestedEventArgs}
+RT_CLASS!{class CoreTextSelectionRequestedEventArgs: ICoreTextSelectionRequestedEventArgs ["Windows.UI.Text.Core.CoreTextSelectionRequestedEventArgs"]}
 DEFINE_IID!(IID_ICoreTextSelectionUpdatingEventArgs, 3561325471, 65151, 19413, 138, 38, 9, 34, 193, 179, 230, 57);
 RT_INTERFACE!{interface ICoreTextSelectionUpdatingEventArgs(ICoreTextSelectionUpdatingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextSelectionUpdatingEventArgs] {
     fn get_Selection(&self, out: *mut CoreTextRange) -> HRESULT,
@@ -19582,8 +19582,8 @@ impl ICoreTextSelectionUpdatingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextSelectionUpdatingEventArgs: ICoreTextSelectionUpdatingEventArgs}
-RT_ENUM! { enum CoreTextSelectionUpdatingResult: i32 {
+RT_CLASS!{class CoreTextSelectionUpdatingEventArgs: ICoreTextSelectionUpdatingEventArgs ["Windows.UI.Text.Core.CoreTextSelectionUpdatingEventArgs"]}
+RT_ENUM! { enum CoreTextSelectionUpdatingResult: i32 ["Windows.UI.Text.Core.CoreTextSelectionUpdatingResult"] {
     Succeeded (CoreTextSelectionUpdatingResult_Succeeded) = 0, Failed (CoreTextSelectionUpdatingResult_Failed) = 1,
 }}
 RT_CLASS!{static class CoreTextServicesConstants}
@@ -19623,7 +19623,7 @@ impl ICoreTextServicesManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextServicesManager: ICoreTextServicesManager}
+RT_CLASS!{class CoreTextServicesManager: ICoreTextServicesManager ["Windows.UI.Text.Core.CoreTextServicesManager"]}
 impl RtActivatable<ICoreTextServicesManagerStatics> for CoreTextServicesManager {}
 impl CoreTextServicesManager {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<CoreTextServicesManager>>> {
@@ -19687,7 +19687,7 @@ impl ICoreTextTextRequest {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextTextRequest: ICoreTextTextRequest}
+RT_CLASS!{class CoreTextTextRequest: ICoreTextTextRequest ["Windows.UI.Text.Core.CoreTextTextRequest"]}
 DEFINE_IID!(IID_ICoreTextTextRequestedEventArgs, 4036403920, 16838, 19458, 139, 26, 217, 83, 176, 12, 171, 179);
 RT_INTERFACE!{interface ICoreTextTextRequestedEventArgs(ICoreTextTextRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextTextRequestedEventArgs] {
     fn get_Request(&self, out: *mut *mut CoreTextTextRequest) -> HRESULT
@@ -19699,7 +19699,7 @@ impl ICoreTextTextRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextTextRequestedEventArgs: ICoreTextTextRequestedEventArgs}
+RT_CLASS!{class CoreTextTextRequestedEventArgs: ICoreTextTextRequestedEventArgs ["Windows.UI.Text.Core.CoreTextTextRequestedEventArgs"]}
 DEFINE_IID!(IID_ICoreTextTextUpdatingEventArgs, 4003959181, 52267, 20227, 143, 246, 2, 253, 33, 125, 180, 80);
 RT_INTERFACE!{interface ICoreTextTextUpdatingEventArgs(ICoreTextTextUpdatingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreTextTextUpdatingEventArgs] {
     fn get_Range(&self, out: *mut CoreTextRange) -> HRESULT,
@@ -19753,8 +19753,8 @@ impl ICoreTextTextUpdatingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreTextTextUpdatingEventArgs: ICoreTextTextUpdatingEventArgs}
-RT_ENUM! { enum CoreTextTextUpdatingResult: i32 {
+RT_CLASS!{class CoreTextTextUpdatingEventArgs: ICoreTextTextUpdatingEventArgs ["Windows.UI.Text.Core.CoreTextTextUpdatingEventArgs"]}
+RT_ENUM! { enum CoreTextTextUpdatingResult: i32 ["Windows.UI.Text.Core.CoreTextTextUpdatingResult"] {
     Succeeded (CoreTextTextUpdatingResult_Succeeded) = 0, Failed (CoreTextTextUpdatingResult_Failed) = 1,
 }}
 } // Windows.UI.Text.Core
@@ -19789,7 +19789,7 @@ impl IAccessibilitySettings {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AccessibilitySettings: IAccessibilitySettings}
+RT_CLASS!{class AccessibilitySettings: IAccessibilitySettings ["Windows.UI.ViewManagement.AccessibilitySettings"]}
 impl RtActivatable<IActivationFactory> for AccessibilitySettings {}
 DEFINE_CLSID!(AccessibilitySettings(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,65,99,99,101,115,115,105,98,105,108,105,116,121,83,101,116,116,105,110,103,115,0]) [CLSID_AccessibilitySettings]);
 DEFINE_IID!(IID_IActivationViewSwitcher, 3701939126, 29520, 18731, 170, 199, 200, 161, 61, 114, 36, 173);
@@ -19815,7 +19815,7 @@ impl IActivationViewSwitcher {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivationViewSwitcher: IActivationViewSwitcher}
+RT_CLASS!{class ActivationViewSwitcher: IActivationViewSwitcher ["Windows.UI.ViewManagement.ActivationViewSwitcher"]}
 DEFINE_IID!(IID_IApplicationView, 3525498137, 17249, 17694, 150, 196, 96, 244, 249, 116, 45, 176);
 RT_INTERFACE!{interface IApplicationView(IApplicationViewVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationView] {
     fn get_Orientation(&self, out: *mut ApplicationViewOrientation) -> HRESULT,
@@ -19890,7 +19890,7 @@ impl IApplicationView {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationView: IApplicationView}
+RT_CLASS!{class ApplicationView: IApplicationView ["Windows.UI.ViewManagement.ApplicationView"]}
 impl RtActivatable<IApplicationViewFullscreenStatics> for ApplicationView {}
 impl RtActivatable<IApplicationViewInteropStatics> for ApplicationView {}
 impl RtActivatable<IApplicationViewStatics> for ApplicationView {}
@@ -20067,7 +20067,7 @@ impl IApplicationView4 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ApplicationViewBoundsMode: i32 {
+RT_ENUM! { enum ApplicationViewBoundsMode: i32 ["Windows.UI.ViewManagement.ApplicationViewBoundsMode"] {
     UseVisible (ApplicationViewBoundsMode_UseVisible) = 0, UseCoreWindow (ApplicationViewBoundsMode_UseCoreWindow) = 1,
 }}
 DEFINE_IID!(IID_IApplicationViewConsolidatedEventArgs, 1363429868, 32418, 19943, 166, 166, 125, 251, 170, 235, 182, 251);
@@ -20081,7 +20081,7 @@ impl IApplicationViewConsolidatedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationViewConsolidatedEventArgs: IApplicationViewConsolidatedEventArgs}
+RT_CLASS!{class ApplicationViewConsolidatedEventArgs: IApplicationViewConsolidatedEventArgs ["Windows.UI.ViewManagement.ApplicationViewConsolidatedEventArgs"]}
 DEFINE_IID!(IID_IApplicationViewConsolidatedEventArgs2, 471441100, 28097, 16628, 175, 238, 7, 217, 234, 41, 100, 48);
 RT_INTERFACE!{interface IApplicationViewConsolidatedEventArgs2(IApplicationViewConsolidatedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IApplicationViewConsolidatedEventArgs2] {
     fn get_IsAppInitiated(&self, out: *mut bool) -> HRESULT
@@ -20115,17 +20115,17 @@ impl IApplicationViewInteropStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ApplicationViewMode: i32 {
+RT_ENUM! { enum ApplicationViewMode: i32 ["Windows.UI.ViewManagement.ApplicationViewMode"] {
     Default (ApplicationViewMode_Default) = 0, CompactOverlay (ApplicationViewMode_CompactOverlay) = 1,
 }}
-RT_ENUM! { enum ApplicationViewOrientation: i32 {
+RT_ENUM! { enum ApplicationViewOrientation: i32 ["Windows.UI.ViewManagement.ApplicationViewOrientation"] {
     Landscape (ApplicationViewOrientation_Landscape) = 0, Portrait (ApplicationViewOrientation_Portrait) = 1,
 }}
 DEFINE_IID!(IID_IApplicationViewScaling, 487447587, 9203, 19245, 132, 254, 116, 191, 55, 180, 139, 102);
 RT_INTERFACE!{interface IApplicationViewScaling(IApplicationViewScalingVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationViewScaling] {
     
 }}
-RT_CLASS!{class ApplicationViewScaling: IApplicationViewScaling}
+RT_CLASS!{class ApplicationViewScaling: IApplicationViewScaling ["Windows.UI.ViewManagement.ApplicationViewScaling"]}
 impl RtActivatable<IApplicationViewScalingStatics> for ApplicationViewScaling {}
 impl ApplicationViewScaling {
     #[inline] pub fn get_disable_layout_scaling() -> Result<bool> {
@@ -20153,7 +20153,7 @@ impl IApplicationViewScalingStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ApplicationViewState: i32 {
+RT_ENUM! { enum ApplicationViewState: i32 ["Windows.UI.ViewManagement.ApplicationViewState"] {
     FullScreenLandscape (ApplicationViewState_FullScreenLandscape) = 0, Filled (ApplicationViewState_Filled) = 1, Snapped (ApplicationViewState_Snapped) = 2, FullScreenPortrait (ApplicationViewState_FullScreenPortrait) = 3,
 }}
 DEFINE_IID!(IID_IApplicationViewStatics, 17457926, 50227, 17637, 169, 242, 189, 132, 212, 3, 10, 149);
@@ -20341,7 +20341,7 @@ impl IApplicationViewSwitcherStatics3 {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ApplicationViewSwitchingOptions: u32 {
+RT_ENUM! { enum ApplicationViewSwitchingOptions: u32 ["Windows.UI.ViewManagement.ApplicationViewSwitchingOptions"] {
     Default (ApplicationViewSwitchingOptions_Default) = 0, SkipAnimation (ApplicationViewSwitchingOptions_SkipAnimation) = 1, ConsolidateViews (ApplicationViewSwitchingOptions_ConsolidateViews) = 2,
 }}
 DEFINE_IID!(IID_IApplicationViewTitleBar, 9587392, 37675, 19051, 156, 75, 220, 56, 200, 36, 120, 206);
@@ -20481,7 +20481,7 @@ impl IApplicationViewTitleBar {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationViewTitleBar: IApplicationViewTitleBar}
+RT_CLASS!{class ApplicationViewTitleBar: IApplicationViewTitleBar ["Windows.UI.ViewManagement.ApplicationViewTitleBar"]}
 DEFINE_IID!(IID_IApplicationViewTransferContext, 2239020131, 15383, 16526, 148, 8, 138, 26, 158, 168, 27, 250);
 RT_INTERFACE!{interface IApplicationViewTransferContext(IApplicationViewTransferContextVtbl): IInspectable(IInspectableVtbl) [IID_IApplicationViewTransferContext] {
     fn get_ViewId(&self, out: *mut i32) -> HRESULT,
@@ -20498,7 +20498,7 @@ impl IApplicationViewTransferContext {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ApplicationViewTransferContext: IApplicationViewTransferContext}
+RT_CLASS!{class ApplicationViewTransferContext: IApplicationViewTransferContext ["Windows.UI.ViewManagement.ApplicationViewTransferContext"]}
 impl RtActivatable<IApplicationViewTransferContextStatics> for ApplicationViewTransferContext {}
 impl RtActivatable<IActivationFactory> for ApplicationViewTransferContext {}
 impl ApplicationViewTransferContext {
@@ -20518,13 +20518,13 @@ impl IApplicationViewTransferContextStatics {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ApplicationViewWindowingMode: i32 {
+RT_ENUM! { enum ApplicationViewWindowingMode: i32 ["Windows.UI.ViewManagement.ApplicationViewWindowingMode"] {
     Auto (ApplicationViewWindowingMode_Auto) = 0, PreferredLaunchViewSize (ApplicationViewWindowingMode_PreferredLaunchViewSize) = 1, FullScreen (ApplicationViewWindowingMode_FullScreen) = 2, CompactOverlay (ApplicationViewWindowingMode_CompactOverlay) = 3, Maximized (ApplicationViewWindowingMode_Maximized) = 4,
 }}
-RT_ENUM! { enum FullScreenSystemOverlayMode: i32 {
+RT_ENUM! { enum FullScreenSystemOverlayMode: i32 ["Windows.UI.ViewManagement.FullScreenSystemOverlayMode"] {
     Standard (FullScreenSystemOverlayMode_Standard) = 0, Minimal (FullScreenSystemOverlayMode_Minimal) = 1,
 }}
-RT_ENUM! { enum HandPreference: i32 {
+RT_ENUM! { enum HandPreference: i32 ["Windows.UI.ViewManagement.HandPreference"] {
     LeftHanded (HandPreference_LeftHanded) = 0, RightHanded (HandPreference_RightHanded) = 1,
 }}
 DEFINE_IID!(IID_IInputPane, 1678432880, 1779, 19591, 166, 120, 152, 41, 201, 18, 124, 40);
@@ -20560,7 +20560,7 @@ impl IInputPane {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InputPane: IInputPane}
+RT_CLASS!{class InputPane: IInputPane ["Windows.UI.ViewManagement.InputPane"]}
 impl RtActivatable<IInputPaneStatics> for InputPane {}
 impl InputPane {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<InputPane>>> {
@@ -20634,7 +20634,7 @@ impl IInputPaneVisibilityEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class InputPaneVisibilityEventArgs: IInputPaneVisibilityEventArgs}
+RT_CLASS!{class InputPaneVisibilityEventArgs: IInputPaneVisibilityEventArgs ["Windows.UI.ViewManagement.InputPaneVisibilityEventArgs"]}
 RT_CLASS!{static class ProjectionManager}
 impl RtActivatable<IProjectionManagerStatics> for ProjectionManager {}
 impl RtActivatable<IProjectionManagerStatics2> for ProjectionManager {}
@@ -20741,10 +20741,10 @@ impl IProjectionManagerStatics2 {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UIColorType: i32 {
+RT_ENUM! { enum UIColorType: i32 ["Windows.UI.ViewManagement.UIColorType"] {
     Background (UIColorType_Background) = 0, Foreground (UIColorType_Foreground) = 1, AccentDark3 (UIColorType_AccentDark3) = 2, AccentDark2 (UIColorType_AccentDark2) = 3, AccentDark1 (UIColorType_AccentDark1) = 4, Accent (UIColorType_Accent) = 5, AccentLight1 (UIColorType_AccentLight1) = 6, AccentLight2 (UIColorType_AccentLight2) = 7, AccentLight3 (UIColorType_AccentLight3) = 8, Complement (UIColorType_Complement) = 9,
 }}
-RT_ENUM! { enum UIElementType: i32 {
+RT_ENUM! { enum UIElementType: i32 ["Windows.UI.ViewManagement.UIElementType"] {
     ActiveCaption (UIElementType_ActiveCaption) = 0, Background (UIElementType_Background) = 1, ButtonFace (UIElementType_ButtonFace) = 2, ButtonText (UIElementType_ButtonText) = 3, CaptionText (UIElementType_CaptionText) = 4, GrayText (UIElementType_GrayText) = 5, Highlight (UIElementType_Highlight) = 6, HighlightText (UIElementType_HighlightText) = 7, Hotlight (UIElementType_Hotlight) = 8, InactiveCaption (UIElementType_InactiveCaption) = 9, InactiveCaptionText (UIElementType_InactiveCaptionText) = 10, Window (UIElementType_Window) = 11, WindowText (UIElementType_WindowText) = 12, AccentColor (UIElementType_AccentColor) = 1000, TextHigh (UIElementType_TextHigh) = 1001, TextMedium (UIElementType_TextMedium) = 1002, TextLow (UIElementType_TextLow) = 1003, TextContrastWithHigh (UIElementType_TextContrastWithHigh) = 1004, NonTextHigh (UIElementType_NonTextHigh) = 1005, NonTextMediumHigh (UIElementType_NonTextMediumHigh) = 1006, NonTextMedium (UIElementType_NonTextMedium) = 1007, NonTextMediumLow (UIElementType_NonTextMediumLow) = 1008, NonTextLow (UIElementType_NonTextLow) = 1009, PageBackground (UIElementType_PageBackground) = 1010, PopupBackground (UIElementType_PopupBackground) = 1011, OverlayOutsidePopup (UIElementType_OverlayOutsidePopup) = 1012,
 }}
 DEFINE_IID!(IID_IUISettings, 2234914304, 7267, 17959, 188, 177, 58, 137, 224, 188, 156, 85);
@@ -20830,7 +20830,7 @@ impl IUISettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UISettings: IUISettings}
+RT_CLASS!{class UISettings: IUISettings ["Windows.UI.ViewManagement.UISettings"]}
 impl RtActivatable<IActivationFactory> for UISettings {}
 DEFINE_CLSID!(UISettings(&[87,105,110,100,111,119,115,46,85,73,46,86,105,101,119,77,97,110,97,103,101,109,101,110,116,46,85,73,83,101,116,116,105,110,103,115,0]) [CLSID_UISettings]);
 DEFINE_IID!(IID_IUISettings2, 3134727169, 10017, 17657, 187, 145, 43, 178, 40, 190, 68, 47);
@@ -20910,7 +20910,7 @@ impl IUIViewSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class UIViewSettings: IUIViewSettings}
+RT_CLASS!{class UIViewSettings: IUIViewSettings ["Windows.UI.ViewManagement.UIViewSettings"]}
 impl RtActivatable<IUIViewSettingsStatics> for UIViewSettings {}
 impl UIViewSettings {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<UIViewSettings>>> {
@@ -20929,7 +20929,7 @@ impl IUIViewSettingsStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum UserInteractionMode: i32 {
+RT_ENUM! { enum UserInteractionMode: i32 ["Windows.UI.ViewManagement.UserInteractionMode"] {
     Mouse (UserInteractionMode_Mouse) = 0, Touch (UserInteractionMode_Touch) = 1,
 }}
 DEFINE_IID!(IID_IViewModePreferences, 2274348346, 2969, 17097, 132, 208, 211, 241, 212, 3, 85, 75);
@@ -20959,7 +20959,7 @@ impl IViewModePreferences {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ViewModePreferences: IViewModePreferences}
+RT_CLASS!{class ViewModePreferences: IViewModePreferences ["Windows.UI.ViewManagement.ViewModePreferences"]}
 impl RtActivatable<IViewModePreferencesStatics> for ViewModePreferences {}
 impl ViewModePreferences {
     #[inline] pub fn create_default(mode: ApplicationViewMode) -> Result<Option<ComPtr<ViewModePreferences>>> {
@@ -20978,7 +20978,7 @@ impl IViewModePreferencesStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum ViewSizePreference: i32 {
+RT_ENUM! { enum ViewSizePreference: i32 ["Windows.UI.ViewManagement.ViewSizePreference"] {
     Default (ViewSizePreference_Default) = 0, UseLess (ViewSizePreference_UseLess) = 1, UseHalf (ViewSizePreference_UseHalf) = 2, UseMore (ViewSizePreference_UseMore) = 3, UseMinimum (ViewSizePreference_UseMinimum) = 4, UseNone (ViewSizePreference_UseNone) = 5, Custom (ViewSizePreference_Custom) = 6,
 }}
 pub mod core { // Windows.UI.ViewManagement.Core
@@ -21017,7 +21017,7 @@ impl ICoreInputView {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreInputView: ICoreInputView}
+RT_CLASS!{class CoreInputView: ICoreInputView ["Windows.UI.ViewManagement.Core.CoreInputView"]}
 impl RtActivatable<ICoreInputViewStatics> for CoreInputView {}
 impl CoreInputView {
     #[inline] pub fn get_for_current_view() -> Result<Option<ComPtr<CoreInputView>>> {
@@ -21081,7 +21081,7 @@ impl ICoreInputView3 {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum CoreInputViewKind: i32 {
+RT_ENUM! { enum CoreInputViewKind: i32 ["Windows.UI.ViewManagement.Core.CoreInputViewKind"] {
     Default (CoreInputViewKind_Default) = 0, Keyboard (CoreInputViewKind_Keyboard) = 1, Handwriting (CoreInputViewKind_Handwriting) = 2, Emoji (CoreInputViewKind_Emoji) = 3,
 }}
 DEFINE_IID!(IID_ICoreInputViewOcclusion, 3426143750, 14437, 16759, 181, 245, 139, 101, 224, 185, 206, 132);
@@ -21101,8 +21101,8 @@ impl ICoreInputViewOcclusion {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreInputViewOcclusion: ICoreInputViewOcclusion}
-RT_ENUM! { enum CoreInputViewOcclusionKind: i32 {
+RT_CLASS!{class CoreInputViewOcclusion: ICoreInputViewOcclusion ["Windows.UI.ViewManagement.Core.CoreInputViewOcclusion"]}
+RT_ENUM! { enum CoreInputViewOcclusionKind: i32 ["Windows.UI.ViewManagement.Core.CoreInputViewOcclusionKind"] {
     Docked (CoreInputViewOcclusionKind_Docked) = 0, Floating (CoreInputViewOcclusionKind_Floating) = 1, Overlay (CoreInputViewOcclusionKind_Overlay) = 2,
 }}
 DEFINE_IID!(IID_ICoreInputViewOcclusionsChangedEventArgs, 3188729832, 46062, 19959, 149, 84, 137, 205, 198, 96, 130, 194);
@@ -21127,7 +21127,7 @@ impl ICoreInputViewOcclusionsChangedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreInputViewOcclusionsChangedEventArgs: ICoreInputViewOcclusionsChangedEventArgs}
+RT_CLASS!{class CoreInputViewOcclusionsChangedEventArgs: ICoreInputViewOcclusionsChangedEventArgs ["Windows.UI.ViewManagement.Core.CoreInputViewOcclusionsChangedEventArgs"]}
 DEFINE_IID!(IID_ICoreInputViewStatics, 2107348941, 60862, 18895, 165, 79, 51, 125, 224, 82, 144, 127);
 RT_INTERFACE!{static interface ICoreInputViewStatics(ICoreInputViewStaticsVtbl): IInspectable(IInspectableVtbl) [IID_ICoreInputViewStatics] {
     fn GetForCurrentView(&self, out: *mut *mut CoreInputView) -> HRESULT
@@ -21178,8 +21178,8 @@ impl ICoreInputViewTransferringXYFocusEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class CoreInputViewTransferringXYFocusEventArgs: ICoreInputViewTransferringXYFocusEventArgs}
-RT_ENUM! { enum CoreInputViewXYFocusTransferDirection: i32 {
+RT_CLASS!{class CoreInputViewTransferringXYFocusEventArgs: ICoreInputViewTransferringXYFocusEventArgs ["Windows.UI.ViewManagement.Core.CoreInputViewTransferringXYFocusEventArgs"]}
+RT_ENUM! { enum CoreInputViewXYFocusTransferDirection: i32 ["Windows.UI.ViewManagement.Core.CoreInputViewXYFocusTransferDirection"] {
     Up (CoreInputViewXYFocusTransferDirection_Up) = 0, Right (CoreInputViewXYFocusTransferDirection_Right) = 1, Down (CoreInputViewXYFocusTransferDirection_Down) = 2, Left (CoreInputViewXYFocusTransferDirection_Left) = 3,
 }}
 } // Windows.UI.ViewManagement.Core
@@ -21196,7 +21196,7 @@ impl IActivatedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivatedDeferral: IActivatedDeferral}
+RT_CLASS!{class ActivatedDeferral: IActivatedDeferral ["Windows.UI.WebUI.ActivatedDeferral"]}
 DEFINE_IID!(IID_IActivatedEventArgsDeferral, 3396165492, 25538, 17574, 185, 123, 217, 160, 60, 32, 188, 155);
 RT_INTERFACE!{interface IActivatedEventArgsDeferral(IActivatedEventArgsDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IActivatedEventArgsDeferral] {
     fn get_ActivatedOperation(&self, out: *mut *mut ActivatedOperation) -> HRESULT
@@ -21229,9 +21229,9 @@ impl IActivatedOperation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ActivatedOperation: IActivatedOperation}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class BackgroundActivatedEventArgs: super::super::applicationmodel::activation::IBackgroundActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class BackgroundActivatedEventArgs: IInspectable}
+RT_CLASS!{class ActivatedOperation: IActivatedOperation ["Windows.UI.WebUI.ActivatedOperation"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class BackgroundActivatedEventArgs: super::super::applicationmodel::activation::IBackgroundActivatedEventArgs ["Windows.UI.WebUI.BackgroundActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class BackgroundActivatedEventArgs: IInspectable ["Windows.UI.WebUI.BackgroundActivatedEventArgs"]}
 DEFINE_IID!(IID_BackgroundActivatedEventHandler, 3987840955, 1889, 18380, 154, 119, 36, 215, 7, 41, 101, 202);
 RT_DELEGATE!{delegate BackgroundActivatedEventHandler(BackgroundActivatedEventHandlerVtbl, BackgroundActivatedEventHandlerImpl) [IID_BackgroundActivatedEventHandler] {
     #[cfg(feature="windows-applicationmodel")] fn Invoke(&self, sender: *mut IInspectable, eventArgs: *mut super::super::applicationmodel::activation::IBackgroundActivatedEventArgs) -> HRESULT
@@ -21242,8 +21242,8 @@ impl BackgroundActivatedEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class EnteredBackgroundEventArgs: super::super::applicationmodel::IEnteredBackgroundEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class EnteredBackgroundEventArgs: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class EnteredBackgroundEventArgs: super::super::applicationmodel::IEnteredBackgroundEventArgs ["Windows.UI.WebUI.EnteredBackgroundEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class EnteredBackgroundEventArgs: IInspectable ["Windows.UI.WebUI.EnteredBackgroundEventArgs"]}
 DEFINE_IID!(IID_EnteredBackgroundEventHandler, 722051443, 46734, 19951, 136, 193, 141, 232, 78, 90, 171, 47);
 RT_DELEGATE!{delegate EnteredBackgroundEventHandler(EnteredBackgroundEventHandlerVtbl, EnteredBackgroundEventHandlerImpl) [IID_EnteredBackgroundEventHandler] {
     #[cfg(feature="windows-applicationmodel")] fn Invoke(&self, sender: *mut IInspectable, e: *mut super::super::applicationmodel::IEnteredBackgroundEventArgs) -> HRESULT
@@ -21359,9 +21359,9 @@ impl IHtmlPrintDocumentSource {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HtmlPrintDocumentSource: IHtmlPrintDocumentSource}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class LeavingBackgroundEventArgs: super::super::applicationmodel::ILeavingBackgroundEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class LeavingBackgroundEventArgs: IInspectable}
+RT_CLASS!{class HtmlPrintDocumentSource: IHtmlPrintDocumentSource ["Windows.UI.WebUI.HtmlPrintDocumentSource"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class LeavingBackgroundEventArgs: super::super::applicationmodel::ILeavingBackgroundEventArgs ["Windows.UI.WebUI.LeavingBackgroundEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class LeavingBackgroundEventArgs: IInspectable ["Windows.UI.WebUI.LeavingBackgroundEventArgs"]}
 DEFINE_IID!(IID_LeavingBackgroundEventHandler, 11848921, 31388, 19307, 154, 196, 19, 71, 79, 38, 139, 196);
 RT_DELEGATE!{delegate LeavingBackgroundEventHandler(LeavingBackgroundEventHandlerVtbl, LeavingBackgroundEventHandlerImpl) [IID_LeavingBackgroundEventHandler] {
     #[cfg(feature="windows-applicationmodel")] fn Invoke(&self, sender: *mut IInspectable, e: *mut super::super::applicationmodel::ILeavingBackgroundEventArgs) -> HRESULT
@@ -21412,8 +21412,8 @@ impl INewWebUIViewCreatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class NewWebUIViewCreatedEventArgs: INewWebUIViewCreatedEventArgs}
-RT_ENUM! { enum PrintContent: i32 {
+RT_CLASS!{class NewWebUIViewCreatedEventArgs: INewWebUIViewCreatedEventArgs ["Windows.UI.WebUI.NewWebUIViewCreatedEventArgs"]}
+RT_ENUM! { enum PrintContent: i32 ["Windows.UI.WebUI.PrintContent"] {
     AllPages (PrintContent_AllPages) = 0, CurrentPage (PrintContent_CurrentPage) = 1, CustomPageRange (PrintContent_CustomPageRange) = 2, CurrentSelection (PrintContent_CurrentSelection) = 3,
 }}
 DEFINE_IID!(IID_ResumingEventHandler, 643406761, 41517, 18438, 167, 40, 172, 173, 193, 208, 117, 250);
@@ -21426,10 +21426,10 @@ impl ResumingEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class SuspendingDeferral: super::super::applicationmodel::ISuspendingDeferral}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class SuspendingDeferral: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class SuspendingEventArgs: super::super::applicationmodel::ISuspendingEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class SuspendingEventArgs: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class SuspendingDeferral: super::super::applicationmodel::ISuspendingDeferral ["Windows.UI.WebUI.SuspendingDeferral"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class SuspendingDeferral: IInspectable ["Windows.UI.WebUI.SuspendingDeferral"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class SuspendingEventArgs: super::super::applicationmodel::ISuspendingEventArgs ["Windows.UI.WebUI.SuspendingEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class SuspendingEventArgs: IInspectable ["Windows.UI.WebUI.SuspendingEventArgs"]}
 DEFINE_IID!(IID_SuspendingEventHandler, 1352417948, 30946, 18563, 171, 200, 137, 96, 220, 222, 27, 92);
 RT_DELEGATE!{delegate SuspendingEventHandler(SuspendingEventHandlerVtbl, SuspendingEventHandlerImpl) [IID_SuspendingEventHandler] {
     #[cfg(feature="windows-applicationmodel")] fn Invoke(&self, sender: *mut IInspectable, e: *mut super::super::applicationmodel::ISuspendingEventArgs) -> HRESULT
@@ -21440,8 +21440,8 @@ impl SuspendingEventHandler {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class SuspendingOperation: super::super::applicationmodel::ISuspendingOperation}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class SuspendingOperation: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class SuspendingOperation: super::super::applicationmodel::ISuspendingOperation ["Windows.UI.WebUI.SuspendingOperation"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class SuspendingOperation: IInspectable ["Windows.UI.WebUI.SuspendingOperation"]}
 DEFINE_IID!(IID_IWebUIActivationStatics, 890996413, 17331, 18475, 133, 219, 53, 216, 123, 81, 122, 217);
 RT_INTERFACE!{static interface IWebUIActivationStatics(IWebUIActivationStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebUIActivationStatics] {
     fn add_Activated(&self, handler: *mut ActivatedEventHandler, out: *mut foundation::EventRegistrationToken) -> HRESULT,
@@ -21633,16 +21633,16 @@ impl WebUIApplication {
     }
 }
 DEFINE_CLSID!(WebUIApplication(&[87,105,110,100,111,119,115,46,85,73,46,87,101,98,85,73,46,87,101,98,85,73,65,112,112,108,105,99,97,116,105,111,110,0]) [CLSID_WebUIApplication]);
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderAddAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderAddAppointmentActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderAddAppointmentActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderRemoveAppointmentActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderReplaceAppointmentActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderShowTimeFrameActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderAddAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderAddAppointmentActivatedEventArgs ["Windows.UI.WebUI.WebUIAppointmentsProviderAddAppointmentActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderAddAppointmentActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIAppointmentsProviderAddAppointmentActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderRemoveAppointmentActivatedEventArgs ["Windows.UI.WebUI.WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderReplaceAppointmentActivatedEventArgs ["Windows.UI.WebUI.WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs ["Windows.UI.WebUI.WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs: super::super::applicationmodel::activation::IAppointmentsProviderShowTimeFrameActivatedEventArgs ["Windows.UI.WebUI.WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs"]}
 DEFINE_IID!(IID_IWebUIBackgroundTaskInstance, 603008037, 58103, 18241, 188, 156, 57, 69, 149, 222, 36, 220);
 RT_INTERFACE!{interface IWebUIBackgroundTaskInstance(IWebUIBackgroundTaskInstanceVtbl): IInspectable(IInspectableVtbl) [IID_IWebUIBackgroundTaskInstance] {
     fn get_Succeeded(&self, out: *mut bool) -> HRESULT,
@@ -21667,7 +21667,7 @@ impl WebUIBackgroundTaskInstance {
     }
 }
 DEFINE_CLSID!(WebUIBackgroundTaskInstance(&[87,105,110,100,111,119,115,46,85,73,46,87,101,98,85,73,46,87,101,98,85,73,66,97,99,107,103,114,111,117,110,100,84,97,115,107,73,110,115,116,97,110,99,101,0]) [CLSID_WebUIBackgroundTaskInstance]);
-RT_CLASS!{class WebUIBackgroundTaskInstanceRuntimeClass: IWebUIBackgroundTaskInstance}
+RT_CLASS!{class WebUIBackgroundTaskInstanceRuntimeClass: IWebUIBackgroundTaskInstance ["Windows.UI.WebUI.WebUIBackgroundTaskInstanceRuntimeClass"]}
 DEFINE_IID!(IID_IWebUIBackgroundTaskInstanceStatics, 2625262225, 6574, 19619, 185, 75, 254, 78, 199, 68, 167, 64);
 RT_INTERFACE!{static interface IWebUIBackgroundTaskInstanceStatics(IWebUIBackgroundTaskInstanceStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IWebUIBackgroundTaskInstanceStatics] {
     fn get_Current(&self, out: *mut *mut IWebUIBackgroundTaskInstance) -> HRESULT
@@ -21679,54 +21679,54 @@ impl IWebUIBackgroundTaskInstanceStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIBarcodeScannerPreviewActivatedEventArgs: super::super::applicationmodel::activation::IBarcodeScannerPreviewActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIBarcodeScannerPreviewActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUICachedFileUpdaterActivatedEventArgs: super::super::applicationmodel::activation::ICachedFileUpdaterActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUICachedFileUpdaterActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUICameraSettingsActivatedEventArgs: super::super::applicationmodel::activation::ICameraSettingsActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUICameraSettingsActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUICommandLineActivatedEventArgs: super::super::applicationmodel::activation::ICommandLineActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUICommandLineActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactCallActivatedEventArgs: super::super::applicationmodel::activation::IContactCallActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactCallActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactMapActivatedEventArgs: super::super::applicationmodel::activation::IContactMapActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactMapActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactMessageActivatedEventArgs: super::super::applicationmodel::activation::IContactMessageActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactMessageActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactPanelActivatedEventArgs: super::super::applicationmodel::activation::IContactPanelActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactPanelActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactPickerActivatedEventArgs: super::super::applicationmodel::activation::IContactPickerActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactPickerActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactPostActivatedEventArgs: super::super::applicationmodel::activation::IContactPostActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactPostActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactVideoCallActivatedEventArgs: super::super::applicationmodel::activation::IContactVideoCallActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactVideoCallActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIDeviceActivatedEventArgs: super::super::applicationmodel::activation::IDeviceActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIDeviceActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIDevicePairingActivatedEventArgs: super::super::applicationmodel::activation::IDevicePairingActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIDevicePairingActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIDialReceiverActivatedEventArgs: super::super::applicationmodel::activation::IDialReceiverActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIDialReceiverActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileActivatedEventArgs: super::super::applicationmodel::activation::IFileActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileOpenPickerActivatedEventArgs: super::super::applicationmodel::activation::IFileOpenPickerActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileOpenPickerActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileOpenPickerContinuationEventArgs: super::super::applicationmodel::activation::IFileOpenPickerContinuationEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileOpenPickerContinuationEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileSavePickerActivatedEventArgs: super::super::applicationmodel::activation::IFileSavePickerActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileSavePickerActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileSavePickerContinuationEventArgs: super::super::applicationmodel::activation::IFileSavePickerContinuationEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileSavePickerContinuationEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFolderPickerContinuationEventArgs: super::super::applicationmodel::activation::IFolderPickerContinuationEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFolderPickerContinuationEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILaunchActivatedEventArgs: super::super::applicationmodel::activation::ILaunchActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILaunchActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILockScreenActivatedEventArgs: super::super::applicationmodel::activation::ILockScreenActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILockScreenActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILockScreenCallActivatedEventArgs: super::super::applicationmodel::activation::ILockScreenCallActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILockScreenCallActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILockScreenComponentActivatedEventArgs: super::super::applicationmodel::activation::IActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILockScreenComponentActivatedEventArgs: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIBarcodeScannerPreviewActivatedEventArgs: super::super::applicationmodel::activation::IBarcodeScannerPreviewActivatedEventArgs ["Windows.UI.WebUI.WebUIBarcodeScannerPreviewActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIBarcodeScannerPreviewActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIBarcodeScannerPreviewActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUICachedFileUpdaterActivatedEventArgs: super::super::applicationmodel::activation::ICachedFileUpdaterActivatedEventArgs ["Windows.UI.WebUI.WebUICachedFileUpdaterActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUICachedFileUpdaterActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUICachedFileUpdaterActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUICameraSettingsActivatedEventArgs: super::super::applicationmodel::activation::ICameraSettingsActivatedEventArgs ["Windows.UI.WebUI.WebUICameraSettingsActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUICameraSettingsActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUICameraSettingsActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUICommandLineActivatedEventArgs: super::super::applicationmodel::activation::ICommandLineActivatedEventArgs ["Windows.UI.WebUI.WebUICommandLineActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUICommandLineActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUICommandLineActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactCallActivatedEventArgs: super::super::applicationmodel::activation::IContactCallActivatedEventArgs ["Windows.UI.WebUI.WebUIContactCallActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactCallActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactCallActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactMapActivatedEventArgs: super::super::applicationmodel::activation::IContactMapActivatedEventArgs ["Windows.UI.WebUI.WebUIContactMapActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactMapActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactMapActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactMessageActivatedEventArgs: super::super::applicationmodel::activation::IContactMessageActivatedEventArgs ["Windows.UI.WebUI.WebUIContactMessageActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactMessageActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactMessageActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactPanelActivatedEventArgs: super::super::applicationmodel::activation::IContactPanelActivatedEventArgs ["Windows.UI.WebUI.WebUIContactPanelActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactPanelActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactPanelActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactPickerActivatedEventArgs: super::super::applicationmodel::activation::IContactPickerActivatedEventArgs ["Windows.UI.WebUI.WebUIContactPickerActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactPickerActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactPickerActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactPostActivatedEventArgs: super::super::applicationmodel::activation::IContactPostActivatedEventArgs ["Windows.UI.WebUI.WebUIContactPostActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactPostActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactPostActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIContactVideoCallActivatedEventArgs: super::super::applicationmodel::activation::IContactVideoCallActivatedEventArgs ["Windows.UI.WebUI.WebUIContactVideoCallActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIContactVideoCallActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIContactVideoCallActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIDeviceActivatedEventArgs: super::super::applicationmodel::activation::IDeviceActivatedEventArgs ["Windows.UI.WebUI.WebUIDeviceActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIDeviceActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIDeviceActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIDevicePairingActivatedEventArgs: super::super::applicationmodel::activation::IDevicePairingActivatedEventArgs ["Windows.UI.WebUI.WebUIDevicePairingActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIDevicePairingActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIDevicePairingActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIDialReceiverActivatedEventArgs: super::super::applicationmodel::activation::IDialReceiverActivatedEventArgs ["Windows.UI.WebUI.WebUIDialReceiverActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIDialReceiverActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIDialReceiverActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileActivatedEventArgs: super::super::applicationmodel::activation::IFileActivatedEventArgs ["Windows.UI.WebUI.WebUIFileActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIFileActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileOpenPickerActivatedEventArgs: super::super::applicationmodel::activation::IFileOpenPickerActivatedEventArgs ["Windows.UI.WebUI.WebUIFileOpenPickerActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileOpenPickerActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIFileOpenPickerActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileOpenPickerContinuationEventArgs: super::super::applicationmodel::activation::IFileOpenPickerContinuationEventArgs ["Windows.UI.WebUI.WebUIFileOpenPickerContinuationEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileOpenPickerContinuationEventArgs: IInspectable ["Windows.UI.WebUI.WebUIFileOpenPickerContinuationEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileSavePickerActivatedEventArgs: super::super::applicationmodel::activation::IFileSavePickerActivatedEventArgs ["Windows.UI.WebUI.WebUIFileSavePickerActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileSavePickerActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIFileSavePickerActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFileSavePickerContinuationEventArgs: super::super::applicationmodel::activation::IFileSavePickerContinuationEventArgs ["Windows.UI.WebUI.WebUIFileSavePickerContinuationEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFileSavePickerContinuationEventArgs: IInspectable ["Windows.UI.WebUI.WebUIFileSavePickerContinuationEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIFolderPickerContinuationEventArgs: super::super::applicationmodel::activation::IFolderPickerContinuationEventArgs ["Windows.UI.WebUI.WebUIFolderPickerContinuationEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIFolderPickerContinuationEventArgs: IInspectable ["Windows.UI.WebUI.WebUIFolderPickerContinuationEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILaunchActivatedEventArgs: super::super::applicationmodel::activation::ILaunchActivatedEventArgs ["Windows.UI.WebUI.WebUILaunchActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILaunchActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUILaunchActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILockScreenActivatedEventArgs: super::super::applicationmodel::activation::ILockScreenActivatedEventArgs ["Windows.UI.WebUI.WebUILockScreenActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILockScreenActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUILockScreenActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILockScreenCallActivatedEventArgs: super::super::applicationmodel::activation::ILockScreenCallActivatedEventArgs ["Windows.UI.WebUI.WebUILockScreenCallActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILockScreenCallActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUILockScreenCallActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUILockScreenComponentActivatedEventArgs: super::super::applicationmodel::activation::IActivatedEventArgs ["Windows.UI.WebUI.WebUILockScreenComponentActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUILockScreenComponentActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUILockScreenComponentActivatedEventArgs"]}
 DEFINE_IID!(IID_IWebUINavigatedDeferral, 3624149069, 33567, 18146, 180, 50, 58, 252, 226, 17, 249, 98);
 RT_INTERFACE!{interface IWebUINavigatedDeferral(IWebUINavigatedDeferralVtbl): IInspectable(IInspectableVtbl) [IID_IWebUINavigatedDeferral] {
     fn Complete(&self) -> HRESULT
@@ -21737,7 +21737,7 @@ impl IWebUINavigatedDeferral {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebUINavigatedDeferral: IWebUINavigatedDeferral}
+RT_CLASS!{class WebUINavigatedDeferral: IWebUINavigatedDeferral ["Windows.UI.WebUI.WebUINavigatedDeferral"]}
 DEFINE_IID!(IID_IWebUINavigatedEventArgs, 2807579064, 9369, 16432, 166, 157, 21, 210, 217, 207, 229, 36);
 RT_INTERFACE!{interface IWebUINavigatedEventArgs(IWebUINavigatedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebUINavigatedEventArgs] {
     fn get_NavigatedOperation(&self, out: *mut *mut WebUINavigatedOperation) -> HRESULT
@@ -21749,7 +21749,7 @@ impl IWebUINavigatedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebUINavigatedEventArgs: IWebUINavigatedEventArgs}
+RT_CLASS!{class WebUINavigatedEventArgs: IWebUINavigatedEventArgs ["Windows.UI.WebUI.WebUINavigatedEventArgs"]}
 DEFINE_IID!(IID_IWebUINavigatedOperation, 2056675080, 33154, 19081, 171, 103, 132, 146, 232, 117, 13, 75);
 RT_INTERFACE!{interface IWebUINavigatedOperation(IWebUINavigatedOperationVtbl): IInspectable(IInspectableVtbl) [IID_IWebUINavigatedOperation] {
     fn GetDeferral(&self, out: *mut *mut WebUINavigatedDeferral) -> HRESULT
@@ -21761,29 +21761,29 @@ impl IWebUINavigatedOperation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebUINavigatedOperation: IWebUINavigatedOperation}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIPrint3DWorkflowActivatedEventArgs: super::super::applicationmodel::activation::IPrint3DWorkflowActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIPrint3DWorkflowActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIPrintTaskSettingsActivatedEventArgs: super::super::applicationmodel::activation::IPrintTaskSettingsActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIPrintTaskSettingsActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIPrintWorkflowForegroundTaskActivatedEventArgs: super::super::applicationmodel::activation::IActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIPrintWorkflowForegroundTaskActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIProtocolActivatedEventArgs: super::super::applicationmodel::activation::IProtocolActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIProtocolActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIProtocolForResultsActivatedEventArgs: super::super::applicationmodel::activation::IProtocolForResultsActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIProtocolForResultsActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIRestrictedLaunchActivatedEventArgs: super::super::applicationmodel::activation::IRestrictedLaunchActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIRestrictedLaunchActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUISearchActivatedEventArgs: super::super::applicationmodel::activation::ISearchActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUISearchActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIShareTargetActivatedEventArgs: super::super::applicationmodel::activation::IShareTargetActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIShareTargetActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIStartupTaskActivatedEventArgs: super::super::applicationmodel::activation::IStartupTaskActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIStartupTaskActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIToastNotificationActivatedEventArgs: super::super::applicationmodel::activation::IToastNotificationActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIToastNotificationActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIUserDataAccountProviderActivatedEventArgs: super::super::applicationmodel::activation::IUserDataAccountProviderActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIUserDataAccountProviderActivatedEventArgs: IInspectable}
+RT_CLASS!{class WebUINavigatedOperation: IWebUINavigatedOperation ["Windows.UI.WebUI.WebUINavigatedOperation"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIPrint3DWorkflowActivatedEventArgs: super::super::applicationmodel::activation::IPrint3DWorkflowActivatedEventArgs ["Windows.UI.WebUI.WebUIPrint3DWorkflowActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIPrint3DWorkflowActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIPrint3DWorkflowActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIPrintTaskSettingsActivatedEventArgs: super::super::applicationmodel::activation::IPrintTaskSettingsActivatedEventArgs ["Windows.UI.WebUI.WebUIPrintTaskSettingsActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIPrintTaskSettingsActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIPrintTaskSettingsActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIPrintWorkflowForegroundTaskActivatedEventArgs: super::super::applicationmodel::activation::IActivatedEventArgs ["Windows.UI.WebUI.WebUIPrintWorkflowForegroundTaskActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIPrintWorkflowForegroundTaskActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIPrintWorkflowForegroundTaskActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIProtocolActivatedEventArgs: super::super::applicationmodel::activation::IProtocolActivatedEventArgs ["Windows.UI.WebUI.WebUIProtocolActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIProtocolActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIProtocolActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIProtocolForResultsActivatedEventArgs: super::super::applicationmodel::activation::IProtocolForResultsActivatedEventArgs ["Windows.UI.WebUI.WebUIProtocolForResultsActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIProtocolForResultsActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIProtocolForResultsActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIRestrictedLaunchActivatedEventArgs: super::super::applicationmodel::activation::IRestrictedLaunchActivatedEventArgs ["Windows.UI.WebUI.WebUIRestrictedLaunchActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIRestrictedLaunchActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIRestrictedLaunchActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUISearchActivatedEventArgs: super::super::applicationmodel::activation::ISearchActivatedEventArgs ["Windows.UI.WebUI.WebUISearchActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUISearchActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUISearchActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIShareTargetActivatedEventArgs: super::super::applicationmodel::activation::IShareTargetActivatedEventArgs ["Windows.UI.WebUI.WebUIShareTargetActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIShareTargetActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIShareTargetActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIStartupTaskActivatedEventArgs: super::super::applicationmodel::activation::IStartupTaskActivatedEventArgs ["Windows.UI.WebUI.WebUIStartupTaskActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIStartupTaskActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIStartupTaskActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIToastNotificationActivatedEventArgs: super::super::applicationmodel::activation::IToastNotificationActivatedEventArgs ["Windows.UI.WebUI.WebUIToastNotificationActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIToastNotificationActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIToastNotificationActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIUserDataAccountProviderActivatedEventArgs: super::super::applicationmodel::activation::IUserDataAccountProviderActivatedEventArgs ["Windows.UI.WebUI.WebUIUserDataAccountProviderActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIUserDataAccountProviderActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIUserDataAccountProviderActivatedEventArgs"]}
 DEFINE_IID!(IID_IWebUIView, 1736701519, 21210, 20439, 190, 105, 142, 246, 40, 75, 66, 60);
 RT_INTERFACE!{interface IWebUIView(IWebUIViewVtbl): IInspectable(IInspectableVtbl) [IID_IWebUIView] {
     fn get_ApplicationViewId(&self, out: *mut i32) -> HRESULT,
@@ -21829,7 +21829,7 @@ impl IWebUIView {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebUIView: IWebUIView}
+RT_CLASS!{class WebUIView: IWebUIView ["Windows.UI.WebUI.WebUIView"]}
 impl RtActivatable<IWebUIViewStatics> for WebUIView {}
 impl WebUIView {
     #[inline] pub fn create_async() -> Result<ComPtr<foundation::IAsyncOperation<WebUIView>>> {
@@ -21857,13 +21857,13 @@ impl IWebUIViewStatics {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIVoiceCommandActivatedEventArgs: super::super::applicationmodel::activation::IVoiceCommandActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIVoiceCommandActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIWalletActionActivatedEventArgs: super::super::applicationmodel::activation::IWalletActionActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIWalletActionActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIWebAccountProviderActivatedEventArgs: super::super::applicationmodel::activation::IWebAccountProviderActivatedEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIWebAccountProviderActivatedEventArgs: IInspectable}
-#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIWebAuthenticationBrokerContinuationEventArgs: super::super::applicationmodel::activation::IWebAuthenticationBrokerContinuationEventArgs}
-#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIWebAuthenticationBrokerContinuationEventArgs: IInspectable}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIVoiceCommandActivatedEventArgs: super::super::applicationmodel::activation::IVoiceCommandActivatedEventArgs ["Windows.UI.WebUI.WebUIVoiceCommandActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIVoiceCommandActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIVoiceCommandActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIWalletActionActivatedEventArgs: super::super::applicationmodel::activation::IWalletActionActivatedEventArgs ["Windows.UI.WebUI.WebUIWalletActionActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIWalletActionActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIWalletActionActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIWebAccountProviderActivatedEventArgs: super::super::applicationmodel::activation::IWebAccountProviderActivatedEventArgs ["Windows.UI.WebUI.WebUIWebAccountProviderActivatedEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIWebAccountProviderActivatedEventArgs: IInspectable ["Windows.UI.WebUI.WebUIWebAccountProviderActivatedEventArgs"]}
+#[cfg(feature="windows-applicationmodel")] RT_CLASS!{class WebUIWebAuthenticationBrokerContinuationEventArgs: super::super::applicationmodel::activation::IWebAuthenticationBrokerContinuationEventArgs ["Windows.UI.WebUI.WebUIWebAuthenticationBrokerContinuationEventArgs"]}
+#[cfg(not(feature="windows-applicationmodel"))] RT_CLASS!{class WebUIWebAuthenticationBrokerContinuationEventArgs: IInspectable ["Windows.UI.WebUI.WebUIWebAuthenticationBrokerContinuationEventArgs"]}
 } // Windows.UI.WebUI
 #[cfg(feature="windows-ui-xaml")] pub mod xaml; // Windows.UI.Xaml

--- a/src/rt/gen/windows/web.rs
+++ b/src/rt/gen/windows/web.rs
@@ -29,7 +29,7 @@ impl IWebErrorStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum WebErrorStatus: i32 {
+RT_ENUM! { enum WebErrorStatus: i32 ["Windows.Web.WebErrorStatus"] {
     Unknown (WebErrorStatus_Unknown) = 0, CertificateCommonNameIsIncorrect (WebErrorStatus_CertificateCommonNameIsIncorrect) = 1, CertificateExpired (WebErrorStatus_CertificateExpired) = 2, CertificateContainsErrors (WebErrorStatus_CertificateContainsErrors) = 3, CertificateRevoked (WebErrorStatus_CertificateRevoked) = 4, CertificateIsInvalid (WebErrorStatus_CertificateIsInvalid) = 5, ServerUnreachable (WebErrorStatus_ServerUnreachable) = 6, Timeout (WebErrorStatus_Timeout) = 7, ErrorHttpInvalidServerResponse (WebErrorStatus_ErrorHttpInvalidServerResponse) = 8, ConnectionAborted (WebErrorStatus_ConnectionAborted) = 9, ConnectionReset (WebErrorStatus_ConnectionReset) = 10, Disconnected (WebErrorStatus_Disconnected) = 11, HttpToHttpsOnRedirection (WebErrorStatus_HttpToHttpsOnRedirection) = 12, HttpsToHttpOnRedirection (WebErrorStatus_HttpsToHttpOnRedirection) = 13, CannotConnect (WebErrorStatus_CannotConnect) = 14, HostNameNotResolved (WebErrorStatus_HostNameNotResolved) = 15, OperationCanceled (WebErrorStatus_OperationCanceled) = 16, RedirectFailed (WebErrorStatus_RedirectFailed) = 17, UnexpectedStatusCode (WebErrorStatus_UnexpectedStatusCode) = 18, UnexpectedRedirection (WebErrorStatus_UnexpectedRedirection) = 19, UnexpectedClientError (WebErrorStatus_UnexpectedClientError) = 20, UnexpectedServerError (WebErrorStatus_UnexpectedServerError) = 21, InsufficientRangeSupport (WebErrorStatus_InsufficientRangeSupport) = 22, MissingContentLengthSupport (WebErrorStatus_MissingContentLengthSupport) = 23, MultipleChoices (WebErrorStatus_MultipleChoices) = 300, MovedPermanently (WebErrorStatus_MovedPermanently) = 301, Found (WebErrorStatus_Found) = 302, SeeOther (WebErrorStatus_SeeOther) = 303, NotModified (WebErrorStatus_NotModified) = 304, UseProxy (WebErrorStatus_UseProxy) = 305, TemporaryRedirect (WebErrorStatus_TemporaryRedirect) = 307, BadRequest (WebErrorStatus_BadRequest) = 400, Unauthorized (WebErrorStatus_Unauthorized) = 401, PaymentRequired (WebErrorStatus_PaymentRequired) = 402, Forbidden (WebErrorStatus_Forbidden) = 403, NotFound (WebErrorStatus_NotFound) = 404, MethodNotAllowed (WebErrorStatus_MethodNotAllowed) = 405, NotAcceptable (WebErrorStatus_NotAcceptable) = 406, ProxyAuthenticationRequired (WebErrorStatus_ProxyAuthenticationRequired) = 407, RequestTimeout (WebErrorStatus_RequestTimeout) = 408, Conflict (WebErrorStatus_Conflict) = 409, Gone (WebErrorStatus_Gone) = 410, LengthRequired (WebErrorStatus_LengthRequired) = 411, PreconditionFailed (WebErrorStatus_PreconditionFailed) = 412, RequestEntityTooLarge (WebErrorStatus_RequestEntityTooLarge) = 413, RequestUriTooLong (WebErrorStatus_RequestUriTooLong) = 414, UnsupportedMediaType (WebErrorStatus_UnsupportedMediaType) = 415, RequestedRangeNotSatisfiable (WebErrorStatus_RequestedRangeNotSatisfiable) = 416, ExpectationFailed (WebErrorStatus_ExpectationFailed) = 417, InternalServerError (WebErrorStatus_InternalServerError) = 500, NotImplemented (WebErrorStatus_NotImplemented) = 501, BadGateway (WebErrorStatus_BadGateway) = 502, ServiceUnavailable (WebErrorStatus_ServiceUnavailable) = 503, GatewayTimeout (WebErrorStatus_GatewayTimeout) = 504, HttpVersionNotSupported (WebErrorStatus_HttpVersionNotSupported) = 505,
 }}
 pub mod atompub { // Windows.Web.AtomPub
@@ -107,7 +107,7 @@ impl IAtomPubClient {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class AtomPubClient: IAtomPubClient}
+RT_CLASS!{class AtomPubClient: IAtomPubClient ["Windows.Web.AtomPub.AtomPubClient"]}
 impl RtActivatable<IAtomPubClientFactory> for AtomPubClient {}
 impl RtActivatable<IActivationFactory> for AtomPubClient {}
 impl AtomPubClient {
@@ -156,7 +156,7 @@ impl IResourceCollection {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ResourceCollection: IResourceCollection}
+RT_CLASS!{class ResourceCollection: IResourceCollection ["Windows.Web.AtomPub.ResourceCollection"]}
 DEFINE_IID!(IID_IServiceDocument, 2340341617, 10931, 19902, 139, 204, 119, 143, 146, 183, 94, 81);
 RT_INTERFACE!{interface IServiceDocument(IServiceDocumentVtbl): IInspectable(IInspectableVtbl) [IID_IServiceDocument] {
     fn get_Workspaces(&self, out: *mut *mut foundation::collections::IVectorView<Workspace>) -> HRESULT
@@ -168,7 +168,7 @@ impl IServiceDocument {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class ServiceDocument: IServiceDocument}
+RT_CLASS!{class ServiceDocument: IServiceDocument ["Windows.Web.AtomPub.ServiceDocument"]}
 DEFINE_IID!(IID_IWorkspace, 3021841979, 42168, 16438, 137, 197, 131, 195, 18, 102, 186, 73);
 RT_INTERFACE!{interface IWorkspace(IWorkspaceVtbl): IInspectable(IInspectableVtbl) [IID_IWorkspace] {
     fn get_Title(&self, out: *mut *mut super::syndication::ISyndicationText) -> HRESULT,
@@ -186,11 +186,11 @@ impl IWorkspace {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class Workspace: IWorkspace}
+RT_CLASS!{class Workspace: IWorkspace ["Windows.Web.AtomPub.Workspace"]}
 } // Windows.Web.AtomPub
 pub mod http { // Windows.Web.Http
 use ::prelude::*;
-RT_CLASS!{class HttpBufferContent: IHttpContent}
+RT_CLASS!{class HttpBufferContent: IHttpContent ["Windows.Web.Http.HttpBufferContent"]}
 impl RtActivatable<IHttpBufferContentFactory> for HttpBufferContent {}
 impl HttpBufferContent {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_from_buffer(content: &super::super::storage::streams::IBuffer) -> Result<ComPtr<HttpBufferContent>> {
@@ -291,7 +291,7 @@ impl IHttpClient {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpClient: IHttpClient}
+RT_CLASS!{class HttpClient: IHttpClient ["Windows.Web.Http.HttpClient"]}
 impl RtActivatable<IHttpClientFactory> for HttpClient {}
 impl RtActivatable<IActivationFactory> for HttpClient {}
 impl HttpClient {
@@ -311,7 +311,7 @@ impl IHttpClientFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HttpCompletionOption: i32 {
+RT_ENUM! { enum HttpCompletionOption: i32 ["Windows.Web.Http.HttpCompletionOption"] {
     ResponseContentRead (HttpCompletionOption_ResponseContentRead) = 0, ResponseHeadersRead (HttpCompletionOption_ResponseHeadersRead) = 1,
 }}
 DEFINE_IID!(IID_IHttpContent, 1796514881, 64423, 19410, 175, 10, 131, 157, 231, 194, 149, 218);
@@ -428,7 +428,7 @@ impl IHttpCookie {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCookie: IHttpCookie}
+RT_CLASS!{class HttpCookie: IHttpCookie ["Windows.Web.Http.HttpCookie"]}
 impl RtActivatable<IHttpCookieFactory> for HttpCookie {}
 impl HttpCookie {
     #[inline] pub fn create(name: &HStringArg, domain: &HStringArg, path: &HStringArg) -> Result<ComPtr<HttpCookie>> {
@@ -436,7 +436,7 @@ impl HttpCookie {
     }
 }
 DEFINE_CLSID!(HttpCookie(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,116,116,112,67,111,111,107,105,101,0]) [CLSID_HttpCookie]);
-RT_CLASS!{class HttpCookieCollection: foundation::collections::IVectorView<HttpCookie>}
+RT_CLASS!{class HttpCookieCollection: foundation::collections::IVectorView<HttpCookie> ["Windows.Web.Http.HttpCookieCollection"]}
 DEFINE_IID!(IID_IHttpCookieFactory, 1778746793, 37660, 19665, 169, 109, 194, 23, 1, 120, 92, 95);
 RT_INTERFACE!{static interface IHttpCookieFactory(IHttpCookieFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpCookieFactory] {
     fn Create(&self, name: HSTRING, domain: HSTRING, path: HSTRING, out: *mut *mut HttpCookie) -> HRESULT
@@ -476,8 +476,8 @@ impl IHttpCookieManager {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCookieManager: IHttpCookieManager}
-RT_CLASS!{class HttpFormUrlEncodedContent: IHttpContent}
+RT_CLASS!{class HttpCookieManager: IHttpCookieManager ["Windows.Web.Http.HttpCookieManager"]}
+RT_CLASS!{class HttpFormUrlEncodedContent: IHttpContent ["Windows.Web.Http.HttpFormUrlEncodedContent"]}
 impl RtActivatable<IHttpFormUrlEncodedContentFactory> for HttpFormUrlEncodedContent {}
 impl HttpFormUrlEncodedContent {
     #[inline] pub fn create(content: &foundation::collections::IIterable<foundation::collections::IKeyValuePair<HString, HString>>) -> Result<ComPtr<HttpFormUrlEncodedContent>> {
@@ -507,7 +507,7 @@ impl IHttpMethod {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMethod: IHttpMethod}
+RT_CLASS!{class HttpMethod: IHttpMethod ["Windows.Web.Http.HttpMethod"]}
 impl RtActivatable<IHttpMethodFactory> for HttpMethod {}
 impl RtActivatable<IHttpMethodStatics> for HttpMethod {}
 impl HttpMethod {
@@ -605,7 +605,7 @@ impl IHttpMultipartContent {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMultipartContent: IHttpContent}
+RT_CLASS!{class HttpMultipartContent: IHttpContent ["Windows.Web.Http.HttpMultipartContent"]}
 impl RtActivatable<IHttpMultipartContentFactory> for HttpMultipartContent {}
 impl RtActivatable<IActivationFactory> for HttpMultipartContent {}
 impl HttpMultipartContent {
@@ -654,7 +654,7 @@ impl IHttpMultipartFormDataContent {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMultipartFormDataContent: IHttpContent}
+RT_CLASS!{class HttpMultipartFormDataContent: IHttpContent ["Windows.Web.Http.HttpMultipartFormDataContent"]}
 impl RtActivatable<IHttpMultipartFormDataContentFactory> for HttpMultipartFormDataContent {}
 impl RtActivatable<IActivationFactory> for HttpMultipartFormDataContent {}
 impl HttpMultipartFormDataContent {
@@ -674,10 +674,10 @@ impl IHttpMultipartFormDataContentFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_STRUCT! { struct HttpProgress {
+RT_STRUCT! { struct HttpProgress ["Windows.Web.Http.HttpProgress"] {
     Stage: HttpProgressStage, BytesSent: u64, TotalBytesToSend: *mut foundation::IReference<u64>, BytesReceived: u64, TotalBytesToReceive: *mut foundation::IReference<u64>, Retries: u32,
 }}
-RT_ENUM! { enum HttpProgressStage: i32 {
+RT_ENUM! { enum HttpProgressStage: i32 ["Windows.Web.Http.HttpProgressStage"] {
     None (HttpProgressStage_None) = 0, DetectingProxy (HttpProgressStage_DetectingProxy) = 10, ResolvingName (HttpProgressStage_ResolvingName) = 20, ConnectingToServer (HttpProgressStage_ConnectingToServer) = 30, NegotiatingSsl (HttpProgressStage_NegotiatingSsl) = 40, SendingHeaders (HttpProgressStage_SendingHeaders) = 50, SendingContent (HttpProgressStage_SendingContent) = 60, WaitingForResponse (HttpProgressStage_WaitingForResponse) = 70, ReceivingHeaders (HttpProgressStage_ReceivingHeaders) = 80, ReceivingContent (HttpProgressStage_ReceivingContent) = 90,
 }}
 DEFINE_IID!(IID_IHttpRequestMessage, 4118162236, 29908, 18449, 181, 220, 159, 139, 78, 47, 154, 191);
@@ -736,7 +736,7 @@ impl IHttpRequestMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpRequestMessage: IHttpRequestMessage}
+RT_CLASS!{class HttpRequestMessage: IHttpRequestMessage ["Windows.Web.Http.HttpRequestMessage"]}
 impl RtActivatable<IHttpRequestMessageFactory> for HttpRequestMessage {}
 impl RtActivatable<IActivationFactory> for HttpRequestMessage {}
 impl HttpRequestMessage {
@@ -845,7 +845,7 @@ impl IHttpResponseMessage {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpResponseMessage: IHttpResponseMessage}
+RT_CLASS!{class HttpResponseMessage: IHttpResponseMessage ["Windows.Web.Http.HttpResponseMessage"]}
 impl RtActivatable<IHttpResponseMessageFactory> for HttpResponseMessage {}
 impl RtActivatable<IActivationFactory> for HttpResponseMessage {}
 impl HttpResponseMessage {
@@ -865,13 +865,13 @@ impl IHttpResponseMessageFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HttpResponseMessageSource: i32 {
+RT_ENUM! { enum HttpResponseMessageSource: i32 ["Windows.Web.Http.HttpResponseMessageSource"] {
     None (HttpResponseMessageSource_None) = 0, Cache (HttpResponseMessageSource_Cache) = 1, Network (HttpResponseMessageSource_Network) = 2,
 }}
-RT_ENUM! { enum HttpStatusCode: i32 {
+RT_ENUM! { enum HttpStatusCode: i32 ["Windows.Web.Http.HttpStatusCode"] {
     None (HttpStatusCode_None) = 0, Continue (HttpStatusCode_Continue) = 100, SwitchingProtocols (HttpStatusCode_SwitchingProtocols) = 101, Processing (HttpStatusCode_Processing) = 102, Ok (HttpStatusCode_Ok) = 200, Created (HttpStatusCode_Created) = 201, Accepted (HttpStatusCode_Accepted) = 202, NonAuthoritativeInformation (HttpStatusCode_NonAuthoritativeInformation) = 203, NoContent (HttpStatusCode_NoContent) = 204, ResetContent (HttpStatusCode_ResetContent) = 205, PartialContent (HttpStatusCode_PartialContent) = 206, MultiStatus (HttpStatusCode_MultiStatus) = 207, AlreadyReported (HttpStatusCode_AlreadyReported) = 208, IMUsed (HttpStatusCode_IMUsed) = 226, MultipleChoices (HttpStatusCode_MultipleChoices) = 300, MovedPermanently (HttpStatusCode_MovedPermanently) = 301, Found (HttpStatusCode_Found) = 302, SeeOther (HttpStatusCode_SeeOther) = 303, NotModified (HttpStatusCode_NotModified) = 304, UseProxy (HttpStatusCode_UseProxy) = 305, TemporaryRedirect (HttpStatusCode_TemporaryRedirect) = 307, PermanentRedirect (HttpStatusCode_PermanentRedirect) = 308, BadRequest (HttpStatusCode_BadRequest) = 400, Unauthorized (HttpStatusCode_Unauthorized) = 401, PaymentRequired (HttpStatusCode_PaymentRequired) = 402, Forbidden (HttpStatusCode_Forbidden) = 403, NotFound (HttpStatusCode_NotFound) = 404, MethodNotAllowed (HttpStatusCode_MethodNotAllowed) = 405, NotAcceptable (HttpStatusCode_NotAcceptable) = 406, ProxyAuthenticationRequired (HttpStatusCode_ProxyAuthenticationRequired) = 407, RequestTimeout (HttpStatusCode_RequestTimeout) = 408, Conflict (HttpStatusCode_Conflict) = 409, Gone (HttpStatusCode_Gone) = 410, LengthRequired (HttpStatusCode_LengthRequired) = 411, PreconditionFailed (HttpStatusCode_PreconditionFailed) = 412, RequestEntityTooLarge (HttpStatusCode_RequestEntityTooLarge) = 413, RequestUriTooLong (HttpStatusCode_RequestUriTooLong) = 414, UnsupportedMediaType (HttpStatusCode_UnsupportedMediaType) = 415, RequestedRangeNotSatisfiable (HttpStatusCode_RequestedRangeNotSatisfiable) = 416, ExpectationFailed (HttpStatusCode_ExpectationFailed) = 417, UnprocessableEntity (HttpStatusCode_UnprocessableEntity) = 422, Locked (HttpStatusCode_Locked) = 423, FailedDependency (HttpStatusCode_FailedDependency) = 424, UpgradeRequired (HttpStatusCode_UpgradeRequired) = 426, PreconditionRequired (HttpStatusCode_PreconditionRequired) = 428, TooManyRequests (HttpStatusCode_TooManyRequests) = 429, RequestHeaderFieldsTooLarge (HttpStatusCode_RequestHeaderFieldsTooLarge) = 431, InternalServerError (HttpStatusCode_InternalServerError) = 500, NotImplemented (HttpStatusCode_NotImplemented) = 501, BadGateway (HttpStatusCode_BadGateway) = 502, ServiceUnavailable (HttpStatusCode_ServiceUnavailable) = 503, GatewayTimeout (HttpStatusCode_GatewayTimeout) = 504, HttpVersionNotSupported (HttpStatusCode_HttpVersionNotSupported) = 505, VariantAlsoNegotiates (HttpStatusCode_VariantAlsoNegotiates) = 506, InsufficientStorage (HttpStatusCode_InsufficientStorage) = 507, LoopDetected (HttpStatusCode_LoopDetected) = 508, NotExtended (HttpStatusCode_NotExtended) = 510, NetworkAuthenticationRequired (HttpStatusCode_NetworkAuthenticationRequired) = 511,
 }}
-RT_CLASS!{class HttpStreamContent: IHttpContent}
+RT_CLASS!{class HttpStreamContent: IHttpContent ["Windows.Web.Http.HttpStreamContent"]}
 impl RtActivatable<IHttpStreamContentFactory> for HttpStreamContent {}
 impl HttpStreamContent {
     #[cfg(feature="windows-storage")] #[inline] pub fn create_from_input_stream(content: &super::super::storage::streams::IInputStream) -> Result<ComPtr<HttpStreamContent>> {
@@ -890,7 +890,7 @@ impl IHttpStreamContentFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpStringContent: IHttpContent}
+RT_CLASS!{class HttpStringContent: IHttpContent ["Windows.Web.Http.HttpStringContent"]}
 impl RtActivatable<IHttpStringContentFactory> for HttpStringContent {}
 impl HttpStringContent {
     #[inline] pub fn create_from_string(content: &HStringArg) -> Result<ComPtr<HttpStringContent>> {
@@ -957,8 +957,8 @@ impl IHttpTransportInformation {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpTransportInformation: IHttpTransportInformation}
-RT_ENUM! { enum HttpVersion: i32 {
+RT_CLASS!{class HttpTransportInformation: IHttpTransportInformation ["Windows.Web.Http.HttpTransportInformation"]}
+RT_ENUM! { enum HttpVersion: i32 ["Windows.Web.Http.HttpVersion"] {
     None (HttpVersion_None) = 0, Http10 (HttpVersion_Http10) = 1, Http11 (HttpVersion_Http11) = 2, Http20 (HttpVersion_Http20) = 3,
 }}
 pub mod diagnostics { // Windows.Web.Http.Diagnostics
@@ -1011,7 +1011,7 @@ impl IHttpDiagnosticProvider {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDiagnosticProvider: IHttpDiagnosticProvider}
+RT_CLASS!{class HttpDiagnosticProvider: IHttpDiagnosticProvider ["Windows.Web.Http.Diagnostics.HttpDiagnosticProvider"]}
 impl RtActivatable<IHttpDiagnosticProviderStatics> for HttpDiagnosticProvider {}
 impl HttpDiagnosticProvider {
     #[cfg(feature="windows-system")] #[inline] pub fn create_from_process_diagnostic_info(processDiagnosticInfo: &::rt::gen::windows::system::diagnostics::ProcessDiagnosticInfo) -> Result<Option<ComPtr<HttpDiagnosticProvider>>> {
@@ -1066,7 +1066,7 @@ impl IHttpDiagnosticProviderRequestResponseCompletedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDiagnosticProviderRequestResponseCompletedEventArgs: IHttpDiagnosticProviderRequestResponseCompletedEventArgs}
+RT_CLASS!{class HttpDiagnosticProviderRequestResponseCompletedEventArgs: IHttpDiagnosticProviderRequestResponseCompletedEventArgs ["Windows.Web.Http.Diagnostics.HttpDiagnosticProviderRequestResponseCompletedEventArgs"]}
 DEFINE_IID!(IID_IHttpDiagnosticProviderRequestResponseTimestamps, 3769622032, 21967, 19457, 145, 212, 162, 5, 87, 216, 73, 240);
 RT_INTERFACE!{interface IHttpDiagnosticProviderRequestResponseTimestamps(IHttpDiagnosticProviderRequestResponseTimestampsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProviderRequestResponseTimestamps] {
     fn get_CacheCheckedTimestamp(&self, out: *mut *mut foundation::IReference<foundation::DateTime>) -> HRESULT,
@@ -1126,7 +1126,7 @@ impl IHttpDiagnosticProviderRequestResponseTimestamps {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDiagnosticProviderRequestResponseTimestamps: IHttpDiagnosticProviderRequestResponseTimestamps}
+RT_CLASS!{class HttpDiagnosticProviderRequestResponseTimestamps: IHttpDiagnosticProviderRequestResponseTimestamps ["Windows.Web.Http.Diagnostics.HttpDiagnosticProviderRequestResponseTimestamps"]}
 DEFINE_IID!(IID_IHttpDiagnosticProviderRequestSentEventArgs, 1062311632, 19487, 20158, 165, 122, 6, 147, 7, 113, 197, 13);
 RT_INTERFACE!{interface IHttpDiagnosticProviderRequestSentEventArgs(IHttpDiagnosticProviderRequestSentEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProviderRequestSentEventArgs] {
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -1174,7 +1174,7 @@ impl IHttpDiagnosticProviderRequestSentEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDiagnosticProviderRequestSentEventArgs: IHttpDiagnosticProviderRequestSentEventArgs}
+RT_CLASS!{class HttpDiagnosticProviderRequestSentEventArgs: IHttpDiagnosticProviderRequestSentEventArgs ["Windows.Web.Http.Diagnostics.HttpDiagnosticProviderRequestSentEventArgs"]}
 DEFINE_IID!(IID_IHttpDiagnosticProviderResponseReceivedEventArgs, 2694993516, 43871, 19814, 187, 45, 8, 76, 244, 22, 53, 208);
 RT_INTERFACE!{interface IHttpDiagnosticProviderResponseReceivedEventArgs(IHttpDiagnosticProviderResponseReceivedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProviderResponseReceivedEventArgs] {
     fn get_Timestamp(&self, out: *mut foundation::DateTime) -> HRESULT,
@@ -1198,7 +1198,7 @@ impl IHttpDiagnosticProviderResponseReceivedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDiagnosticProviderResponseReceivedEventArgs: IHttpDiagnosticProviderResponseReceivedEventArgs}
+RT_CLASS!{class HttpDiagnosticProviderResponseReceivedEventArgs: IHttpDiagnosticProviderResponseReceivedEventArgs ["Windows.Web.Http.Diagnostics.HttpDiagnosticProviderResponseReceivedEventArgs"]}
 DEFINE_IID!(IID_IHttpDiagnosticProviderStatics, 1535266497, 27244, 18380, 175, 236, 30, 134, 188, 38, 5, 59);
 RT_INTERFACE!{static interface IHttpDiagnosticProviderStatics(IHttpDiagnosticProviderStaticsVtbl): IInspectable(IInspectableVtbl) [IID_IHttpDiagnosticProviderStatics] {
     #[cfg(feature="windows-system")] fn CreateFromProcessDiagnosticInfo(&self, processDiagnosticInfo: *mut ::rt::gen::windows::system::diagnostics::ProcessDiagnosticInfo, out: *mut *mut HttpDiagnosticProvider) -> HRESULT
@@ -1210,7 +1210,7 @@ impl IHttpDiagnosticProviderStatics {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum HttpDiagnosticRequestInitiator: i32 {
+RT_ENUM! { enum HttpDiagnosticRequestInitiator: i32 ["Windows.Web.Http.Diagnostics.HttpDiagnosticRequestInitiator"] {
     ParsedElement (HttpDiagnosticRequestInitiator_ParsedElement) = 0, Script (HttpDiagnosticRequestInitiator_Script) = 1, Image (HttpDiagnosticRequestInitiator_Image) = 2, Link (HttpDiagnosticRequestInitiator_Link) = 3, Style (HttpDiagnosticRequestInitiator_Style) = 4, XmlHttpRequest (HttpDiagnosticRequestInitiator_XmlHttpRequest) = 5, Media (HttpDiagnosticRequestInitiator_Media) = 6, HtmlDownload (HttpDiagnosticRequestInitiator_HtmlDownload) = 7, Prefetch (HttpDiagnosticRequestInitiator_Prefetch) = 8, Other (HttpDiagnosticRequestInitiator_Other) = 9, CrossOriginPreFlight (HttpDiagnosticRequestInitiator_CrossOriginPreFlight) = 10, Fetch (HttpDiagnosticRequestInitiator_Fetch) = 11, Beacon (HttpDiagnosticRequestInitiator_Beacon) = 12,
 }}
 DEFINE_IID!(IID_IHttpDiagnosticSourceLocation, 1420415584, 34912, 16959, 182, 250, 215, 119, 22, 246, 71, 167);
@@ -1236,7 +1236,7 @@ impl IHttpDiagnosticSourceLocation {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDiagnosticSourceLocation: IHttpDiagnosticSourceLocation}
+RT_CLASS!{class HttpDiagnosticSourceLocation: IHttpDiagnosticSourceLocation ["Windows.Web.Http.Diagnostics.HttpDiagnosticSourceLocation"]}
 } // Windows.Web.Http.Diagnostics
 pub mod filters { // Windows.Web.Http.Filters
 use ::prelude::*;
@@ -1358,7 +1358,7 @@ impl IHttpBaseProtocolFilter {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpBaseProtocolFilter: IHttpBaseProtocolFilter}
+RT_CLASS!{class HttpBaseProtocolFilter: IHttpBaseProtocolFilter ["Windows.Web.Http.Filters.HttpBaseProtocolFilter"]}
 impl RtActivatable<IActivationFactory> for HttpBaseProtocolFilter {}
 DEFINE_CLSID!(HttpBaseProtocolFilter(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,70,105,108,116,101,114,115,46,72,116,116,112,66,97,115,101,80,114,111,116,111,99,111,108,70,105,108,116,101,114,0]) [CLSID_HttpBaseProtocolFilter]);
 DEFINE_IID!(IID_IHttpBaseProtocolFilter2, 784531475, 37927, 18688, 160, 23, 250, 125, 163, 181, 201, 174);
@@ -1441,14 +1441,14 @@ impl IHttpCacheControl {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCacheControl: IHttpCacheControl}
-RT_ENUM! { enum HttpCacheReadBehavior: i32 {
+RT_CLASS!{class HttpCacheControl: IHttpCacheControl ["Windows.Web.Http.Filters.HttpCacheControl"]}
+RT_ENUM! { enum HttpCacheReadBehavior: i32 ["Windows.Web.Http.Filters.HttpCacheReadBehavior"] {
     Default (HttpCacheReadBehavior_Default) = 0, MostRecent (HttpCacheReadBehavior_MostRecent) = 1, OnlyFromCache (HttpCacheReadBehavior_OnlyFromCache) = 2, NoCache (HttpCacheReadBehavior_NoCache) = 3,
 }}
-RT_ENUM! { enum HttpCacheWriteBehavior: i32 {
+RT_ENUM! { enum HttpCacheWriteBehavior: i32 ["Windows.Web.Http.Filters.HttpCacheWriteBehavior"] {
     Default (HttpCacheWriteBehavior_Default) = 0, NoCache (HttpCacheWriteBehavior_NoCache) = 1,
 }}
-RT_ENUM! { enum HttpCookieUsageBehavior: i32 {
+RT_ENUM! { enum HttpCookieUsageBehavior: i32 ["Windows.Web.Http.Filters.HttpCookieUsageBehavior"] {
     Default (HttpCookieUsageBehavior_Default) = 0, NoCookies (HttpCookieUsageBehavior_NoCookies) = 1,
 }}
 DEFINE_IID!(IID_IHttpFilter, 2764795349, 2306, 17310, 191, 215, 225, 37, 82, 177, 101, 206);
@@ -1512,7 +1512,7 @@ impl IHttpServerCustomValidationRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpServerCustomValidationRequestedEventArgs: IHttpServerCustomValidationRequestedEventArgs}
+RT_CLASS!{class HttpServerCustomValidationRequestedEventArgs: IHttpServerCustomValidationRequestedEventArgs ["Windows.Web.Http.Filters.HttpServerCustomValidationRequestedEventArgs"]}
 } // Windows.Web.Http.Filters
 pub mod headers { // Windows.Web.Http.Headers
 use ::prelude::*;
@@ -1576,7 +1576,7 @@ impl IHttpCacheDirectiveHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCacheDirectiveHeaderValueCollection: IHttpCacheDirectiveHeaderValueCollection}
+RT_CLASS!{class HttpCacheDirectiveHeaderValueCollection: IHttpCacheDirectiveHeaderValueCollection ["Windows.Web.Http.Headers.HttpCacheDirectiveHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpChallengeHeaderValue, 959668655, 3965, 18464, 159, 221, 162, 185, 86, 238, 174, 171);
 RT_INTERFACE!{interface IHttpChallengeHeaderValue(IHttpChallengeHeaderValueVtbl): IInspectable(IInspectableVtbl) [IID_IHttpChallengeHeaderValue] {
     fn get_Parameters(&self, out: *mut *mut foundation::collections::IVector<HttpNameValueHeaderValue>) -> HRESULT,
@@ -1600,7 +1600,7 @@ impl IHttpChallengeHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpChallengeHeaderValue: IHttpChallengeHeaderValue}
+RT_CLASS!{class HttpChallengeHeaderValue: IHttpChallengeHeaderValue ["Windows.Web.Http.Headers.HttpChallengeHeaderValue"]}
 impl RtActivatable<IHttpChallengeHeaderValueFactory> for HttpChallengeHeaderValue {}
 impl RtActivatable<IHttpChallengeHeaderValueStatics> for HttpChallengeHeaderValue {}
 impl HttpChallengeHeaderValue {
@@ -1634,7 +1634,7 @@ impl IHttpChallengeHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpChallengeHeaderValueCollection: IHttpChallengeHeaderValueCollection}
+RT_CLASS!{class HttpChallengeHeaderValueCollection: IHttpChallengeHeaderValueCollection ["Windows.Web.Http.Headers.HttpChallengeHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpChallengeHeaderValueFactory, 3293758545, 55708, 16554, 147, 153, 144, 238, 185, 143, 198, 19);
 RT_INTERFACE!{static interface IHttpChallengeHeaderValueFactory(IHttpChallengeHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpChallengeHeaderValueFactory] {
     fn CreateFromScheme(&self, scheme: HSTRING, out: *mut *mut HttpChallengeHeaderValue) -> HRESULT,
@@ -1680,7 +1680,7 @@ impl IHttpConnectionOptionHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpConnectionOptionHeaderValue: IHttpConnectionOptionHeaderValue}
+RT_CLASS!{class HttpConnectionOptionHeaderValue: IHttpConnectionOptionHeaderValue ["Windows.Web.Http.Headers.HttpConnectionOptionHeaderValue"]}
 impl RtActivatable<IHttpConnectionOptionHeaderValueFactory> for HttpConnectionOptionHeaderValue {}
 impl RtActivatable<IHttpConnectionOptionHeaderValueStatics> for HttpConnectionOptionHeaderValue {}
 impl HttpConnectionOptionHeaderValue {
@@ -1711,7 +1711,7 @@ impl IHttpConnectionOptionHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpConnectionOptionHeaderValueCollection: IHttpConnectionOptionHeaderValueCollection}
+RT_CLASS!{class HttpConnectionOptionHeaderValueCollection: IHttpConnectionOptionHeaderValueCollection ["Windows.Web.Http.Headers.HttpConnectionOptionHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpConnectionOptionHeaderValueFactory, 3644640286, 2941, 19519, 165, 141, 162, 161, 189, 234, 188, 10);
 RT_INTERFACE!{static interface IHttpConnectionOptionHeaderValueFactory(IHttpConnectionOptionHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpConnectionOptionHeaderValueFactory] {
     fn Create(&self, token: HSTRING, out: *mut *mut HttpConnectionOptionHeaderValue) -> HRESULT
@@ -1751,7 +1751,7 @@ impl IHttpContentCodingHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentCodingHeaderValue: IHttpContentCodingHeaderValue}
+RT_CLASS!{class HttpContentCodingHeaderValue: IHttpContentCodingHeaderValue ["Windows.Web.Http.Headers.HttpContentCodingHeaderValue"]}
 impl RtActivatable<IHttpContentCodingHeaderValueFactory> for HttpContentCodingHeaderValue {}
 impl RtActivatable<IHttpContentCodingHeaderValueStatics> for HttpContentCodingHeaderValue {}
 impl HttpContentCodingHeaderValue {
@@ -1782,7 +1782,7 @@ impl IHttpContentCodingHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentCodingHeaderValueCollection: IHttpContentCodingHeaderValueCollection}
+RT_CLASS!{class HttpContentCodingHeaderValueCollection: IHttpContentCodingHeaderValueCollection ["Windows.Web.Http.Headers.HttpContentCodingHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpContentCodingHeaderValueFactory, 3309120471, 13099, 17232, 133, 16, 46, 103, 162, 40, 154, 90);
 RT_INTERFACE!{static interface IHttpContentCodingHeaderValueFactory(IHttpContentCodingHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentCodingHeaderValueFactory] {
     fn Create(&self, contentCoding: HSTRING, out: *mut *mut HttpContentCodingHeaderValue) -> HRESULT
@@ -1828,7 +1828,7 @@ impl IHttpContentCodingWithQualityHeaderValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentCodingWithQualityHeaderValue: IHttpContentCodingWithQualityHeaderValue}
+RT_CLASS!{class HttpContentCodingWithQualityHeaderValue: IHttpContentCodingWithQualityHeaderValue ["Windows.Web.Http.Headers.HttpContentCodingWithQualityHeaderValue"]}
 impl RtActivatable<IHttpContentCodingWithQualityHeaderValueFactory> for HttpContentCodingWithQualityHeaderValue {}
 impl RtActivatable<IHttpContentCodingWithQualityHeaderValueStatics> for HttpContentCodingWithQualityHeaderValue {}
 impl HttpContentCodingWithQualityHeaderValue {
@@ -1862,7 +1862,7 @@ impl IHttpContentCodingWithQualityHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentCodingWithQualityHeaderValueCollection: IHttpContentCodingWithQualityHeaderValueCollection}
+RT_CLASS!{class HttpContentCodingWithQualityHeaderValueCollection: IHttpContentCodingWithQualityHeaderValueCollection ["Windows.Web.Http.Headers.HttpContentCodingWithQualityHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpContentCodingWithQualityHeaderValueFactory, 3294555674, 50515, 18172, 173, 226, 215, 92, 29, 83, 223, 123);
 RT_INTERFACE!{static interface IHttpContentCodingWithQualityHeaderValueFactory(IHttpContentCodingWithQualityHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpContentCodingWithQualityHeaderValueFactory] {
     fn CreateFromValue(&self, contentCoding: HSTRING, out: *mut *mut HttpContentCodingWithQualityHeaderValue) -> HRESULT,
@@ -1963,7 +1963,7 @@ impl IHttpContentDispositionHeaderValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentDispositionHeaderValue: IHttpContentDispositionHeaderValue}
+RT_CLASS!{class HttpContentDispositionHeaderValue: IHttpContentDispositionHeaderValue ["Windows.Web.Http.Headers.HttpContentDispositionHeaderValue"]}
 impl RtActivatable<IHttpContentDispositionHeaderValueFactory> for HttpContentDispositionHeaderValue {}
 impl RtActivatable<IHttpContentDispositionHeaderValueStatics> for HttpContentDispositionHeaderValue {}
 impl HttpContentDispositionHeaderValue {
@@ -2124,7 +2124,7 @@ impl IHttpContentHeaderCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentHeaderCollection: IHttpContentHeaderCollection}
+RT_CLASS!{class HttpContentHeaderCollection: IHttpContentHeaderCollection ["Windows.Web.Http.Headers.HttpContentHeaderCollection"]}
 impl RtActivatable<IActivationFactory> for HttpContentHeaderCollection {}
 DEFINE_CLSID!(HttpContentHeaderCollection(&[87,105,110,100,111,119,115,46,87,101,98,46,72,116,116,112,46,72,101,97,100,101,114,115,46,72,116,116,112,67,111,110,116,101,110,116,72,101,97,100,101,114,67,111,108,108,101,99,116,105,111,110,0]) [CLSID_HttpContentHeaderCollection]);
 DEFINE_IID!(IID_IHttpContentRangeHeaderValue, 81356755, 42230, 18780, 149, 48, 133, 121, 252, 186, 138, 169);
@@ -2161,7 +2161,7 @@ impl IHttpContentRangeHeaderValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpContentRangeHeaderValue: IHttpContentRangeHeaderValue}
+RT_CLASS!{class HttpContentRangeHeaderValue: IHttpContentRangeHeaderValue ["Windows.Web.Http.Headers.HttpContentRangeHeaderValue"]}
 impl RtActivatable<IHttpContentRangeHeaderValueFactory> for HttpContentRangeHeaderValue {}
 impl RtActivatable<IHttpContentRangeHeaderValueStatics> for HttpContentRangeHeaderValue {}
 impl HttpContentRangeHeaderValue {
@@ -2244,7 +2244,7 @@ impl IHttpCookiePairHeaderValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCookiePairHeaderValue: IHttpCookiePairHeaderValue}
+RT_CLASS!{class HttpCookiePairHeaderValue: IHttpCookiePairHeaderValue ["Windows.Web.Http.Headers.HttpCookiePairHeaderValue"]}
 impl RtActivatable<IHttpCookiePairHeaderValueFactory> for HttpCookiePairHeaderValue {}
 impl RtActivatable<IHttpCookiePairHeaderValueStatics> for HttpCookiePairHeaderValue {}
 impl HttpCookiePairHeaderValue {
@@ -2278,7 +2278,7 @@ impl IHttpCookiePairHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCookiePairHeaderValueCollection: IHttpCookiePairHeaderValueCollection}
+RT_CLASS!{class HttpCookiePairHeaderValueCollection: IHttpCookiePairHeaderValueCollection ["Windows.Web.Http.Headers.HttpCookiePairHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpCookiePairHeaderValueFactory, 1667117679, 5231, 20310, 170, 33, 44, 183, 214, 213, 139, 30);
 RT_INTERFACE!{static interface IHttpCookiePairHeaderValueFactory(IHttpCookiePairHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpCookiePairHeaderValueFactory] {
     fn CreateFromName(&self, name: HSTRING, out: *mut *mut HttpCookiePairHeaderValue) -> HRESULT,
@@ -2336,7 +2336,7 @@ impl IHttpCredentialsHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpCredentialsHeaderValue: IHttpCredentialsHeaderValue}
+RT_CLASS!{class HttpCredentialsHeaderValue: IHttpCredentialsHeaderValue ["Windows.Web.Http.Headers.HttpCredentialsHeaderValue"]}
 impl RtActivatable<IHttpCredentialsHeaderValueFactory> for HttpCredentialsHeaderValue {}
 impl RtActivatable<IHttpCredentialsHeaderValueStatics> for HttpCredentialsHeaderValue {}
 impl HttpCredentialsHeaderValue {
@@ -2405,7 +2405,7 @@ impl IHttpDateOrDeltaHeaderValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpDateOrDeltaHeaderValue: IHttpDateOrDeltaHeaderValue}
+RT_CLASS!{class HttpDateOrDeltaHeaderValue: IHttpDateOrDeltaHeaderValue ["Windows.Web.Http.Headers.HttpDateOrDeltaHeaderValue"]}
 impl RtActivatable<IHttpDateOrDeltaHeaderValueStatics> for HttpDateOrDeltaHeaderValue {}
 impl HttpDateOrDeltaHeaderValue {
     #[inline] pub fn parse(input: &HStringArg) -> Result<Option<ComPtr<HttpDateOrDeltaHeaderValue>>> {
@@ -2461,7 +2461,7 @@ impl IHttpExpectationHeaderValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpExpectationHeaderValue: IHttpExpectationHeaderValue}
+RT_CLASS!{class HttpExpectationHeaderValue: IHttpExpectationHeaderValue ["Windows.Web.Http.Headers.HttpExpectationHeaderValue"]}
 impl RtActivatable<IHttpExpectationHeaderValueFactory> for HttpExpectationHeaderValue {}
 impl RtActivatable<IHttpExpectationHeaderValueStatics> for HttpExpectationHeaderValue {}
 impl HttpExpectationHeaderValue {
@@ -2495,7 +2495,7 @@ impl IHttpExpectationHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpExpectationHeaderValueCollection: IHttpExpectationHeaderValueCollection}
+RT_CLASS!{class HttpExpectationHeaderValueCollection: IHttpExpectationHeaderValueCollection ["Windows.Web.Http.Headers.HttpExpectationHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpExpectationHeaderValueFactory, 1319269835, 54590, 18536, 136, 86, 30, 33, 165, 3, 13, 192);
 RT_INTERFACE!{static interface IHttpExpectationHeaderValueFactory(IHttpExpectationHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpExpectationHeaderValueFactory] {
     fn CreateFromName(&self, name: HSTRING, out: *mut *mut HttpExpectationHeaderValue) -> HRESULT,
@@ -2546,7 +2546,7 @@ impl IHttpLanguageHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpLanguageHeaderValueCollection: IHttpLanguageHeaderValueCollection}
+RT_CLASS!{class HttpLanguageHeaderValueCollection: IHttpLanguageHeaderValueCollection ["Windows.Web.Http.Headers.HttpLanguageHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpLanguageRangeWithQualityHeaderValue, 1918296322, 128, 19892, 160, 131, 125, 231, 178, 229, 186, 76);
 RT_INTERFACE!{interface IHttpLanguageRangeWithQualityHeaderValue(IHttpLanguageRangeWithQualityHeaderValueVtbl): IInspectable(IInspectableVtbl) [IID_IHttpLanguageRangeWithQualityHeaderValue] {
     fn get_LanguageRange(&self, out: *mut HSTRING) -> HRESULT,
@@ -2564,7 +2564,7 @@ impl IHttpLanguageRangeWithQualityHeaderValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpLanguageRangeWithQualityHeaderValue: IHttpLanguageRangeWithQualityHeaderValue}
+RT_CLASS!{class HttpLanguageRangeWithQualityHeaderValue: IHttpLanguageRangeWithQualityHeaderValue ["Windows.Web.Http.Headers.HttpLanguageRangeWithQualityHeaderValue"]}
 impl RtActivatable<IHttpLanguageRangeWithQualityHeaderValueFactory> for HttpLanguageRangeWithQualityHeaderValue {}
 impl RtActivatable<IHttpLanguageRangeWithQualityHeaderValueStatics> for HttpLanguageRangeWithQualityHeaderValue {}
 impl HttpLanguageRangeWithQualityHeaderValue {
@@ -2598,7 +2598,7 @@ impl IHttpLanguageRangeWithQualityHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpLanguageRangeWithQualityHeaderValueCollection: IHttpLanguageRangeWithQualityHeaderValueCollection}
+RT_CLASS!{class HttpLanguageRangeWithQualityHeaderValueCollection: IHttpLanguageRangeWithQualityHeaderValueCollection ["Windows.Web.Http.Headers.HttpLanguageRangeWithQualityHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpLanguageRangeWithQualityHeaderValueFactory, 2075670896, 30735, 19587, 159, 228, 220, 48, 135, 246, 189, 85);
 RT_INTERFACE!{static interface IHttpLanguageRangeWithQualityHeaderValueFactory(IHttpLanguageRangeWithQualityHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpLanguageRangeWithQualityHeaderValueFactory] {
     fn CreateFromLanguageRange(&self, languageRange: HSTRING, out: *mut *mut HttpLanguageRangeWithQualityHeaderValue) -> HRESULT,
@@ -2666,7 +2666,7 @@ impl IHttpMediaTypeHeaderValue {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMediaTypeHeaderValue: IHttpMediaTypeHeaderValue}
+RT_CLASS!{class HttpMediaTypeHeaderValue: IHttpMediaTypeHeaderValue ["Windows.Web.Http.Headers.HttpMediaTypeHeaderValue"]}
 impl RtActivatable<IHttpMediaTypeHeaderValueFactory> for HttpMediaTypeHeaderValue {}
 impl RtActivatable<IHttpMediaTypeHeaderValueStatics> for HttpMediaTypeHeaderValue {}
 impl HttpMediaTypeHeaderValue {
@@ -2753,7 +2753,7 @@ impl IHttpMediaTypeWithQualityHeaderValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMediaTypeWithQualityHeaderValue: IHttpMediaTypeWithQualityHeaderValue}
+RT_CLASS!{class HttpMediaTypeWithQualityHeaderValue: IHttpMediaTypeWithQualityHeaderValue ["Windows.Web.Http.Headers.HttpMediaTypeWithQualityHeaderValue"]}
 impl RtActivatable<IHttpMediaTypeWithQualityHeaderValueFactory> for HttpMediaTypeWithQualityHeaderValue {}
 impl RtActivatable<IHttpMediaTypeWithQualityHeaderValueStatics> for HttpMediaTypeWithQualityHeaderValue {}
 impl HttpMediaTypeWithQualityHeaderValue {
@@ -2787,7 +2787,7 @@ impl IHttpMediaTypeWithQualityHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMediaTypeWithQualityHeaderValueCollection: IHttpMediaTypeWithQualityHeaderValueCollection}
+RT_CLASS!{class HttpMediaTypeWithQualityHeaderValueCollection: IHttpMediaTypeWithQualityHeaderValueCollection ["Windows.Web.Http.Headers.HttpMediaTypeWithQualityHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpMediaTypeWithQualityHeaderValueFactory, 1282220276, 37975, 17638, 163, 35, 209, 34, 185, 88, 120, 11);
 RT_INTERFACE!{static interface IHttpMediaTypeWithQualityHeaderValueFactory(IHttpMediaTypeWithQualityHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpMediaTypeWithQualityHeaderValueFactory] {
     fn CreateFromMediaType(&self, mediaType: HSTRING, out: *mut *mut HttpMediaTypeWithQualityHeaderValue) -> HRESULT,
@@ -2838,7 +2838,7 @@ impl IHttpMethodHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpMethodHeaderValueCollection: IHttpMethodHeaderValueCollection}
+RT_CLASS!{class HttpMethodHeaderValueCollection: IHttpMethodHeaderValueCollection ["Windows.Web.Http.Headers.HttpMethodHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpNameValueHeaderValue, 3636098147, 23450, 19739, 147, 249, 170, 91, 68, 236, 253, 223);
 RT_INTERFACE!{interface IHttpNameValueHeaderValue(IHttpNameValueHeaderValueVtbl): IInspectable(IInspectableVtbl) [IID_IHttpNameValueHeaderValue] {
     fn get_Name(&self, out: *mut HSTRING) -> HRESULT,
@@ -2861,7 +2861,7 @@ impl IHttpNameValueHeaderValue {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpNameValueHeaderValue: IHttpNameValueHeaderValue}
+RT_CLASS!{class HttpNameValueHeaderValue: IHttpNameValueHeaderValue ["Windows.Web.Http.Headers.HttpNameValueHeaderValue"]}
 impl RtActivatable<IHttpNameValueHeaderValueFactory> for HttpNameValueHeaderValue {}
 impl RtActivatable<IHttpNameValueHeaderValueStatics> for HttpNameValueHeaderValue {}
 impl HttpNameValueHeaderValue {
@@ -2930,7 +2930,7 @@ impl IHttpProductHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpProductHeaderValue: IHttpProductHeaderValue}
+RT_CLASS!{class HttpProductHeaderValue: IHttpProductHeaderValue ["Windows.Web.Http.Headers.HttpProductHeaderValue"]}
 impl RtActivatable<IHttpProductHeaderValueFactory> for HttpProductHeaderValue {}
 impl RtActivatable<IHttpProductHeaderValueStatics> for HttpProductHeaderValue {}
 impl HttpProductHeaderValue {
@@ -2999,7 +2999,7 @@ impl IHttpProductInfoHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpProductInfoHeaderValue: IHttpProductInfoHeaderValue}
+RT_CLASS!{class HttpProductInfoHeaderValue: IHttpProductInfoHeaderValue ["Windows.Web.Http.Headers.HttpProductInfoHeaderValue"]}
 impl RtActivatable<IHttpProductInfoHeaderValueFactory> for HttpProductInfoHeaderValue {}
 impl RtActivatable<IHttpProductInfoHeaderValueStatics> for HttpProductInfoHeaderValue {}
 impl HttpProductInfoHeaderValue {
@@ -3033,7 +3033,7 @@ impl IHttpProductInfoHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpProductInfoHeaderValueCollection: IHttpProductInfoHeaderValueCollection}
+RT_CLASS!{class HttpProductInfoHeaderValueCollection: IHttpProductInfoHeaderValueCollection ["Windows.Web.Http.Headers.HttpProductInfoHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpProductInfoHeaderValueFactory, 606212030, 60094, 17508, 180, 96, 236, 1, 11, 124, 65, 226);
 RT_INTERFACE!{static interface IHttpProductInfoHeaderValueFactory(IHttpProductInfoHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpProductInfoHeaderValueFactory] {
     fn CreateFromComment(&self, productComment: HSTRING, out: *mut *mut HttpProductInfoHeaderValue) -> HRESULT,
@@ -3239,7 +3239,7 @@ impl IHttpRequestHeaderCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpRequestHeaderCollection: IHttpRequestHeaderCollection}
+RT_CLASS!{class HttpRequestHeaderCollection: IHttpRequestHeaderCollection ["Windows.Web.Http.Headers.HttpRequestHeaderCollection"]}
 DEFINE_IID!(IID_IHttpResponseHeaderCollection, 2056849769, 64063, 16877, 170, 198, 191, 149, 121, 117, 193, 107);
 RT_INTERFACE!{interface IHttpResponseHeaderCollection(IHttpResponseHeaderCollectionVtbl): IInspectable(IInspectableVtbl) [IID_IHttpResponseHeaderCollection] {
     fn get_Age(&self, out: *mut *mut foundation::IReference<foundation::TimeSpan>) -> HRESULT,
@@ -3336,7 +3336,7 @@ impl IHttpResponseHeaderCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpResponseHeaderCollection: IHttpResponseHeaderCollection}
+RT_CLASS!{class HttpResponseHeaderCollection: IHttpResponseHeaderCollection ["Windows.Web.Http.Headers.HttpResponseHeaderCollection"]}
 DEFINE_IID!(IID_IHttpTransferCodingHeaderValue, 1131361017, 15853, 17085, 179, 138, 84, 150, 162, 81, 28, 230);
 RT_INTERFACE!{interface IHttpTransferCodingHeaderValue(IHttpTransferCodingHeaderValueVtbl): IInspectable(IInspectableVtbl) [IID_IHttpTransferCodingHeaderValue] {
     fn get_Parameters(&self, out: *mut *mut foundation::collections::IVector<HttpNameValueHeaderValue>) -> HRESULT,
@@ -3354,7 +3354,7 @@ impl IHttpTransferCodingHeaderValue {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpTransferCodingHeaderValue: IHttpTransferCodingHeaderValue}
+RT_CLASS!{class HttpTransferCodingHeaderValue: IHttpTransferCodingHeaderValue ["Windows.Web.Http.Headers.HttpTransferCodingHeaderValue"]}
 impl RtActivatable<IHttpTransferCodingHeaderValueFactory> for HttpTransferCodingHeaderValue {}
 impl RtActivatable<IHttpTransferCodingHeaderValueStatics> for HttpTransferCodingHeaderValue {}
 impl HttpTransferCodingHeaderValue {
@@ -3385,7 +3385,7 @@ impl IHttpTransferCodingHeaderValueCollection {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class HttpTransferCodingHeaderValueCollection: IHttpTransferCodingHeaderValueCollection}
+RT_CLASS!{class HttpTransferCodingHeaderValueCollection: IHttpTransferCodingHeaderValueCollection ["Windows.Web.Http.Headers.HttpTransferCodingHeaderValueCollection"]}
 DEFINE_IID!(IID_IHttpTransferCodingHeaderValueFactory, 3143819260, 58209, 20232, 142, 79, 201, 231, 35, 222, 112, 59);
 RT_INTERFACE!{static interface IHttpTransferCodingHeaderValueFactory(IHttpTransferCodingHeaderValueFactoryVtbl): IInspectable(IInspectableVtbl) [IID_IHttpTransferCodingHeaderValueFactory] {
     fn Create(&self, input: HSTRING, out: *mut *mut HttpTransferCodingHeaderValue) -> HRESULT
@@ -3418,7 +3418,7 @@ impl IHttpTransferCodingHeaderValueStatics {
 } // Windows.Web.Http
 pub mod syndication { // Windows.Web.Syndication
 use ::prelude::*;
-RT_STRUCT! { struct RetrievalProgress {
+RT_STRUCT! { struct RetrievalProgress ["Windows.Web.Syndication.RetrievalProgress"] {
     BytesRetrieved: u32, TotalBytesToRetrieve: u32,
 }}
 DEFINE_IID!(IID_ISyndicationAttribute, 1911093609, 21102, 16385, 154, 145, 232, 79, 131, 22, 26, 177);
@@ -3459,7 +3459,7 @@ impl ISyndicationAttribute {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationAttribute: ISyndicationAttribute}
+RT_CLASS!{class SyndicationAttribute: ISyndicationAttribute ["Windows.Web.Syndication.SyndicationAttribute"]}
 impl RtActivatable<ISyndicationAttributeFactory> for SyndicationAttribute {}
 impl RtActivatable<IActivationFactory> for SyndicationAttribute {}
 impl SyndicationAttribute {
@@ -3517,7 +3517,7 @@ impl ISyndicationCategory {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationCategory: ISyndicationCategory}
+RT_CLASS!{class SyndicationCategory: ISyndicationCategory ["Windows.Web.Syndication.SyndicationCategory"]}
 impl RtActivatable<ISyndicationCategoryFactory> for SyndicationCategory {}
 impl RtActivatable<IActivationFactory> for SyndicationCategory {}
 impl SyndicationCategory {
@@ -3621,7 +3621,7 @@ impl ISyndicationClient {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationClient: ISyndicationClient}
+RT_CLASS!{class SyndicationClient: ISyndicationClient ["Windows.Web.Syndication.SyndicationClient"]}
 impl RtActivatable<ISyndicationClientFactory> for SyndicationClient {}
 impl RtActivatable<IActivationFactory> for SyndicationClient {}
 impl SyndicationClient {
@@ -3657,7 +3657,7 @@ impl ISyndicationContent {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationContent: ISyndicationContent}
+RT_CLASS!{class SyndicationContent: ISyndicationContent ["Windows.Web.Syndication.SyndicationContent"]}
 impl RtActivatable<ISyndicationContentFactory> for SyndicationContent {}
 impl RtActivatable<IActivationFactory> for SyndicationContent {}
 impl SyndicationContent {
@@ -3705,7 +3705,7 @@ impl ISyndicationErrorStatics {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SyndicationErrorStatus: i32 {
+RT_ENUM! { enum SyndicationErrorStatus: i32 ["Windows.Web.Syndication.SyndicationErrorStatus"] {
     Unknown (SyndicationErrorStatus_Unknown) = 0, MissingRequiredElement (SyndicationErrorStatus_MissingRequiredElement) = 1, MissingRequiredAttribute (SyndicationErrorStatus_MissingRequiredAttribute) = 2, InvalidXml (SyndicationErrorStatus_InvalidXml) = 3, UnexpectedContent (SyndicationErrorStatus_UnexpectedContent) = 4, UnsupportedFormat (SyndicationErrorStatus_UnsupportedFormat) = 5,
 }}
 DEFINE_IID!(IID_ISyndicationFeed, 2147368146, 23398, 19810, 132, 3, 27, 193, 13, 145, 13, 107);
@@ -3871,7 +3871,7 @@ impl ISyndicationFeed {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationFeed: ISyndicationFeed}
+RT_CLASS!{class SyndicationFeed: ISyndicationFeed ["Windows.Web.Syndication.SyndicationFeed"]}
 impl RtActivatable<ISyndicationFeedFactory> for SyndicationFeed {}
 impl RtActivatable<IActivationFactory> for SyndicationFeed {}
 impl SyndicationFeed {
@@ -3891,7 +3891,7 @@ impl ISyndicationFeedFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SyndicationFormat: i32 {
+RT_ENUM! { enum SyndicationFormat: i32 ["Windows.Web.Syndication.SyndicationFormat"] {
     Atom10 (SyndicationFormat_Atom10) = 0, Rss20 (SyndicationFormat_Rss20) = 1, Rss10 (SyndicationFormat_Rss10) = 2, Rss092 (SyndicationFormat_Rss092) = 3, Rss091 (SyndicationFormat_Rss091) = 4, Atom03 (SyndicationFormat_Atom03) = 5,
 }}
 DEFINE_IID!(IID_ISyndicationGenerator, 2540221305, 64299, 20333, 180, 28, 8, 138, 88, 104, 130, 92);
@@ -3932,7 +3932,7 @@ impl ISyndicationGenerator {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationGenerator: ISyndicationGenerator}
+RT_CLASS!{class SyndicationGenerator: ISyndicationGenerator ["Windows.Web.Syndication.SyndicationGenerator"]}
 impl RtActivatable<ISyndicationGeneratorFactory> for SyndicationGenerator {}
 impl RtActivatable<IActivationFactory> for SyndicationGenerator {}
 impl SyndicationGenerator {
@@ -4114,7 +4114,7 @@ impl ISyndicationItem {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationItem: ISyndicationItem}
+RT_CLASS!{class SyndicationItem: ISyndicationItem ["Windows.Web.Syndication.SyndicationItem"]}
 impl RtActivatable<ISyndicationItemFactory> for SyndicationItem {}
 impl RtActivatable<IActivationFactory> for SyndicationItem {}
 impl SyndicationItem {
@@ -4205,7 +4205,7 @@ impl ISyndicationLink {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationLink: ISyndicationLink}
+RT_CLASS!{class SyndicationLink: ISyndicationLink ["Windows.Web.Syndication.SyndicationLink"]}
 impl RtActivatable<ISyndicationLinkFactory> for SyndicationLink {}
 impl RtActivatable<IActivationFactory> for SyndicationLink {}
 impl SyndicationLink {
@@ -4312,7 +4312,7 @@ impl ISyndicationNode {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationNode: ISyndicationNode}
+RT_CLASS!{class SyndicationNode: ISyndicationNode ["Windows.Web.Syndication.SyndicationNode"]}
 impl RtActivatable<ISyndicationNodeFactory> for SyndicationNode {}
 impl RtActivatable<IActivationFactory> for SyndicationNode {}
 impl SyndicationNode {
@@ -4370,7 +4370,7 @@ impl ISyndicationPerson {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationPerson: ISyndicationPerson}
+RT_CLASS!{class SyndicationPerson: ISyndicationPerson ["Windows.Web.Syndication.SyndicationPerson"]}
 impl RtActivatable<ISyndicationPersonFactory> for SyndicationPerson {}
 impl RtActivatable<IActivationFactory> for SyndicationPerson {}
 impl SyndicationPerson {
@@ -4437,7 +4437,7 @@ impl ISyndicationText {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class SyndicationText: ISyndicationText}
+RT_CLASS!{class SyndicationText: ISyndicationText ["Windows.Web.Syndication.SyndicationText"]}
 impl RtActivatable<ISyndicationTextFactory> for SyndicationText {}
 impl RtActivatable<IActivationFactory> for SyndicationText {}
 impl SyndicationText {
@@ -4466,10 +4466,10 @@ impl ISyndicationTextFactory {
         if hr == S_OK { Ok(ComPtr::wrap(out)) } else { err(hr) }
     }}
 }
-RT_ENUM! { enum SyndicationTextType: i32 {
+RT_ENUM! { enum SyndicationTextType: i32 ["Windows.Web.Syndication.SyndicationTextType"] {
     Text (SyndicationTextType_Text) = 0, Html (SyndicationTextType_Html) = 1, Xhtml (SyndicationTextType_Xhtml) = 2,
 }}
-RT_STRUCT! { struct TransferProgress {
+RT_STRUCT! { struct TransferProgress ["Windows.Web.Syndication.TransferProgress"] {
     BytesSent: u32, TotalBytesToSend: u32, BytesRetrieved: u32, TotalBytesToRetrieve: u32,
 }}
 } // Windows.Web.Syndication
@@ -4820,7 +4820,7 @@ impl IWebViewControlContentLoadingEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlContentLoadingEventArgs: IWebViewControlContentLoadingEventArgs}
+RT_CLASS!{class WebViewControlContentLoadingEventArgs: IWebViewControlContentLoadingEventArgs ["Windows.Web.UI.WebViewControlContentLoadingEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlDeferredPermissionRequest, 753093088, 55129, 17500, 153, 38, 137, 149, 41, 143, 21, 43);
 RT_INTERFACE!{interface IWebViewControlDeferredPermissionRequest(IWebViewControlDeferredPermissionRequestVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlDeferredPermissionRequest] {
     fn get_Id(&self, out: *mut u32) -> HRESULT,
@@ -4854,7 +4854,7 @@ impl IWebViewControlDeferredPermissionRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlDeferredPermissionRequest: IWebViewControlDeferredPermissionRequest}
+RT_CLASS!{class WebViewControlDeferredPermissionRequest: IWebViewControlDeferredPermissionRequest ["Windows.Web.UI.WebViewControlDeferredPermissionRequest"]}
 DEFINE_IID!(IID_IWebViewControlDOMContentLoadedEventArgs, 3196829704, 38209, 17733, 159, 242, 45, 245, 133, 178, 159, 125);
 RT_INTERFACE!{interface IWebViewControlDOMContentLoadedEventArgs(IWebViewControlDOMContentLoadedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlDOMContentLoadedEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT
@@ -4866,7 +4866,7 @@ impl IWebViewControlDOMContentLoadedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlDOMContentLoadedEventArgs: IWebViewControlDOMContentLoadedEventArgs}
+RT_CLASS!{class WebViewControlDOMContentLoadedEventArgs: IWebViewControlDOMContentLoadedEventArgs ["Windows.Web.UI.WebViewControlDOMContentLoadedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlLongRunningScriptDetectedEventArgs, 711875514, 39092, 17852, 187, 235, 15, 105, 206, 73, 197, 153);
 RT_INTERFACE!{interface IWebViewControlLongRunningScriptDetectedEventArgs(IWebViewControlLongRunningScriptDetectedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlLongRunningScriptDetectedEventArgs] {
     fn get_ExecutionTime(&self, out: *mut foundation::TimeSpan) -> HRESULT,
@@ -4889,7 +4889,7 @@ impl IWebViewControlLongRunningScriptDetectedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlLongRunningScriptDetectedEventArgs: IWebViewControlLongRunningScriptDetectedEventArgs}
+RT_CLASS!{class WebViewControlLongRunningScriptDetectedEventArgs: IWebViewControlLongRunningScriptDetectedEventArgs ["Windows.Web.UI.WebViewControlLongRunningScriptDetectedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlNavigationCompletedEventArgs, 541104408, 18965, 19526, 165, 93, 247, 158, 219, 11, 222, 139);
 RT_INTERFACE!{interface IWebViewControlNavigationCompletedEventArgs(IWebViewControlNavigationCompletedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlNavigationCompletedEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -4913,7 +4913,7 @@ impl IWebViewControlNavigationCompletedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlNavigationCompletedEventArgs: IWebViewControlNavigationCompletedEventArgs}
+RT_CLASS!{class WebViewControlNavigationCompletedEventArgs: IWebViewControlNavigationCompletedEventArgs ["Windows.Web.UI.WebViewControlNavigationCompletedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlNavigationStartingEventArgs, 210786245, 2568, 16839, 134, 59, 113, 227, 169, 84, 145, 55);
 RT_INTERFACE!{interface IWebViewControlNavigationStartingEventArgs(IWebViewControlNavigationStartingEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlNavigationStartingEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -4936,7 +4936,7 @@ impl IWebViewControlNavigationStartingEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlNavigationStartingEventArgs: IWebViewControlNavigationStartingEventArgs}
+RT_CLASS!{class WebViewControlNavigationStartingEventArgs: IWebViewControlNavigationStartingEventArgs ["Windows.Web.UI.WebViewControlNavigationStartingEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlNewWindowRequestedEventArgs, 1039420347, 41252, 18133, 160, 131, 208, 44, 172, 223, 245, 173);
 RT_INTERFACE!{interface IWebViewControlNewWindowRequestedEventArgs(IWebViewControlNewWindowRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlNewWindowRequestedEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -4965,7 +4965,7 @@ impl IWebViewControlNewWindowRequestedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlNewWindowRequestedEventArgs: IWebViewControlNewWindowRequestedEventArgs}
+RT_CLASS!{class WebViewControlNewWindowRequestedEventArgs: IWebViewControlNewWindowRequestedEventArgs ["Windows.Web.UI.WebViewControlNewWindowRequestedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlNewWindowRequestedEventArgs2, 3040631974, 10926, 19452, 146, 185, 195, 14, 146, 180, 128, 152);
 RT_INTERFACE!{interface IWebViewControlNewWindowRequestedEventArgs2(IWebViewControlNewWindowRequestedEventArgs2Vtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlNewWindowRequestedEventArgs2] {
     fn get_NewWindow(&self, out: *mut *mut IWebViewControl) -> HRESULT,
@@ -5032,7 +5032,7 @@ impl IWebViewControlPermissionRequest {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlPermissionRequest: IWebViewControlPermissionRequest}
+RT_CLASS!{class WebViewControlPermissionRequest: IWebViewControlPermissionRequest ["Windows.Web.UI.WebViewControlPermissionRequest"]}
 DEFINE_IID!(IID_IWebViewControlPermissionRequestedEventArgs, 656428369, 9352, 19653, 150, 142, 10, 119, 30, 89, 193, 71);
 RT_INTERFACE!{interface IWebViewControlPermissionRequestedEventArgs(IWebViewControlPermissionRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlPermissionRequestedEventArgs] {
     fn get_PermissionRequest(&self, out: *mut *mut WebViewControlPermissionRequest) -> HRESULT
@@ -5044,11 +5044,11 @@ impl IWebViewControlPermissionRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlPermissionRequestedEventArgs: IWebViewControlPermissionRequestedEventArgs}
-RT_ENUM! { enum WebViewControlPermissionState: i32 {
+RT_CLASS!{class WebViewControlPermissionRequestedEventArgs: IWebViewControlPermissionRequestedEventArgs ["Windows.Web.UI.WebViewControlPermissionRequestedEventArgs"]}
+RT_ENUM! { enum WebViewControlPermissionState: i32 ["Windows.Web.UI.WebViewControlPermissionState"] {
     Unknown (WebViewControlPermissionState_Unknown) = 0, Defer (WebViewControlPermissionState_Defer) = 1, Allow (WebViewControlPermissionState_Allow) = 2, Deny (WebViewControlPermissionState_Deny) = 3,
 }}
-RT_ENUM! { enum WebViewControlPermissionType: i32 {
+RT_ENUM! { enum WebViewControlPermissionType: i32 ["Windows.Web.UI.WebViewControlPermissionType"] {
     Geolocation (WebViewControlPermissionType_Geolocation) = 0, UnlimitedIndexedDBQuota (WebViewControlPermissionType_UnlimitedIndexedDBQuota) = 1, Media (WebViewControlPermissionType_Media) = 2, PointerLock (WebViewControlPermissionType_PointerLock) = 3, WebNotifications (WebViewControlPermissionType_WebNotifications) = 4, Screen (WebViewControlPermissionType_Screen) = 5, ImmersiveView (WebViewControlPermissionType_ImmersiveView) = 6,
 }}
 DEFINE_IID!(IID_IWebViewControlScriptNotifyEventArgs, 1226696059, 28489, 16827, 181, 145, 81, 184, 91, 129, 112, 55);
@@ -5068,7 +5068,7 @@ impl IWebViewControlScriptNotifyEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlScriptNotifyEventArgs: IWebViewControlScriptNotifyEventArgs}
+RT_CLASS!{class WebViewControlScriptNotifyEventArgs: IWebViewControlScriptNotifyEventArgs ["Windows.Web.UI.WebViewControlScriptNotifyEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlSettings, 3382083519, 24216, 19709, 140, 206, 39, 176, 145, 30, 61, 232);
 RT_INTERFACE!{interface IWebViewControlSettings(IWebViewControlSettingsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlSettings] {
     fn put_IsJavaScriptEnabled(&self, value: bool) -> HRESULT,
@@ -5107,7 +5107,7 @@ impl IWebViewControlSettings {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlSettings: IWebViewControlSettings}
+RT_CLASS!{class WebViewControlSettings: IWebViewControlSettings ["Windows.Web.UI.WebViewControlSettings"]}
 DEFINE_IID!(IID_IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs, 3820493124, 58620, 17372, 148, 202, 249, 128, 243, 11, 197, 29);
 RT_INTERFACE!{interface IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs(IWebViewControlUnsupportedUriSchemeIdentifiedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -5130,7 +5130,7 @@ impl IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlUnsupportedUriSchemeIdentifiedEventArgs: IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs}
+RT_CLASS!{class WebViewControlUnsupportedUriSchemeIdentifiedEventArgs: IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs ["Windows.Web.UI.WebViewControlUnsupportedUriSchemeIdentifiedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlUnviewableContentIdentifiedEventArgs, 1251377371, 35058, 20000, 182, 147, 180, 226, 223, 74, 165, 129);
 RT_INTERFACE!{interface IWebViewControlUnviewableContentIdentifiedEventArgs(IWebViewControlUnviewableContentIdentifiedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlUnviewableContentIdentifiedEventArgs] {
     fn get_Uri(&self, out: *mut *mut foundation::Uri) -> HRESULT,
@@ -5154,7 +5154,7 @@ impl IWebViewControlUnviewableContentIdentifiedEventArgs {
         if hr == S_OK { Ok(HString::wrap(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlUnviewableContentIdentifiedEventArgs: IWebViewControlUnviewableContentIdentifiedEventArgs}
+RT_CLASS!{class WebViewControlUnviewableContentIdentifiedEventArgs: IWebViewControlUnviewableContentIdentifiedEventArgs ["Windows.Web.UI.WebViewControlUnviewableContentIdentifiedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlWebResourceRequestedEventArgs, 1154896461, 21924, 19851, 137, 28, 147, 29, 142, 37, 212, 46);
 RT_INTERFACE!{interface IWebViewControlWebResourceRequestedEventArgs(IWebViewControlWebResourceRequestedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlWebResourceRequestedEventArgs] {
     fn GetDeferral(&self, out: *mut *mut foundation::Deferral) -> HRESULT,
@@ -5183,10 +5183,10 @@ impl IWebViewControlWebResourceRequestedEventArgs {
         if hr == S_OK { Ok(ComPtr::wrap_optional(out)) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlWebResourceRequestedEventArgs: IWebViewControlWebResourceRequestedEventArgs}
+RT_CLASS!{class WebViewControlWebResourceRequestedEventArgs: IWebViewControlWebResourceRequestedEventArgs ["Windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"]}
 pub mod interop { // Windows.Web.UI.Interop
 use ::prelude::*;
-RT_CLASS!{class WebViewControl: super::IWebViewControl}
+RT_CLASS!{class WebViewControl: super::IWebViewControl ["Windows.Web.UI.Interop.WebViewControl"]}
 DEFINE_IID!(IID_IWebViewControlAcceleratorKeyPressedEventArgs, 2007147838, 31860, 17277, 162, 144, 58, 192, 216, 205, 86, 85);
 RT_INTERFACE!{interface IWebViewControlAcceleratorKeyPressedEventArgs(IWebViewControlAcceleratorKeyPressedEventArgsVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlAcceleratorKeyPressedEventArgs] {
     #[cfg(not(feature="windows-ui"))] fn __Dummy0(&self) -> (),
@@ -5230,11 +5230,11 @@ impl IWebViewControlAcceleratorKeyPressedEventArgs {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlAcceleratorKeyPressedEventArgs: IWebViewControlAcceleratorKeyPressedEventArgs}
-RT_ENUM! { enum WebViewControlAcceleratorKeyRoutingStage: i32 {
+RT_CLASS!{class WebViewControlAcceleratorKeyPressedEventArgs: IWebViewControlAcceleratorKeyPressedEventArgs ["Windows.Web.UI.Interop.WebViewControlAcceleratorKeyPressedEventArgs"]}
+RT_ENUM! { enum WebViewControlAcceleratorKeyRoutingStage: i32 ["Windows.Web.UI.Interop.WebViewControlAcceleratorKeyRoutingStage"] {
     Tunneling (WebViewControlAcceleratorKeyRoutingStage_Tunneling) = 0, Bubbling (WebViewControlAcceleratorKeyRoutingStage_Bubbling) = 1,
 }}
-RT_ENUM! { enum WebViewControlMoveFocusReason: i32 {
+RT_ENUM! { enum WebViewControlMoveFocusReason: i32 ["Windows.Web.UI.Interop.WebViewControlMoveFocusReason"] {
     Programmatic (WebViewControlMoveFocusReason_Programmatic) = 0, Next (WebViewControlMoveFocusReason_Next) = 1, Previous (WebViewControlMoveFocusReason_Previous) = 2,
 }}
 DEFINE_IID!(IID_IWebViewControlMoveFocusRequestedEventArgs, 1797927949, 19408, 16478, 183, 193, 30, 114, 164, 146, 244, 70);
@@ -5248,7 +5248,7 @@ impl IWebViewControlMoveFocusRequestedEventArgs {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlMoveFocusRequestedEventArgs: IWebViewControlMoveFocusRequestedEventArgs}
+RT_CLASS!{class WebViewControlMoveFocusRequestedEventArgs: IWebViewControlMoveFocusRequestedEventArgs ["Windows.Web.UI.Interop.WebViewControlMoveFocusRequestedEventArgs"]}
 DEFINE_IID!(IID_IWebViewControlProcess, 46605292, 39126, 16970, 182, 62, 198, 19, 108, 54, 160, 242);
 RT_INTERFACE!{interface IWebViewControlProcess(IWebViewControlProcessVtbl): IInspectable(IInspectableVtbl) [IID_IWebViewControlProcess] {
     fn get_ProcessId(&self, out: *mut u32) -> HRESULT,
@@ -5300,7 +5300,7 @@ impl IWebViewControlProcess {
         if hr == S_OK { Ok(()) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlProcess: IWebViewControlProcess}
+RT_CLASS!{class WebViewControlProcess: IWebViewControlProcess ["Windows.Web.UI.Interop.WebViewControlProcess"]}
 impl RtActivatable<IWebViewControlProcessFactory> for WebViewControlProcess {}
 impl RtActivatable<IActivationFactory> for WebViewControlProcess {}
 impl WebViewControlProcess {
@@ -5309,7 +5309,7 @@ impl WebViewControlProcess {
     }
 }
 DEFINE_CLSID!(WebViewControlProcess(&[87,105,110,100,111,119,115,46,87,101,98,46,85,73,46,73,110,116,101,114,111,112,46,87,101,98,86,105,101,119,67,111,110,116,114,111,108,80,114,111,99,101,115,115,0]) [CLSID_WebViewControlProcess]);
-RT_ENUM! { enum WebViewControlProcessCapabilityState: i32 {
+RT_ENUM! { enum WebViewControlProcessCapabilityState: i32 ["Windows.Web.UI.Interop.WebViewControlProcessCapabilityState"] {
     Default (WebViewControlProcessCapabilityState_Default) = 0, Disabled (WebViewControlProcessCapabilityState_Disabled) = 1, Enabled (WebViewControlProcessCapabilityState_Enabled) = 2,
 }}
 DEFINE_IID!(IID_IWebViewControlProcessFactory, 1203133689, 41682, 17724, 176, 151, 246, 119, 157, 75, 142, 2);
@@ -5350,7 +5350,7 @@ impl IWebViewControlProcessOptions {
         if hr == S_OK { Ok(out) } else { err(hr) }
     }}
 }
-RT_CLASS!{class WebViewControlProcessOptions: IWebViewControlProcessOptions}
+RT_CLASS!{class WebViewControlProcessOptions: IWebViewControlProcessOptions ["Windows.Web.UI.Interop.WebViewControlProcessOptions"]}
 impl RtActivatable<IActivationFactory> for WebViewControlProcessOptions {}
 DEFINE_CLSID!(WebViewControlProcessOptions(&[87,105,110,100,111,119,115,46,87,101,98,46,85,73,46,73,110,116,101,114,111,112,46,87,101,98,86,105,101,119,67,111,110,116,114,111,108,80,114,111,99,101,115,115,79,112,116,105,111,110,115,0]) [CLSID_WebViewControlProcessOptions]);
 DEFINE_IID!(IID_IWebViewControlSite, 322914246, 4828, 18584, 189, 71, 4, 150, 125, 230, 72, 186);

--- a/src/rt/handler.rs
+++ b/src/rt/handler.rs
@@ -53,7 +53,7 @@ pub unsafe extern "system" fn ComReprHandler_QueryInterface<T, I>(this_: *mut IU
     //println!("QueryInterface called with GUID {:?}", guid);
 
     // IAgileObject is only supported for Send objects
-    if guid != *IUnknown::iid() && guid != *IAgileObject::iid() && guid != *<I as ComIid>::iid() { 
+    if guid != IUnknown::iid() && guid != IAgileObject::iid() && guid != <I as ComIid>::iid() { 
         *ppv = ::std::ptr::null_mut();
         return E_NOINTERFACE;
     }


### PR DESCRIPTION
First step towards const fn evaluation. Changes:
- Change `ComIid` trait to return by value (should be changed to an associated const before merging this)
- Add fullname strings to RT_CLASS, RT_STRUCT & RT_ENUM
- Add dependency on `uuid` crate ... we need to see whether they will support const fn evaluation eventually

Finishing this depends on at least https://github.com/rust-lang/rfcs/pull/2632