### PR TITLE
Enforce README examples testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2018"
 [dependencies]
 winapi = { version = "0.3", features = ["winnt", "combaseapi", "oleauto", "roapi", "roerrorapi", "hstring", "winstring", "winerror", "restrictederrorinfo"] }
 
+[dev-dependencies]
+doc-comment = "0.3"
+
 [features]
 nightly = []
 windows-ai = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! ## Example
 //! ```
-//! # // THIS IS THE SAME CODE THAT IS SHOWN IN README.md
-//! # // PLEASE KEEP THEM IN SYNC SO WE CAN RELY ON DOCTESTS!
 //! extern crate winrt;
 //!
 //! use winrt::*; // import various helper types
@@ -28,12 +26,18 @@
 
 #![allow(dead_code,non_upper_case_globals,non_snake_case)]
 
+#[cfg(doctest)]
+#[macro_use]
+extern crate doc_comment;
 extern crate winapi as w;
+
+#[cfg(doctest)]
+doctest!("../README.md");
 
 mod guid;
 pub use guid::Guid;
 
-///Represents the trust level of an activatable class (re-export from WinAPI crate)
+/// Represents the trust level of an activatable class (re-export from WinAPI crate)
 pub type TrustLevel = w::winrt::inspectable::TrustLevel;
 
 // Compared to the DEFINE_GUID macro from winapi, this one creates a private const


### PR DESCRIPTION
I saw the comment in your `lib.rs` file so here you go!

PS: to enforce this even more, I'd recommend you to run `cargo test` in your appveyor CI (didn't see a file to set it up in the repository). It'll run doc tests as well.